### PR TITLE
Allows optimization passes more flexibility when walking the AST, WIP.

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1476,7 +1476,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
 void Asm2WasmBuilder::optimize() {
   // Optimization passes. Note: no effort is made to free nodes that are no longer held on to.
 
-  struct BlockBreakOptimizer : public WasmWalker<BlockBreakOptimizer> {
+  struct BlockBreakOptimizer : public PreOrPostWalker<BlockBreakOptimizer> {
     void visitBlock(Block *curr) {
       // if the block ends in a break on this very block, then just put the value there
       Break *last = curr->list[curr->list.size()-1]->dyn_cast<Break>();
@@ -1491,7 +1491,7 @@ void Asm2WasmBuilder::optimize() {
       }
       // we might be broken to, but maybe there isn't a break (and we may have removed it, leading to this)
 
-      struct BreakSeeker : public WasmWalker<BreakSeeker> {
+      struct BreakSeeker : public PreOrPostWalker<BreakSeeker> {
         IString target; // look for this one
         size_t found;
 

--- a/src/pass.h
+++ b/src/pass.h
@@ -121,7 +121,7 @@ public:
 // e.g. through PassRunner::getLast
 
 // Handles names in a module, in particular adding names without duplicates
-class NameManager : public WalkerPass<WasmWalker<NameManager>> {
+class NameManager : public WalkerPass<PreOrPostWalker<NameManager>> {
  public:
   Name getUnique(std::string prefix);
   // TODO: getUniqueInFunction

--- a/src/passes/LowerIfElse.cpp
+++ b/src/passes/LowerIfElse.cpp
@@ -32,7 +32,7 @@
 
 namespace wasm {
 
-struct LowerIfElse : public WalkerPass<WasmWalker<LowerIfElse, void>> {
+struct LowerIfElse : public WalkerPass<PreOrPostWalker<LowerIfElse, void>> {
   MixedArena* allocator;
   std::unique_ptr<NameManager> namer;
 

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct MergeBlocks : public WalkerPass<WasmWalker<MergeBlocks>> {
+struct MergeBlocks : public WalkerPass<PreOrPostWalker<MergeBlocks>> {
   void visitBlock(Block *curr) {
     bool more = true;
     while (more) {

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -24,7 +24,7 @@ namespace wasm {
 using namespace std;
 
 // Prints metrics between optimization passes.
-struct Metrics : public WalkerPass<WasmWalker<Metrics>> {
+struct Metrics : public WalkerPass<PreOrPostWalker<Metrics>> {
   static Metrics *lastMetricsPass;
 
   map<const char *, int> counts;

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-struct PostEmscripten : public WalkerPass<WasmWalker<PostEmscripten>> {
+struct PostEmscripten : public WalkerPass<PreOrPostWalker<PostEmscripten>> {
   // When we have a Load from a local value (typically a GetLocal) plus a constant offset,
   // we may be able to fold it in.
   // The semantics of the Add are to wrap, while wasm offset semantics purposefully do

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct RemoveImports : public WalkerPass<WasmWalker<RemoveImports>> {
+struct RemoveImports : public WalkerPass<PreOrPostWalker<RemoveImports>> {
   MixedArena* allocator;
   std::map<Name, Import*> importsMap;
 

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedBrs : public WalkerPass<WasmWalker<RemoveUnusedBrs>> {
+struct RemoveUnusedBrs : public WalkerPass<PreOrPostWalker<RemoveUnusedBrs>> {
   // preparation: try to unify branches, as the fewer there are, the higher a chance we can remove them
   // specifically for if-else, turn an if-else with branches to the same target at the end of each
   // child, and with a value, to a branch to that target containing the if-else

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedNames : public WalkerPass<WasmWalker<RemoveUnusedNames>> {
+struct RemoveUnusedNames : public WalkerPass<PreOrPostWalker<RemoveUnusedNames>> {
   // We maintain a list of branches that we saw in children, then when we reach
   // a parent block, we know if it was branched to
   std::set<Name> branchesSeen;

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct SimplifyLocals : public WalkerPass<WasmWalker<SimplifyLocals>> {
+struct SimplifyLocals : public WalkerPass<PreOrPostWalker<SimplifyLocals>> {
   void visitBlock(Block *curr) {
     // look for pairs of setlocal-getlocal, which can be just a setlocal (since it returns a value)
     if (curr->list.size() == 0) return;

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1193,7 +1193,7 @@ public:
 
     o << ";; METADATA: { ";
     // find asmConst calls, and emit their metadata
-    struct AsmConstWalker : public WasmWalker<AsmConstWalker> {
+    struct AsmConstWalker : public PreOrPostWalker<AsmConstWalker> {
       S2WasmBuilder* parent;
 
       std::map<std::string, std::set<std::string>> sigsForCode;

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -25,7 +25,7 @@
 
 namespace wasm {
 
-struct WasmValidator : public WasmWalker<WasmValidator> {
+struct WasmValidator : public PreOrPostWalker<WasmValidator> {
   bool valid;
 
 public:
@@ -98,7 +98,7 @@ public:
 private:
 
   // the "in" label has a none type, since no one can receive its value. make sure no one breaks to it with a value.
-  struct LoopChildChecker : public WasmWalker<LoopChildChecker> {
+  struct LoopChildChecker : public PreOrPostWalker<LoopChildChecker> {
     Name in;
     bool valid = true;
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1437,10 +1437,10 @@ struct ChildWalker : public WasmWalkerBase<ChildWalker<ParentType>> {
 //
 
 template<typename SubType, typename ReturnType = void>
-struct WasmWalker : public WasmWalkerBase<SubType, ReturnType> {
+struct PreOrPostWalker : public WasmWalkerBase<SubType, ReturnType> {
   Expression* replace;
-
-  WasmWalker() : replace(nullptr) {}
+  bool postOrder;
+  PreOrPostWalker(bool postOrder = true) : replace(nullptr), postOrder(postOrder) {}
 
   // the visit* methods can call this to replace the current node
   void replaceCurrent(Expression *expression) {
@@ -1477,17 +1477,22 @@ struct WasmWalker : public WasmWalkerBase<SubType, ReturnType> {
   ReturnType visitMemory(Memory *curr) {}
   ReturnType visitModule(Module *curr) {}
 
-  // children-first
   void walk(Expression*& curr) override {
     if (!curr) return;
-
-    ChildWalker<WasmWalker<SubType, ReturnType>>(*this).visit(curr);
-
-    this->visit(curr);
-
-    if (replace) {
-      curr = replace;
-      replace = nullptr;
+    if (postOrder) {
+      ChildWalker<PreOrPostWalker<SubType, ReturnType>>(*this).visit(curr);
+      this->visit(curr);
+      if (replace) {
+        curr = replace;
+        replace = nullptr;
+      }
+    } else {
+      this->visit(curr);
+      if (replace) {
+        curr = replace;
+        replace = nullptr;
+      }
+      ChildWalker<PreOrPostWalker<SubType, ReturnType>>(*this).visit(curr);
     }
   }
 
@@ -1511,6 +1516,143 @@ struct WasmWalker : public WasmWalkerBase<SubType, ReturnType> {
       assert(!replace);
     }
     for (auto curr : module->functions) {
+      startWalk(curr);
+      self->visitFunction(curr);
+      assert(!replace);
+    }
+    self->visitTable(&module->table);
+    assert(!replace);
+    self->visitMemory(&module->memory);
+    assert(!replace);
+    self->visitModule(module);
+    assert(!replace);
+  }
+};
+
+template <typename SubType>
+struct RecursiveWalker : public WasmWalkerBase<SubType, void> {
+protected:
+  Expression *replace;
+
+public:
+  RecursiveWalker() : replace(nullptr) {}
+
+  // The visitXXX methods can call this to replace the current node.
+  void replaceCurrent(Expression *expression) {
+    assert(!replace);
+    replace = expression;
+  }
+
+  // The expression to be visited is passed in as a double pointer so its
+  // value can be replaced.
+  void recursiveVisit(Expression **curr) {
+    if (!*curr) {
+      return;
+    }
+    this->visit(*curr);
+    if (replace) {
+      *curr = replace;
+      replace = nullptr;
+    }
+  }
+  void visitBlock(Block *curr) {
+    ExpressionList &list = curr->list;
+    for (size_t z = 0; z < list.size(); z++) {
+      recursiveVisit(&list[z]);
+    }
+  }
+  void visitIf(If *curr) {
+    recursiveVisit(&curr->condition);
+    recursiveVisit(&curr->ifTrue);
+    recursiveVisit(&curr->ifFalse);
+  }
+  void visitLoop(Loop *curr) { recursiveVisit(&curr->body); }
+  void visitBreak(Break *curr) {
+    recursiveVisit(&curr->condition);
+    recursiveVisit(&curr->value);
+  }
+  void visitSwitch(Switch *curr) {
+    recursiveVisit(&curr->value);
+    for (auto &case_ : curr->cases) {
+      recursiveVisit(&case_.body);
+    }
+  }
+  void visitCall(Call *curr) {
+    ExpressionList &list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      recursiveVisit(&list[z]);
+    }
+  }
+  void visitCallImport(CallImport *curr) {
+    ExpressionList &list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      recursiveVisit(&list[z]);
+    }
+  }
+  void visitCallIndirect(CallIndirect *curr) {
+    recursiveVisit(&curr->target);
+    ExpressionList &list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      recursiveVisit(&list[z]);
+    }
+  }
+  void visitGetLocal(GetLocal *curr) {}
+  void visitSetLocal(SetLocal *curr) {
+    recursiveVisit(&curr->value);
+  }
+  void visitLoad(Load *curr) {
+    recursiveVisit(&curr->ptr);
+  }
+  void visitStore(Store *curr) {
+    recursiveVisit(&curr->ptr);
+    recursiveVisit(&curr->value);
+  }
+  void visitConst(Const *curr) {}
+  void visitUnary(Unary *curr) {
+    recursiveVisit(&curr->value);
+  }
+  void visitBinary(Binary *curr) {
+    recursiveVisit(&curr->left);
+    recursiveVisit(&curr->right);
+  }
+  void visitSelect(Select *curr) {
+    recursiveVisit(&curr->condition);
+    recursiveVisit(&curr->ifTrue);
+    recursiveVisit(&curr->ifFalse);
+  }
+  void visitHost(Host *curr) {
+    ExpressionList &list = curr->operands;
+    for (size_t z = 0; z < list.size(); z++) {
+      recursiveVisit(&list[z]);
+    }
+  }
+  void visitNop(Nop *curr) {}
+  void visitUnreachable(Unreachable *curr) {}
+  void visitFunctionType(FunctionType *curr) {}
+  void visitImport(Import *curr) {}
+  void visitExport(Export *curr) {}
+  void visitFunction(Function *curr) {}
+  void visitTable(Table *curr) {}
+  void visitMemory(Memory *curr) {}
+  void visitModule(Module *curr) {}
+  void startWalk(Function *func) override {
+    this->visit(func->body);
+  }
+  void startWalk(Module *module) override {
+    SubType *self = static_cast<SubType *>(this);
+    for (auto &curr : module->functionTypes) {
+      self->visitFunctionType(curr);
+      assert(!replace);
+    }
+    for (auto &curr : module->imports) {
+      self->visitImport(curr);
+      assert(!replace);
+    }
+    for (auto &curr : module->exports) {
+      self->visitExport(curr);
+      assert(!replace);
+    }
+    for (auto &curr : module->functions) {
       startWalk(curr);
       self->visitFunction(curr);
       assert(!replace);

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -392,7 +392,7 @@ Ref Wasm2AsmBuilder::processFunction(Function* func) {
 }
 
 void Wasm2AsmBuilder::scanFunctionBody(Expression* curr) {
-  struct ExpressionScanner : public WasmWalker<ExpressionScanner> {
+  struct ExpressionScanner : public PreOrPostWalker<ExpressionScanner> {
     Wasm2AsmBuilder* parent;
 
     ExpressionScanner(Wasm2AsmBuilder* parent) : parent(parent) {}

--- a/test/example/find_div0s.cpp
+++ b/test/example/find_div0s.cpp
@@ -38,7 +38,7 @@ int main() {
 
   // Search it for divisions by zero: Walk the module, looking for
   // that operation.
-  struct DivZeroSeeker : public WasmWalker<DivZeroSeeker> {
+  struct DivZeroSeeker : public PreOrPostWalker<DivZeroSeeker> {
     void visitBinary(Binary* curr) {
       // In every Binary, look for integer divisions
       if (curr->op == BinaryOp::DivS || curr->op == BinaryOp::DivU) {


### PR DESCRIPTION
This renames `WasmWalker` to `PreOrPostWalker` and adds a new walker called `RecursiveWalker` that allows for more flexibility when adding logic that should be inserted in the middle of visiting an AST node rather than just before or after.

This PR cherry picks some of the changes in #122 which has now become stale, and will be closed soon.