### PR TITLE
wasm-as testing

### DIFF
--- a/check.py
+++ b/check.py
@@ -278,6 +278,16 @@ if torture:
   if unexpected_result_count:
     fail(unexpected_result_count, 0)
 
+print '\n[ checking wasm-as testcases... ]\n'
+
+for wast in tests:
+  if wast.endswith('.wast'):
+    cmd = [os.path.join('bin', 'wasm-as'), os.path.join('test', wast), '-o', 'a.wasm']
+    print cmd
+    if os.path.exists('a.wasm'): os.unlink('a.wasm')
+    subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert os.path.exists('a.wasm')
+
 print '\n[ checking example testcases... ]\n'
 
 cmd = [os.environ.get('CXX') or 'g++', '-std=c++11', os.path.join('test', 'example', 'find_div0s.cpp'), '-Isrc', '-g', '-lsupport', '-Llib/.']

--- a/check.py
+++ b/check.py
@@ -281,7 +281,7 @@ if torture:
 print '\n[ checking wasm-as testcases... ]\n'
 
 for wast in tests:
-  if wast.endswith('.wast'):
+  if wast.endswith('.wast') and not wast in ['unit.wast']: # blacklist some known failures
     cmd = [os.path.join('bin', 'wasm-as'), os.path.join('test', wast), '-o', 'a.wasm']
     print cmd
     if os.path.exists('a.wasm'): os.unlink('a.wasm')

--- a/check.py
+++ b/check.py
@@ -18,7 +18,7 @@ import os, shutil, sys, subprocess, difflib, json, time
 
 interpreter = None
 requested = []
-torture = False # XXX fix this when they pass again
+torture = True
 
 for arg in sys.argv[1:]:
   if arg.startswith('--interpreter='):

--- a/check.py
+++ b/check.py
@@ -18,13 +18,15 @@ import os, shutil, sys, subprocess, difflib, json, time
 
 interpreter = None
 requested = []
-torture = True
+torture = False # XXX fix this when they pass again
 
 for arg in sys.argv[1:]:
   if arg.startswith('--interpreter='):
     interpreter = arg.split('=')[1]
     print '[ using wasm interpreter at "%s" ]' % interpreter
     assert os.path.exists(interpreter), 'interpreter not found'
+  elif arg == '--torture':
+    torture = True
   elif arg == '--no-torture':
     torture = False
   else:

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -712,6 +712,7 @@ public:
         case f64: o << int8_t(BinaryConsts::F64##code); break; \
         default: abort(); \
       } \
+      break; \
     }
     #define INT_TYPED_CODE(code) { \
       switch (curr->left->type) { \
@@ -719,6 +720,7 @@ public:
         case i64: o << int8_t(BinaryConsts::I64##code); break; \
         default: abort(); \
       } \
+      break; \
     }
     #define FLOAT_TYPED_CODE(code) { \
       switch (curr->left->type) { \
@@ -726,6 +728,7 @@ public:
         case f64: o << int8_t(BinaryConsts::F64##code); break; \
         default: abort(); \
       } \
+      break; \
     }
 
     switch (curr->op) {

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -543,14 +543,14 @@ public:
     breakStack.pop_back();
   }
   void visitBreak(Break *curr) {
-    o << int8_t(BinaryConsts::Br);
+    o << int8_t(curr->condition ? BinaryConsts::BrIf : BinaryConsts::Br);
     for (int i = breakStack.size() - 1; i >= 0; i--) {
       if (breakStack[i] == curr->name) {
         o << int8_t(breakStack.size() - 1 - i);
         return;
       }
     }
-    abort();
+    if (curr->condition) visit(curr->condition);
   }
   void visitSwitch(Switch *curr) {
     o << int8_t(BinaryConsts::TableSwitch) << int16_t(curr->cases.size())

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -554,8 +554,18 @@ public:
   }
   void visitSwitch(Switch *curr) {
     o << int8_t(BinaryConsts::TableSwitch) << int16_t(curr->cases.size())
-                                     << int16_t(curr->targets.size());
-    abort(); // WTF
+                                           << int16_t(curr->targets.size());
+    std::map<Name, int16_t> mapping; // target name => index in cases
+    for (size_t i = 0; i < curr->cases.size(); i++) {
+      mapping[curr->cases[i].name] = i;
+    }
+    for (auto target : curr->targets) {
+      o << mapping[target];
+    }
+    visit(curr->value);
+    for (auto c : curr->cases) {
+      visit(c.body);
+    }
   }
   void visitCall(Call *curr) {
     o << int8_t(BinaryConsts::CallFunction) << LEB128(getFunctionIndex(curr->target));


### PR DESCRIPTION
`wasm-as` can now emit *something* for the wasts in `/test/`, without crashing.

 * This is still not including the spec test suite.
 * This output may be totally wrong, it isn't tested yet.
 * I had to disable one test already, due to something missing in the binary format (noted [here](https://github.com/WebAssembly/design/issues/497#issuecomment-171036017)).