### PR TITLE
Ignore meta data emitted by clang on Mac OS X

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -387,7 +387,8 @@ private:
       if (!*s) break;
       if (*s != '.') break;
       s++;
-      if (match("file")) parseFile();
+      if (parseVersionMin());
+      else if (match("file")) parseFile();
       else if (match("globl")) parseGlobl();
       else if (match("type")) parseType();
       else {
@@ -412,6 +413,15 @@ private:
   void parseGlobl() {
     (void)getStr();
     skipWhitespace();
+  }
+
+  bool parseVersionMin() {
+    if (match("watchos_version_min") || match("tvos_version_min") || match("ios_version_min") || match("macosx_version_min")) {
+      s = strchr(s, '\n');
+      skipWhitespace();
+      return true;
+    } else
+      return false;
   }
 
   void parseFunction() {

--- a/test/dot_s/macClangMetaData.s
+++ b/test/dot_s/macClangMetaData.s
@@ -1,0 +1,25 @@
+.text
+.macosx_version_min 10, 10
+.file	"test.ll"
+.globl	main
+.type	main,@function
+main:                                   # @main
+.param  	i32, i32
+.result 	i32
+# BB#0:                                 # %entry
+i32.const	$push0=, .Lstr
+i32.call	$discard=, puts@FUNCTION, $pop0
+i32.const	$push1=, 0
+return  	$pop1
+.endfunc
+.Lfunc_end0:
+.size	main, .Lfunc_end0-main
+
+.type	.Lstr,@object           # @str
+.section	.rodata.str1.1,"aMS",@progbits,1
+.Lstr:
+.asciz	"Hello, World!"
+.size	.Lstr, 14
+
+
+.ident	"clang version 3.9.0 (trunk 258659)"

--- a/test/dot_s/macClangMetaData.wast
+++ b/test/dot_s/macClangMetaData.wast
@@ -1,0 +1,19 @@
+(module
+  (memory 30 4294967295 (segment 16 "Hello, World!\00"))
+  (type $FUNCSIG$ii (func (param i32) (result i32)))
+  (import $puts "env" "puts" (param i32) (result i32))
+  (export "main" $main)
+  (func $main (param $$0 i32) (param $$1 i32) (result i32)
+    (block $fake_return_waka123
+      (block
+        (call_import $puts
+          (i32.const 16)
+        )
+        (br $fake_return_waka123
+          (i32.const 0)
+        )
+      )
+    )
+  )
+)
+;; METADATA: { "asmConsts": {},"staticBump": 29 }


### PR DESCRIPTION
Clang likes to add some meta data (in llvm::MCStreamer::EmitVersionMin):

	.text
	.macosx_version_min 10, 10
	.file	"test.ll"
	.globl	main
	.type	main,@function

This patch lets the parser ignore .macosx_version_min and others without crashing.