### PR TITLE
Shell: fix --entry parameter numbers

### DIFF
--- a/src/binaryen-shell.cpp
+++ b/src/binaryen-shell.cpp
@@ -183,10 +183,18 @@ static void run_asserts(size_t* i, bool* checked, AllocatingModule* wasm,
   auto interface = new ShellExternalInterface();
   auto instance = new ModuleInstance(*wasm, interface);
   if (entry.is() > 0) {
-    ModuleInstance::LiteralList arguments;
-    try {
-      instance->callExport(entry, arguments);
-    } catch (ExitException& x) {
+    Function* function = wasm->functionsMap[entry];
+    if (!function) {
+      std::cerr << "Unknown entry " << entry << std::endl;
+    } else {
+      ModuleInstance::LiteralList arguments;
+      for (NameType param : function->params) {
+        arguments.push_back(Literal(param.type));
+      }
+      try {
+        instance->callExport(entry, arguments);
+      } catch (ExitException& x) {
+      }
     }
   }
   while (*i < root->size()) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -123,14 +123,26 @@ private:
   Literal callFunction(IString name, LiteralList& arguments) {
 
     class FunctionScope {
-    public:
+     public:
       std::map<IString, Literal> locals;
       Function* function;
 
-      FunctionScope(Function* function, LiteralList& arguments) : function(function) {
-        assert(function->params.size() == arguments.size());
+      FunctionScope(Function* function, LiteralList& arguments)
+          : function(function) {
+        if (function->params.size() != arguments.size()) {
+          std::cerr << "Function `" << function->name << "` expects "
+                    << function->params.size() << " parameters, got "
+                    << arguments.size() << " arguments." << std::endl;
+          abort();
+        }
         for (size_t i = 0; i < arguments.size(); i++) {
-          assert(function->params[i].type == arguments[i].type);
+          if (function->params[i].type != arguments[i].type) {
+            std::cerr << "Function `" << function->name << "` expects type "
+                      << printWasmType(function->params[i].type)
+                      << " for parameter " << i << ", got "
+                      << printWasmType(arguments[i].type) << "." << std::endl;
+            abort();
+          }
           locals[function->params[i].name] = arguments[i];
         }
         for (auto& local : function->locals) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -149,7 +149,8 @@ struct Literal {
     double f64;
   };
 
-  Literal() : type(WasmType::none), f64(0) {}
+  Literal() : Literal(WasmType::none) {}
+  explicit Literal(WasmType type) : type(type) { memset(&f64, 0, sizeof(f64)); }
   Literal(int32_t  init) : type(WasmType::i32), i32(init) {}
   Literal(uint32_t init) : type(WasmType::i32), i32(init) {}
   Literal(int64_t  init) : type(WasmType::i64), i64(init) {}

--- a/test/s2wasm_known_binaryen_shell_test_failures.txt
+++ b/test/s2wasm_known_binaryen_shell_test_failures.txt
@@ -1,40 +1,3 @@
-# wasm-interpreter.h:131: wasm::ModuleInstance::callFunction(cashew::IString, LiteralList &)::FunctionScope::FunctionScope(wasm::Function *, LiteralList &): Assertion `function->params.size() == arguments.size()' failed.
-20000412-2.c.s.wast
-20000412-4.c.s.wast
-20001124-1.c.s.wast
-20010915-1.c.s.wast
-20020206-2.c.s.wast
-20020402-2.c.s.wast
-20021204-1.c.s.wast
-20031012-1.c.s.wast
-20041113-1.c.s.wast
-20041114-1.c.s.wast
-20050125-1.c.s.wast
-20080122-1.c.s.wast
-980506-3.c.s.wast
-990106-2.c.s.wast
-anon-1.c.s.wast
-bitfld-1.c.s.wast
-const-addr-expr-1.c.s.wast
-ipa-sra-1.c.s.wast
-ipa-sra-2.c.s.wast
-loop-9.c.s.wast
-pending-4.c.s.wast
-pr22493-1.c.s.wast
-pr23047.c.s.wast
-pr28651.c.s.wast
-pr32500.c.s.wast
-pr36321.c.s.wast
-pr40493.c.s.wast
-pr56982.c.s.wast
-pr61375.c.s.wast
-switch-1.c.s.wast
-vrp-1.c.s.wast
-vrp-2.c.s.wast
-vrp-3.c.s.wast
-vrp-5.c.s.wast
-vrp-6.c.s.wast
-
 # [trap highest > memory]
 20000528-1.c.s.wast
 20001111-1.c.s.wast
@@ -63,6 +26,7 @@ simd-2.c.s.wast
 simd-5.c.s.wast
 
 # [trap final > memory]
+20000412-2.c.s.wast
 20000519-1.c.s.wast
 20000706-4.c.s.wast
 20000801-1.c.s.wast
@@ -70,6 +34,7 @@ simd-5.c.s.wast
 20010116-1.c.s.wast
 20010129-1.c.s.wast
 20010518-2.c.s.wast
+20010915-1.c.s.wast
 20020206-1.c.s.wast
 20020413-1.c.s.wast
 20020418-1.c.s.wast
@@ -82,6 +47,7 @@ simd-5.c.s.wast
 20030828-1.c.s.wast
 20030914-2.c.s.wast
 20030916-1.c.s.wast
+20031012-1.c.s.wast
 20031201-1.c.s.wast
 20040218-1.c.s.wast
 20040625-1.c.s.wast
@@ -89,6 +55,7 @@ simd-5.c.s.wast
 20040709-1.c.s.wast
 20040811-1.c.s.wast
 20040823-1.c.s.wast
+20041113-1.c.s.wast
 20041124-1.c.s.wast
 20041214-1.c.s.wast
 20050203-1.c.s.wast
@@ -185,6 +152,7 @@ pr56205.c.s.wast
 pr56799.c.s.wast
 pr56837.c.s.wast
 pr56866.c.s.wast
+pr56982.c.s.wast
 pr57124.c.s.wast
 pr57130.c.s.wast
 pr57131.c.s.wast
@@ -243,6 +211,7 @@ bitfld-3.c.s.wast
 builtin-constant.c.s.wast
 builtin-prefetch-4.c.s.wast
 eeprof-1.c.s.wast
+pr22493-1.c.s.wast
 pr32244-1.c.s.wast
 pr34971.c.s.wast
 pr48814-1.c.s.wast
@@ -271,10 +240,12 @@ pr48814-1.c.s.wast
 960215-1.c.s.wast # __addtf3
 960405-1.c.s.wast # __eqtf2
 960521-1.c.s.wast # malloc
+980506-3.c.s.wast # memset
 990628-1.c.s.wast # malloc
 991112-1.c.s.wast # isprint
 align-2.c.s.wast # __eqtf2
 complex-5.c.s.wast # __divsc3
+ipa-sra-2.c.s.wast # calloc
 loop-2f.c.s.wast # open
 loop-2g.c.s.wast # open
 memcpy-2.c.s.wast # memset


### PR DESCRIPTION
When running the shell with --entry it was assumed that the signature had zero parameters. This isn't true for main, so look at the function's parameter list and construct a zero-initialized arguments vector of the right types. This fixes a few failures, some of which were hiding other failures.