### PR TITLE
Fix colors on OSX.

### DIFF
--- a/src/support/colors.cpp
+++ b/src/support/colors.cpp
@@ -19,7 +19,7 @@
 #include <cstdlib>
 #include <ostream>
 
-#if defined(__linux__) || defined(__apple__)
+#if defined(__linux__) || defined(__APPLE__)
 # define CAN_HAZ_COLOR 1
 # include <unistd.h>
 #endif


### PR DESCRIPTION
Apple OSes define `__APPLE__` instead of the lower case `__apple__`.