### PR TITLE
A more generic compiler pass system.

### DIFF
--- a/src/passes/LowerIfElse.cpp
+++ b/src/passes/LowerIfElse.cpp
@@ -32,7 +32,7 @@
 
 namespace wasm {
 
-struct LowerIfElse : public Pass {
+struct LowerIfElse : public WalkerPass<WasmWalker> {
   MixedArena* allocator;
   std::unique_ptr<NameManager> namer;
 

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct MergeBlocks : public Pass {
+struct MergeBlocks : public WalkerPass<WasmWalker> {
   void visitBlock(Block *curr) override {
     bool more = true;
     while (more) {

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct RemoveImports : public Pass {
+struct RemoveImports : public WalkerPass<WasmWalker> {
   MixedArena* allocator;
   std::map<Name, Import*> importsMap;
 

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedBrs : public Pass {
+struct RemoveUnusedBrs : public WalkerPass<WasmWalker> {
   // preparation: try to unify branches, as the fewer there are, the higher a chance we can remove them
   // specifically for if-else, turn an if-else with branches to the same target at the end of each
   // child, and with a value, to a branch to that target containing the if-else

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedNames : public Pass {
+struct RemoveUnusedNames : public WalkerPass<WasmWalker> {
   // We maintain a list of branches that we saw in children, then when we reach
   // a parent block, we know if it was branched to
   std::set<Name> branchesSeen;

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct SimplifyLocals : public Pass {
+struct SimplifyLocals : public WalkerPass<WasmWalker> {
   void visitBlock(Block *curr) override {
     // look for pairs of setlocal-getlocal, which can be just a setlocal (since it returns a value)
     if (curr->list.size() == 0) return;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1229,13 +1229,101 @@ std::ostream& Expression::print(std::ostream &o, unsigned indent) {
   return o;
 }
 
+struct WasmWalkerBase : public WasmVisitor<void> {
+  virtual void walk(Expression*& curr) { abort(); }
+  virtual void startWalk(Function *func) { abort(); }
+  virtual void startWalk(Module *module) { abort(); }
+};
+
+struct ChildWalker : public WasmWalkerBase {
+  WasmWalkerBase& parent;
+
+  ChildWalker(WasmWalkerBase& parent) : parent(parent) {}
+
+  void visitBlock(Block *curr) override {
+    ExpressionList& list = curr->list;
+    for (size_t z = 0; z < list.size(); z++) {
+      parent.walk(list[z]);
+    }
+  }
+  void visitIf(If *curr) override {
+    parent.walk(curr->condition);
+    parent.walk(curr->ifTrue);
+    parent.walk(curr->ifFalse);
+  }
+  void visitLoop(Loop *curr) override {
+    parent.walk(curr->body);
+  }
+  void visitBreak(Break *curr) override {
+    parent.walk(curr->condition);
+    parent.walk(curr->value);
+  }
+  void visitSwitch(Switch *curr) override {
+    parent.walk(curr->value);
+    for (auto& case_ : curr->cases) {
+      parent.walk(case_.body);
+    }
+  }
+  void visitCall(Call *curr) override {
+    ExpressionList& list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      parent.walk(list[z]);
+    }
+  }
+  void visitCallImport(CallImport *curr) override {
+    ExpressionList& list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      parent.walk(list[z]);
+    }
+  }
+  void visitCallIndirect(CallIndirect *curr) override {
+    parent.walk(curr->target);
+    ExpressionList& list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      parent.walk(list[z]);
+    }
+  }
+  void visitGetLocal(GetLocal *curr) override {}
+  void visitSetLocal(SetLocal *curr) override {
+    parent.walk(curr->value);
+  }
+  void visitLoad(Load *curr) override {
+    parent.walk(curr->ptr);
+  }
+  void visitStore(Store *curr) override {
+    parent.walk(curr->ptr);
+    parent.walk(curr->value);
+  }
+  void visitConst(Const *curr) override {}
+  void visitUnary(Unary *curr) override {
+    parent.walk(curr->value);
+  }
+  void visitBinary(Binary *curr) override {
+    parent.walk(curr->left);
+    parent.walk(curr->right);
+  }
+  void visitSelect(Select *curr) override {
+    parent.walk(curr->condition);
+    parent.walk(curr->ifTrue);
+    parent.walk(curr->ifFalse);
+  }
+  void visitHost(Host *curr) override {
+    ExpressionList& list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      parent.walk(list[z]);
+    }
+  }
+  void visitNop(Nop *curr) override {}
+  void visitUnreachable(Unreachable *curr) override {}
+};
+
 //
 // Simple WebAssembly children-first walking (i.e., post-order, if you look
 // at the children as subtrees of the current node), with the ability to replace
 // the current expression node. Useful for writing optimization passes.
 //
 
-struct WasmWalker : public WasmVisitor<void> {
+struct WasmWalker : public WasmWalkerBase {
   Expression* replace;
 
   WasmWalker() : replace(nullptr) {}
@@ -1275,90 +1363,8 @@ struct WasmWalker : public WasmVisitor<void> {
   void visitModule(Module *curr) override {}
 
   // children-first
-  void walk(Expression*& curr) {
+  void walk(Expression*& curr) override {
     if (!curr) return;
-
-    struct ChildWalker : public WasmVisitor {
-      WasmWalker& parent;
-
-      ChildWalker(WasmWalker& parent) : parent(parent) {}
-
-      void visitBlock(Block *curr) override {
-        ExpressionList& list = curr->list;
-        for (size_t z = 0; z < list.size(); z++) {
-          parent.walk(list[z]);
-        }
-      }
-      void visitIf(If *curr) override {
-        parent.walk(curr->condition);
-        parent.walk(curr->ifTrue);
-        parent.walk(curr->ifFalse);
-      }
-      void visitLoop(Loop *curr) override {
-        parent.walk(curr->body);
-      }
-      void visitBreak(Break *curr) override {
-        parent.walk(curr->condition);
-        parent.walk(curr->value);
-      }
-      void visitSwitch(Switch *curr) override {
-        parent.walk(curr->value);
-        for (auto& case_ : curr->cases) {
-          parent.walk(case_.body);
-        }
-      }
-      void visitCall(Call *curr) override {
-        ExpressionList& list = curr->operands;
-        for (size_t z = 0; z < list.size(); z++) {
-          parent.walk(list[z]);
-        }
-      }
-      void visitCallImport(CallImport *curr) override {
-        ExpressionList& list = curr->operands;
-        for (size_t z = 0; z < list.size(); z++) {
-          parent.walk(list[z]);
-        }
-      }
-      void visitCallIndirect(CallIndirect *curr) override {
-        parent.walk(curr->target);
-        ExpressionList& list = curr->operands;
-        for (size_t z = 0; z < list.size(); z++) {
-          parent.walk(list[z]);
-        }
-      }
-      void visitGetLocal(GetLocal *curr) override {}
-      void visitSetLocal(SetLocal *curr) override {
-        parent.walk(curr->value);
-      }
-      void visitLoad(Load *curr) override {
-        parent.walk(curr->ptr);
-      }
-      void visitStore(Store *curr) override {
-        parent.walk(curr->ptr);
-        parent.walk(curr->value);
-      }
-      void visitConst(Const *curr) override {}
-      void visitUnary(Unary *curr) override {
-        parent.walk(curr->value);
-      }
-      void visitBinary(Binary *curr) override {
-        parent.walk(curr->left);
-        parent.walk(curr->right);
-      }
-      void visitSelect(Select *curr) override {
-        parent.walk(curr->condition);
-        parent.walk(curr->ifTrue);
-        parent.walk(curr->ifFalse);
-      }
-      void visitHost(Host *curr) override {
-        ExpressionList& list = curr->operands;
-        for (size_t z = 0; z < list.size(); z++) {
-          parent.walk(list[z]);
-        }
-      }
-      void visitNop(Nop *curr) override {}
-      void visitUnreachable(Unreachable *curr) override {}
-    };
 
     ChildWalker(*this).visit(curr);
 
@@ -1370,11 +1376,11 @@ struct WasmWalker : public WasmVisitor<void> {
     }
   }
 
-  void startWalk(Function *func) {
+  void startWalk(Function *func) override {
     walk(func->body);
   }
 
-  void startWalk(Module *module) {
+  void startWalk(Module *module) override {
     for (auto curr : module->functionTypes) {
       visitFunctionType(curr);
       assert(!replace);


### PR DESCRIPTION
The goal of this PR is to make it possible to write optimization passes that use different kinds of AST walkers. Previously, all optimization passes inherited from the `Pass` class which inherited directly from the `WasmWalker` class. This is no longer the case. The `Pass` class is now a base class. The old `Pass` class is now called `WalkerPass` which is a template class that can be parameterized with different AST walker types. So, instead of

```
struct MyOptimization : public Pass { }
```
you can now write
```
struct MyOptimization : public WalkerPass<WasmWalker> { }
```
or
```
struct MyOptimization : public WalkerPass<SomeOtherKindOfASTWalker> { }
```
