### PR TITLE
Update llvm_autogenerated tests to LLVM r258792.

### DIFF
--- a/test/llvm_autogenerated/global.s
+++ b/test/llvm_autogenerated/global.s
@@ -16,21 +16,21 @@ foo:
 call_memcpy:
 	.param  	i32, i32, i32
 	.result 	i32
-	i32.call	$discard=, memcpy@FUNCTION, $0, $1, $2
-	return  	$0
+	i32.call	$push0=, memcpy@FUNCTION, $0, $1, $2
+	return  	$pop0
 	.endfunc
 .Lfunc_end1:
 	.size	call_memcpy, .Lfunc_end1-call_memcpy
 
 	.type	.Lg,@object
 	.data
-	.align	2
+	.p2align	2
 .Lg:
 	.int32	1337
 	.size	.Lg, 4
 
 	.type	ud,@object
-	.align	2
+	.p2align	2
 ud:
 	.skip	4
 	.size	ud, 4
@@ -40,25 +40,25 @@ ud:
 	.type	z,@object
 	.lcomm	z,4,2
 	.type	one,@object
-	.align	2
+	.p2align	2
 one:
 	.int32	1
 	.size	one, 4
 
 	.type	answer,@object
-	.align	2
+	.p2align	2
 answer:
 	.int32	42
 	.size	answer, 4
 
 	.type	u32max,@object
-	.align	2
+	.p2align	2
 u32max:
 	.int32	4294967295
 	.size	u32max, 4
 
 	.type	ud64,@object
-	.align	3
+	.p2align	3
 ud64:
 	.skip	8
 	.size	ud64, 8
@@ -68,19 +68,19 @@ ud64:
 	.type	z64,@object
 	.lcomm	z64,8,3
 	.type	twoP32,@object
-	.align	3
+	.p2align	3
 twoP32:
 	.int64	4294967296
 	.size	twoP32, 8
 
 	.type	u64max,@object
-	.align	3
+	.p2align	3
 u64max:
 	.int64	-1
 	.size	u64max, 8
 
 	.type	f32ud,@object
-	.align	2
+	.p2align	2
 f32ud:
 	.skip	4
 	.size	f32ud, 4
@@ -90,19 +90,19 @@ f32ud:
 	.type	f32z,@object
 	.lcomm	f32z,4,2
 	.type	f32nz,@object
-	.align	2
+	.p2align	2
 f32nz:
 	.int32	2147483648
 	.size	f32nz, 4
 
 	.type	f32two,@object
-	.align	2
+	.p2align	2
 f32two:
 	.int32	1073741824
 	.size	f32two, 4
 
 	.type	f64ud,@object
-	.align	3
+	.p2align	3
 f64ud:
 	.skip	8
 	.size	f64ud, 8
@@ -112,13 +112,13 @@ f64ud:
 	.type	f64z,@object
 	.lcomm	f64z,8,3
 	.type	f64nz,@object
-	.align	3
+	.p2align	3
 f64nz:
 	.int64	-9223372036854775808
 	.size	f64nz, 8
 
 	.type	f64two,@object
-	.align	3
+	.p2align	3
 f64two:
 	.int64	4611686018427387904
 	.size	f64two, 8
@@ -126,7 +126,7 @@ f64two:
 	.type	arr,@object
 	.bss
 	.globl	arr
-	.align	4
+	.p2align	4
 arr:
 	.skip	512
 	.size	arr, 512
@@ -134,7 +134,7 @@ arr:
 	.type	ptr,@object
 	.data
 	.globl	ptr
-	.align	2
+	.p2align	2
 ptr:
 	.int32	arr+80
 	.size	ptr, 4
@@ -142,7 +142,7 @@ ptr:
 	.type	rom,@object
 	.section	.rodata,"a",@progbits
 	.globl	rom
-	.align	4
+	.p2align	4
 rom:
 	.skip	512
 	.size	rom, 512
@@ -155,7 +155,7 @@ array:
 	.type	pointer_to_array,@object
 	.section	.data.rel.ro,"aw",@progbits
 	.globl	pointer_to_array
-	.align	2
+	.p2align	2
 pointer_to_array:
 	.int32	array+4
 	.size	pointer_to_array, 4

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -18,13 +18,12 @@
   (func $call_memcpy (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
     (block $fake_return_waka123
       (block
-        (call_import $memcpy
-          (get_local $$0)
-          (get_local $$1)
-          (get_local $$2)
-        )
         (br $fake_return_waka123
-          (get_local $$0)
+          (call_import $memcpy
+            (get_local $$0)
+            (get_local $$1)
+            (get_local $$2)
+          )
         )
       )
     )

--- a/test/llvm_autogenerated/mem-intrinsics.s
+++ b/test/llvm_autogenerated/mem-intrinsics.s
@@ -1,0 +1,66 @@
+	.text
+	.file	"/s/llvm/llvm/test/CodeGen/WebAssembly/mem-intrinsics.ll"
+	.globl	copy_yes
+	.type	copy_yes,@function
+copy_yes:
+	.param  	i32, i32, i32
+	.result 	i32
+	i32.call	$push0=, memcpy@FUNCTION, $0, $1, $2
+	return  	$pop0
+	.endfunc
+.Lfunc_end0:
+	.size	copy_yes, .Lfunc_end0-copy_yes
+
+	.globl	copy_no
+	.type	copy_no,@function
+copy_no:
+	.param  	i32, i32, i32
+	i32.call	$discard=, memcpy@FUNCTION, $0, $1, $2
+	return
+	.endfunc
+.Lfunc_end1:
+	.size	copy_no, .Lfunc_end1-copy_no
+
+	.globl	move_yes
+	.type	move_yes,@function
+move_yes:
+	.param  	i32, i32, i32
+	.result 	i32
+	i32.call	$push0=, memmove@FUNCTION, $0, $1, $2
+	return  	$pop0
+	.endfunc
+.Lfunc_end2:
+	.size	move_yes, .Lfunc_end2-move_yes
+
+	.globl	move_no
+	.type	move_no,@function
+move_no:
+	.param  	i32, i32, i32
+	i32.call	$discard=, memmove@FUNCTION, $0, $1, $2
+	return
+	.endfunc
+.Lfunc_end3:
+	.size	move_no, .Lfunc_end3-move_no
+
+	.globl	set_yes
+	.type	set_yes,@function
+set_yes:
+	.param  	i32, i32, i32
+	.result 	i32
+	i32.call	$push0=, memset@FUNCTION, $0, $1, $2
+	return  	$pop0
+	.endfunc
+.Lfunc_end4:
+	.size	set_yes, .Lfunc_end4-set_yes
+
+	.globl	set_no
+	.type	set_no,@function
+set_no:
+	.param  	i32, i32, i32
+	i32.call	$discard=, memset@FUNCTION, $0, $1, $2
+	return
+	.endfunc
+.Lfunc_end5:
+	.size	set_no, .Lfunc_end5-set_no
+
+

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -1,0 +1,89 @@
+(module
+  (memory 0 4294967295)
+  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+  (import $memcpy "env" "memcpy" (param i32 i32 i32) (result i32))
+  (import $memmove "env" "memmove" (param i32 i32 i32) (result i32))
+  (import $memset "env" "memset" (param i32 i32 i32) (result i32))
+  (export "copy_yes" $copy_yes)
+  (export "copy_no" $copy_no)
+  (export "move_yes" $move_yes)
+  (export "move_no" $move_no)
+  (export "set_yes" $set_yes)
+  (export "set_no" $set_no)
+  (func $copy_yes (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
+    (block $fake_return_waka123
+      (block
+        (br $fake_return_waka123
+          (call_import $memcpy
+            (get_local $$0)
+            (get_local $$1)
+            (get_local $$2)
+          )
+        )
+      )
+    )
+  )
+  (func $copy_no (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (block $fake_return_waka123
+      (block
+        (call_import $memcpy
+          (get_local $$0)
+          (get_local $$1)
+          (get_local $$2)
+        )
+        (br $fake_return_waka123)
+      )
+    )
+  )
+  (func $move_yes (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
+    (block $fake_return_waka123
+      (block
+        (br $fake_return_waka123
+          (call_import $memmove
+            (get_local $$0)
+            (get_local $$1)
+            (get_local $$2)
+          )
+        )
+      )
+    )
+  )
+  (func $move_no (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (block $fake_return_waka123
+      (block
+        (call_import $memmove
+          (get_local $$0)
+          (get_local $$1)
+          (get_local $$2)
+        )
+        (br $fake_return_waka123)
+      )
+    )
+  )
+  (func $set_yes (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
+    (block $fake_return_waka123
+      (block
+        (br $fake_return_waka123
+          (call_import $memset
+            (get_local $$0)
+            (get_local $$1)
+            (get_local $$2)
+          )
+        )
+      )
+    )
+  )
+  (func $set_no (param $$0 i32) (param $$1 i32) (param $$2 i32)
+    (block $fake_return_waka123
+      (block
+        (call_import $memset
+          (get_local $$0)
+          (get_local $$1)
+          (get_local $$2)
+        )
+        (br $fake_return_waka123)
+      )
+    )
+  )
+)
+;; METADATA: { "asmConsts": {},"staticBump": 4 }

--- a/test/llvm_autogenerated/offset.s
+++ b/test/llvm_autogenerated/offset.s
@@ -402,7 +402,7 @@ aggregate_return_without_merge:
 	.type	gv,@object
 	.bss
 	.globl	gv
-	.align	2
+	.p2align	2
 gv:
 	.int32	0
 	.size	gv, 4

--- a/test/llvm_autogenerated/store-results.s
+++ b/test/llvm_autogenerated/store-results.s
@@ -57,7 +57,7 @@ bar:
 	.type	pos,@object
 	.bss
 	.globl	pos
-	.align	2
+	.p2align	2
 pos:
 	.skip	12
 	.size	pos, 12


### PR DESCRIPTION
Changes:
 - Call memset/memcpy/memmove with the correct signature
 - Optimize memset/memcpy/memmove calls by using their return values
 - Change .align to .p2align