### PR TITLE
Allow failures on TSan Travis build, require ASan to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
           packages: ['cmake', 'nodejs', 'g++-5']
 
   allow_failures:
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=address"
+    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=thread"
       compiler: clang
       addons: *clang36
 


### PR DESCRIPTION
We've fixed the ASan errors, so this bot can stay green. Now there's
flake on the TSan bot :(