### PR TITLE
Float refactoring and nan comparison change

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -804,8 +804,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
         ret->offset = 0;
         ret->align = ret->bytes;
         auto ptr = allocator.alloc<Const>();
-        ptr->value.type = WasmType::i32; // XXX for wasm64, need 64
-        ptr->value.i32 = global.address;
+        ptr->value = Literal(int32_t(global.address)); // XXX for wasm64, need 64
         ret->ptr = ptr;
         ret->value = process(ast[3]);
         ret->type = global.type;
@@ -874,14 +873,11 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       auto ret = allocator.alloc<Const>();
       double num = ast[1]->getNumber();
       if (isSInteger32(num)) {
-        ret->value.type = WasmType::i32;
-        ret->value.i32 = toSInteger32(num);
+        ret->value = Literal(int32_t(toSInteger32(num)));
       } else if (isUInteger32(num)) {
-        ret->value.type = WasmType::i32;
-        ret->value.i32 = toUInteger32(num);
+        ret->value = Literal(uint32_t(toUInteger32(num)));
       } else {
-        ret->value.type = WasmType::f64;
-        ret->value.f64 = num;
+        ret->value = Literal(num);
       }
       ret->type = ret->value.type;
       return ret;
@@ -919,8 +915,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       ret->offset = 0;
       ret->align = ret->bytes;
       auto ptr = allocator.alloc<Const>();
-      ptr->value.type = WasmType::i32; // XXX for wasm64, need 64
-      ptr->value.i32 = global.address;
+      ptr->value = Literal(int32_t(global.address)); // XXX for wasm64, need 64
       ret->ptr = ptr;
       ret->type = global.type;
       return ret;
@@ -1446,8 +1441,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       unsigned addr = ptr[1]->getInteger();
       unsigned shifted = addr << shifts;
       auto ret = allocator.alloc<Const>();
-      ret->value.type = WasmType::i32;
-      ret->value.i32 = shifted;
+      ret->value = Literal(int32_t(shifted));
       return (Expression*)ret;
     }
     abort_on("bad processUnshifted", ptr);

--- a/src/binaryen-shell.cpp
+++ b/src/binaryen-shell.cpp
@@ -175,6 +175,19 @@ struct Invocation {
   }
 };
 
+static void verify_result(Literal a, Literal b) {
+  if (a == b) return;
+  // accept equal nans if equal in all bits
+  assert(a.type == b.type);
+  if (a.type == f32) {
+    assert(a.reinterpreti32() == b.reinterpreti32());
+  } else if (a.type == f64) {
+    assert(a.reinterpreti64() == b.reinterpreti64());
+  } else {
+    abort();
+  }
+}
+
 static void run_asserts(size_t* i, bool* checked, AllocatingModule* wasm,
                         Element* root,
                         std::unique_ptr<SExpressionWasmBuilder>* builder,
@@ -251,11 +264,11 @@ static void run_asserts(size_t* i, bool* checked, AllocatingModule* wasm,
                                  ->dyn_cast<Const>()
                                  ->value;
           std::cerr << "seen " << result << ", expected " << expected << '\n';
-          assert(expected == result);
+          verify_result(expected, result);
         } else {
           Literal expected;
           std::cerr << "seen " << result << ", expected " << expected << '\n';
-          assert(expected == result);
+          verify_result(expected, result);
         }
       }
       if (id == ASSERT_TRAP) assert(trapped);

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -80,7 +80,7 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
           }
           if (negative) pattern |= 0x80000000U;
           if (!isnan(bit_cast<float>(pattern))) pattern |= 1U;
-          ret->value = Literal(bit_cast<float>(pattern)); // XXX
+          ret->value = Literal(pattern).castToF32();
           break;
         }
         case f64: {
@@ -94,7 +94,7 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
           }
           if (negative) pattern |= 0x8000000000000000ULL;
           if (!isnan(bit_cast<double>(pattern))) pattern |= 1ULL;
-          ret->value = Literal(bit_cast<double>(pattern)); // XXX
+          ret->value = Literal(pattern).castToF64();
           break;
         }
         default: return nullptr;

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -744,7 +744,7 @@ class S2WasmBuilder {
               // may be a relocation
               auto curr = allocator.alloc<Const>();
               curr->type = curr->value.type = i32;
-              getConst((uint32_t*)&curr->value.i32);
+              getConst((uint32_t*)curr->value.geti32Ptr());
               setOutput(curr, assign);
             } else {
               cashew::IString str = getStr();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -647,7 +647,14 @@ public:
         return breakStack.size() - 1 - i;
       }
     }
+printf("bad!\n");
     std::cerr << "bad break: " << name << std::endl;
+
+
+
+assert(0);
+
+
     abort();
   }
 
@@ -782,10 +789,10 @@ public:
     recurse(curr->value);
   }
   void visitConst(Const *curr) {
-    if (debug) std::cerr << "zz node: Const" << std::endl;
+    if (debug) std::cerr << "zz node: Const" << curr << " : " << curr->type << std::endl;
     switch (curr->type) {
       case i32: {
-        uint32_t value = curr->value.i32;
+        uint32_t value = curr->value.geti32();
         if (value <= 255) {
           o << int8_t(BinaryConsts::I8Const) << uint8_t(value);
           break;
@@ -794,19 +801,20 @@ public:
         break;
       }
       case i64: {
-        o << int8_t(BinaryConsts::I64Const) << curr->value.i64;
+        o << int8_t(BinaryConsts::I64Const) << curr->value.geti64();
         break;
       }
       case f32: {
-        o << int8_t(BinaryConsts::F32Const) << curr->value.f32;
+        o << int8_t(BinaryConsts::F32Const) << curr->value.getf32();
         break;
       }
       case f64: {
-        o << int8_t(BinaryConsts::F64Const) << curr->value.f64;
+        o << int8_t(BinaryConsts::F64Const) << curr->value.getf64();
         break;
       }
       default: abort();
     }
+    if (debug) std::cerr << "zz const node done.\n";
   }
   void visitUnary(Unary *curr) {
     if (debug) std::cerr << "zz node: Unary" << std::endl;
@@ -1480,14 +1488,14 @@ public:
   }
   bool maybeVisitImpl(Const *curr, uint8_t code) {
     switch (code) {
-      case BinaryConsts::I8Const:  curr->value.i32 = getInt8();    curr->type = i32; break;
-      case BinaryConsts::I32Const: curr->value.i32 = getInt32();   curr->type = i32; break;
-      case BinaryConsts::I64Const: curr->value.i64 = getInt64();   curr->type = i64; break;
-      case BinaryConsts::F32Const: curr->value.f32 = getFloat32(); curr->type = f32; break;
-      case BinaryConsts::F64Const: curr->value.f64 = getFloat64(); curr->type = f64; break;
+      case BinaryConsts::I8Const:  curr->value = Literal(int32_t(getInt8())); break;
+      case BinaryConsts::I32Const: curr->value = Literal(getInt32()); break;
+      case BinaryConsts::I64Const: curr->value = Literal(getInt64()); break;
+      case BinaryConsts::F32Const: curr->value = Literal(getFloat32()); break;
+      case BinaryConsts::F64Const: curr->value = Literal(getFloat64()); break;
       default: return false;
     }
-    curr->value.type = curr->type;
+    curr->type = curr->value.type;
     if (debug) std::cerr << "zz node: Const" << std::endl;
     return true;
   }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -412,7 +412,7 @@ private:
           float ret;
           switch (curr->op) {
             case Neg:     ret = -v; break;
-            case Abs:     ret = std::abs(v); break;
+            case Abs:     return Literal(value.reinterpreti32() & 0x7fffffff).castToF32(); break; // operate on bits directly, to avoid signalling bit being set on a float
             case Ceil:    ret = std::ceil(v); break;
             case Floor:   ret = std::floor(v); break;
             case Trunc:   ret = std::trunc(v); break;
@@ -431,7 +431,7 @@ private:
           double ret;
           switch (curr->op) {
             case Neg:     ret = -v; break;
-            case Abs:     ret = std::abs(v); break;
+            case Abs:     return Literal(value.reinterpreti64() & 0x7fffffffffffffffUL).castToF64(); break; // operate on bits directly, to avoid signalling bit being set on a float
             case Ceil:    ret = std::ceil(v); break;
             case Floor:   ret = std::floor(v); break;
             case Trunc:   ret = std::trunc(v); break;

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -378,13 +378,7 @@ private:
             case Clz: return Literal((int32_t)CountLeadingZeroes(v));
             case Ctz: return Literal((int32_t)CountTrailingZeroes(v));
             case Popcnt: return Literal((int32_t)PopCount(v));
-            case ReinterpretInt: {
-              float v = value.reinterpretf32();
-              if (isnan(v)) {
-                return Literal(Literal(value.geti32() | 0x7f800000).reinterpretf32());
-              }
-              return Literal(value.reinterpretf32());
-            }
+            case ReinterpretInt: return value.castToF32();
             case ExtendSInt32: return Literal(int64_t(value.geti32()));
             case ExtendUInt32: return Literal(uint64_t((uint32_t)value.geti32()));
             case ConvertUInt32: return curr->type == f32 ? Literal(float(uint32_t(value.geti32()))) : Literal(double(uint32_t(value.geti32())));
@@ -399,9 +393,7 @@ private:
             case Ctz: return Literal((int64_t)CountTrailingZeroes(v));
             case Popcnt: return Literal((int64_t)PopCount(v));
             case WrapInt64: return Literal(int32_t(value.geti64()));
-            case ReinterpretInt: {
-              return Literal(value.reinterpretf64());
-            }
+            case ReinterpretInt: return value.castToF64();
             case ConvertUInt64: return curr->type == f32 ? Literal(float((uint64_t)value.geti64())) : Literal(double((uint64_t)value.geti64()));
             case ConvertSInt64: return curr->type == f32 ? Literal(float(value.geti64())) : Literal(double(value.geti64()));
             default: abort();

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -570,10 +570,8 @@ private:
             case Sub:      ret = l - r; break;
             case Mul:      ret = l * r; break;
             case Div:      ret = l / r; break;
-            case CopySign: {
-              ret = std::copysign(l, r);
-              return Literal(ret);
-            }
+            // operate on bits directly, to avoid signalling bit being set on a float
+            case CopySign: return Literal((left.reinterpreti32() & 0x7fffffff) | (right.reinterpreti32() & 0x80000000)).castToF32(); break;
             case Min: {
               if (l == r && l == 0) ret = 1/l < 0 ? l : r;
               else ret = std::min(l, r);
@@ -601,10 +599,8 @@ private:
             case Sub:      ret = l - r; break;
             case Mul:      ret = l * r; break;
             case Div:      ret = l / r; break;
-            case CopySign: {
-              ret = std::copysign(l, r);
-              return Literal(ret);
-            }
+            // operate on bits directly, to avoid signalling bit being set on a float
+            case CopySign: return Literal((left.reinterpreti64() & 0x7fffffffffffffffUL) | (right.reinterpreti64() & 0x8000000000000000UL)).castToF64(); break;
             case Min: {
               if (l == r && l == 0) ret = 1/l < 0 ? l : r;
               else ret = std::min(l, r);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -424,8 +424,8 @@ private:
           double ret;
           switch (curr->op) {
             // operate on bits directly, to avoid signalling bit being set on a float
-            case Neg:     return Literal(value.reinterpreti64() ^ 0x8000000000000000UL).castToF64(); break;
-            case Abs:     return Literal(value.reinterpreti64() & 0x7fffffffffffffffUL).castToF64(); break;
+            case Neg:     return Literal(value.reinterpreti64() ^ 0x8000000000000000ULL).castToF64(); break;
+            case Abs:     return Literal(value.reinterpreti64() & 0x7fffffffffffffffULL).castToF64(); break;
             case Ceil:    ret = std::ceil(v); break;
             case Floor:   ret = std::floor(v); break;
             case Trunc:   ret = std::trunc(v); break;

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -411,8 +411,9 @@ private:
           float v = value.getf32();
           float ret;
           switch (curr->op) {
-            case Neg:     ret = -v; break;
-            case Abs:     return Literal(value.reinterpreti32() & 0x7fffffff).castToF32(); break; // operate on bits directly, to avoid signalling bit being set on a float
+            // operate on bits directly, to avoid signalling bit being set on a float
+            case Neg:     return Literal(value.reinterpreti32() ^ 0x80000000).castToF32(); break;
+            case Abs:     return Literal(value.reinterpreti32() & 0x7fffffff).castToF32(); break;
             case Ceil:    ret = std::ceil(v); break;
             case Floor:   ret = std::floor(v); break;
             case Trunc:   ret = std::trunc(v); break;
@@ -430,8 +431,9 @@ private:
           double v = value.getf64();
           double ret;
           switch (curr->op) {
-            case Neg:     ret = -v; break;
-            case Abs:     return Literal(value.reinterpreti64() & 0x7fffffffffffffffUL).castToF64(); break; // operate on bits directly, to avoid signalling bit being set on a float
+            // operate on bits directly, to avoid signalling bit being set on a float
+            case Neg:     return Literal(value.reinterpreti64() ^ 0x8000000000000000UL).castToF64(); break;
+            case Abs:     return Literal(value.reinterpreti64() & 0x7fffffffffffffffUL).castToF64(); break;
             case Ceil:    ret = std::ceil(v); break;
             case Floor:   ret = std::floor(v); break;
             case Trunc:   ret = std::trunc(v); break;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -162,6 +162,19 @@ public:
   explicit Literal(float    init) : type(WasmType::f32), i32(bit_cast<int32_t>(init)) {}
   explicit Literal(double   init) : type(WasmType::f64), i64(bit_cast<int64_t>(init)) {}
 
+  Literal castToF32() {
+    assert(type == WasmType::i32);
+    Literal ret(i32);
+    ret.type = f32;
+    return ret;
+  }
+  Literal castToF64() {
+    assert(type == WasmType::i64);
+    Literal ret(i64);
+    ret.type = f64;
+    return ret;
+  }
+
   int32_t geti32() { assert(type == WasmType::i32); return i32; }
   int64_t geti64() { assert(type == WasmType::i64); return i64; }
   float   getf32() { assert(type == WasmType::f32); return bit_cast<float>(i32); }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -207,10 +207,10 @@ public:
     if (type != other.type) return false;
     switch (type) {
       case WasmType::none: return true;
-      case WasmType::i32:
-      case WasmType::f32: return i32 == other.i32;
-      case WasmType::i64:
-      case WasmType::f64: return i64 == other.i64;
+      case WasmType::i32: return i32 == other.i32;
+      case WasmType::f32: return getf32() == other.getf32();
+      case WasmType::i64: return i64 == other.i64;
+      case WasmType::f64: return getf64() == other.getf64();
       default: abort();
     }
   }

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -915,21 +915,21 @@ Ref Wasm2AsmBuilder::processFunctionBody(Expression* curr, IString result) {
     }
     Ref visitConst(Const *curr) {
       switch (curr->type) {
-        case i32: return ValueBuilder::makeInt(curr->value.i32);
+        case i32: return ValueBuilder::makeInt(curr->value.geti32());
         case f32: {
           Ref ret = ValueBuilder::makeCall(MATH_FROUND);
           Const fake;
-          fake.value = Literal(double(curr->value.f32));
+          fake.value = Literal(double(curr->value.getf32()));
           fake.type = f64;
           ret[2]->push_back(visitConst(&fake));
           return ret;
         }
         case f64: {
-          double d = curr->value.f64;
+          double d = curr->value.getf64();
           if (d == 0 && std::signbit(d)) { // negative zero
             return ValueBuilder::makeUnary(PLUS, ValueBuilder::makeUnary(MINUS, ValueBuilder::makeDouble(0)));
           }
-          return ValueBuilder::makeUnary(PLUS, ValueBuilder::makeDouble(curr->value.f64));
+          return ValueBuilder::makeUnary(PLUS, ValueBuilder::makeDouble(curr->value.getf64()));
         }
         default: abort();
       }


### PR DESCRIPTION
Followup to #151.

This began as just using `bit_cast` in the `Literal.reinterpret` methods. But this made some tests break. Investigating, I ended up with the following patch, which also refactors out float and double payload methods.

**This uses only the payload+signbit to compare floats and doubles when they are nans.** It fixes the test failures. But is this correct? What are the proper semantics for comparing floats for equality when they are nans?

Taking into account only the payload seems reasonable given that we now only print the payload for nans. If that's not true, how do those two make sense?

cc @jfbastien @sunfishcode 