### PR TITLE
Disable importing of the offset-folding test.

### DIFF
--- a/test/llvm_autogenerated/llvm-to-s.py
+++ b/test/llvm_autogenerated/llvm-to-s.py
@@ -56,6 +56,7 @@ def main(args):
         BLACKLIST = ['inline-asm', # inline asm containing invalid syntax
                      'returned',   # external global symbol
                      'vtable',     # external global symbol
+                     'offset-folding', # external global symbol
                      ]
         if name_noext in BLACKLIST:
           continue


### PR DESCRIPTION
The LLVM test its generated from has external global variables, which
isn't supported in s2wasm.