### PR TITLE
Make Literal's ctors explicit

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1104,13 +1104,13 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
             auto isNegative = allocator.alloc<Binary>();
             isNegative->op = LtS;
             isNegative->left = get();
-            isNegative->right = allocator.alloc<Const>()->set(0);
+            isNegative->right = allocator.alloc<Const>()->set(Literal(0));
             isNegative->finalize();
             auto block = allocator.alloc<Block>();
             block->list.push_back(set);
             auto flip = allocator.alloc<Binary>();
             flip->op = Sub;
-            flip->left = allocator.alloc<Const>()->set(0);
+            flip->left = allocator.alloc<Const>()->set(Literal(0));
             flip->right = get();
             flip->type = i32;
             auto select = allocator.alloc<Select>();

--- a/src/binaryen-shell.cpp
+++ b/src/binaryen-shell.cpp
@@ -85,25 +85,25 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     switch (load->type) {
       case i32: {
         switch (load->bytes) {
-          case 1: return load->signed_ ? (int32_t)*((int8_t*)(memory+addr))  : (int32_t)*((uint8_t*)(memory+addr));
-          case 2: return load->signed_ ? (int32_t)*((int16_t*)(memory+addr)) : (int32_t)*((uint16_t*)(memory+addr));
-          case 4: return load->signed_ ? (int32_t)*((int32_t*)(memory+addr)) : (int32_t)*((uint32_t*)(memory+addr));
+          case 1: return Literal(load->signed_ ? (int32_t)*((int8_t*)(memory+addr))  : (int32_t)*((uint8_t*)(memory+addr)));
+          case 2: return Literal(load->signed_ ? (int32_t)*((int16_t*)(memory+addr)) : (int32_t)*((uint16_t*)(memory+addr)));
+          case 4: return Literal(load->signed_ ? (int32_t)*((int32_t*)(memory+addr)) : (int32_t)*((uint32_t*)(memory+addr)));
           default: abort();
         }
         break;
       }
       case i64: {
         switch (load->bytes) {
-          case 1: return load->signed_ ? (int64_t)*((int8_t*)(memory+addr))  : (int64_t)*((uint8_t*)(memory+addr));
-          case 2: return load->signed_ ? (int64_t)*((int16_t*)(memory+addr)) : (int64_t)*((uint16_t*)(memory+addr));
-          case 4: return load->signed_ ? (int64_t)*((int32_t*)(memory+addr)) : (int64_t)*((uint32_t*)(memory+addr));
-          case 8: return load->signed_ ? (int64_t)*((int64_t*)(memory+addr)) : (int64_t)*((uint64_t*)(memory+addr));
+          case 1: return Literal(load->signed_ ? (int64_t)*((int8_t*)(memory+addr))  : (int64_t)*((uint8_t*)(memory+addr)));
+          case 2: return Literal(load->signed_ ? (int64_t)*((int16_t*)(memory+addr)) : (int64_t)*((uint16_t*)(memory+addr)));
+          case 4: return Literal(load->signed_ ? (int64_t)*((int32_t*)(memory+addr)) : (int64_t)*((uint32_t*)(memory+addr)));
+          case 8: return Literal(load->signed_ ? (int64_t)*((int64_t*)(memory+addr)) : (int64_t)*((uint64_t*)(memory+addr)));
           default: abort();
         }
         break;
       }
-      case f32: return *((float*)(memory+addr));
-      case f64: return *((double*)(memory+addr));
+      case f32: return Literal(*((float*)(memory+addr)));
+      case f64: return Literal(*((double*)(memory+addr)));
       default: abort();
     }
   }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -151,12 +151,12 @@ struct Literal {
 
   Literal() : Literal(WasmType::none) {}
   explicit Literal(WasmType type) : type(type) { memset(&f64, 0, sizeof(f64)); }
-  Literal(int32_t  init) : type(WasmType::i32), i32(init) {}
-  Literal(uint32_t init) : type(WasmType::i32), i32(init) {}
-  Literal(int64_t  init) : type(WasmType::i64), i64(init) {}
-  Literal(uint64_t init) : type(WasmType::i64), i64(init) {}
-  Literal(float    init) : type(WasmType::f32), f32(init) {}
-  Literal(double   init) : type(WasmType::f64), f64(init) {}
+  explicit Literal(int32_t  init) : type(WasmType::i32), i32(init) {}
+  explicit Literal(uint32_t init) : type(WasmType::i32), i32(init) {}
+  explicit Literal(int64_t  init) : type(WasmType::i64), i64(init) {}
+  explicit Literal(uint64_t init) : type(WasmType::i64), i64(init) {}
+  explicit Literal(float    init) : type(WasmType::f32), f32(init) {}
+  explicit Literal(double   init) : type(WasmType::f64), f64(init) {}
 
   int32_t geti32() { assert(type == WasmType::i32); return i32; }
   int64_t geti64() { assert(type == WasmType::i64); return i64; }

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -919,7 +919,7 @@ Ref Wasm2AsmBuilder::processFunctionBody(Expression* curr, IString result) {
         case f32: {
           Ref ret = ValueBuilder::makeCall(MATH_FROUND);
           Const fake;
-          fake.value = double(curr->value.f32);
+          fake.value = Literal(double(curr->value.f32));
           fake.type = f64;
           ret[2]->push_back(visitConst(&fake));
           return ret;


### PR DESCRIPTION
This tends to avoid silly mistakes, which I'm worried about after adding an explicit ctor with the enum WasmType parameter. See 'C++ Coding Standards: 101 Rules, Guidelines, and Best Practices' rule #40 'avoid providing implicit conversion'.