### PR TITLE
Add tests for more assembler constructs that LLVM may use soon.

### DIFF
--- a/test/dot_s/function-data-sections.s
+++ b/test/dot_s/function-data-sections.s
@@ -1,0 +1,53 @@
+	.text
+	.section	.text.foo,"ax",@progbits
+	.globl	foo
+	.type	foo,@function
+foo:
+	return
+func_end0:
+	.size	foo, func_end0-foo
+
+	.section	.text.bar,"ax",@progbits
+	.globl	bar
+	.type	bar,@function
+bar:
+	.param  	i32
+	.result 	i32
+	return  	$0
+func_end1:
+	.size	bar, func_end1-bar
+
+	.section	.text.qux,"ax",@progbits
+	.globl	qux
+	.type	qux,@function
+qux:
+	.param  	f64, f64
+	.result 	f64
+	f64.add 	$push0=, $0, $1
+	return  	$pop0
+func_end2:
+	.size	qux, func_end2-qux
+
+	.type	aaa,@object
+	.section	.bss.aaa,"aw",@nobits
+	.globl	aaa
+	.align	2
+aaa:
+	.int32	0
+	.size	aaa, 4
+
+	.type	bbb,@object
+	.section	.data.bbb,"aw",@progbits
+	.globl	bbb
+	.align	2
+bbb:
+	.int32	1
+	.size	bbb, 4
+
+	.type	ccc,@object
+	.section	.data.ccc,"aw",@progbits
+	.globl	ccc
+	.align	2
+ccc:
+	.int32	1075000115
+	.size	ccc, 4

--- a/test/dot_s/visibilities.s
+++ b/test/dot_s/visibilities.s
@@ -1,0 +1,24 @@
+	.text
+	.hidden	foo
+	.globl	foo
+	.type	foo,@function
+foo:
+	return
+func_end0:
+	.size	foo, func_end0-foo
+
+	.protected	bar
+	.globl	bar
+	.type	bar,@function
+bar:
+	return
+func_end1:
+	.size	bar, func_end1-bar
+
+	.internal	qux
+	.globl	qux
+	.type	qux,@function
+qux:
+	return
+func_end2:
+	.size	qux, func_end2-qux


### PR DESCRIPTION
This adds tests for the assembly constructs produced when clang is invoked with
-ffunction-sections, -fdata-sections, -fvisibility=hidden,
-fvisibility=protected, and -fvisibility=internal.

Visibilities only matter for dynamic library linking, so s2wasm can just ignore them for now.