### PR TITLE
Avoid potential setjmp clobber

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ IF(MSVC)
 ELSE()
   SET(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
   SET(CMAKE_CXX_FLAGS "-msse2 -mfpmath=sse ${CMAKE_CXX_FLAGS}")
-  SET(CMAKE_CXX_FLAGS "-O2 -Wall -Werror ${CMAKE_CXX_FLAGS}")
+  SET(CMAKE_CXX_FLAGS "-O2 ${CMAKE_CXX_FLAGS}")
+  SET(CMAKE_CXX_FLAGS "-Wall -Werror -Wextra -Wno-unused-parameter ${CMAKE_CXX_FLAGS}")
 ENDIF()
 
 # clang doesn't print colored diagnostics when invoked from Ninja


### PR DESCRIPTION
-Wextra adds checks for potential clobbers which triggered in binaryen-shell.cpp:
  might be clobbered by ‘longjmp’ or ‘vfork’ [-Werror=clobbered]

The fix moves the setjmp/longjmp using code into another function, and passes in potentially-clobbered values from the parent frame so they can't be clobbered. We could also mark them as volatile but that's a big hammer.