### PR TITLE
Store floating point values as bits in an integer type.

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -880,8 +880,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
         ret->value.type = WasmType::i32;
         ret->value.i32 = toUInteger32(num);
       } else {
-        ret->value.type = WasmType::f64;
-        ret->value.f64 = num;
+        ret->value = Literal(num);
       }
       ret->type = ret->value.type;
       return ret;

--- a/src/binaryen-shell.cpp
+++ b/src/binaryen-shell.cpp
@@ -102,8 +102,8 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
         }
         break;
       }
-      case f32: return Literal(*((float*)(memory+addr)));
-      case f64: return Literal(*((double*)(memory+addr)));
+      case f32: return Literal::makeFloatFromBits(*(int32_t*)(memory+addr));
+      case f64: return Literal::makeDoubleFromBits(*(int64_t*)(memory+addr));
       default: abort();
     }
   }

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -33,8 +33,8 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
   if (isWasmTypeFloat(type)) {
     if (s == INFINITY_) {
       switch (type) {
-        case f32: ret->value.f32 = std::numeric_limits<float>::infinity(); break;
-        case f64: ret->value.f64 = std::numeric_limits<double>::infinity(); break;
+        case f32: ret->value = Literal(std::numeric_limits<float>::infinity()); break;
+        case f64: ret->value = Literal(std::numeric_limits<double>::infinity()); break;
         default: return nullptr;
       }
       //std::cerr << "make constant " << str << " ==> " << ret->value << '\n';
@@ -42,8 +42,8 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
     }
     if (s == NEG_INFINITY) {
       switch (type) {
-        case f32: ret->value.f32 = -std::numeric_limits<float>::infinity(); break;
-        case f64: ret->value.f64 = -std::numeric_limits<double>::infinity(); break;
+        case f32: ret->value = Literal(-std::numeric_limits<float>::infinity()); break;
+        case f64: ret->value = Literal(-std::numeric_limits<double>::infinity()); break;
         default: return nullptr;
       }
       //std::cerr << "make constant " << str << " ==> " << ret->value << '\n';
@@ -51,8 +51,8 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
     }
     if (s == NAN_) {
       switch (type) {
-        case f32: ret->value.f32 = std::nan(""); break;
-        case f64: ret->value.f64 = std::nan(""); break;
+        case f32: ret->value = Literal(std::nanf("")); break;
+        case f64: ret->value = Literal(std::nan("")); break;
         default: return nullptr;
       }
       //std::cerr << "make constant " << str << " ==> " << ret->value << '\n';
@@ -76,8 +76,8 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
           }
           if (negative) pattern |= 0x80000000U;
           if (!isnan(bit_cast<float>(pattern))) pattern |= 1U;
-          ret->value.f32 = bit_cast<float>(pattern);
-          assert(isnan(ret->value.f32));
+          ret->value.f32bits = pattern;
+          assert(isnan(ret->value.getf32()));
           break;
         }
         case f64: {
@@ -91,8 +91,8 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
           }
           if (negative) pattern |= 0x8000000000000000ULL;
           if (!isnan(bit_cast<double>(pattern))) pattern |= 1ULL;
-          ret->value.f64 = bit_cast<double>(pattern);
-          assert(isnan(ret->value.f64));
+          ret->value.f64bits = pattern;
+          assert(isnan(ret->value.getf64()));
           break;
         }
         default: return nullptr;
@@ -102,8 +102,8 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
     }
     if (s == NEG_NAN) {
       switch (type) {
-        case f32: ret->value.f32 = -std::nan(""); break;
-        case f64: ret->value.f64 = -std::nan(""); break;
+        case f32: ret->value = Literal(-std::nanf("")); break;
+        case f64: ret->value = Literal(-std::nan("")); break;
         default: return nullptr;
       }
       //std::cerr << "make constant " << str << " ==> " << ret->value << '\n';
@@ -145,14 +145,14 @@ Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) 
     }
     case f32: {
       char *end;
-      ret->value.f32 = strtof(str, &end);
-      assert(!isnan(ret->value.f32));
+      ret->value = Literal(strtof(str, &end));
+      assert(!isnan(ret->value.getf32()));
       break;
     }
     case f64: {
       char *end;
-      ret->value.f64 = strtod(str, &end);
-      assert(!isnan(ret->value.f64));
+      ret->value = Literal(strtod(str, &end));
+      assert(!isnan(ret->value.getf64()));
       break;
     }
     default: return nullptr;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -798,11 +798,11 @@ public:
         break;
       }
       case f32: {
-        o << int8_t(BinaryConsts::F32Const) << curr->value.f32;
+        o << int8_t(BinaryConsts::F32Const) << curr->value.getf32();
         break;
       }
       case f64: {
-        o << int8_t(BinaryConsts::F64Const) << curr->value.f64;
+        o << int8_t(BinaryConsts::F64Const) << curr->value.getf64();
         break;
       }
       default: abort();
@@ -1483,8 +1483,8 @@ public:
       case BinaryConsts::I8Const:  curr->value.i32 = getInt8();    curr->type = i32; break;
       case BinaryConsts::I32Const: curr->value.i32 = getInt32();   curr->type = i32; break;
       case BinaryConsts::I64Const: curr->value.i64 = getInt64();   curr->type = i64; break;
-      case BinaryConsts::F32Const: curr->value.f32 = getFloat32(); curr->type = f32; break;
-      case BinaryConsts::F64Const: curr->value.f64 = getFloat64(); curr->type = f64; break;
+      case BinaryConsts::F32Const: curr->value = Literal(getFloat32()); break;
+      case BinaryConsts::F64Const: curr->value = Literal(getFloat64()); break;
       default: return false;
     }
     curr->value.type = curr->type;

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -919,17 +919,16 @@ Ref Wasm2AsmBuilder::processFunctionBody(Expression* curr, IString result) {
         case f32: {
           Ref ret = ValueBuilder::makeCall(MATH_FROUND);
           Const fake;
-          fake.value = Literal(double(curr->value.f32));
-          fake.type = f64;
+          fake.value = Literal(double(curr->value.getf32()));
           ret[2]->push_back(visitConst(&fake));
           return ret;
         }
         case f64: {
-          double d = curr->value.f64;
+          double d = curr->value.getf64();
           if (d == 0 && std::signbit(d)) { // negative zero
             return ValueBuilder::makeUnary(PLUS, ValueBuilder::makeUnary(MINUS, ValueBuilder::makeDouble(0)));
           }
-          return ValueBuilder::makeUnary(PLUS, ValueBuilder::makeDouble(curr->value.f64));
+          return ValueBuilder::makeUnary(PLUS, ValueBuilder::makeDouble(d));
         }
         default: abort();
       }


### PR DESCRIPTION
Here's one way to avoid the x87 NaN bit-munging problem.