### PR TITLE
Disable colors when outputting to a file

### DIFF
--- a/src/s2wasm-main.cpp
+++ b/src/s2wasm-main.cpp
@@ -18,6 +18,7 @@
 // wasm2asm console tool
 //
 
+#include "support/colors.h"
 #include "support/command-line.h"
 #include "s2wasm.h"
 
@@ -30,6 +31,7 @@ int main(int argc, const char *argv[]) {
               Options::Arguments::One,
               [](Options *o, const std::string &argument) {
                 o->extra["output"] = argument;
+                Colors::disable();
               })
       .add("--global-base", "-g", "Where to start to place globals",
            Options::Arguments::One,

--- a/src/support/colors.cpp
+++ b/src/support/colors.cpp
@@ -24,15 +24,19 @@
 # include <unistd.h>
 #endif
 
-namespace Colors {
-void outputColorCode(std::ostream& stream, const char* colorCode) {
+namespace {
+bool colors_disabled = false;
+}  // anonymous namespace
+
+void Colors::disable() { colors_disabled = true; }
+
+void Colors::outputColorCode(std::ostream& stream, const char* colorCode) {
 #if defined(CAN_HAZ_COLOR)
   const static bool has_color = []() {
     return (getenv("COLORS") && getenv("COLORS")[0] == '1') ||  // forced
            (isatty(STDOUT_FILENO) &&
             (!getenv("COLORS") || getenv("COLORS")[0] != '0'));  // implicit
   }();
-  if (has_color) stream << colorCode;
+  if (has_color && !colors_disabled) stream << colorCode;
 #endif
 }
-}  // namespace Colors

--- a/src/support/colors.h
+++ b/src/support/colors.h
@@ -20,6 +20,7 @@
 #include <iosfwd>
 
 namespace Colors {
+void disable();
 void outputColorCode(std::ostream&stream, const char *colorCode);
 inline void normal(std::ostream& stream) { outputColorCode(stream,"\033[0m"); }
 inline void red(std::ostream& stream) { outputColorCode(stream,"\033[31m"); }


### PR DESCRIPTION
This will allow other tools to consume the output.

Note that I didn't make colors_disabled atomic because it doesn't need to be at the moment. We may want to do so later, but atomic_bool isn't guaranteed to be lock free (realistically it is) whereas atomic_flag is but doesn't support load, so the choices are kind of sad.