### PR TITLE
A few Travis change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,12 @@ matrix:
           packages: ['cmake', 'clang-3.7']
       compiler: clang
       env: COMPILER_VERSION=3.7
-#before_script:
-#  - python update.py
-script:
+before_script:
+  - git submodule update --init # Initialize the submodules recorded in the index.
   - export CC="${CC}-${COMPILER_VERSION}"
   - export CXX="${CXX}-${COMPILER_VERSION}"
+  - $CC --version
+script:
   - cmake .
   - make -j2
-  - python check.py
+  - ./check.py

--- a/check.py
+++ b/check.py
@@ -72,16 +72,12 @@ else:
 
 if not interpreter:
   print 'warning: no interpreter provided (not testing spec interpreter validation)'
-  time.sleep(0.5)
 if not has_node:
   print 'warning: no node found (not checking proper js form)'
-  time.sleep(0.5)
 if not has_mozjs:
   print 'warning: no mozjs found (not checking asm.js validation)'
-  time.sleep(0.5)
 if not has_emcc:
   print 'warning: no emcc found (not checking emscripten/binaryen integration)'
-  time.sleep(0.5)
 
 print '[ checking asm2wasm testcases... ]\n'
 


### PR DESCRIPTION
Initialize the git submodules to the index (I'm not sure what they're initialized to right now).
Move exports to before_script, and print out compiler version.
Invoke check directly (the shebang and x permissions should take care of it).
Remove the sleep on warnings, it slows down Travis.