### PR TITLE
Adds a --metrics command line argument.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ SET(binaryen-shell_SOURCES
   src/passes/RemoveUnusedBrs.cpp
   src/passes/RemoveUnusedNames.cpp
   src/passes/SimplifyLocals.cpp
+  src/passes/Metrics.cpp
 )
 ADD_EXECUTABLE(binaryen-shell
                ${binaryen-shell_SOURCES})

--- a/src/pass.h
+++ b/src/pass.h
@@ -94,6 +94,8 @@ public:
   // Override this to perform preparation work before the pass runs.
   virtual void prepare(PassRunner* runner, Module* module) {}
   virtual void run(PassRunner* runner, Module* module) = 0;
+  // Override this to perform finalization work after the pass runs.
+  virtual void finalize(PassRunner* runner, Module* module) {}
 protected:
   Pass() {}
   Pass(Pass &) {}
@@ -110,6 +112,7 @@ public:
   void run(PassRunner* runner, Module* module) override {
     prepare(runner, module);
     WalkerType::startWalk(module);
+    finalize(runner, module);
   }
 };
 

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iomanip>
+#include <pass.h>
+#include <wasm.h>
+
+namespace wasm {
+
+using namespace std;
+
+// Prints metrics between optimization passes.
+struct Metrics : public WalkerPass<WasmWalker<Metrics>> {
+  static Metrics *lastMetricsPass;
+
+  map<const char *, int> counts;
+  void walk(Expression *&curr) override {
+    WalkerPass::walk(curr);
+    if (!curr)
+      return;
+    auto name = getExpressionName(curr);
+    counts[name]++;
+  }
+  void finalize(PassRunner *runner, Module *module) override {
+    ostream &o = cout;
+    o << "Counts"
+      << "\n";
+    for (auto i = counts.cbegin(); i != counts.cend(); i++) {
+      o << " " << left << setw(15) << i->first << ": " << setw(8)
+        << i->second;
+      if (lastMetricsPass) {
+        if (lastMetricsPass->counts.count(i->first)) {
+          int before = lastMetricsPass->counts[i->first];
+          int after = i->second;
+          if (after - before) {
+            if (after > before) {
+              Colors::red(o);
+            } else {
+              Colors::green(o);
+            }
+            o << right << setw(8);
+            o << showpos << after - before << noshowpos;
+            Colors::normal(o);
+          }
+        }
+      }
+      o << "\n";
+    }
+    lastMetricsPass = this;
+  }
+};
+
+Metrics *Metrics::lastMetricsPass;
+static RegisterPass<Metrics> registerPass("metrics", "reports metrics");
+
+} // namespace wasm

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -350,6 +350,32 @@ public:
   }
 };
 
+inline const char *getExpressionName(Expression *curr) {
+  switch (curr->_id) {
+    case Expression::Id::InvalidId: abort();
+    case Expression::Id::BlockId: return "block";
+    case Expression::Id::IfId: return "if";
+    case Expression::Id::LoopId: return "loop";
+    case Expression::Id::BreakId: return "break";
+    case Expression::Id::SwitchId: return "switch";
+    case Expression::Id::CallId: return "call";
+    case Expression::Id::CallImportId: return "call_import";
+    case Expression::Id::CallIndirectId: return "call_indirect";
+    case Expression::Id::GetLocalId: return "get_local";
+    case Expression::Id::SetLocalId: return "set_local";
+    case Expression::Id::LoadId: return "load";
+    case Expression::Id::StoreId: return "store";
+    case Expression::Id::ConstId: return "const";
+    case Expression::Id::UnaryId: return "unary";
+    case Expression::Id::BinaryId: return "binary";
+    case Expression::Id::SelectId: return "select";
+    case Expression::Id::HostId: return "host";
+    case Expression::Id::NopId: return "nop";
+    case Expression::Id::UnreachableId: return "unreachable";
+    default: WASM_UNREACHABLE();
+  }
+}
+
 typedef std::vector<Expression*> ExpressionList; // TODO: optimize?
 
 class Nop : public Expression {


### PR DESCRIPTION
This prints metrics about the state of an AST at a certain point in the optimization pipeline. You can specify `--metrics` multiple times to see how a set of optimization passes modify the AST, e.g. the `./bin/binaryen-shell --metrics -O --metrics test/passes/O.wast` command prints:
```
Counts
 call           : 150     
 call_import    : 105     
 call_indirect  : 9       
 block          : 779     
 if             : 702     
 loop           : 103     
 nop            : 17      
 switch         : 6       
 break          : 413     
 get_local      : 4125    
 set_local      : 1735    
 load           : 606     
 store          : 589     
 const          : 2858    
 unary          : 13      
 binary         : 2762    

Counts
 call           : 150     
 call_import    : 105     
 call_indirect  : 9       
 block          : 753          -26
 if             : 658          -44
 loop           : 103     
 nop            : 17      
 switch         : 6       
 break          : 405           -8
 get_local      : 4124          -1
 set_local      : 1735    
 load           : 606     
 store          : 589     
 const          : 2858    
 unary          : 13      
 binary         : 2762   

```

Indicating that `44` `if` expressions were removed.