### PR TITLE
Update torture tests to 3321

### DIFF
--- a/test/s2wasm_known_binaryen_shell_test_failures.txt
+++ b/test/s2wasm_known_binaryen_shell_test_failures.txt
@@ -82,6 +82,7 @@ pr34971.c.s.wast
 20011024-1.c.s.wast # strcmp
 20020406-1.c.s.wast # malloc
 20021011-1.c.s.wast # strcmp
+20030914-2.c.s.wast # memcpy
 20031204-1.c.s.wast # strcmp
 20041126-1.c.s.wast # memcpy
 20041218-1.c.s.wast # memset
@@ -105,6 +106,7 @@ pr34971.c.s.wast
 align-2.c.s.wast # __eqtf2
 builtin-bitops-1.c.s.wast # __builtin_clrsb
 complex-5.c.s.wast # __divsc3
+frame-address.c.s.wast # abort
 ipa-sra-2.c.s.wast # calloc
 loop-2f.c.s.wast # open
 loop-2g.c.s.wast # open
@@ -113,6 +115,7 @@ memcpy-bi.c.s.wast # memcpy
 memset-1.c.s.wast # memset
 memset-2.c.s.wast # memset
 memset-3.c.s.wast # memset
+pr28982b.c.s.wast # memset
 pr33870-1.c.s.wast # memset
 pr33870.c.s.wast # memset
 pr34456.c.s.wast # qsort

--- a/test/torture-s/20000412-6.c.s
+++ b/test/torture-s/20000412-6.c.s
@@ -49,20 +49,20 @@ bug:                                    # @bug
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.const	$push2=, 65535
-	i32.and 	$push3=, $0, $pop2
+	i32.const	$push7=, 65535
+	i32.and 	$push2=, $0, $pop7
 	i32.load16_u	$push1=, 0($1)
-	i32.sub 	$0=, $pop3, $pop1
-	i32.const	$push4=, 2
-	i32.add 	$1=, $1, $pop4
-	i32.lt_u	$push5=, $1, $2
-	br_if   	0, $pop5        # 0: up to label2
+	i32.sub 	$0=, $pop2, $pop1
+	i32.const	$push6=, 2
+	i32.add 	$1=, $1, $pop6
+	i32.lt_u	$push3=, $1, $2
+	br_if   	0, $pop3        # 0: up to label2
 .LBB1_2:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:
-	i32.const	$push6=, 65535
-	i32.and 	$push7=, $0, $pop6
-	return  	$pop7
+	i32.const	$push4=, 65535
+	i32.and 	$push5=, $0, $pop4
+	return  	$pop5
 	.endfunc
 .Lfunc_end1:
 	.size	bug, .Lfunc_end1-bug

--- a/test/torture-s/20000422-1.c.s
+++ b/test/torture-s/20000422-1.c.s
@@ -10,19 +10,19 @@ main:                                   # @main
 # BB#0:                                 # %entry
 	block
 	block
-	i32.const	$push18=, 0
-	i32.load	$push17=, num($pop18)
-	tee_local	$push16=, $5=, $pop17
-	i32.const	$push15=, 1
-	i32.lt_s	$push0=, $pop16, $pop15
+	i32.const	$push16=, 0
+	i32.load	$push15=, num($pop16)
+	tee_local	$push14=, $5=, $pop15
+	i32.const	$push13=, 1
+	i32.lt_s	$push0=, $pop14, $pop13
 	br_if   	0, $pop0        # 0: down to label1
 # BB#1:                                 # %for.cond1.preheader.preheader
 	i32.const	$push1=, 2
 	i32.shl 	$push2=, $5, $pop1
 	i32.const	$push3=, ops-8
 	i32.add 	$1=, $pop2, $pop3
-	i32.const	$push19=, -1
-	i32.add 	$0=, $5, $pop19
+	i32.const	$push17=, -1
+	i32.add 	$0=, $5, $pop17
 	i32.const	$2=, 0
 .LBB0_2:                                # %for.cond1.preheader
                                         # =>This Loop Header: Depth=1
@@ -38,14 +38,14 @@ main:                                   # @main
                                         # =>  This Inner Loop Header: Depth=2
 	loop                            # label5:
 	block
-	i32.load	$push27=, 0($3)
-	tee_local	$push26=, $8=, $pop27
-	i32.const	$push25=, 4
-	i32.add 	$push24=, $3, $pop25
-	tee_local	$push23=, $7=, $pop24
-	i32.load	$push22=, 0($pop23)
-	tee_local	$push21=, $6=, $pop22
-	i32.ge_s	$push5=, $pop26, $pop21
+	i32.load	$push25=, 0($3)
+	tee_local	$push24=, $8=, $pop25
+	i32.const	$push23=, 4
+	i32.add 	$push22=, $3, $pop23
+	tee_local	$push21=, $7=, $pop22
+	i32.load	$push20=, 0($pop21)
+	tee_local	$push19=, $6=, $pop20
+	i32.ge_s	$push5=, $pop24, $pop19
 	br_if   	0, $pop5        # 0: down to label7
 # BB#4:                                 # %if.then
                                         #   in Loop: Header=BB0_3 Depth=2
@@ -54,49 +54,50 @@ main:                                   # @main
 .LBB0_5:                                # %for.cond1.backedge
                                         #   in Loop: Header=BB0_3 Depth=2
 	end_block                       # label7:
-	i32.const	$push29=, -1
-	i32.add 	$4=, $4, $pop29
-	i32.const	$push28=, -4
-	i32.add 	$3=, $3, $pop28
+	i32.const	$push27=, -1
+	i32.add 	$4=, $4, $pop27
+	i32.const	$push26=, -4
+	i32.add 	$3=, $3, $pop26
 	i32.gt_s	$push6=, $4, $2
 	br_if   	0, $pop6        # 0: up to label5
 .LBB0_6:                                # %for.end
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_loop                        # label6:
 	end_block                       # label4:
-	i32.const	$push30=, 1
-	i32.add 	$2=, $2, $pop30
+	i32.const	$push28=, 1
+	i32.add 	$2=, $2, $pop28
 	i32.lt_s	$push7=, $2, $5
 	br_if   	0, $pop7        # 0: up to label2
 # BB#7:                                 # %for.cond15.preheader
 	end_loop                        # label3:
 	i32.const	$3=, 0
-	i32.const	$4=, 0
-	i32.const	$push20=, 0
-	i32.le_s	$push8=, $5, $pop20
+	i32.const	$push18=, 0
+	i32.le_s	$push8=, $5, $pop18
 	br_if   	0, $pop8        # 0: down to label1
-.LBB0_8:                                # %for.body17
+# BB#8:
+	i32.const	$4=, 0
+.LBB0_9:                                # %for.body17
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label8:
 	i32.load	$push9=, ops($3)
 	i32.load	$push10=, correct($3)
 	i32.ne  	$push11=, $pop9, $pop10
 	br_if   	3, $pop11       # 3: down to label0
-# BB#9:                                 # %for.cond15
-                                        #   in Loop: Header=BB0_8 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$4=, $4, $pop12
-	i32.const	$push13=, 4
-	i32.add 	$3=, $3, $pop13
-	i32.lt_s	$push14=, $4, $5
-	br_if   	0, $pop14       # 0: up to label8
-.LBB0_10:                               # %for.end25
+# BB#10:                                # %for.cond15
+                                        #   in Loop: Header=BB0_9 Depth=1
+	i32.const	$push30=, 1
+	i32.add 	$4=, $4, $pop30
+	i32.const	$push29=, 4
+	i32.add 	$3=, $3, $pop29
+	i32.lt_s	$push12=, $4, $5
+	br_if   	0, $pop12       # 0: up to label8
+.LBB0_11:                               # %for.end25
 	end_loop                        # label9:
 	end_block                       # label1:
 	i32.const	$push31=, 0
 	call    	exit@FUNCTION, $pop31
 	unreachable
-.LBB0_11:                               # %if.then21
+.LBB0_12:                               # %if.then21
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20000605-2.c.s
+++ b/test/torture-s/20000605-2.c.s
@@ -8,38 +8,39 @@ f1:                                     # @f1
 	.param  	i32, i32
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$3=, 0
 	block
 	block
-	i32.load	$push11=, 0($0)
-	tee_local	$push10=, $4=, $pop11
+	i32.load	$push9=, 0($0)
+	tee_local	$push8=, $4=, $pop9
 	i32.load	$push0=, 0($1)
-	i32.ge_s	$push1=, $pop10, $pop0
+	i32.ge_s	$push1=, $pop8, $pop0
 	br_if   	0, $pop1        # 0: down to label1
-.LBB0_1:                                # %for.body
+# BB#1:
+	i32.const	$3=, 0
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.const	$push2=, 5
-	i32.ge_s	$push3=, $3, $pop2
-	br_if   	3, $pop3        # 3: down to label0
-# BB#2:                                 # %for.inc
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.add 	$push5=, $4, $3
-	i32.const	$push4=, 1
-	i32.add 	$push6=, $pop5, $pop4
-	i32.store	$discard=, 0($0), $pop6
+	i32.const	$push10=, 5
+	i32.ge_s	$push2=, $3, $pop10
+	br_if   	3, $pop2        # 3: down to label0
+# BB#3:                                 # %for.inc
+                                        #   in Loop: Header=BB0_2 Depth=1
+	i32.add 	$push3=, $4, $3
 	i32.const	$push12=, 1
-	i32.add 	$2=, $3, $pop12
+	i32.add 	$push4=, $pop3, $pop12
+	i32.store	$discard=, 0($0), $pop4
+	i32.const	$push11=, 1
+	i32.add 	$2=, $3, $pop11
 	copy_local	$3=, $2
-	i32.add 	$push8=, $4, $2
-	i32.load	$push7=, 0($1)
-	i32.lt_s	$push9=, $pop8, $pop7
-	br_if   	0, $pop9        # 0: up to label2
-.LBB0_3:                                # %for.end
+	i32.add 	$push6=, $4, $2
+	i32.load	$push5=, 0($1)
+	i32.lt_s	$push7=, $pop6, $pop5
+	br_if   	0, $pop7        # 0: up to label2
+.LBB0_4:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:
 	return
-.LBB0_4:                                # %if.then
+.LBB0_5:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20000801-1.c.s
+++ b/test/torture-s/20000801-1.c.s
@@ -8,36 +8,37 @@ foo:                                    # @foo
 	.param  	i32, i32
 	.local  	i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.add 	$2=, $0, $1
 	block
-	i32.const	$push6=, 1
-	i32.lt_s	$push0=, $1, $pop6
+	i32.const	$push3=, 1
+	i32.lt_s	$push0=, $1, $pop3
 	br_if   	0, $pop0        # 0: down to label0
-.LBB0_1:                                # %while.body
+# BB#1:
+	i32.add 	$2=, $0, $1
+.LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	i32.const	$push13=, 1
 	i32.add 	$push12=, $0, $pop13
 	tee_local	$push11=, $1=, $pop12
 	i32.load8_u	$5=, 0($pop11)
-	i32.const	$push3=, 2
-	i32.add 	$push10=, $0, $pop3
-	tee_local	$push9=, $7=, $pop10
-	i32.load8_u	$4=, 0($pop9)
-	i32.const	$push1=, 3
-	i32.add 	$push8=, $0, $pop1
-	tee_local	$push7=, $6=, $pop8
-	i32.load8_u	$3=, 0($pop7)
-	i32.load8_u	$push2=, 0($0)
-	i32.store8	$discard=, 0($6), $pop2
+	i32.const	$push10=, 2
+	i32.add 	$push9=, $0, $pop10
+	tee_local	$push8=, $7=, $pop9
+	i32.load8_u	$4=, 0($pop8)
+	i32.const	$push7=, 3
+	i32.add 	$push6=, $0, $pop7
+	tee_local	$push5=, $6=, $pop6
+	i32.load8_u	$3=, 0($pop5)
+	i32.load8_u	$push1=, 0($0)
+	i32.store8	$discard=, 0($6), $pop1
 	i32.store8	$discard=, 0($7), $5
 	i32.store8	$discard=, 0($1), $4
 	i32.store8	$discard=, 0($0), $3
 	i32.const	$push4=, 4
 	i32.add 	$0=, $0, $pop4
-	i32.lt_u	$push5=, $0, $2
-	br_if   	0, $pop5        # 0: up to label1
-.LBB0_2:                                # %while.end
+	i32.lt_u	$push2=, $0, $2
+	br_if   	0, $pop2        # 0: up to label1
+.LBB0_3:                                # %while.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	return

--- a/test/torture-s/20001009-2.c.s
+++ b/test/torture-s/20001009-2.c.s
@@ -9,29 +9,30 @@ foo:                                    # @foo
 	.local  	i32
 # BB#0:                                 # %entry
 	block
-	i32.const	$push6=, 0
-	i32.load	$push0=, b($pop6)
+	i32.const	$push5=, 0
+	i32.load	$push0=, b($pop5)
 	i32.const	$push9=, 0
 	i32.eq  	$push10=, $pop0, $pop9
 	br_if   	0, $pop10       # 0: down to label0
-.LBB0_1:                                # %for.body
+# BB#1:
+	i32.const	$0=, 1
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$0=, 1
 	#APP
 	#NO_APP
 	i32.const	$push8=, 0
 	i32.const	$push7=, 0
 	i32.load	$push1=, b($pop7)
-	i32.const	$push2=, -1
-	i32.add 	$push3=, $pop1, $pop2
-	i32.store	$push4=, b($pop8), $pop3
-	br_if   	0, $pop4        # 0: up to label1
-.LBB0_2:                                # %if.end
+	i32.const	$push6=, -1
+	i32.add 	$push2=, $pop1, $pop6
+	i32.store	$push3=, b($pop8), $pop2
+	br_if   	0, $pop3        # 0: up to label1
+.LBB0_3:                                # %if.end
 	end_loop                        # label2:
 	end_block                       # label0:
-	i32.const	$push5=, -1
-	return  	$pop5
+	i32.const	$push4=, -1
+	return  	$pop4
 	.endfunc
 .Lfunc_end0:
 	.size	foo, .Lfunc_end0-foo
@@ -45,25 +46,26 @@ main:                                   # @main
 	.local  	i32
 # BB#0:                                 # %entry
 	block
-	i32.const	$push5=, 0
-	i32.load	$push0=, b($pop5)
+	i32.const	$push4=, 0
+	i32.load	$push0=, b($pop4)
 	i32.const	$push9=, 0
 	i32.eq  	$push10=, $pop0, $pop9
 	br_if   	0, $pop10       # 0: down to label3
-.LBB1_1:                                # %for.body.i
+# BB#1:
+	i32.const	$0=, 1
+.LBB1_2:                                # %for.body.i
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label4:
-	i32.const	$0=, 1
 	#APP
 	#NO_APP
 	i32.const	$push7=, 0
 	i32.const	$push6=, 0
 	i32.load	$push1=, b($pop6)
-	i32.const	$push2=, -1
-	i32.add 	$push3=, $pop1, $pop2
-	i32.store	$push4=, b($pop7), $pop3
-	br_if   	0, $pop4        # 0: up to label4
-.LBB1_2:                                # %foo.exit
+	i32.const	$push5=, -1
+	i32.add 	$push2=, $pop1, $pop5
+	i32.store	$push3=, b($pop7), $pop2
+	br_if   	0, $pop3        # 0: up to label4
+.LBB1_3:                                # %foo.exit
 	end_loop                        # label5:
 	end_block                       # label3:
 	i32.const	$push8=, 0

--- a/test/torture-s/20010221-1.c.s
+++ b/test/torture-s/20010221-1.c.s
@@ -9,7 +9,6 @@ main:                                   # @main
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$1=, 0
-	i32.const	$0=, 45
 	block
 	i32.const	$push8=, 0
 	i32.load	$push7=, n($pop8)
@@ -17,7 +16,9 @@ main:                                   # @main
 	i32.const	$push5=, 1
 	i32.lt_s	$push0=, $pop6, $pop5
 	br_if   	0, $pop0        # 0: down to label0
-.LBB0_1:                                # %for.body
+# BB#1:
+	i32.const	$0=, 45
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	i32.select	$0=, $1, $0, $1
@@ -25,16 +26,16 @@ main:                                   # @main
 	i32.add 	$1=, $1, $pop9
 	i32.lt_s	$push1=, $1, $2
 	br_if   	0, $pop1        # 0: up to label1
-# BB#2:                                 # %for.end
+# BB#3:                                 # %for.end
 	end_loop                        # label2:
 	i32.const	$push2=, 1
 	i32.ne  	$push3=, $0, $pop2
 	br_if   	0, $pop3        # 0: down to label0
-# BB#3:                                 # %if.end5
+# BB#4:                                 # %if.end5
 	i32.const	$push4=, 0
 	call    	exit@FUNCTION, $pop4
 	unreachable
-.LBB0_4:                                # %if.then4
+.LBB0_5:                                # %if.then4
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20010915-1.c.s
+++ b/test/torture-s/20010915-1.c.s
@@ -65,17 +65,15 @@ x:                                      # @x
 # BB#0:                                 # %entry
 	block
 	block
-	block
-	block
 	i32.const	$push4=, 3
 	i32.lt_s	$push5=, $0, $pop4
-	br_if   	0, $pop5        # 0: down to label4
+	br_if   	0, $pop5        # 0: down to label2
 # BB#1:                                 # %entry
 	i32.const	$push3=, 0
 	i32.load	$push35=, o($pop3)
 	tee_local	$push34=, $2=, $pop35
 	i32.ge_s	$push6=, $pop34, $0
-	br_if   	0, $pop6        # 0: down to label4
+	br_if   	0, $pop6        # 0: down to label2
 # BB#2:                                 # %land.lhs.true2
 	i32.const	$push7=, 2
 	i32.shl 	$push8=, $2, $pop7
@@ -85,11 +83,12 @@ x:                                      # @x
 	tee_local	$push36=, $5=, $pop37
 	i32.const	$push68=, 0
 	i32.eq  	$push69=, $pop36, $pop68
-	br_if   	0, $pop69       # 0: down to label4
+	br_if   	0, $pop69       # 0: down to label2
 # BB#3:                                 # %if.then
+	block
 	i32.const	$push9=, .L.str
 	i32.call	$push10=, strcmp@FUNCTION, $5, $pop9
-	br_if   	1, $pop10       # 1: down to label3
+	br_if   	0, $pop10       # 0: down to label3
 # BB#4:                                 # %lor.lhs.false.i
 	i32.const	$push11=, 0
 	i32.const	$push42=, 0
@@ -100,11 +99,11 @@ x:                                      # @x
 	i32.store	$discard=, check($pop11), $pop13
 	i32.const	$push14=, 2
 	i32.ge_s	$push15=, $3, $pop14
-	br_if   	1, $pop15       # 1: down to label3
+	br_if   	0, $pop15       # 0: down to label3
 # BB#5:                                 # %s.exit
 	i32.const	$push16=, .L.str
 	i32.call	$push17=, strcmp@FUNCTION, $5, $pop16
-	br_if   	2, $pop17       # 2: down to label2
+	br_if   	0, $pop17       # 0: down to label3
 # BB#6:                                 # %lor.lhs.false.i45
 	i32.const	$push44=, 0
 	i32.const	$push18=, 2
@@ -112,7 +111,7 @@ x:                                      # @x
 	i32.store	$discard=, check($pop44), $pop19
 	i32.const	$push43=, 1
 	i32.ge_s	$push20=, $3, $pop43
-	br_if   	2, $pop20       # 2: down to label2
+	br_if   	0, $pop20       # 0: down to label3
 # BB#7:                                 # %s.exit48
 	i32.const	$push47=, 0
 	i32.const	$push46=, 0
@@ -121,7 +120,7 @@ x:                                      # @x
 	i32.const	$push45=, 1
 	i32.add 	$push21=, $5, $pop45
 	i32.eq  	$push23=, $pop22, $pop21
-	br_if   	3, $pop23       # 3: down to label1
+	br_if   	2, $pop23       # 2: down to label1
 # BB#8:                                 # %while.cond.preheader
 	block
 	block
@@ -131,7 +130,7 @@ x:                                      # @x
 	i32.store	$push49=, o($pop51), $pop0
 	tee_local	$push48=, $5=, $pop49
 	i32.ge_s	$push24=, $pop48, $0
-	br_if   	0, $pop24       # 0: down to label6
+	br_if   	0, $pop24       # 0: down to label5
 # BB#9:                                 # %while.body.preheader
 	i32.const	$push52=, 0
 	i32.load8_u	$3=, r.c.0($pop52)
@@ -140,18 +139,18 @@ x:                                      # @x
 	i32.add 	$2=, $1, $pop26
 .LBB1_10:                               # %while.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label7:
+	loop                            # label6:
 	i32.load	$push55=, 0($2)
 	tee_local	$push54=, $1=, $pop55
 	i32.load8_u	$push27=, 0($pop54)
 	i32.const	$push53=, 255
 	i32.and 	$push28=, $3, $pop53
 	i32.ne  	$push29=, $pop27, $pop28
-	br_if   	3, $pop29       # 3: down to label5
+	br_if   	3, $pop29       # 3: down to label4
 # BB#11:                                # %lor.lhs.false.i50
                                         #   in Loop: Header=BB1_10 Depth=1
 	i32.load8_u	$push30=, 1($1)
-	br_if   	3, $pop30       # 3: down to label5
+	br_if   	3, $pop30       # 3: down to label4
 # BB#12:                                # %lor.lhs.false.i50
                                         #   in Loop: Header=BB1_10 Depth=1
 	i32.const	$push59=, 0
@@ -159,7 +158,7 @@ x:                                      # @x
 	tee_local	$push57=, $1=, $pop58
 	i32.const	$push56=, 4
 	i32.ge_s	$push31=, $pop57, $pop56
-	br_if   	3, $pop31       # 3: down to label5
+	br_if   	3, $pop31       # 3: down to label4
 # BB#13:                                # %r.exit
                                         #   in Loop: Header=BB1_10 Depth=1
 	i32.const	$push66=, 0
@@ -177,29 +176,25 @@ x:                                      # @x
 	i32.const	$push60=, 4
 	i32.add 	$2=, $2, $pop60
 	i32.lt_s	$push33=, $5, $0
-	br_if   	0, $pop33       # 0: up to label7
+	br_if   	0, $pop33       # 0: up to label6
 .LBB1_14:                               # %cleanup
-	end_loop                        # label8:
-	end_block                       # label6:
+	end_loop                        # label7:
+	end_block                       # label5:
 	i32.const	$push67=, 0
 	return  	$pop67
 .LBB1_15:                               # %if.then.i51
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_16:                               # %if.else
 	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_17:                               # %if.then.i
+.LBB1_16:                               # %if.then.i46
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_18:                               # %if.then.i46
+.LBB1_17:                               # %if.else
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_19:                               # %if.then15
+.LBB1_18:                               # %if.then15
 	end_block                       # label1:
 	i32.call	$discard=, m@FUNCTION, $5
 	unreachable
@@ -219,7 +214,7 @@ s:                                      # @s
 	block
 	i32.const	$push0=, .L.str
 	i32.call	$push1=, strcmp@FUNCTION, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label9
+	br_if   	0, $pop1        # 0: down to label8
 # BB#1:                                 # %lor.lhs.false
 	i32.const	$push10=, 0
 	i32.const	$push9=, 0
@@ -230,7 +225,7 @@ s:                                      # @s
 	i32.store	$discard=, check($pop10), $pop2
 	i32.const	$push3=, 2
 	i32.ge_s	$push4=, $2, $pop3
-	br_if   	0, $pop4        # 0: down to label9
+	br_if   	0, $pop4        # 0: down to label8
 # BB#2:                                 # %if.end
 	i32.const	$push12=, 1
 	i32.add 	$push5=, $0, $pop12
@@ -238,7 +233,7 @@ s:                                      # @s
 	i32.const	$push11=, 0
 	return  	$pop11
 .LBB2_3:                                # %if.then
-	end_block                       # label9:
+	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -274,17 +269,17 @@ r:                                      # @r
 	i32.const	$push9=, 0
 	i32.load8_u	$push0=, r.c.0($pop9)
 	i32.ne  	$push1=, $pop10, $pop0
-	br_if   	0, $pop1        # 0: down to label10
+	br_if   	0, $pop1        # 0: down to label9
 # BB#1:                                 # %lor.lhs.false
 	i32.load8_u	$push2=, 1($0)
-	br_if   	0, $pop2        # 0: down to label10
+	br_if   	0, $pop2        # 0: down to label9
 # BB#2:                                 # %lor.lhs.false
 	i32.const	$push14=, 0
 	i32.load	$push13=, r.cnt($pop14)
 	tee_local	$push12=, $0=, $pop13
 	i32.const	$push3=, 4
 	i32.ge_s	$push4=, $pop12, $pop3
-	br_if   	0, $pop4        # 0: down to label10
+	br_if   	0, $pop4        # 0: down to label9
 # BB#3:                                 # %if.end
 	i32.const	$push7=, 0
 	i32.const	$push5=, 1
@@ -297,7 +292,7 @@ r:                                      # @r
 	i32.const	$push15=, 1
 	return  	$pop15
 .LBB4_4:                                # %if.then
-	end_block                       # label10:
+	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20010924-1.c.s
+++ b/test/torture-s/20010924-1.c.s
@@ -9,23 +9,11 @@ main:                                   # @main
 	.local  	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push37=, 0
 	i32.load8_u	$push0=, a1($pop37):p2align=2
 	i32.const	$push1=, 52
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label12
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push40=, 0
 	i32.load	$push39=, a1+4($pop40)
@@ -33,121 +21,73 @@ main:                                   # @main
 	i32.load8_u	$push3=, 0($pop38)
 	i32.const	$push4=, 54
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label11
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.load8_u	$push6=, 1($0)
 	i32.const	$push7=, 50
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label10
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end12
 	i32.load8_u	$push9=, 2($0)
-	br_if   	3, $pop9        # 3: down to label9
+	br_if   	0, $pop9        # 0: down to label0
 # BB#4:                                 # %if.end18
 	i32.const	$push41=, 0
 	i32.load8_u	$push10=, a2($pop41)
 	i32.const	$push11=, 118
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	4, $pop12       # 4: down to label8
+	br_if   	0, $pop12       # 0: down to label0
 # BB#5:                                 # %if.end23
 	i32.const	$push42=, 0
 	i32.load8_u	$push13=, a2+1($pop42)
 	i32.const	$push14=, 99
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	5, $pop15       # 5: down to label7
+	br_if   	0, $pop15       # 0: down to label0
 # BB#6:                                 # %if.end28
 	i32.const	$push43=, 0
 	i32.load8_u	$push16=, a2+2($pop43)
 	i32.const	$push17=, 113
 	i32.ne  	$push18=, $pop16, $pop17
-	br_if   	6, $pop18       # 6: down to label6
+	br_if   	0, $pop18       # 0: down to label0
 # BB#7:                                 # %if.end33
 	i32.const	$push44=, 0
 	i32.load8_u	$push19=, a3($pop44)
 	i32.const	$push20=, 111
 	i32.ne  	$push21=, $pop19, $pop20
-	br_if   	7, $pop21       # 7: down to label5
+	br_if   	0, $pop21       # 0: down to label0
 # BB#8:                                 # %if.end38
 	i32.const	$push45=, 0
 	i32.load8_u	$push22=, a3+1($pop45)
 	i32.const	$push23=, 119
 	i32.ne  	$push24=, $pop22, $pop23
-	br_if   	8, $pop24       # 8: down to label4
+	br_if   	0, $pop24       # 0: down to label0
 # BB#9:                                 # %if.end43
 	i32.const	$push46=, 0
 	i32.load8_u	$push25=, a3+2($pop46)
 	i32.const	$push26=, 120
 	i32.ne  	$push27=, $pop25, $pop26
-	br_if   	9, $pop27       # 9: down to label3
+	br_if   	0, $pop27       # 0: down to label0
 # BB#10:                                # %if.end48
 	i32.const	$push47=, 0
 	i32.load8_u	$push28=, a4($pop47)
 	i32.const	$push29=, 57
 	i32.ne  	$push30=, $pop28, $pop29
-	br_if   	10, $pop30      # 10: down to label2
+	br_if   	0, $pop30       # 0: down to label0
 # BB#11:                                # %if.end53
 	i32.const	$push48=, 0
 	i32.load8_u	$push31=, a4+1($pop48)
 	i32.const	$push32=, 101
 	i32.ne  	$push33=, $pop31, $pop32
-	br_if   	11, $pop33      # 11: down to label1
+	br_if   	0, $pop33       # 0: down to label0
 # BB#12:                                # %if.end58
 	i32.const	$push49=, 0
 	i32.load8_u	$push34=, a4+2($pop49)
 	i32.const	$push35=, 98
 	i32.ne  	$push36=, $pop34, $pop35
-	br_if   	12, $pop36      # 12: down to label0
+	br_if   	0, $pop36       # 0: down to label0
 # BB#13:                                # %if.end63
 	i32.const	$push50=, 0
 	return  	$pop50
-.LBB0_14:                               # %if.then
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then5
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then11
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then17
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then22
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then27
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_20:                               # %if.then32
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_21:                               # %if.then37
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_22:                               # %if.then42
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_23:                               # %if.then47
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then52
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then57
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then62
+.LBB0_14:                               # %if.then62
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20011219-1.c.s
+++ b/test/torture-s/20011219-1.c.s
@@ -31,35 +31,11 @@ foo:                                    # @foo
 	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	tableswitch	$0, 0, 0, 1, 2, 3, 4 # 0: down to label5
-                                        # 1: down to label4
-                                        # 2: down to label3
-                                        # 3: down to label2
-                                        # 4: down to label1
-.LBB1_2:                                # %sw.bb
-	end_block                       # label5:
-	i32.load	$2=, 0($1)
-	br      	4               # 4: down to label0
-.LBB1_3:                                # %sw.bb1
-	end_block                       # label4:
-	i32.load	$2=, 0($1)
-	br      	3               # 3: down to label0
-.LBB1_4:                                # %sw.bb2
-	end_block                       # label3:
-	i32.load	$2=, 0($1)
-	br      	2               # 2: down to label0
-.LBB1_5:                                # %sw.bb3
-	end_block                       # label2:
-	i32.load	$2=, 0($1)
-	br      	1               # 1: down to label0
-.LBB1_6:                                # %sw.bb4
+	tableswitch	$0, 0, 0, 0, 0, 0, 0 # 0: down to label1
+.LBB1_2:                                # %sw.bb4
 	end_block                       # label1:
 	i32.load	$2=, 0($1)
-.LBB1_7:                                # %sw.epilog
+.LBB1_3:                                # %sw.epilog
 	end_block                       # label0:
 	return  	$2
 	.endfunc

--- a/test/torture-s/20020129-1.c.s
+++ b/test/torture-s/20020129-1.c.s
@@ -11,19 +11,20 @@ foo:                                    # @foo
 	i32.load	$3=, 28($1)
 	block
 	block
+	block
+	block
+	block
 	i32.load	$push0=, 28($0)
 	i32.const	$push17=, 0
 	i32.eq  	$push18=, $pop0, $pop17
-	br_if   	0, $pop18       # 0: down to label1
+	br_if   	0, $pop18       # 0: down to label4
 # BB#1:                                 # %if.end
 	i32.const	$push19=, 0
 	i32.eq  	$push20=, $3, $pop19
-	br_if   	1, $pop20       # 1: down to label0
-# BB#2:                                 # %if.then6
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
+	br_if   	1, $pop20       # 1: down to label3
+	br      	2               # 2: down to label2
+.LBB0_2:                                # %if.then
+	end_block                       # label4:
 	i32.const	$push1=, 28
 	i32.add 	$push2=, $0, $pop1
 	i32.store	$discard=, 0($pop2), $3
@@ -33,32 +34,31 @@ foo:                                    # @foo
 	i32.store	$discard=, 0($pop3), $pop4
 	i32.const	$push21=, 0
 	i32.eq  	$push22=, $3, $pop21
-	br_if   	0, $pop22       # 0: down to label0
-.LBB0_4:                                # %for.body
+	br_if   	0, $pop22       # 0: down to label3
+.LBB0_3:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label2:
+	loop                            # label5:
 	i32.store	$discard=, 4($3), $0
 	i32.load	$3=, 0($3)
-	br_if   	0, $3           # 0: up to label2
-.LBB0_5:                                # %if.end7
-	end_loop                        # label3:
-	end_block                       # label0:
+	br_if   	0, $3           # 0: up to label5
+.LBB0_4:                                # %if.end7
+	end_loop                        # label6:
+	end_block                       # label3:
 	i32.load	$3=, 12($1)
-	block
-	block
 	i32.load	$push5=, 12($0)
 	i32.const	$push13=, -1
 	i32.eq  	$push6=, $pop5, $pop13
-	br_if   	0, $pop6        # 0: down to label5
-# BB#6:                                 # %if.end22
+	br_if   	1, $pop6        # 1: down to label1
+# BB#5:                                 # %if.end22
 	i32.const	$push16=, -1
 	i32.eq  	$push7=, $3, $pop16
-	br_if   	1, $pop7        # 1: down to label4
-# BB#7:                                 # %if.then26
+	br_if   	2, $pop7        # 2: down to label0
+.LBB0_6:                                # %if.then26
+	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_8:                                # %if.end22.thread
-	end_block                       # label5:
+.LBB0_7:                                # %if.end22.thread
+	end_block                       # label1:
 	i32.load	$2=, 16($1)
 	i32.const	$push8=, 12
 	i32.add 	$push9=, $0, $pop8
@@ -70,8 +70,8 @@ foo:                                    # @foo
 	i32.store	$discard=, 0($pop10), $pop14
 	i32.const	$push11=, 0
 	i32.store	$discard=, 16($1), $pop11
-.LBB0_9:                                # %if.end27
-	end_block                       # label4:
+.LBB0_8:                                # %if.end27
+	end_block                       # label0:
 	return
 	.endfunc
 .Lfunc_end0:

--- a/test/torture-s/20020201-1.c.s
+++ b/test/torture-s/20020201-1.c.s
@@ -17,23 +17,17 @@ main:                                   # @main
 	i32.const	$push41=, 255
 	i32.and 	$push3=, $pop2, $pop41
 	i32.const	$push40=, 6
-	i32.lt_u	$push4=, $pop3, $pop40
+	i32.ge_u	$push4=, $pop3, $pop40
 	br_if   	0, $pop4        # 0: down to label0
-# BB#1:                                 # %if.then
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_2:                                # %if.end
-	end_block                       # label0:
-	block
-	block
+# BB#1:                                 # %if.end
 	i32.const	$push45=, 255
 	i32.and 	$push5=, $0, $pop45
 	i32.const	$push44=, 6
 	i32.rem_u	$push6=, $pop5, $pop44
 	i32.const	$push7=, 1
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	0, $pop8        # 0: down to label2
-# BB#3:                                 # %if.end10
+	br_if   	0, $pop8        # 0: down to label0
+# BB#2:                                 # %if.end10
 	i32.const	$push9=, 0
 	i32.load16_u	$push49=, sx($pop9)
 	tee_local	$push48=, $0=, $pop49
@@ -42,106 +36,67 @@ main:                                   # @main
 	i32.const	$push47=, 65535
 	i32.and 	$push12=, $pop11, $pop47
 	i32.const	$push46=, 6
-	i32.lt_u	$push13=, $pop12, $pop46
-	br_if   	1, $pop13       # 1: down to label1
-# BB#4:                                 # %if.then17
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then9
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.end18
-	end_block                       # label1:
-	block
-	block
+	i32.ge_u	$push13=, $pop12, $pop46
+	br_if   	0, $pop13       # 0: down to label0
+# BB#3:                                 # %if.end18
 	i32.const	$push51=, 65535
 	i32.and 	$push14=, $0, $pop51
 	i32.const	$push50=, 6
 	i32.rem_u	$push15=, $pop14, $pop50
 	i32.const	$push16=, 2
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	0, $pop17       # 0: down to label4
-# BB#7:                                 # %if.end26
+	br_if   	0, $pop17       # 0: down to label0
+# BB#4:                                 # %if.end26
 	i32.const	$push18=, 0
 	i32.load	$push54=, ix($pop18)
 	tee_local	$push53=, $0=, $pop54
 	i32.const	$push19=, -18
 	i32.add 	$push20=, $pop53, $pop19
 	i32.const	$push52=, 6
-	i32.lt_u	$push21=, $pop20, $pop52
-	br_if   	1, $pop21       # 1: down to label3
-# BB#8:                                 # %if.then30
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then25
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.end31
-	end_block                       # label3:
-	block
-	block
+	i32.ge_u	$push21=, $pop20, $pop52
+	br_if   	0, $pop21       # 0: down to label0
+# BB#5:                                 # %if.end31
 	i32.const	$push55=, 6
 	i32.rem_u	$push22=, $0, $pop55
 	i32.const	$push23=, 3
 	i32.ne  	$push24=, $pop22, $pop23
-	br_if   	0, $pop24       # 0: down to label6
-# BB#11:                                # %if.end36
+	br_if   	0, $pop24       # 0: down to label0
+# BB#6:                                 # %if.end36
 	i32.const	$push25=, 0
 	i32.load	$push58=, lx($pop25)
 	tee_local	$push57=, $0=, $pop58
 	i32.const	$push26=, -24
 	i32.add 	$push27=, $pop57, $pop26
 	i32.const	$push56=, 6
-	i32.lt_u	$push28=, $pop27, $pop56
-	br_if   	1, $pop28       # 1: down to label5
-# BB#12:                                # %if.then40
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then35
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.end41
-	end_block                       # label5:
-	block
-	block
+	i32.ge_u	$push28=, $pop27, $pop56
+	br_if   	0, $pop28       # 0: down to label0
+# BB#7:                                 # %if.end41
 	i32.const	$push59=, 6
 	i32.rem_u	$push29=, $0, $pop59
 	i32.const	$push30=, 4
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	0, $pop31       # 0: down to label8
-# BB#15:                                # %if.end46
+	br_if   	0, $pop31       # 0: down to label0
+# BB#8:                                 # %if.end46
 	i32.const	$push32=, 0
 	i64.load	$push62=, Lx($pop32)
 	tee_local	$push61=, $1=, $pop62
 	i64.const	$push33=, -30
 	i64.add 	$push34=, $pop61, $pop33
 	i64.const	$push60=, 6
-	i64.lt_u	$push35=, $pop34, $pop60
-	br_if   	1, $pop35       # 1: down to label7
-# BB#16:                                # %if.then50
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then45
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.end51
-	end_block                       # label7:
-	block
+	i64.ge_u	$push35=, $pop34, $pop60
+	br_if   	0, $pop35       # 0: down to label0
+# BB#9:                                 # %if.end51
 	i64.const	$push63=, 6
 	i64.rem_u	$push36=, $1, $pop63
 	i64.const	$push37=, 5
 	i64.ne  	$push38=, $pop36, $pop37
-	br_if   	0, $pop38       # 0: down to label9
-# BB#19:                                # %if.end56
+	br_if   	0, $pop38       # 0: down to label0
+# BB#10:                                # %if.end56
 	i32.const	$push39=, 0
 	call    	exit@FUNCTION, $pop39
 	unreachable
-.LBB0_20:                               # %if.then55
-	end_block                       # label9:
+.LBB0_11:                               # %if.then55
+	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20020226-1.c.s
+++ b/test/torture-s/20020226-1.c.s
@@ -9,26 +9,6 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i64, i64, i64, i64, i64, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push0=, 0
 	i32.load8_u	$push125=, uc($pop0)
 	tee_local	$push124=, $2=, $pop125
@@ -43,7 +23,7 @@ main:                                   # @main
 	i32.or  	$push4=, $pop3, $pop1
 	i32.const	$push118=, 835
 	i32.ne  	$push5=, $pop4, $pop118
-	br_if   	0, $pop5        # 0: down to label20
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 4
 	i32.shr_u	$push7=, $2, $pop6
@@ -52,7 +32,7 @@ main:                                   # @main
 	i32.or  	$push9=, $pop7, $pop8
 	i32.const	$push126=, 835
 	i32.ne  	$push10=, $pop9, $pop126
-	br_if   	1, $pop10       # 1: down to label19
+	br_if   	0, $pop10       # 0: down to label0
 # BB#2:                                 # %if.end11
 	i32.const	$push11=, 0
 	i32.load16_u	$push132=, us($pop11)
@@ -65,7 +45,7 @@ main:                                   # @main
 	i32.or  	$push15=, $pop12, $pop14
 	i32.const	$push128=, 19087651
 	i32.ne  	$push16=, $pop15, $pop128
-	br_if   	2, $pop16       # 2: down to label18
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end21
 	i32.const	$push17=, 4
 	i32.shr_u	$push18=, $4, $pop17
@@ -74,7 +54,7 @@ main:                                   # @main
 	i32.or  	$push21=, $pop18, $pop20
 	i32.const	$push133=, 19087651
 	i32.ne  	$push22=, $pop21, $pop133
-	br_if   	3, $pop22       # 3: down to label17
+	br_if   	0, $pop22       # 0: down to label0
 # BB#4:                                 # %if.end30
 	i32.const	$push23=, 0
 	i32.load	$push138=, ui($pop23)
@@ -87,7 +67,7 @@ main:                                   # @main
 	i32.or  	$push27=, $pop24, $pop26
 	i32.const	$push134=, 1073742115
 	i32.ne  	$push28=, $pop27, $pop134
-	br_if   	4, $pop28       # 4: down to label16
+	br_if   	0, $pop28       # 0: down to label0
 # BB#5:                                 # %if.end38
 	i32.const	$push29=, 4
 	i32.shr_u	$push30=, $6, $pop29
@@ -96,7 +76,7 @@ main:                                   # @main
 	i32.or  	$push33=, $pop30, $pop32
 	i32.const	$push139=, 1073742115
 	i32.ne  	$push34=, $pop33, $pop139
-	br_if   	5, $pop34       # 5: down to label15
+	br_if   	0, $pop34       # 0: down to label0
 # BB#6:                                 # %if.end45
 	i32.const	$push35=, 0
 	i32.load	$push142=, ul($pop35)
@@ -106,7 +86,7 @@ main:                                   # @main
 	i32.or  	$push38=, $pop36, $pop37
 	i32.const	$push140=, -2128394905
 	i32.ne  	$push39=, $pop38, $pop140
-	br_if   	6, $pop39       # 6: down to label14
+	br_if   	0, $pop39       # 0: down to label0
 # BB#7:                                 # %if.end53
 	i32.const	$push40=, 4
 	i32.shr_u	$push41=, $7, $pop40
@@ -115,7 +95,7 @@ main:                                   # @main
 	i32.or  	$push44=, $pop41, $pop43
 	i32.const	$push143=, -2128394905
 	i32.ne  	$push45=, $pop44, $pop143
-	br_if   	7, $pop45       # 7: down to label13
+	br_if   	0, $pop45       # 0: down to label0
 # BB#8:                                 # %if.end60
 	i32.const	$push46=, 0
 	i64.load	$push150=, ull($pop46)
@@ -131,7 +111,7 @@ main:                                   # @main
 	i64.or  	$push51=, $pop47, $pop50
 	i64.const	$push144=, 5124095577148911
 	i64.ne  	$push52=, $pop51, $pop144
-	br_if   	8, $pop52       # 8: down to label12
+	br_if   	0, $pop52       # 0: down to label0
 # BB#9:                                 # %if.end69
 	i64.const	$push53=, 4
 	i64.shr_u	$push54=, $10, $pop53
@@ -140,7 +120,7 @@ main:                                   # @main
 	i64.or  	$push57=, $pop54, $pop56
 	i64.const	$push151=, 5124095577148911
 	i64.ne  	$push58=, $pop57, $pop151
-	br_if   	9, $pop58       # 9: down to label11
+	br_if   	0, $pop58       # 0: down to label0
 # BB#10:                                # %if.end76
 	i32.const	$push61=, 64
 	i32.const	$push59=, 0
@@ -156,7 +136,7 @@ main:                                   # @main
 	i64.or  	$push64=, $pop63, $pop60
 	i64.const	$push152=, 1311768467750121216
 	i64.ne  	$push65=, $pop64, $pop152
-	br_if   	10, $pop65      # 10: down to label10
+	br_if   	0, $pop65       # 0: down to label0
 # BB#11:                                # %if.end86
 	i64.const	$push66=, 60
 	i64.shr_u	$push67=, $10, $pop66
@@ -165,21 +145,21 @@ main:                                   # @main
 	i64.or  	$push70=, $pop67, $pop69
 	i64.const	$push159=, 1311768467750121216
 	i64.ne  	$push71=, $pop70, $pop159
-	br_if   	11, $pop71      # 11: down to label9
+	br_if   	0, $pop71       # 0: down to label0
 # BB#12:                                # %if.end93
 	i32.shr_u	$push73=, $2, $0
 	i32.shl 	$push72=, $2, $1
 	i32.or  	$push74=, $pop73, $pop72
 	i32.const	$push75=, 835
 	i32.ne  	$push76=, $pop74, $pop75
-	br_if   	12, $pop76      # 12: down to label8
+	br_if   	0, $pop76       # 0: down to label0
 # BB#13:                                # %if.end112
 	i32.shl 	$push77=, $4, $1
 	i32.shr_u	$push78=, $4, $3
 	i32.or  	$push79=, $pop77, $pop78
 	i32.const	$push160=, 74561
 	i32.ne  	$push80=, $pop79, $pop160
-	br_if   	13, $pop80      # 13: down to label7
+	br_if   	0, $pop80       # 0: down to label0
 # BB#14:                                # %if.end122
 	i32.const	$push81=, 4
 	i32.shl 	$push82=, $4, $pop81
@@ -188,14 +168,14 @@ main:                                   # @main
 	i32.or  	$push85=, $pop82, $pop84
 	i32.const	$push161=, 74561
 	i32.ne  	$push86=, $pop85, $pop161
-	br_if   	14, $pop86      # 14: down to label6
+	br_if   	0, $pop86       # 0: down to label0
 # BB#15:                                # %if.end131
 	i32.shl 	$push87=, $6, $1
 	i32.shr_u	$push88=, $6, $5
 	i32.or  	$push89=, $pop87, $pop88
 	i32.const	$push162=, 74560
 	i32.ne  	$push90=, $pop89, $pop162
-	br_if   	15, $pop90      # 15: down to label5
+	br_if   	0, $pop90       # 0: down to label0
 # BB#16:                                # %if.end139
 	i32.const	$push91=, 4
 	i32.shl 	$push92=, $6, $pop91
@@ -204,14 +184,14 @@ main:                                   # @main
 	i32.or  	$push95=, $pop92, $pop94
 	i32.const	$push163=, 74560
 	i32.ne  	$push96=, $pop95, $pop163
-	br_if   	16, $pop96      # 16: down to label4
+	br_if   	0, $pop96       # 0: down to label0
 # BB#17:                                # %if.end146
 	i32.shl 	$push97=, $7, $1
 	i32.shr_u	$push98=, $7, $5
 	i32.or  	$push99=, $pop97, $pop98
 	i32.const	$push164=, 591751041
 	i32.ne  	$push100=, $pop99, $pop164
-	br_if   	17, $pop100     # 17: down to label3
+	br_if   	0, $pop100      # 0: down to label0
 # BB#18:                                # %if.end154
 	i32.const	$push101=, 4
 	i32.shl 	$push102=, $7, $pop101
@@ -220,106 +200,26 @@ main:                                   # @main
 	i32.or  	$push105=, $pop102, $pop104
 	i32.const	$push165=, 591751041
 	i32.ne  	$push106=, $pop105, $pop165
-	br_if   	18, $pop106     # 18: down to label2
+	br_if   	0, $pop106      # 0: down to label0
 # BB#19:                                # %if.end161
 	i64.shl 	$push107=, $10, $9
 	i64.shr_u	$push108=, $10, $8
 	i64.or  	$push109=, $pop107, $pop108
 	i64.const	$push110=, 1311768467750121216
 	i64.ne  	$push111=, $pop109, $pop110
-	br_if   	19, $pop111     # 19: down to label1
+	br_if   	0, $pop111      # 0: down to label0
 # BB#20:                                # %if.end178
 	i64.shr_u	$push113=, $10, $12
 	i64.shl 	$push112=, $10, $11
 	i64.or  	$push114=, $pop113, $pop112
 	i64.const	$push115=, 5124095577148911
 	i64.ne  	$push116=, $pop114, $pop115
-	br_if   	20, $pop116     # 20: down to label0
+	br_if   	0, $pop116      # 0: down to label0
 # BB#21:                                # %if.end195
 	i32.const	$push117=, 0
 	call    	exit@FUNCTION, $pop117
 	unreachable
-.LBB0_22:                               # %if.then
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_23:                               # %if.then10
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then20
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then29
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then37
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_27:                               # %if.then44
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_28:                               # %if.then52
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_29:                               # %if.then59
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_30:                               # %if.then68
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_31:                               # %if.then75
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_32:                               # %if.then85
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_33:                               # %if.then92
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_34:                               # %if.then102
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_35:                               # %if.then121
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_36:                               # %if.then130
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_37:                               # %if.then138
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_38:                               # %if.then145
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_39:                               # %if.then153
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_40:                               # %if.then160
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_41:                               # %if.then170
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_42:                               # %if.then187
+.LBB0_22:                               # %if.then187
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20020402-3.c.s
+++ b/test/torture-s/20020402-3.c.s
@@ -9,77 +9,81 @@ blockvector_for_pc_sect:                # @blockvector_for_pc_sect
 	.result 	i32
 	.local  	i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$4=, 0
+	block
+	block
 	i32.load	$push23=, 0($1)
 	tee_local	$push22=, $5=, $pop23
-	i32.load	$1=, 0($pop22)
-	i32.const	$4=, 0
-	copy_local	$3=, $1
-	block
-	block
-	i32.const	$push21=, 1
-	i32.le_s	$push0=, $1, $pop21
+	i32.load	$push21=, 0($pop22)
+	tee_local	$push20=, $1=, $pop21
+	i32.const	$push19=, 1
+	i32.le_s	$push0=, $pop20, $pop19
 	br_if   	0, $pop0        # 0: down to label1
-.LBB0_1:                                # %while.body
+# BB#1:
+	copy_local	$3=, $1
+.LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.const	$push31=, 1
-	i32.add 	$push1=, $1, $pop31
-	i32.const	$push30=, 1
-	i32.shr_s	$push29=, $pop1, $pop30
-	tee_local	$push28=, $7=, $pop29
-	i32.add 	$1=, $pop28, $4
-	i32.const	$push2=, 2
-	i32.shl 	$push3=, $1, $pop2
-	i32.add 	$push4=, $5, $pop3
-	i32.const	$push5=, 4
-	i32.add 	$push6=, $pop4, $pop5
-	i32.load	$push7=, 0($pop6)
-	i64.load	$push8=, 0($pop7)
-	i64.gt_u	$push27=, $pop8, $0
+	i32.const	$push33=, 1
+	i32.add 	$push1=, $1, $pop33
+	i32.const	$push32=, 1
+	i32.shr_s	$push31=, $pop1, $pop32
+	tee_local	$push30=, $7=, $pop31
+	i32.add 	$1=, $pop30, $4
+	i32.const	$push29=, 2
+	i32.shl 	$push2=, $1, $pop29
+	i32.add 	$push3=, $5, $pop2
+	i32.const	$push28=, 4
+	i32.add 	$push4=, $pop3, $pop28
+	i32.load	$push5=, 0($pop4)
+	i64.load	$push6=, 0($pop5)
+	i64.gt_u	$push27=, $pop6, $0
 	tee_local	$push26=, $6=, $pop27
 	i32.select	$4=, $4, $1, $pop26
 	i32.select	$2=, $1, $3, $6
-	i32.sub 	$push9=, $3, $1
-	i32.select	$1=, $7, $pop9, $6
+	i32.sub 	$push7=, $3, $1
+	i32.select	$1=, $7, $pop7, $6
 	copy_local	$3=, $2
 	i32.const	$push25=, 1
-	i32.gt_s	$push10=, $1, $pop25
-	br_if   	0, $pop10       # 0: up to label2
-# BB#2:                                 # %while.cond8.preheader
+	i32.gt_s	$push8=, $1, $pop25
+	br_if   	0, $pop8        # 0: up to label2
+# BB#3:                                 # %while.cond8.preheader
 	end_loop                        # label3:
 	i32.const	$3=, 0
-	i32.const	$push11=, -1
-	i32.le_s	$push12=, $4, $pop11
-	br_if   	1, $pop12       # 1: down to label0
-.LBB0_3:                                # %while.body10.preheader
+	i32.const	$push9=, -1
+	i32.le_s	$push10=, $4, $pop9
+	br_if   	1, $pop10       # 1: down to label0
+.LBB0_4:                                # %while.body10.preheader
 	end_block                       # label1:
-	i32.const	$push13=, 2
-	i32.shl 	$push14=, $4, $pop13
-	i32.add 	$push15=, $pop14, $5
-	i32.const	$push16=, 4
-	i32.add 	$1=, $pop15, $pop16
+	i32.const	$push11=, 2
+	i32.shl 	$push12=, $4, $pop11
+	i32.add 	$push13=, $pop12, $5
+	i32.const	$push14=, 4
+	i32.add 	$1=, $pop13, $pop14
 	i32.const	$push24=, 1
 	i32.add 	$4=, $4, $pop24
-.LBB0_4:                                # %while.body10
+.LBB0_5:                                # %while.body10
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label4:
-	copy_local	$3=, $5
-	i32.load	$push17=, 0($1)
-	i64.load	$push18=, 8($pop17)
-	i64.gt_u	$push19=, $pop18, $0
-	br_if   	1, $pop19       # 1: down to label5
-# BB#5:                                 # %while.cond8
-                                        #   in Loop: Header=BB0_4 Depth=1
-	i32.const	$push34=, -1
-	i32.add 	$4=, $4, $pop34
-	i32.const	$push33=, -4
-	i32.add 	$1=, $1, $pop33
+	i32.load	$push15=, 0($1)
+	i64.load	$push16=, 8($pop15)
+	i64.gt_u	$push17=, $pop16, $0
+	br_if   	1, $pop17       # 1: down to label5
+# BB#6:                                 # %while.cond8
+                                        #   in Loop: Header=BB0_5 Depth=1
+	i32.const	$push36=, -1
+	i32.add 	$4=, $4, $pop36
+	i32.const	$push35=, -4
+	i32.add 	$1=, $1, $pop35
 	i32.const	$3=, 0
-	i32.const	$push32=, 1
-	i32.ge_s	$push20=, $4, $pop32
-	br_if   	0, $pop20       # 0: up to label4
-.LBB0_6:                                # %cleanup
+	i32.const	$push34=, 1
+	i32.ge_s	$push18=, $4, $pop34
+	br_if   	0, $pop18       # 0: up to label4
+	br      	2               # 2: down to label0
+.LBB0_7:
 	end_loop                        # label5:
+	copy_local	$3=, $5
+.LBB0_8:                                # %cleanup
 	end_block                       # label0:
 	return  	$3
 	.endfunc

--- a/test/torture-s/20020418-1.c.s
+++ b/test/torture-s/20020418-1.c.s
@@ -8,25 +8,26 @@ gcc_crash:                              # @gcc_crash
 	.param  	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.load	$1=, 0($0)
-	copy_local	$2=, $1
 	block
+	i32.load	$push4=, 0($0)
+	tee_local	$push3=, $2=, $pop4
 	i32.const	$push0=, 52
-	i32.lt_s	$push1=, $1, $pop0
+	i32.lt_s	$push1=, $pop3, $pop0
 	br_if   	0, $pop1        # 0: down to label0
-.LBB0_1:                                # %top
+# BB#1:
+	i32.const	$push2=, 60
+	i32.gt_s	$1=, $2, $pop2
+.LBB0_2:                                # %top
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push4=, 1
-	i32.add 	$2=, $2, $pop4
-	i32.const	$push2=, 60
-	i32.gt_s	$push3=, $1, $pop2
-	br_if   	0, $pop3        # 0: up to label1
-# BB#2:                                 # %if.end6
+	i32.const	$push5=, 1
+	i32.add 	$2=, $2, $pop5
+	br_if   	0, $1           # 0: up to label1
+# BB#3:                                 # %if.end6
 	end_loop                        # label2:
 	i32.store	$discard=, 0($0), $2
 	return
-.LBB0_3:                                # %if.then
+.LBB0_4:                                # %if.then
 	end_block                       # label0:
 	unreachable
 	unreachable

--- a/test/torture-s/20020508-1.c.s
+++ b/test/torture-s/20020508-1.c.s
@@ -9,26 +9,6 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i64, i64, i64, i64, i64, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push0=, 0
 	i32.load8_u	$push125=, uc($pop0)
 	tee_local	$push124=, $2=, $pop125
@@ -43,7 +23,7 @@ main:                                   # @main
 	i32.or  	$push4=, $pop3, $pop1
 	i32.const	$push118=, 835
 	i32.ne  	$push5=, $pop4, $pop118
-	br_if   	0, $pop5        # 0: down to label20
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 4
 	i32.shr_u	$push7=, $2, $pop6
@@ -52,7 +32,7 @@ main:                                   # @main
 	i32.or  	$push9=, $pop7, $pop8
 	i32.const	$push126=, 835
 	i32.ne  	$push10=, $pop9, $pop126
-	br_if   	1, $pop10       # 1: down to label19
+	br_if   	0, $pop10       # 0: down to label0
 # BB#2:                                 # %if.end11
 	i32.const	$push11=, 0
 	i32.load16_u	$push132=, us($pop11)
@@ -65,7 +45,7 @@ main:                                   # @main
 	i32.or  	$push15=, $pop12, $pop14
 	i32.const	$push128=, 253972259
 	i32.ne  	$push16=, $pop15, $pop128
-	br_if   	2, $pop16       # 2: down to label18
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end21
 	i32.const	$push17=, 4
 	i32.shr_u	$push18=, $4, $pop17
@@ -74,7 +54,7 @@ main:                                   # @main
 	i32.or  	$push21=, $pop18, $pop20
 	i32.const	$push133=, 253972259
 	i32.ne  	$push22=, $pop21, $pop133
-	br_if   	3, $pop22       # 3: down to label17
+	br_if   	0, $pop22       # 0: down to label0
 # BB#4:                                 # %if.end30
 	i32.const	$push23=, 0
 	i32.load	$push138=, ui($pop23)
@@ -87,7 +67,7 @@ main:                                   # @main
 	i32.or  	$push27=, $pop24, $pop26
 	i32.const	$push134=, 1073745699
 	i32.ne  	$push28=, $pop27, $pop134
-	br_if   	4, $pop28       # 4: down to label16
+	br_if   	0, $pop28       # 0: down to label0
 # BB#5:                                 # %if.end38
 	i32.const	$push29=, 4
 	i32.shr_u	$push30=, $6, $pop29
@@ -96,7 +76,7 @@ main:                                   # @main
 	i32.or  	$push33=, $pop30, $pop32
 	i32.const	$push139=, 1073745699
 	i32.ne  	$push34=, $pop33, $pop139
-	br_if   	5, $pop34       # 5: down to label15
+	br_if   	0, $pop34       # 0: down to label0
 # BB#6:                                 # %if.end45
 	i32.const	$push35=, 0
 	i32.load	$push142=, ul($pop35)
@@ -106,7 +86,7 @@ main:                                   # @main
 	i32.or  	$push38=, $pop36, $pop37
 	i32.const	$push140=, -1893513881
 	i32.ne  	$push39=, $pop38, $pop140
-	br_if   	6, $pop39       # 6: down to label14
+	br_if   	0, $pop39       # 0: down to label0
 # BB#7:                                 # %if.end53
 	i32.const	$push40=, 4
 	i32.shr_u	$push41=, $7, $pop40
@@ -115,7 +95,7 @@ main:                                   # @main
 	i32.or  	$push44=, $pop41, $pop43
 	i32.const	$push143=, -1893513881
 	i32.ne  	$push45=, $pop44, $pop143
-	br_if   	7, $pop45       # 7: down to label13
+	br_if   	0, $pop45       # 0: down to label0
 # BB#8:                                 # %if.end60
 	i32.const	$push46=, 0
 	i64.load	$push150=, ull($pop46)
@@ -131,7 +111,7 @@ main:                                   # @main
 	i64.or  	$push51=, $pop47, $pop50
 	i64.const	$push144=, 68174490360335855
 	i64.ne  	$push52=, $pop51, $pop144
-	br_if   	8, $pop52       # 8: down to label12
+	br_if   	0, $pop52       # 0: down to label0
 # BB#9:                                 # %if.end69
 	i64.const	$push53=, 4
 	i64.shr_u	$push54=, $10, $pop53
@@ -140,7 +120,7 @@ main:                                   # @main
 	i64.or  	$push57=, $pop54, $pop56
 	i64.const	$push151=, 68174490360335855
 	i64.ne  	$push58=, $pop57, $pop151
-	br_if   	9, $pop58       # 9: down to label11
+	br_if   	0, $pop58       # 0: down to label0
 # BB#10:                                # %if.end76
 	i32.const	$push61=, 64
 	i32.const	$push59=, 0
@@ -156,7 +136,7 @@ main:                                   # @main
 	i64.or  	$push64=, $pop63, $pop60
 	i64.const	$push152=, -994074541463572736
 	i64.ne  	$push65=, $pop64, $pop152
-	br_if   	10, $pop65      # 10: down to label10
+	br_if   	0, $pop65       # 0: down to label0
 # BB#11:                                # %if.end86
 	i64.const	$push66=, 60
 	i64.shr_u	$push67=, $10, $pop66
@@ -165,21 +145,21 @@ main:                                   # @main
 	i64.or  	$push70=, $pop67, $pop69
 	i64.const	$push159=, -994074541463572736
 	i64.ne  	$push71=, $pop70, $pop159
-	br_if   	11, $pop71      # 11: down to label9
+	br_if   	0, $pop71       # 0: down to label0
 # BB#12:                                # %if.end93
 	i32.shr_u	$push73=, $2, $0
 	i32.shl 	$push72=, $2, $1
 	i32.or  	$push74=, $pop73, $pop72
 	i32.const	$push75=, 835
 	i32.ne  	$push76=, $pop74, $pop75
-	br_if   	12, $pop76      # 12: down to label8
+	br_if   	0, $pop76       # 0: down to label0
 # BB#13:                                # %if.end112
 	i32.shl 	$push77=, $4, $1
 	i32.shr_u	$push78=, $4, $3
 	i32.or  	$push79=, $pop77, $pop78
 	i32.const	$push160=, 992079
 	i32.ne  	$push80=, $pop79, $pop160
-	br_if   	13, $pop80      # 13: down to label7
+	br_if   	0, $pop80       # 0: down to label0
 # BB#14:                                # %if.end122
 	i32.const	$push81=, 4
 	i32.shl 	$push82=, $4, $pop81
@@ -188,14 +168,14 @@ main:                                   # @main
 	i32.or  	$push85=, $pop82, $pop84
 	i32.const	$push161=, 992079
 	i32.ne  	$push86=, $pop85, $pop161
-	br_if   	14, $pop86      # 14: down to label6
+	br_if   	0, $pop86       # 0: down to label0
 # BB#15:                                # %if.end131
 	i32.shl 	$push87=, $6, $1
 	i32.shr_u	$push88=, $6, $5
 	i32.or  	$push89=, $pop87, $pop88
 	i32.const	$push162=, 992064
 	i32.ne  	$push90=, $pop89, $pop162
-	br_if   	15, $pop90      # 15: down to label5
+	br_if   	0, $pop90       # 0: down to label0
 # BB#16:                                # %if.end139
 	i32.const	$push91=, 4
 	i32.shl 	$push92=, $6, $pop91
@@ -204,14 +184,14 @@ main:                                   # @main
 	i32.or  	$push95=, $pop92, $pop94
 	i32.const	$push163=, 992064
 	i32.ne  	$push96=, $pop95, $pop163
-	br_if   	16, $pop96      # 16: down to label4
+	br_if   	0, $pop96       # 0: down to label0
 # BB#17:                                # %if.end146
 	i32.shl 	$push97=, $7, $1
 	i32.shr_u	$push98=, $7, $5
 	i32.or  	$push99=, $pop97, $pop98
 	i32.const	$push164=, 591751055
 	i32.ne  	$push100=, $pop99, $pop164
-	br_if   	17, $pop100     # 17: down to label3
+	br_if   	0, $pop100      # 0: down to label0
 # BB#18:                                # %if.end154
 	i32.const	$push101=, 4
 	i32.shl 	$push102=, $7, $pop101
@@ -220,106 +200,26 @@ main:                                   # @main
 	i32.or  	$push105=, $pop102, $pop104
 	i32.const	$push165=, 591751055
 	i32.ne  	$push106=, $pop105, $pop165
-	br_if   	18, $pop106     # 18: down to label2
+	br_if   	0, $pop106      # 0: down to label0
 # BB#19:                                # %if.end161
 	i64.shl 	$push107=, $10, $9
 	i64.shr_u	$push108=, $10, $8
 	i64.or  	$push109=, $pop107, $pop108
 	i64.const	$push110=, -994074541463572736
 	i64.ne  	$push111=, $pop109, $pop110
-	br_if   	19, $pop111     # 19: down to label1
+	br_if   	0, $pop111      # 0: down to label0
 # BB#20:                                # %if.end178
 	i64.shr_u	$push113=, $10, $12
 	i64.shl 	$push112=, $10, $11
 	i64.or  	$push114=, $pop113, $pop112
 	i64.const	$push115=, 68174490360335855
 	i64.ne  	$push116=, $pop114, $pop115
-	br_if   	20, $pop116     # 20: down to label0
+	br_if   	0, $pop116      # 0: down to label0
 # BB#21:                                # %if.end195
 	i32.const	$push117=, 0
 	call    	exit@FUNCTION, $pop117
 	unreachable
-.LBB0_22:                               # %if.then
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_23:                               # %if.then10
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then20
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then29
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then37
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_27:                               # %if.then44
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_28:                               # %if.then52
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_29:                               # %if.then59
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_30:                               # %if.then68
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_31:                               # %if.then75
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_32:                               # %if.then85
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_33:                               # %if.then92
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_34:                               # %if.then102
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_35:                               # %if.then121
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_36:                               # %if.then130
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_37:                               # %if.then138
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_38:                               # %if.then145
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_39:                               # %if.then153
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_40:                               # %if.then160
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_41:                               # %if.then170
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_42:                               # %if.then187
+.LBB0_22:                               # %if.then187
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20020508-2.c.s
+++ b/test/torture-s/20020508-2.c.s
@@ -9,26 +9,6 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i64, i64, i64, i64, i64, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push0=, 0
 	i32.load8_s	$push125=, c($pop0)
 	tee_local	$push124=, $2=, $pop125
@@ -43,7 +23,7 @@ main:                                   # @main
 	i32.or  	$push4=, $pop3, $pop1
 	i32.const	$push118=, 835
 	i32.ne  	$push5=, $pop4, $pop118
-	br_if   	0, $pop5        # 0: down to label20
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 4
 	i32.shr_s	$push7=, $2, $pop6
@@ -52,7 +32,7 @@ main:                                   # @main
 	i32.or  	$push9=, $pop7, $pop8
 	i32.const	$push126=, 835
 	i32.ne  	$push10=, $pop9, $pop126
-	br_if   	1, $pop10       # 1: down to label19
+	br_if   	0, $pop10       # 0: down to label0
 # BB#2:                                 # %if.end11
 	i32.const	$push11=, 0
 	i32.load16_s	$push132=, s($pop11)
@@ -65,7 +45,7 @@ main:                                   # @main
 	i32.or  	$push15=, $pop12, $pop14
 	i32.const	$push128=, 19087651
 	i32.ne  	$push16=, $pop15, $pop128
-	br_if   	2, $pop16       # 2: down to label18
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end21
 	i32.const	$push17=, 4
 	i32.shr_s	$push18=, $4, $pop17
@@ -74,7 +54,7 @@ main:                                   # @main
 	i32.or  	$push21=, $pop18, $pop20
 	i32.const	$push133=, 19087651
 	i32.ne  	$push22=, $pop21, $pop133
-	br_if   	3, $pop22       # 3: down to label17
+	br_if   	0, $pop22       # 0: down to label0
 # BB#4:                                 # %if.end30
 	i32.const	$push23=, 0
 	i32.load	$push138=, i($pop23)
@@ -87,7 +67,7 @@ main:                                   # @main
 	i32.or  	$push27=, $pop24, $pop26
 	i32.const	$push134=, 1073742115
 	i32.ne  	$push28=, $pop27, $pop134
-	br_if   	4, $pop28       # 4: down to label16
+	br_if   	0, $pop28       # 0: down to label0
 # BB#5:                                 # %if.end38
 	i32.const	$push29=, 4
 	i32.shr_s	$push30=, $6, $pop29
@@ -96,7 +76,7 @@ main:                                   # @main
 	i32.or  	$push33=, $pop30, $pop32
 	i32.const	$push139=, 1073742115
 	i32.ne  	$push34=, $pop33, $pop139
-	br_if   	5, $pop34       # 5: down to label15
+	br_if   	0, $pop34       # 0: down to label0
 # BB#6:                                 # %if.end45
 	i32.const	$push35=, 0
 	i32.load	$push142=, l($pop35)
@@ -106,7 +86,7 @@ main:                                   # @main
 	i32.or  	$push38=, $pop36, $pop37
 	i32.const	$push140=, -2128394905
 	i32.ne  	$push39=, $pop38, $pop140
-	br_if   	6, $pop39       # 6: down to label14
+	br_if   	0, $pop39       # 0: down to label0
 # BB#7:                                 # %if.end53
 	i32.const	$push40=, 4
 	i32.shr_s	$push41=, $7, $pop40
@@ -115,7 +95,7 @@ main:                                   # @main
 	i32.or  	$push44=, $pop41, $pop43
 	i32.const	$push143=, -2128394905
 	i32.ne  	$push45=, $pop44, $pop143
-	br_if   	7, $pop45       # 7: down to label13
+	br_if   	0, $pop45       # 0: down to label0
 # BB#8:                                 # %if.end60
 	i32.const	$push46=, 0
 	i64.load	$push150=, ll($pop46)
@@ -131,7 +111,7 @@ main:                                   # @main
 	i64.or  	$push51=, $pop47, $pop50
 	i64.const	$push144=, 5124095577148911
 	i64.ne  	$push52=, $pop51, $pop144
-	br_if   	8, $pop52       # 8: down to label12
+	br_if   	0, $pop52       # 0: down to label0
 # BB#9:                                 # %if.end69
 	i64.const	$push53=, 4
 	i64.shr_s	$push54=, $10, $pop53
@@ -140,7 +120,7 @@ main:                                   # @main
 	i64.or  	$push57=, $pop54, $pop56
 	i64.const	$push151=, 5124095577148911
 	i64.ne  	$push58=, $pop57, $pop151
-	br_if   	9, $pop58       # 9: down to label11
+	br_if   	0, $pop58       # 0: down to label0
 # BB#10:                                # %if.end76
 	i32.const	$push61=, 64
 	i32.const	$push59=, 0
@@ -156,7 +136,7 @@ main:                                   # @main
 	i64.or  	$push64=, $pop63, $pop60
 	i64.const	$push152=, 1311768467750121216
 	i64.ne  	$push65=, $pop64, $pop152
-	br_if   	10, $pop65      # 10: down to label10
+	br_if   	0, $pop65       # 0: down to label0
 # BB#11:                                # %if.end86
 	i64.const	$push66=, 60
 	i64.shr_s	$push67=, $10, $pop66
@@ -165,21 +145,21 @@ main:                                   # @main
 	i64.or  	$push70=, $pop67, $pop69
 	i64.const	$push159=, 1311768467750121216
 	i64.ne  	$push71=, $pop70, $pop159
-	br_if   	11, $pop71      # 11: down to label9
+	br_if   	0, $pop71       # 0: down to label0
 # BB#12:                                # %if.end93
 	i32.shr_s	$push73=, $2, $0
 	i32.shl 	$push72=, $2, $1
 	i32.or  	$push74=, $pop73, $pop72
 	i32.const	$push75=, 835
 	i32.ne  	$push76=, $pop74, $pop75
-	br_if   	12, $pop76      # 12: down to label8
+	br_if   	0, $pop76       # 0: down to label0
 # BB#13:                                # %if.end112
 	i32.shl 	$push77=, $4, $1
 	i32.shr_s	$push78=, $4, $3
 	i32.or  	$push79=, $pop77, $pop78
 	i32.const	$push160=, 74561
 	i32.ne  	$push80=, $pop79, $pop160
-	br_if   	13, $pop80      # 13: down to label7
+	br_if   	0, $pop80       # 0: down to label0
 # BB#14:                                # %if.end122
 	i32.const	$push81=, 4
 	i32.shl 	$push82=, $4, $pop81
@@ -188,14 +168,14 @@ main:                                   # @main
 	i32.or  	$push85=, $pop82, $pop84
 	i32.const	$push161=, 74561
 	i32.ne  	$push86=, $pop85, $pop161
-	br_if   	14, $pop86      # 14: down to label6
+	br_if   	0, $pop86       # 0: down to label0
 # BB#15:                                # %if.end131
 	i32.shl 	$push87=, $6, $1
 	i32.shr_s	$push88=, $6, $5
 	i32.or  	$push89=, $pop87, $pop88
 	i32.const	$push162=, 74560
 	i32.ne  	$push90=, $pop89, $pop162
-	br_if   	15, $pop90      # 15: down to label5
+	br_if   	0, $pop90       # 0: down to label0
 # BB#16:                                # %if.end139
 	i32.const	$push91=, 4
 	i32.shl 	$push92=, $6, $pop91
@@ -204,14 +184,14 @@ main:                                   # @main
 	i32.or  	$push95=, $pop92, $pop94
 	i32.const	$push163=, 74560
 	i32.ne  	$push96=, $pop95, $pop163
-	br_if   	16, $pop96      # 16: down to label4
+	br_if   	0, $pop96       # 0: down to label0
 # BB#17:                                # %if.end146
 	i32.shl 	$push97=, $7, $1
 	i32.shr_s	$push98=, $7, $5
 	i32.or  	$push99=, $pop97, $pop98
 	i32.const	$push164=, 591751041
 	i32.ne  	$push100=, $pop99, $pop164
-	br_if   	17, $pop100     # 17: down to label3
+	br_if   	0, $pop100      # 0: down to label0
 # BB#18:                                # %if.end154
 	i32.const	$push101=, 4
 	i32.shl 	$push102=, $7, $pop101
@@ -220,106 +200,26 @@ main:                                   # @main
 	i32.or  	$push105=, $pop102, $pop104
 	i32.const	$push165=, 591751041
 	i32.ne  	$push106=, $pop105, $pop165
-	br_if   	18, $pop106     # 18: down to label2
+	br_if   	0, $pop106      # 0: down to label0
 # BB#19:                                # %if.end161
 	i64.shl 	$push107=, $10, $9
 	i64.shr_s	$push108=, $10, $8
 	i64.or  	$push109=, $pop107, $pop108
 	i64.const	$push110=, 1311768467750121216
 	i64.ne  	$push111=, $pop109, $pop110
-	br_if   	19, $pop111     # 19: down to label1
+	br_if   	0, $pop111      # 0: down to label0
 # BB#20:                                # %if.end178
 	i64.shr_s	$push113=, $10, $12
 	i64.shl 	$push112=, $10, $11
 	i64.or  	$push114=, $pop113, $pop112
 	i64.const	$push115=, 5124095577148911
 	i64.ne  	$push116=, $pop114, $pop115
-	br_if   	20, $pop116     # 20: down to label0
+	br_if   	0, $pop116      # 0: down to label0
 # BB#21:                                # %if.end195
 	i32.const	$push117=, 0
 	call    	exit@FUNCTION, $pop117
 	unreachable
-.LBB0_22:                               # %if.then
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_23:                               # %if.then10
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then20
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then29
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then37
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_27:                               # %if.then44
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_28:                               # %if.then52
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_29:                               # %if.then59
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_30:                               # %if.then68
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_31:                               # %if.then75
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_32:                               # %if.then85
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_33:                               # %if.then92
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_34:                               # %if.then102
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_35:                               # %if.then121
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_36:                               # %if.then130
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_37:                               # %if.then138
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_38:                               # %if.then145
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_39:                               # %if.then153
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_40:                               # %if.then160
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_41:                               # %if.then170
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_42:                               # %if.then187
+.LBB0_22:                               # %if.then187
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20020508-3.c.s
+++ b/test/torture-s/20020508-3.c.s
@@ -9,26 +9,6 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i64, i64, i64, i64, i64, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push0=, 0
 	i32.load8_s	$push125=, c($pop0)
 	tee_local	$push124=, $2=, $pop125
@@ -43,7 +23,7 @@ main:                                   # @main
 	i32.or  	$push4=, $pop3, $pop1
 	i32.const	$push118=, 835
 	i32.ne  	$push5=, $pop4, $pop118
-	br_if   	0, $pop5        # 0: down to label20
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 4
 	i32.shr_s	$push7=, $2, $pop6
@@ -52,7 +32,7 @@ main:                                   # @main
 	i32.or  	$push9=, $pop7, $pop8
 	i32.const	$push126=, 835
 	i32.ne  	$push10=, $pop9, $pop126
-	br_if   	1, $pop10       # 1: down to label19
+	br_if   	0, $pop10       # 0: down to label0
 # BB#2:                                 # %if.end11
 	i32.const	$push11=, 0
 	i32.load16_s	$push132=, s($pop11)
@@ -65,7 +45,7 @@ main:                                   # @main
 	i32.or  	$push15=, $pop12, $pop14
 	i32.const	$push128=, -221
 	i32.ne  	$push16=, $pop15, $pop128
-	br_if   	2, $pop16       # 2: down to label18
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end21
 	i32.const	$push17=, 4
 	i32.shr_s	$push18=, $4, $pop17
@@ -74,7 +54,7 @@ main:                                   # @main
 	i32.or  	$push21=, $pop18, $pop20
 	i32.const	$push133=, -221
 	i32.ne  	$push22=, $pop21, $pop133
-	br_if   	3, $pop22       # 3: down to label17
+	br_if   	0, $pop22       # 0: down to label0
 # BB#4:                                 # %if.end30
 	i32.const	$push23=, 0
 	i32.load	$push138=, i($pop23)
@@ -87,7 +67,7 @@ main:                                   # @main
 	i32.or  	$push27=, $pop24, $pop26
 	i32.const	$push134=, 1073745699
 	i32.ne  	$push28=, $pop27, $pop134
-	br_if   	4, $pop28       # 4: down to label16
+	br_if   	0, $pop28       # 0: down to label0
 # BB#5:                                 # %if.end38
 	i32.const	$push29=, 4
 	i32.shr_s	$push30=, $6, $pop29
@@ -96,7 +76,7 @@ main:                                   # @main
 	i32.or  	$push33=, $pop30, $pop32
 	i32.const	$push139=, 1073745699
 	i32.ne  	$push34=, $pop33, $pop139
-	br_if   	5, $pop34       # 5: down to label15
+	br_if   	0, $pop34       # 0: down to label0
 # BB#6:                                 # %if.end45
 	i32.const	$push35=, 0
 	i32.load	$push142=, l($pop35)
@@ -106,7 +86,7 @@ main:                                   # @main
 	i32.or  	$push38=, $pop36, $pop37
 	i32.const	$push140=, -14465689
 	i32.ne  	$push39=, $pop38, $pop140
-	br_if   	6, $pop39       # 6: down to label14
+	br_if   	0, $pop39       # 0: down to label0
 # BB#7:                                 # %if.end53
 	i32.const	$push40=, 4
 	i32.shr_s	$push41=, $7, $pop40
@@ -115,7 +95,7 @@ main:                                   # @main
 	i32.or  	$push44=, $pop41, $pop43
 	i32.const	$push143=, -14465689
 	i32.ne  	$push45=, $pop44, $pop143
-	br_if   	7, $pop45       # 7: down to label13
+	br_if   	0, $pop45       # 0: down to label0
 # BB#8:                                 # %if.end60
 	i32.const	$push46=, 0
 	i64.load	$push150=, ll($pop46)
@@ -131,7 +111,7 @@ main:                                   # @main
 	i64.or  	$push51=, $pop47, $pop50
 	i64.const	$push144=, 68174490360335855
 	i64.ne  	$push52=, $pop51, $pop144
-	br_if   	8, $pop52       # 8: down to label12
+	br_if   	0, $pop52       # 0: down to label0
 # BB#9:                                 # %if.end69
 	i64.const	$push53=, 4
 	i64.shr_s	$push54=, $10, $pop53
@@ -140,7 +120,7 @@ main:                                   # @main
 	i64.or  	$push57=, $pop54, $pop56
 	i64.const	$push151=, 68174490360335855
 	i64.ne  	$push58=, $pop57, $pop151
-	br_if   	9, $pop58       # 9: down to label11
+	br_if   	0, $pop58       # 0: down to label0
 # BB#10:                                # %if.end76
 	i32.const	$push61=, 64
 	i32.const	$push59=, 0
@@ -156,7 +136,7 @@ main:                                   # @main
 	i64.or  	$push64=, $pop63, $pop60
 	i64.const	$push152=, -994074541463572736
 	i64.ne  	$push65=, $pop64, $pop152
-	br_if   	10, $pop65      # 10: down to label10
+	br_if   	0, $pop65       # 0: down to label0
 # BB#11:                                # %if.end86
 	i64.const	$push66=, 60
 	i64.shr_s	$push67=, $10, $pop66
@@ -165,21 +145,21 @@ main:                                   # @main
 	i64.or  	$push70=, $pop67, $pop69
 	i64.const	$push159=, -994074541463572736
 	i64.ne  	$push71=, $pop70, $pop159
-	br_if   	11, $pop71      # 11: down to label9
+	br_if   	0, $pop71       # 0: down to label0
 # BB#12:                                # %if.end93
 	i32.shr_s	$push73=, $2, $0
 	i32.shl 	$push72=, $2, $1
 	i32.or  	$push74=, $pop73, $pop72
 	i32.const	$push75=, 835
 	i32.ne  	$push76=, $pop74, $pop75
-	br_if   	12, $pop76      # 12: down to label8
+	br_if   	0, $pop76       # 0: down to label0
 # BB#13:                                # %if.end112
 	i32.shl 	$push77=, $4, $1
 	i32.shr_s	$push78=, $4, $3
 	i32.or  	$push79=, $pop77, $pop78
 	i32.const	$push160=, -1
 	i32.ne  	$push80=, $pop79, $pop160
-	br_if   	13, $pop80      # 13: down to label7
+	br_if   	0, $pop80       # 0: down to label0
 # BB#14:                                # %if.end122
 	i32.const	$push81=, 4
 	i32.shl 	$push82=, $4, $pop81
@@ -188,14 +168,14 @@ main:                                   # @main
 	i32.or  	$push85=, $pop82, $pop84
 	i32.const	$push161=, -1
 	i32.ne  	$push86=, $pop85, $pop161
-	br_if   	14, $pop86      # 14: down to label6
+	br_if   	0, $pop86       # 0: down to label0
 # BB#15:                                # %if.end131
 	i32.shl 	$push87=, $6, $1
 	i32.shr_s	$push88=, $6, $5
 	i32.or  	$push89=, $pop87, $pop88
 	i32.const	$push162=, 992064
 	i32.ne  	$push90=, $pop89, $pop162
-	br_if   	15, $pop90      # 15: down to label5
+	br_if   	0, $pop90       # 0: down to label0
 # BB#16:                                # %if.end139
 	i32.const	$push91=, 4
 	i32.shl 	$push92=, $6, $pop91
@@ -204,14 +184,14 @@ main:                                   # @main
 	i32.or  	$push95=, $pop92, $pop94
 	i32.const	$push163=, 992064
 	i32.ne  	$push96=, $pop95, $pop163
-	br_if   	16, $pop96      # 16: down to label4
+	br_if   	0, $pop96       # 0: down to label0
 # BB#17:                                # %if.end146
 	i32.shl 	$push97=, $7, $1
 	i32.shr_s	$push98=, $7, $5
 	i32.or  	$push99=, $pop97, $pop98
 	i32.const	$push164=, -1
 	i32.ne  	$push100=, $pop99, $pop164
-	br_if   	17, $pop100     # 17: down to label3
+	br_if   	0, $pop100      # 0: down to label0
 # BB#18:                                # %if.end154
 	i32.const	$push101=, 4
 	i32.shl 	$push102=, $7, $pop101
@@ -220,106 +200,26 @@ main:                                   # @main
 	i32.or  	$push105=, $pop102, $pop104
 	i32.const	$push165=, -1
 	i32.ne  	$push106=, $pop105, $pop165
-	br_if   	18, $pop106     # 18: down to label2
+	br_if   	0, $pop106      # 0: down to label0
 # BB#19:                                # %if.end161
 	i64.shl 	$push107=, $10, $9
 	i64.shr_s	$push108=, $10, $8
 	i64.or  	$push109=, $pop107, $pop108
 	i64.const	$push110=, -994074541463572736
 	i64.ne  	$push111=, $pop109, $pop110
-	br_if   	19, $pop111     # 19: down to label1
+	br_if   	0, $pop111      # 0: down to label0
 # BB#20:                                # %if.end178
 	i64.shr_s	$push113=, $10, $12
 	i64.shl 	$push112=, $10, $11
 	i64.or  	$push114=, $pop113, $pop112
 	i64.const	$push115=, 68174490360335855
 	i64.ne  	$push116=, $pop114, $pop115
-	br_if   	20, $pop116     # 20: down to label0
+	br_if   	0, $pop116      # 0: down to label0
 # BB#21:                                # %if.end195
 	i32.const	$push117=, 0
 	call    	exit@FUNCTION, $pop117
 	unreachable
-.LBB0_22:                               # %if.then
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_23:                               # %if.then10
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then20
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then29
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then37
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_27:                               # %if.then44
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_28:                               # %if.then52
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_29:                               # %if.then59
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_30:                               # %if.then68
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_31:                               # %if.then75
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_32:                               # %if.then85
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_33:                               # %if.then92
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_34:                               # %if.then102
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_35:                               # %if.then121
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_36:                               # %if.then130
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_37:                               # %if.then138
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_38:                               # %if.then145
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_39:                               # %if.then153
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_40:                               # %if.then160
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_41:                               # %if.then170
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_42:                               # %if.then187
+.LBB0_22:                               # %if.then187
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20020529-1.c.s
+++ b/test/torture-s/20020529-1.c.s
@@ -17,58 +17,53 @@ foo:                                    # @foo
                                         # =>This Inner Loop Header: Depth=1
 	block
 	block
-	block
-	loop                            # label3:
+	loop                            # label2:
 	i32.const	$push8=, 1
 	i32.add 	$4=, $6, $pop8
 	i32.const	$push7=, 2
 	i32.ge_s	$push0=, $6, $pop7
-	br_if   	3, $pop0        # 3: down to label1
+	br_if   	3, $pop0        # 3: down to label0
 # BB#2:                                 # %f1.exit
                                         #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push9=, 1
 	i32.ge_s	$push1=, $6, $pop9
-	br_if   	2, $pop1        # 2: down to label2
+	br_if   	2, $pop1        # 2: down to label1
 # BB#3:                                 # %if.end
                                         #   in Loop: Header=BB0_1 Depth=1
 	copy_local	$6=, $4
-	br_if   	0, $1           # 0: up to label3
+	br_if   	0, $1           # 0: up to label2
 # BB#4:                                 # %if.end3
                                         #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push11=, 0
 	i32.store	$6=, f1.beenhere($pop11), $4
 	i32.load	$4=, 0($0)
 	i32.store16	$discard=, 0($5):p2align=2, $3
-	br_if   	4, $4           # 4: down to label0
+	br_if   	1, $4           # 1: down to label3
 # BB#5:                                 # %if.end8
                                         #   in Loop: Header=BB0_1 Depth=1
-	br_if   	1, $2           # 1: down to label4
+	br_if   	1, $2           # 1: down to label3
 # BB#6:                                 # %for.cond.outer.backedge
                                         #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push13=, 16
 	i32.shl 	$push3=, $3, $pop13
 	i32.const	$push12=, 16
 	i32.shr_s	$3=, $pop3, $pop12
-	br      	0               # 0: up to label3
+	br      	0               # 0: up to label2
 .LBB0_7:                                # %if.then10
-	end_loop                        # label4:
+	end_loop                        # label3:
 	call    	f2@FUNCTION
 	unreachable
 .LBB0_8:                                # %if.then
-	end_block                       # label2:
+	end_block                       # label1:
 	i32.const	$push4=, 0
 	i32.store	$discard=, f1.beenhere($pop4), $4
 	i32.const	$push10=, 0
 	return  	$pop10
 .LBB0_9:                                # %if.then.i
-	end_block                       # label1:
+	end_block                       # label0:
 	i32.const	$push5=, 0
 	i32.store	$discard=, f1.beenhere($pop5), $4
 	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.then7
-	end_block                       # label0:
-	call    	f2@FUNCTION
 	unreachable
 	.endfunc
 .Lfunc_end0:
@@ -93,13 +88,13 @@ f1:                                     # @f1
 	block
 	i32.const	$push2=, 2
 	i32.ge_s	$push3=, $1, $pop2
-	br_if   	0, $pop3        # 0: down to label5
+	br_if   	0, $pop3        # 0: down to label4
 # BB#1:                                 # %if.end
 	i32.const	$push9=, 0
 	i32.gt_s	$push4=, $1, $pop9
 	return  	$pop4
 .LBB1_2:                                # %if.then
-	end_block                       # label5:
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -124,75 +119,78 @@ f2:                                     # @f2
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$4=, __stack_pointer
-	i32.load	$4=, 0($4)
-	i32.const	$5=, 16
-	i32.sub 	$6=, $4, $5
 	i32.const	$5=, __stack_pointer
-	i32.store	$6=, 0($5), $6
-	i32.const	$push3=, 4
-	i32.or  	$push4=, $6, $pop3
-	i32.store	$discard=, 0($pop4), $6
-	i32.const	$push2=, 0
-	i32.store	$push19=, 0($6):p2align=3, $pop2
-	tee_local	$push18=, $2=, $pop19
-	i32.load	$0=, f1.beenhere($pop18)
-	i32.const	$push1=, 23
-	i32.store16	$1=, 8($6):p2align=3, $pop1
-	i32.const	$push17=, 1
-	i32.add 	$3=, $0, $pop17
+	i32.load	$5=, 0($5)
+	i32.const	$6=, 16
+	i32.sub 	$7=, $5, $6
+	i32.const	$6=, __stack_pointer
+	i32.store	$7=, 0($6), $7
+	i32.const	$push2=, 4
+	i32.or  	$push3=, $7, $pop2
+	i32.store	$discard=, 0($pop3), $7
+	i32.const	$push1=, 0
+	i32.store	$push14=, 0($7):p2align=3, $pop1
+	tee_local	$push13=, $3=, $pop14
+	i32.load	$1=, f1.beenhere($pop13)
+	i32.const	$push0=, 23
+	i32.store16	$2=, 8($7):p2align=3, $pop0
 	block
 	block
-	i32.const	$push16=, 1
-	i32.gt_s	$push5=, $0, $pop16
-	br_if   	0, $pop5        # 0: down to label7
-.LBB3_1:                                # %f1.exit.i
+	i32.const	$push12=, 1
+	i32.gt_s	$push4=, $1, $pop12
+	br_if   	0, $pop4        # 0: down to label6
+# BB#1:
+	i32.const	$push7=, 8
+	i32.add 	$0=, $7, $pop7
+.LBB3_2:                                # %f1.exit.i
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label8:
-	copy_local	$push21=, $0
-	tee_local	$push20=, $3=, $pop21
-	i32.gt_s	$push6=, $pop20, $2
-	br_if   	3, $pop6        # 3: down to label6
-# BB#2:                                 # %if.end.i
-                                        #   in Loop: Header=BB3_1 Depth=1
-	i32.const	$push8=, 8
-	i32.add 	$push9=, $6, $pop8
-	i32.const	$push7=, 0
-	i32.store16	$1=, 0($pop9):p2align=3, $pop7
-	i32.const	$push10=, 1
-	i32.add 	$0=, $3, $pop10
-	i32.const	$push22=, 1
-	i32.le_s	$push11=, $0, $pop22
-	br_if   	0, $pop11       # 0: up to label8
-# BB#3:                                 # %if.then.i.i.loopexit
-	end_loop                        # label9:
-	i32.const	$push13=, 0
-	i32.store	$discard=, f1.beenhere($pop13), $0
-	i32.const	$push12=, 2
-	i32.add 	$3=, $3, $pop12
-.LBB3_4:                                # %if.then.i.i
-	end_block                       # label7:
-	i32.store	$discard=, f1.beenhere($2), $3
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_5:                                # %foo.exit
-	end_block                       # label6:
-	i32.const	$push24=, 0
-	i32.const	$push23=, 1
-	i32.add 	$push0=, $3, $pop23
-	i32.store	$discard=, f1.beenhere($pop24), $pop0
 	block
-	i32.const	$push14=, 65535
-	i32.and 	$push15=, $1, $pop14
-	br_if   	0, $pop15       # 0: down to label10
+	loop                            # label8:
+	copy_local	$push19=, $1
+	tee_local	$push18=, $4=, $pop19
+	i32.const	$push17=, 1
+	i32.add 	$1=, $pop18, $pop17
+	i32.gt_s	$push5=, $4, $3
+	br_if   	2, $pop5        # 2: down to label7
+# BB#3:                                 # %if.end.i
+                                        #   in Loop: Header=BB3_2 Depth=1
+	i32.const	$push6=, 0
+	i32.store16	$2=, 0($0):p2align=3, $pop6
+	i32.const	$push20=, 1
+	i32.le_s	$push8=, $1, $pop20
+	br_if   	0, $pop8        # 0: up to label8
+# BB#4:                                 # %if.then.i.i.loopexit
+	end_loop                        # label9:
+	i32.const	$push9=, 0
+	i32.store	$discard=, f1.beenhere($pop9), $1
+	i32.const	$push16=, 2
+	i32.add 	$1=, $4, $pop16
+	br      	2               # 2: down to label5
+.LBB3_5:                                # %foo.exit
+	end_block                       # label7:
+	i32.const	$push21=, 0
+	i32.store	$discard=, f1.beenhere($pop21), $1
+	block
+	i32.const	$push10=, 65535
+	i32.and 	$push11=, $2, $pop10
+	br_if   	0, $pop11       # 0: down to label10
 # BB#6:                                 # %if.end
-	i32.const	$push25=, 0
-	call    	exit@FUNCTION, $pop25
+	i32.const	$push22=, 0
+	call    	exit@FUNCTION, $pop22
 	unreachable
 .LBB3_7:                                # %if.then
 	end_block                       # label10:
+	call    	abort@FUNCTION
+	unreachable
+.LBB3_8:
+	end_block                       # label6:
+	i32.const	$push15=, 1
+	i32.add 	$1=, $1, $pop15
+.LBB3_9:                                # %if.then.i.i
+	end_block                       # label5:
+	i32.store	$discard=, f1.beenhere($3), $1
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20021011-1.c.s
+++ b/test/torture-s/20021011-1.c.s
@@ -26,11 +26,10 @@ main:                                   # @main
 	i32.store8	$discard=, buf+8($pop60):p2align=3, $0
 	i32.const	$push59=, 0
 	i64.store	$discard=, buf($pop59):p2align=4, $1
-	block
 	i32.const	$push58=, buf
 	i32.const	$push57=, .L.str
 	i32.call	$push3=, strcmp@FUNCTION, $pop58, $pop57
-	br_if   	0, $pop3        # 0: down to label1
+	br_if   	0, $pop3        # 0: down to label0
 # BB#2:                                 # %for.cond
 	i32.const	$push65=, 0
 	i32.const	$push64=, 0
@@ -43,7 +42,7 @@ main:                                   # @main
 	i32.const	$push6=, buf+1
 	i32.const	$push61=, .L.str
 	i32.call	$push7=, strcmp@FUNCTION, $pop6, $pop61
-	br_if   	0, $pop7        # 0: down to label1
+	br_if   	0, $pop7        # 0: down to label0
 # BB#3:                                 # %for.cond.1
 	i32.const	$push68=, 0
 	i32.store8	$discard=, buf+10($pop68):p2align=1, $0
@@ -52,7 +51,7 @@ main:                                   # @main
 	i32.const	$push8=, buf+2
 	i32.const	$push66=, .L.str
 	i32.call	$push9=, strcmp@FUNCTION, $pop8, $pop66
-	br_if   	0, $pop9        # 0: down to label1
+	br_if   	0, $pop9        # 0: down to label0
 # BB#4:                                 # %for.cond.2
 	i32.const	$push73=, 0
 	i32.const	$push72=, 0
@@ -65,7 +64,7 @@ main:                                   # @main
 	i32.const	$push12=, buf+3
 	i32.const	$push69=, .L.str
 	i32.call	$push13=, strcmp@FUNCTION, $pop12, $pop69
-	br_if   	0, $pop13       # 0: down to label1
+	br_if   	0, $pop13       # 0: down to label0
 # BB#5:                                 # %for.cond.3
 	i32.const	$push76=, 0
 	i32.store8	$discard=, buf+12($pop76):p2align=2, $0
@@ -74,7 +73,7 @@ main:                                   # @main
 	i32.const	$push14=, buf+4
 	i32.const	$push74=, .L.str
 	i32.call	$push15=, strcmp@FUNCTION, $pop14, $pop74
-	br_if   	0, $pop15       # 0: down to label1
+	br_if   	0, $pop15       # 0: down to label0
 # BB#6:                                 # %for.cond.4
 	i32.const	$push81=, 0
 	i32.const	$push80=, 0
@@ -87,7 +86,7 @@ main:                                   # @main
 	i32.const	$push18=, buf+5
 	i32.const	$push77=, .L.str
 	i32.call	$push19=, strcmp@FUNCTION, $pop18, $pop77
-	br_if   	0, $pop19       # 0: down to label1
+	br_if   	0, $pop19       # 0: down to label0
 # BB#7:                                 # %for.cond.5
 	i32.const	$push84=, 0
 	i32.store8	$discard=, buf+14($pop84):p2align=1, $0
@@ -96,7 +95,7 @@ main:                                   # @main
 	i32.const	$push20=, buf+6
 	i32.const	$push82=, .L.str
 	i32.call	$push21=, strcmp@FUNCTION, $pop20, $pop82
-	br_if   	0, $pop21       # 0: down to label1
+	br_if   	0, $pop21       # 0: down to label0
 # BB#8:                                 # %for.cond.6
 	i32.const	$push89=, 0
 	i32.const	$push88=, 0
@@ -109,7 +108,7 @@ main:                                   # @main
 	i32.const	$push24=, buf+7
 	i32.const	$push85=, .L.str
 	i32.call	$push25=, strcmp@FUNCTION, $pop24, $pop85
-	br_if   	0, $pop25       # 0: down to label1
+	br_if   	0, $pop25       # 0: down to label0
 # BB#9:                                 # %for.cond.7
 	i32.const	$push92=, 0
 	i32.store8	$discard=, buf+16($pop92):p2align=3, $0
@@ -118,7 +117,7 @@ main:                                   # @main
 	i32.const	$push26=, buf+8
 	i32.const	$push90=, .L.str
 	i32.call	$push27=, strcmp@FUNCTION, $pop26, $pop90
-	br_if   	0, $pop27       # 0: down to label1
+	br_if   	0, $pop27       # 0: down to label0
 # BB#10:                                # %for.cond.8
 	i32.const	$push97=, 0
 	i32.const	$push96=, 0
@@ -131,7 +130,7 @@ main:                                   # @main
 	i32.const	$push30=, buf+9
 	i32.const	$push93=, .L.str
 	i32.call	$push31=, strcmp@FUNCTION, $pop30, $pop93
-	br_if   	0, $pop31       # 0: down to label1
+	br_if   	0, $pop31       # 0: down to label0
 # BB#11:                                # %for.cond.9
 	i32.const	$push100=, 0
 	i32.store8	$discard=, buf+18($pop100):p2align=1, $0
@@ -140,7 +139,7 @@ main:                                   # @main
 	i32.const	$push32=, buf+10
 	i32.const	$push98=, .L.str
 	i32.call	$push33=, strcmp@FUNCTION, $pop32, $pop98
-	br_if   	0, $pop33       # 0: down to label1
+	br_if   	0, $pop33       # 0: down to label0
 # BB#12:                                # %for.cond.10
 	i32.const	$push105=, 0
 	i32.const	$push104=, 0
@@ -153,7 +152,7 @@ main:                                   # @main
 	i32.const	$push36=, buf+11
 	i32.const	$push101=, .L.str
 	i32.call	$push37=, strcmp@FUNCTION, $pop36, $pop101
-	br_if   	0, $pop37       # 0: down to label1
+	br_if   	0, $pop37       # 0: down to label0
 # BB#13:                                # %for.cond.11
 	i32.const	$push108=, 0
 	i32.store8	$discard=, buf+20($pop108):p2align=2, $0
@@ -162,7 +161,7 @@ main:                                   # @main
 	i32.const	$push38=, buf+12
 	i32.const	$push106=, .L.str
 	i32.call	$push39=, strcmp@FUNCTION, $pop38, $pop106
-	br_if   	0, $pop39       # 0: down to label1
+	br_if   	0, $pop39       # 0: down to label0
 # BB#14:                                # %for.cond.12
 	i32.const	$push113=, 0
 	i32.const	$push112=, 0
@@ -175,7 +174,7 @@ main:                                   # @main
 	i32.const	$push42=, buf+13
 	i32.const	$push109=, .L.str
 	i32.call	$push43=, strcmp@FUNCTION, $pop42, $pop109
-	br_if   	0, $pop43       # 0: down to label1
+	br_if   	0, $pop43       # 0: down to label0
 # BB#15:                                # %for.cond.13
 	i32.const	$push116=, 0
 	i32.store8	$discard=, buf+22($pop116):p2align=1, $0
@@ -184,7 +183,7 @@ main:                                   # @main
 	i32.const	$push44=, buf+14
 	i32.const	$push114=, .L.str
 	i32.call	$push45=, strcmp@FUNCTION, $pop44, $pop114
-	br_if   	0, $pop45       # 0: down to label1
+	br_if   	0, $pop45       # 0: down to label0
 # BB#16:                                # %for.cond.14
 	i32.const	$push120=, 0
 	i32.const	$push119=, 0
@@ -197,15 +196,11 @@ main:                                   # @main
 	i32.const	$push49=, buf+15
 	i32.const	$push48=, .L.str
 	i32.call	$push50=, strcmp@FUNCTION, $pop49, $pop48
-	br_if   	0, $pop50       # 0: down to label1
+	br_if   	0, $pop50       # 0: down to label0
 # BB#17:                                # %for.cond.15
 	i32.const	$push121=, 0
 	return  	$pop121
 .LBB0_18:                               # %if.then7
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20021120-1.c.s
+++ b/test/torture-s/20021120-1.c.s
@@ -8,70 +8,70 @@ foo:                                    # @foo
 	.param  	i32
 	.local  	f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64, f64
 # BB#0:                                 # %entry
-	i32.const	$push98=, 0
-	f64.load	$129=, gd($pop98):p2align=4
 	i32.const	$push97=, 0
-	f64.load	$130=, gd+8($pop97)
+	f64.load	$129=, gd($pop97):p2align=4
 	i32.const	$push96=, 0
-	f64.load	$131=, gd+16($pop96):p2align=4
+	f64.load	$130=, gd+8($pop96)
 	i32.const	$push95=, 0
-	f64.load	$132=, gd+24($pop95)
+	f64.load	$131=, gd+16($pop95):p2align=4
 	i32.const	$push94=, 0
-	f64.load	$133=, gd+32($pop94):p2align=4
+	f64.load	$132=, gd+24($pop94)
 	i32.const	$push93=, 0
-	f64.load	$134=, gd+40($pop93)
+	f64.load	$133=, gd+32($pop93):p2align=4
 	i32.const	$push92=, 0
-	f64.load	$135=, gd+48($pop92):p2align=4
+	f64.load	$134=, gd+40($pop92)
 	i32.const	$push91=, 0
-	f64.load	$136=, gd+56($pop91)
+	f64.load	$135=, gd+48($pop91):p2align=4
 	i32.const	$push90=, 0
-	f64.load	$137=, gd+64($pop90):p2align=4
+	f64.load	$136=, gd+56($pop90)
 	i32.const	$push89=, 0
-	f64.load	$138=, gd+72($pop89)
+	f64.load	$137=, gd+64($pop89):p2align=4
 	i32.const	$push88=, 0
-	f64.load	$139=, gd+80($pop88):p2align=4
+	f64.load	$138=, gd+72($pop88)
 	i32.const	$push87=, 0
-	f64.load	$140=, gd+88($pop87)
+	f64.load	$139=, gd+80($pop87):p2align=4
 	i32.const	$push86=, 0
-	f64.load	$141=, gd+96($pop86):p2align=4
+	f64.load	$140=, gd+88($pop86)
 	i32.const	$push85=, 0
-	f64.load	$142=, gd+104($pop85)
+	f64.load	$141=, gd+96($pop85):p2align=4
 	i32.const	$push84=, 0
-	f64.load	$143=, gd+112($pop84):p2align=4
+	f64.load	$142=, gd+104($pop84)
 	i32.const	$push83=, 0
-	f64.load	$144=, gd+120($pop83)
+	f64.load	$143=, gd+112($pop83):p2align=4
 	i32.const	$push82=, 0
-	f64.load	$145=, gd+128($pop82):p2align=4
+	f64.load	$144=, gd+120($pop82)
 	i32.const	$push81=, 0
-	f64.load	$146=, gd+136($pop81)
+	f64.load	$145=, gd+128($pop81):p2align=4
 	i32.const	$push80=, 0
-	f64.load	$147=, gd+144($pop80):p2align=4
+	f64.load	$146=, gd+136($pop80)
 	i32.const	$push79=, 0
-	f64.load	$148=, gd+152($pop79)
+	f64.load	$147=, gd+144($pop79):p2align=4
 	i32.const	$push78=, 0
-	f64.load	$149=, gd+160($pop78):p2align=4
+	f64.load	$148=, gd+152($pop78)
 	i32.const	$push77=, 0
-	f64.load	$150=, gd+168($pop77)
+	f64.load	$149=, gd+160($pop77):p2align=4
 	i32.const	$push76=, 0
-	f64.load	$151=, gd+176($pop76):p2align=4
+	f64.load	$150=, gd+168($pop76)
 	i32.const	$push75=, 0
-	f64.load	$152=, gd+184($pop75)
+	f64.load	$151=, gd+176($pop75):p2align=4
 	i32.const	$push74=, 0
-	f64.load	$153=, gd+192($pop74):p2align=4
+	f64.load	$152=, gd+184($pop74)
 	i32.const	$push73=, 0
-	f64.load	$154=, gd+200($pop73)
+	f64.load	$153=, gd+192($pop73):p2align=4
 	i32.const	$push72=, 0
-	f64.load	$155=, gd+208($pop72):p2align=4
+	f64.load	$154=, gd+200($pop72)
 	i32.const	$push71=, 0
-	f64.load	$156=, gd+216($pop71)
+	f64.load	$155=, gd+208($pop71):p2align=4
 	i32.const	$push70=, 0
-	f64.load	$157=, gd+224($pop70):p2align=4
+	f64.load	$156=, gd+216($pop70)
 	i32.const	$push69=, 0
-	f64.load	$158=, gd+232($pop69)
+	f64.load	$157=, gd+224($pop69):p2align=4
 	i32.const	$push68=, 0
-	f64.load	$159=, gd+240($pop68):p2align=4
+	f64.load	$158=, gd+232($pop68)
 	i32.const	$push67=, 0
-	f64.load	$160=, gd+248($pop67)
+	f64.load	$159=, gd+240($pop67):p2align=4
+	i32.const	$push66=, 0
+	f64.load	$160=, gd+248($pop66)
 	block
 	i32.const	$push0=, 1
 	i32.lt_s	$push1=, $0, $pop0
@@ -493,10 +493,10 @@ foo:                                    # @foo
 	f64.add 	$push33=, $160, $64
 	f64.add 	$push65=, $96, $pop33
 	f64.add 	$160=, $128, $pop65
-	i32.const	$push66=, -1
-	i32.add 	$0=, $0, $pop66
 	i32.const	$push99=, 0
 	f32.store	$discard=, gf+124($pop99), $32
+	i32.const	$push98=, -1
+	i32.add 	$0=, $0, $pop98
 	br_if   	0, $0           # 0: up to label1
 .LBB0_2:                                # %for.end
 	end_loop                        # label2:

--- a/test/torture-s/20030313-1.c.s
+++ b/test/torture-s/20030313-1.c.s
@@ -12,98 +12,68 @@ foo:                                    # @foo
 	i32.ne  	$push1=, $1, $pop0
 	br_if   	0, $pop1        # 0: down to label0
 # BB#1:                                 # %if.end
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load	$push2=, 0($0)
 	i32.const	$push3=, 1
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label6
+	br_if   	0, $pop4        # 0: down to label0
 # BB#2:                                 # %lor.lhs.false
 	i32.load	$push5=, 4($0)
 	i32.const	$push6=, 11
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	0, $pop7        # 0: down to label6
+	br_if   	0, $pop7        # 0: down to label0
 # BB#3:                                 # %if.end5
 	i32.load	$push8=, 8($0)
 	i32.const	$push9=, 2
 	i32.ne  	$push10=, $pop8, $pop9
-	br_if   	1, $pop10       # 1: down to label5
+	br_if   	0, $pop10       # 0: down to label0
 # BB#4:                                 # %lor.lhs.false8
 	i32.load	$push11=, 12($0)
 	i32.const	$push12=, 12
 	i32.ne  	$push13=, $pop11, $pop12
-	br_if   	1, $pop13       # 1: down to label5
+	br_if   	0, $pop13       # 0: down to label0
 # BB#5:                                 # %if.end12
 	i32.load	$push14=, 16($0)
 	i32.const	$push15=, 3
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	2, $pop16       # 2: down to label4
+	br_if   	0, $pop16       # 0: down to label0
 # BB#6:                                 # %lor.lhs.false15
 	i32.load	$push17=, 20($0)
 	i32.const	$push18=, 13
 	i32.ne  	$push19=, $pop17, $pop18
-	br_if   	2, $pop19       # 2: down to label4
+	br_if   	0, $pop19       # 0: down to label0
 # BB#7:                                 # %if.end19
 	i32.load	$push20=, 24($0)
 	i32.const	$push21=, 4
 	i32.ne  	$push22=, $pop20, $pop21
-	br_if   	3, $pop22       # 3: down to label3
+	br_if   	0, $pop22       # 0: down to label0
 # BB#8:                                 # %lor.lhs.false22
 	i32.load	$push23=, 28($0)
 	i32.const	$push24=, 14
 	i32.ne  	$push25=, $pop23, $pop24
-	br_if   	3, $pop25       # 3: down to label3
+	br_if   	0, $pop25       # 0: down to label0
 # BB#9:                                 # %if.end26
 	i32.load	$push26=, 32($0)
 	i32.const	$push27=, 5
 	i32.ne  	$push28=, $pop26, $pop27
-	br_if   	4, $pop28       # 4: down to label2
+	br_if   	0, $pop28       # 0: down to label0
 # BB#10:                                # %lor.lhs.false29
 	i32.load	$push29=, 36($0)
 	i32.const	$push30=, 15
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	4, $pop31       # 4: down to label2
+	br_if   	0, $pop31       # 0: down to label0
 # BB#11:                                # %if.end33
 	i32.load	$push32=, 40($0)
 	i32.const	$push33=, 6
 	i32.ne  	$push34=, $pop32, $pop33
-	br_if   	5, $pop34       # 5: down to label1
+	br_if   	0, $pop34       # 0: down to label0
 # BB#12:                                # %lor.lhs.false36
 	i32.load	$push35=, 44($0)
 	i32.const	$push36=, 16
 	i32.ne  	$push37=, $pop35, $pop36
-	br_if   	5, $pop37       # 5: down to label1
+	br_if   	0, $pop37       # 0: down to label0
 # BB#13:                                # %if.end40
 	return
-.LBB0_14:                               # %if.then4
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then11
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then18
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then25
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then32
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then39
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_20:                               # %if.then
+.LBB0_14:                               # %if.then39
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -119,50 +89,35 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %lor.lhs.false15.i
 	block
-	block
-	block
-	block
 	i32.const	$push13=, 0
 	i32.load	$push2=, x($pop13)
 	i32.const	$push3=, 13
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label10
+	br_if   	0, $pop4        # 0: down to label1
 # BB#1:                                 # %lor.lhs.false22.i
 	i32.const	$push14=, 0
 	i32.load	$push5=, x+4($pop14)
 	i32.const	$push6=, 14
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label9
+	br_if   	0, $pop7        # 0: down to label1
 # BB#2:                                 # %lor.lhs.false29.i
 	i32.const	$push15=, 0
 	i32.load	$push0=, x+8($pop15)
 	i32.const	$push8=, 15
 	i32.ne  	$push9=, $pop0, $pop8
-	br_if   	2, $pop9        # 2: down to label8
+	br_if   	0, $pop9        # 0: down to label1
 # BB#3:                                 # %lor.lhs.false36.i
 	i32.const	$push16=, 0
 	i32.load	$push1=, x+12($pop16)
 	i32.const	$push10=, 16
 	i32.ne  	$push11=, $pop1, $pop10
-	br_if   	3, $pop11       # 3: down to label7
+	br_if   	0, $pop11       # 0: down to label1
 # BB#4:                                 # %foo.exit
 	i32.const	$push12=, 0
 	call    	exit@FUNCTION, $pop12
 	unreachable
-.LBB1_5:                                # %if.then18.i
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_6:                                # %if.then25.i
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_7:                                # %if.then32.i
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_8:                                # %if.then39.i
-	end_block                       # label7:
+.LBB1_5:                                # %if.then39.i
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20030606-1.c.s
+++ b/test/torture-s/20030606-1.c.s
@@ -7,25 +7,28 @@
 foo:                                    # @foo
 	.param  	i32, i32
 	.result 	i32
-	.local  	i32
 # BB#0:                                 # %entry
 	i32.const	$push0=, 55
 	i32.store	$discard=, 0($0), $pop0
-	i32.const	$push3=, 4
-	i32.add 	$2=, $0, $pop3
+	block
 	block
 	i32.const	$push5=, 0
 	i32.eq  	$push6=, $1, $pop5
-	br_if   	0, $pop6        # 0: down to label0
+	br_if   	0, $pop6        # 0: down to label1
 # BB#1:                                 # %if.then
 	i32.const	$push4=, 4
 	i32.add 	$push2=, $0, $pop4
 	i32.store	$discard=, 0($pop2), $1
 	i32.const	$push1=, 8
-	i32.add 	$2=, $0, $pop1
-.LBB0_2:                                # %if.end
+	i32.add 	$0=, $0, $pop1
+	br      	1               # 1: down to label0
+.LBB0_2:
+	end_block                       # label1:
+	i32.const	$push3=, 4
+	i32.add 	$0=, $0, $pop3
+.LBB0_3:                                # %if.end
 	end_block                       # label0:
-	return  	$2
+	return  	$0
 	.endfunc
 .Lfunc_end0:
 	.size	foo, .Lfunc_end0-foo

--- a/test/torture-s/20030903-1.c.s
+++ b/test/torture-s/20030903-1.c.s
@@ -23,26 +23,8 @@ main:                                   # @main
 .LBB0_2:                                # %entry
 	end_block                       # label0:
 	block
-	block
-	block
-	block
-	tableswitch	$0, 0, 0, 3, 1, 2 # 0: down to label4
-                                        # 3: down to label1
-                                        # 1: down to label3
-                                        # 2: down to label2
-.LBB0_3:                                # %sw.bb
-	end_block                       # label4:
-	call    	y@FUNCTION
-	unreachable
-.LBB0_4:                                # %sw.bb2
-	end_block                       # label3:
-	call    	y@FUNCTION
-	unreachable
-.LBB0_5:                                # %sw.bb3
-	end_block                       # label2:
-	call    	y@FUNCTION
-	unreachable
-.LBB0_6:                                # %sw.bb1
+	tableswitch	$0, 0, 0, 0, 0, 0 # 0: down to label1
+.LBB0_3:                                # %sw.bb3
 	end_block                       # label1:
 	call    	y@FUNCTION
 	unreachable

--- a/test/torture-s/20030914-2.c.s
+++ b/test/torture-s/20030914-2.c.s
@@ -19,85 +19,31 @@ f:                                      # @f
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$0=, __stack_pointer
 	i32.load	$0=, 0($0)
 	i32.const	$1=, 80
-	i32.sub 	$11=, $0, $1
+	i32.sub 	$4=, $0, $1
 	i32.const	$1=, __stack_pointer
-	i32.store	$11=, 0($1), $11
-	i32.const	$push1=, 64
+	i32.store	$4=, 0($1), $4
+	i32.const	$push0=, gs
+	i32.const	$push1=, 72
 	i32.const	$2=, 8
-	i32.add 	$2=, $11, $2
-	i32.add 	$push2=, $2, $pop1
-	i32.const	$push38=, 0
-	i64.load	$push0=, gs+64($pop38):p2align=2
-	i64.store	$discard=, 0($pop2):p2align=2, $pop0
-	i32.const	$push4=, 56
+	i32.add 	$2=, $4, $2
+	i32.call	$discard=, memcpy@FUNCTION, $2, $pop0, $pop1
+	i32.const	$push2=, 4660
+	i32.const	$push6=, 0
 	i32.const	$3=, 8
-	i32.add 	$3=, $11, $3
-	i32.add 	$push5=, $3, $pop4
-	i32.const	$push37=, 0
-	i64.load	$push3=, gs+56($pop37):p2align=2
-	i64.store	$discard=, 0($pop5):p2align=2, $pop3
-	i32.const	$push7=, 48
-	i32.const	$4=, 8
-	i32.add 	$4=, $11, $4
-	i32.add 	$push8=, $4, $pop7
-	i32.const	$push36=, 0
-	i64.load	$push6=, gs+48($pop36):p2align=2
-	i64.store	$discard=, 0($pop8):p2align=2, $pop6
-	i32.const	$push10=, 40
-	i32.const	$5=, 8
-	i32.add 	$5=, $11, $5
-	i32.add 	$push11=, $5, $pop10
-	i32.const	$push35=, 0
-	i64.load	$push9=, gs+40($pop35):p2align=2
-	i64.store	$discard=, 0($pop11):p2align=2, $pop9
-	i32.const	$push13=, 32
-	i32.const	$6=, 8
-	i32.add 	$6=, $11, $6
-	i32.add 	$push14=, $6, $pop13
-	i32.const	$push34=, 0
-	i64.load	$push12=, gs+32($pop34):p2align=2
-	i64.store	$discard=, 0($pop14):p2align=2, $pop12
-	i32.const	$push16=, 24
-	i32.const	$7=, 8
-	i32.add 	$7=, $11, $7
-	i32.add 	$push17=, $7, $pop16
-	i32.const	$push33=, 0
-	i64.load	$push15=, gs+24($pop33):p2align=2
-	i64.store	$discard=, 0($pop17):p2align=2, $pop15
-	i32.const	$push19=, 16
-	i32.const	$8=, 8
-	i32.add 	$8=, $11, $8
-	i32.add 	$push20=, $8, $pop19
-	i32.const	$push32=, 0
-	i64.load	$push18=, gs+16($pop32):p2align=2
-	i64.store	$discard=, 0($pop20):p2align=2, $pop18
-	i32.const	$push22=, 8
-	i32.const	$9=, 8
-	i32.add 	$9=, $11, $9
-	i32.add 	$push23=, $9, $pop22
-	i32.const	$push31=, 0
-	i64.load	$push21=, gs+8($pop31):p2align=2
-	i64.store	$discard=, 0($pop23):p2align=2, $pop21
-	i32.const	$push30=, 0
-	i64.load	$push24=, gs($pop30):p2align=2
-	i64.store	$discard=, 8($11):p2align=2, $pop24
-	i32.const	$push25=, 4660
-	i32.const	$push29=, 0
-	i32.const	$10=, 8
-	i32.add 	$10=, $11, $10
+	i32.add 	$3=, $4, $3
 	block
-	i32.call	$push26=, f@FUNCTION, $10, $pop25, $pop29
-	i32.const	$push28=, 4660
-	i32.ne  	$push27=, $pop26, $pop28
-	br_if   	0, $pop27       # 0: down to label0
+	i32.call	$push3=, f@FUNCTION, $3, $pop2, $pop6
+	i32.const	$push5=, 4660
+	i32.ne  	$push4=, $pop3, $pop5
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %if.end
-	i32.const	$push39=, 0
-	call    	exit@FUNCTION, $pop39
+	i32.const	$push7=, 0
+	call    	exit@FUNCTION, $pop7
 	unreachable
 .LBB1_2:                                # %if.then
 	end_block                       # label0:

--- a/test/torture-s/20031010-1.c.s
+++ b/test/torture-s/20031010-1.c.s
@@ -13,19 +13,23 @@ foo:                                    # @foo
 	i32.eq  	$push3=, $2, $pop2
 	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.then
-	i32.sub 	$2=, $0, $1
+	block
 	block
 	i32.const	$push4=, 0
 	i32.eq  	$push5=, $3, $pop4
-	br_if   	0, $pop5        # 0: down to label1
+	br_if   	0, $pop5        # 0: down to label2
 # BB#2:                                 # %if.then4
 	i32.select	$push1=, $1, $0, $4
 	i32.select	$push0=, $0, $1, $4
-	i32.sub 	$2=, $pop1, $pop0
-.LBB0_3:                                # %if.end8
+	i32.sub 	$1=, $pop1, $pop0
+	br      	1               # 1: down to label1
+.LBB0_3:
+	end_block                       # label2:
+	i32.sub 	$1=, $0, $1
+.LBB0_4:                                # %if.end8
 	end_block                       # label1:
-	return  	$2
-.LBB0_4:                                # %if.end9
+	return  	$1
+.LBB0_5:                                # %if.end9
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -49,12 +53,12 @@ main:                                   # @main
 	i32.call	$push3=, foo@FUNCTION, $pop2, $pop1, $pop0, $pop6, $pop5
 	i32.const	$push7=, 0
 	i32.eq  	$push8=, $pop3, $pop7
-	br_if   	0, $pop8        # 0: down to label2
+	br_if   	0, $pop8        # 0: down to label3
 # BB#1:                                 # %if.end
 	i32.const	$push4=, 0
 	return  	$pop4
 .LBB1_2:                                # %if.then
-	end_block                       # label2:
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20031204-1.c.s
+++ b/test/torture-s/20031204-1.c.s
@@ -21,91 +21,93 @@ in_aton:                                # @in_aton
 root_nfs_parse_addr:                    # @root_nfs_parse_addr
 	.param  	i32
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$3=, 0
-	copy_local	$1=, $0
+	i32.const	$1=, 0
+	copy_local	$2=, $0
 .LBB1_1:                                # %while.cond1.preheader
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB1_2 Depth 2
-	loop                            # label0:
-	copy_local	$2=, $1
+	block
+	loop                            # label1:
+	copy_local	$3=, $2
 .LBB1_2:                                # %while.cond1
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label2:
-	copy_local	$push24=, $2
-	tee_local	$push23=, $6=, $pop24
+	loop                            # label3:
+	copy_local	$push24=, $3
+	tee_local	$push23=, $5=, $pop24
 	i32.const	$push22=, 1
-	i32.add 	$2=, $pop23, $pop22
-	i32.load8_u	$push21=, 0($6)
-	tee_local	$push20=, $5=, $pop21
+	i32.add 	$3=, $pop23, $pop22
+	i32.load8_u	$push21=, 0($5)
+	tee_local	$push20=, $4=, $pop21
 	i32.const	$push19=, -48
 	i32.add 	$push0=, $pop20, $pop19
 	i32.const	$push18=, 255
 	i32.and 	$push1=, $pop0, $pop18
 	i32.const	$push17=, 10
 	i32.lt_u	$push2=, $pop1, $pop17
-	br_if   	0, $pop2        # 0: up to label2
+	br_if   	0, $pop2        # 0: up to label3
 # BB#3:                                 # %while.end
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_loop                        # label3:
-	copy_local	$4=, $1
-	i32.eq  	$push3=, $6, $1
-	br_if   	1, $pop3        # 1: down to label1
+	end_loop                        # label4:
+	i32.eq  	$push3=, $5, $2
+	br_if   	1, $pop3        # 1: down to label2
 # BB#4:                                 # %lor.lhs.false
                                         #   in Loop: Header=BB1_1 Depth=1
-	copy_local	$4=, $6
-	i32.sub 	$push4=, $6, $1
+	i32.sub 	$push4=, $5, $2
 	i32.const	$push25=, 3
 	i32.gt_s	$push5=, $pop4, $pop25
-	br_if   	1, $pop5        # 1: down to label1
+	br_if   	2, $pop5        # 2: down to label0
 # BB#5:                                 # %if.end
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push29=, 3
-	i32.eq  	$push8=, $3, $pop29
+	i32.eq  	$push8=, $1, $pop29
 	i32.const	$push28=, 255
-	i32.and 	$push6=, $5, $pop28
+	i32.and 	$push6=, $4, $pop28
 	i32.const	$push27=, 46
 	i32.eq  	$push7=, $pop6, $pop27
 	i32.or  	$push9=, $pop8, $pop7
-	i32.add 	$3=, $pop9, $3
-	copy_local	$1=, $2
-	copy_local	$4=, $6
+	i32.add 	$1=, $pop9, $1
+	copy_local	$2=, $3
 	i32.const	$push26=, 4
-	i32.lt_s	$push10=, $3, $pop26
-	br_if   	0, $pop10       # 0: up to label0
-.LBB1_6:                                # %while.end25
-	end_loop                        # label1:
-	i32.const	$6=, -1
+	i32.lt_s	$push10=, $1, $pop26
+	br_if   	0, $pop10       # 0: up to label1
+	br      	2               # 2: down to label0
+.LBB1_6:
+	end_loop                        # label2:
+	copy_local	$5=, $2
+.LBB1_7:                                # %while.end25
+	end_block                       # label0:
+	i32.const	$3=, -1
 	block
 	i32.const	$push11=, 4
-	i32.ne  	$push12=, $3, $pop11
-	br_if   	0, $pop12       # 0: down to label4
-# BB#7:                                 # %land.lhs.true
+	i32.ne  	$push12=, $1, $pop11
+	br_if   	0, $pop12       # 0: down to label5
+# BB#8:                                 # %land.lhs.true
 	block
-	i32.load8_u	$push31=, 0($4)
-	tee_local	$push30=, $2=, $pop31
+	i32.load8_u	$push31=, 0($5)
+	tee_local	$push30=, $4=, $pop31
 	i32.const	$push32=, 0
 	i32.eq  	$push33=, $pop30, $pop32
-	br_if   	0, $pop33       # 0: down to label5
-# BB#8:                                 # %land.lhs.true
+	br_if   	0, $pop33       # 0: down to label6
+# BB#9:                                 # %land.lhs.true
 	i32.const	$push13=, 58
-	i32.ne  	$push14=, $2, $pop13
-	br_if   	1, $pop14       # 1: down to label4
-# BB#9:                                 # %if.then39
+	i32.ne  	$push14=, $4, $pop13
+	br_if   	1, $pop14       # 1: down to label5
+# BB#10:                                # %if.then39
 	i32.const	$push15=, 1
-	i32.add 	$6=, $4, $pop15
+	i32.add 	$3=, $5, $pop15
 	i32.const	$push16=, 0
-	i32.store8	$discard=, 0($4), $pop16
-	copy_local	$4=, $6
-.LBB1_10:                               # %if.end41
+	i32.store8	$discard=, 0($5), $pop16
+	copy_local	$5=, $3
+.LBB1_11:                               # %if.end41
+	end_block                       # label6:
+	i32.call	$discard=, strcpy@FUNCTION, $0, $5
+	i32.const	$3=, 168496141
+.LBB1_12:                               # %if.end43
 	end_block                       # label5:
-	i32.call	$discard=, strcpy@FUNCTION, $0, $4
-	i32.const	$6=, 168496141
-.LBB1_11:                               # %if.end43
-	end_block                       # label4:
-	return  	$6
+	return  	$3
 	.endfunc
 .Lfunc_end1:
 	.size	root_nfs_parse_addr, .Lfunc_end1-root_nfs_parse_addr
@@ -116,91 +118,93 @@ root_nfs_parse_addr:                    # @root_nfs_parse_addr
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$2=, 0
-	i32.const	$0=, main.addr
+	i32.const	$0=, 0
+	i32.const	$1=, main.addr
 .LBB2_1:                                # %while.cond1.preheader.i
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB2_2 Depth 2
-	loop                            # label6:
-	copy_local	$1=, $0
+	block
+	loop                            # label8:
+	copy_local	$2=, $1
 .LBB2_2:                                # %while.cond1.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label8:
-	copy_local	$push26=, $1
-	tee_local	$push25=, $5=, $pop26
+	loop                            # label10:
+	copy_local	$push26=, $2
+	tee_local	$push25=, $4=, $pop26
 	i32.const	$push24=, 1
-	i32.add 	$1=, $pop25, $pop24
-	i32.load8_u	$push23=, 0($5)
-	tee_local	$push22=, $4=, $pop23
+	i32.add 	$2=, $pop25, $pop24
+	i32.load8_u	$push23=, 0($4)
+	tee_local	$push22=, $3=, $pop23
 	i32.const	$push21=, -48
 	i32.add 	$push0=, $pop22, $pop21
 	i32.const	$push20=, 255
 	i32.and 	$push1=, $pop0, $pop20
 	i32.const	$push19=, 10
 	i32.lt_u	$push2=, $pop1, $pop19
-	br_if   	0, $pop2        # 0: up to label8
+	br_if   	0, $pop2        # 0: up to label10
 # BB#3:                                 # %while.end.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label9:
-	copy_local	$3=, $0
-	i32.eq  	$push3=, $5, $0
-	br_if   	1, $pop3        # 1: down to label7
+	end_loop                        # label11:
+	i32.eq  	$push3=, $4, $1
+	br_if   	1, $pop3        # 1: down to label9
 # BB#4:                                 # %lor.lhs.false.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	copy_local	$3=, $5
-	i32.sub 	$push4=, $5, $0
+	i32.sub 	$push4=, $4, $1
 	i32.const	$push27=, 3
 	i32.gt_s	$push5=, $pop4, $pop27
-	br_if   	1, $pop5        # 1: down to label7
+	br_if   	2, $pop5        # 2: down to label7
 # BB#5:                                 # %if.end.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push31=, 3
-	i32.eq  	$push8=, $2, $pop31
+	i32.eq  	$push8=, $0, $pop31
 	i32.const	$push30=, 255
-	i32.and 	$push6=, $4, $pop30
+	i32.and 	$push6=, $3, $pop30
 	i32.const	$push29=, 46
 	i32.eq  	$push7=, $pop6, $pop29
 	i32.or  	$push9=, $pop8, $pop7
-	i32.add 	$2=, $pop9, $2
-	copy_local	$0=, $1
-	copy_local	$3=, $5
+	i32.add 	$0=, $pop9, $0
+	copy_local	$1=, $2
 	i32.const	$push28=, 4
-	i32.lt_s	$push10=, $2, $pop28
-	br_if   	0, $pop10       # 0: up to label6
-.LBB2_6:                                # %while.end25.i
-	end_loop                        # label7:
+	i32.lt_s	$push10=, $0, $pop28
+	br_if   	0, $pop10       # 0: up to label8
+	br      	2               # 2: down to label7
+.LBB2_6:
+	end_loop                        # label9:
+	copy_local	$4=, $1
+.LBB2_7:                                # %while.end25.i
+	end_block                       # label7:
 	block
 	i32.const	$push11=, 4
-	i32.ne  	$push12=, $2, $pop11
-	br_if   	0, $pop12       # 0: down to label10
-# BB#7:                                 # %land.lhs.true.i
+	i32.ne  	$push12=, $0, $pop11
+	br_if   	0, $pop12       # 0: down to label12
+# BB#8:                                 # %land.lhs.true.i
 	block
-	i32.load8_u	$push33=, 0($3)
-	tee_local	$push32=, $5=, $pop33
+	i32.load8_u	$push33=, 0($4)
+	tee_local	$push32=, $2=, $pop33
 	i32.const	$push34=, 0
 	i32.eq  	$push35=, $pop32, $pop34
-	br_if   	0, $pop35       # 0: down to label11
-# BB#8:                                 # %land.lhs.true.i
+	br_if   	0, $pop35       # 0: down to label13
+# BB#9:                                 # %land.lhs.true.i
 	i32.const	$push13=, 58
-	i32.ne  	$push14=, $5, $pop13
-	br_if   	1, $pop14       # 1: down to label10
-# BB#9:                                 # %if.then39.i
+	i32.ne  	$push14=, $2, $pop13
+	br_if   	1, $pop14       # 1: down to label12
+# BB#10:                                # %if.then39.i
 	i32.const	$push15=, 1
-	i32.add 	$5=, $3, $pop15
+	i32.add 	$2=, $4, $pop15
 	i32.const	$push16=, 0
-	i32.store8	$discard=, 0($3), $pop16
-	copy_local	$3=, $5
-.LBB2_10:                               # %if.end
-	end_block                       # label11:
+	i32.store8	$discard=, 0($4), $pop16
+	copy_local	$4=, $2
+.LBB2_11:                               # %if.end
+	end_block                       # label13:
 	i32.const	$push17=, main.addr
-	i32.call	$discard=, strcpy@FUNCTION, $pop17, $3
+	i32.call	$discard=, strcpy@FUNCTION, $pop17, $4
 	i32.const	$push18=, 0
 	return  	$pop18
-.LBB2_11:                               # %if.then
-	end_block                       # label10:
+.LBB2_12:                               # %if.then
+	end_block                       # label12:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20040703-1.c.s
+++ b/test/torture-s/20040703-1.c.s
@@ -6,7 +6,7 @@
 	.type	num_lshift,@function
 num_lshift:                             # @num_lshift
 	.param  	i32, i32, i32, i32
-	.local  	i32, i32, i64, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i64, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	block
 	block
@@ -20,9 +20,9 @@ num_lshift:                             # @num_lshift
 # BB#1:                                 # %if.else
 	i32.load	$4=, 0($1)
 	i32.load	$5=, 4($1)
-	copy_local	$8=, $5
+	copy_local	$6=, $5
 	copy_local	$9=, $4
-	copy_local	$7=, $3
+	copy_local	$8=, $3
 	block
 	i32.const	$push11=, 32
 	i32.lt_u	$push12=, $3, $pop11
@@ -31,45 +31,45 @@ num_lshift:                             # @num_lshift
 	i32.const	$push15=, 4
 	i32.add 	$push16=, $1, $pop15
 	i32.const	$push13=, 0
-	i32.store	$8=, 0($pop16), $pop13
+	i32.store	$6=, 0($pop16), $pop13
 	i32.const	$push14=, -32
-	i32.add 	$7=, $3, $pop14
+	i32.add 	$8=, $3, $pop14
 	i32.store	$9=, 0($1), $5
 .LBB0_3:                                # %if.end
 	end_block                       # label7:
 	block
 	i32.const	$push106=, 0
-	i32.eq  	$push107=, $7, $pop106
+	i32.eq  	$push107=, $8, $pop106
 	br_if   	0, $pop107      # 0: down to label8
 # BB#4:                                 # %if.then10
 	i32.const	$push18=, 32
-	i32.sub 	$push19=, $pop18, $7
-	i32.shr_u	$11=, $8, $pop19
+	i32.sub 	$push19=, $pop18, $8
+	i32.shr_u	$11=, $6, $pop19
 	i32.const	$push20=, 4
 	i32.add 	$push21=, $1, $pop20
-	i32.shl 	$push1=, $8, $7
-	i32.store	$8=, 0($pop21), $pop1
-	i32.shl 	$push17=, $9, $7
+	i32.shl 	$push1=, $6, $8
+	i32.store	$6=, 0($pop21), $pop1
+	i32.shl 	$push17=, $9, $8
 	i32.or  	$push0=, $11, $pop17
 	i32.store	$9=, 0($1), $pop0
 .LBB0_5:                                # %if.end18
 	end_block                       # label8:
 	i32.const	$push22=, 8
 	i32.add 	$push23=, $1, $pop22
-	i64.load	$6=, 0($pop23):p2align=2
+	i64.load	$7=, 0($pop23):p2align=2
 	i32.const	$push24=, 33
 	i32.lt_u	$push25=, $2, $pop24
 	br_if   	1, $pop25       # 1: down to label5
 # BB#6:                                 # %if.then.i
 	i32.const	$push32=, -32
 	i32.add 	$push93=, $2, $pop32
-	tee_local	$push92=, $7=, $pop93
+	tee_local	$push92=, $8=, $pop93
 	i32.const	$push33=, 31
 	i32.gt_u	$push34=, $pop92, $pop33
 	br_if   	2, $pop34       # 2: down to label4
 # BB#7:                                 # %if.then2.i
 	i32.const	$push35=, 1
-	i32.shl 	$push36=, $pop35, $7
+	i32.shl 	$push36=, $pop35, $8
 	i32.const	$push37=, -1
 	i32.add 	$push38=, $pop36, $pop37
 	i32.and 	$9=, $9, $pop38
@@ -94,14 +94,14 @@ num_lshift:                             # @num_lshift
 	i32.shl 	$push29=, $pop28, $2
 	i32.const	$push30=, -1
 	i32.add 	$push31=, $pop29, $pop30
-	i32.and 	$8=, $8, $pop31
+	i32.and 	$6=, $6, $pop31
 .LBB0_12:                               # %num_trim.exit
 	end_block                       # label4:
 	i32.const	$push39=, 4
 	i32.add 	$push40=, $1, $pop39
-	i32.store	$7=, 0($pop40), $8
-	i32.store	$8=, 0($1), $9
-	i32.wrap/i64	$push41=, $6
+	i32.store	$8=, 0($pop40), $6
+	i32.store	$6=, 0($1), $9
+	i32.wrap/i64	$push41=, $7
 	i32.const	$push110=, 0
 	i32.eq  	$push111=, $pop41, $pop110
 	br_if   	2, $pop111      # 2: down to label1
@@ -140,7 +140,7 @@ num_lshift:                             # @num_lshift
 	i32.const	$push53=, -33
 	i32.add 	$push54=, $2, $pop53
 	i32.shl 	$push56=, $pop55, $pop54
-	i32.and 	$push57=, $8, $pop56
+	i32.and 	$push57=, $6, $pop56
 	i32.select	$11=, $pop58, $pop96, $pop57
 	i32.const	$push59=, 63
 	i32.gt_u	$push60=, $2, $pop59
@@ -155,30 +155,30 @@ num_lshift:                             # @num_lshift
 	i32.const	$push94=, -1
 	i32.add 	$push46=, $2, $pop94
 	i32.shl 	$push47=, $pop95, $pop46
-	i32.and 	$push48=, $7, $pop47
+	i32.and 	$push48=, $8, $pop47
 	i32.select	$11=, $pop45, $pop49, $pop48
 	i32.const	$push50=, 31
 	i32.gt_u	$push51=, $2, $pop50
 	br_if   	0, $pop51       # 0: down to label10
 # BB#19:                                # %if.then5.i64
 	i32.shl 	$push52=, $11, $2
-	i32.or  	$7=, $pop52, $7
-	copy_local	$8=, $11
+	i32.or  	$8=, $pop52, $8
+	copy_local	$6=, $11
 	br      	1               # 1: down to label9
 .LBB0_20:                               # %if.then10.i
 	end_block                       # label10:
 	i32.const	$push61=, -32
 	i32.add 	$push62=, $2, $pop61
 	i32.shl 	$push63=, $11, $pop62
-	i32.or  	$8=, $pop63, $8
+	i32.or  	$6=, $pop63, $6
 	i32.const	$10=, 0
 .LBB0_21:                               # %if.end15.i
 	end_block                       # label9:
 	i32.const	$push64=, 31
 	i32.gt_u	$push100=, $3, $pop64
 	tee_local	$push99=, $12=, $pop100
-	i32.select	$9=, $8, $7, $pop99
-	i32.select	$8=, $11, $8, $12
+	i32.select	$9=, $6, $8, $pop99
+	i32.select	$6=, $11, $6, $12
 	block
 	i32.const	$push65=, -32
 	i32.add 	$push66=, $3, $pop65
@@ -190,13 +190,13 @@ num_lshift:                             # @num_lshift
 # BB#22:                                # %if.then24.i
 	i32.const	$push68=, 32
 	i32.sub 	$push102=, $pop68, $3
-	tee_local	$push101=, $7=, $pop102
-	i32.shl 	$push69=, $8, $pop101
+	tee_local	$push101=, $8=, $pop102
+	i32.shl 	$push69=, $6, $pop101
 	i32.shr_u	$push67=, $9, $3
 	i32.or  	$9=, $pop69, $pop67
-	i32.shr_u	$push70=, $8, $3
-	i32.shl 	$push71=, $11, $7
-	i32.or  	$8=, $pop70, $pop71
+	i32.shr_u	$push70=, $6, $3
+	i32.shl 	$push71=, $11, $8
+	i32.or  	$6=, $pop70, $pop71
 .LBB0_23:                               # %if.end38.i
 	end_block                       # label12:
 	block
@@ -216,11 +216,11 @@ num_lshift:                             # @num_lshift
 	i32.shl 	$push82=, $pop81, $2
 	i32.const	$push83=, -1
 	i32.add 	$push84=, $pop82, $pop83
-	i32.and 	$8=, $8, $pop84
+	i32.and 	$6=, $6, $pop84
 	br      	1               # 1: down to label13
 .LBB0_26:                               # %if.else.i.i
 	end_block                       # label14:
-	i32.const	$8=, 0
+	i32.const	$6=, 0
 	i32.const	$push114=, 0
 	i32.eq  	$push115=, $10, $pop114
 	br_if   	0, $pop115      # 0: down to label13
@@ -233,19 +233,19 @@ num_lshift:                             # @num_lshift
 .LBB0_28:                               # %num_rshift.exit
 	end_block                       # label13:
 	i32.ne  	$push86=, $5, $9
-	i32.ne  	$push85=, $4, $8
+	i32.ne  	$push85=, $4, $6
 	i32.or  	$push87=, $pop86, $pop85
 	i32.store	$discard=, 12($1), $pop87
 .LBB0_29:                               # %if.end37
 	end_block                       # label0:
 	i32.const	$push89=, 8
 	i32.add 	$push91=, $1, $pop89
-	i64.load	$6=, 0($pop91):p2align=2
+	i64.load	$7=, 0($pop91):p2align=2
 	i64.load	$push88=, 0($1):p2align=2
 	i64.store	$discard=, 0($0):p2align=2, $pop88
 	i32.const	$push105=, 8
 	i32.add 	$push90=, $0, $pop105
-	i64.store	$discard=, 0($pop90):p2align=2, $6
+	i64.store	$discard=, 0($pop90):p2align=2, $7
 	return
 	.endfunc
 .Lfunc_end0:
@@ -288,32 +288,22 @@ main:                                   # @main
 	i32.const	$4=, 16
 	i32.add 	$4=, $5, $4
 	block
-	block
-	block
 	i32.or  	$push10=, $4, $pop9
 	i32.load	$push11=, 0($pop10)
 	i32.const	$push12=, 196608
 	i32.ne  	$push13=, $pop11, $pop12
-	br_if   	0, $pop13       # 0: down to label17
+	br_if   	0, $pop13       # 0: down to label15
 # BB#1:                                 # %if.end
 	i32.load	$push14=, 16($5):p2align=3
-	br_if   	1, $pop14       # 1: down to label16
+	br_if   	0, $pop14       # 0: down to label15
 # BB#2:                                 # %if.end3
 	i32.load	$push15=, 28($5)
-	br_if   	2, $pop15       # 2: down to label15
+	br_if   	0, $pop15       # 0: down to label15
 # BB#3:                                 # %if.end6
 	i32.const	$push16=, 0
 	call    	exit@FUNCTION, $pop16
 	unreachable
-.LBB1_4:                                # %if.then
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_5:                                # %if.then2
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_6:                                # %if.then5
+.LBB1_4:                                # %if.then5
 	end_block                       # label15:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20040709-1.c.s
+++ b/test/torture-s/20040709-1.c.s
@@ -206,7 +206,6 @@ testA:                                  # @testA
 	i32.ne  	$push22=, $pop21, $pop20
 	br_if   	0, $pop22       # 0: down to label0
 # BB#1:                                 # %if.end87
-	block
 	i32.const	$push110=, 0
 	i32.const	$push109=, 0
 	i32.const	$push23=, -2139243339
@@ -240,20 +239,16 @@ testA:                                  # @testA
 	i32.xor 	$push34=, $pop93, $2
 	i32.const	$push92=, 131071
 	i32.and 	$push35=, $pop34, $pop92
-	br_if   	0, $pop35       # 0: down to label1
+	br_if   	0, $pop35       # 0: down to label0
 # BB#2:                                 # %lor.lhs.false125
 	i32.add 	$push38=, $3, $1
 	i32.const	$push36=, 17
 	i32.shr_u	$push37=, $0, $pop36
 	i32.ne  	$push39=, $pop38, $pop37
-	br_if   	0, $pop39       # 0: down to label1
+	br_if   	0, $pop39       # 0: down to label0
 # BB#3:                                 # %if.end131
 	return
 .LBB6_4:                                # %if.then130
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_5:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -476,9 +471,8 @@ testB:                                  # @testB
 	i32.const	$push56=, 17
 	i32.shr_u	$push28=, $pop27, $pop56
 	i32.ne  	$push30=, $pop29, $pop28
-	br_if   	0, $pop30       # 0: down to label2
+	br_if   	0, $pop30       # 0: down to label1
 # BB#1:                                 # %if.end76
-	block
 	i32.const	$push156=, 0
 	i32.const	$push155=, 0
 	i32.const	$push154=, 1103515245
@@ -526,25 +520,21 @@ testB:                                  # @testB
 	tee_local	$push130=, $3=, $pop131
 	i32.const	$push48=, 63
 	i32.and 	$push49=, $pop130, $pop48
-	br_if   	0, $pop49       # 0: down to label3
+	br_if   	0, $pop49       # 0: down to label1
 # BB#2:                                 # %lor.lhs.false91
 	i32.add 	$push54=, $2, $1
 	i32.const	$push51=, 17
 	i32.shr_u	$push52=, $4, $pop51
 	i32.ne  	$push55=, $pop54, $pop52
-	br_if   	0, $pop55       # 0: down to label3
+	br_if   	0, $pop55       # 0: down to label1
 # BB#3:                                 # %lor.lhs.false91
 	i32.const	$push53=, 131008
 	i32.and 	$push50=, $3, $pop53
-	br_if   	0, $pop50       # 0: down to label3
+	br_if   	0, $pop50       # 0: down to label1
 # BB#4:                                 # %if.end115
 	return
 .LBB12_5:                               # %if.then114
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_6:                               # %if.then
-	end_block                       # label2:
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -766,9 +756,8 @@ testC:                                  # @testC
 	i32.const	$push57=, 17
 	i32.shr_u	$push29=, $pop28, $pop57
 	i32.ne  	$push31=, $pop30, $pop29
-	br_if   	0, $pop31       # 0: down to label4
+	br_if   	0, $pop31       # 0: down to label2
 # BB#1:                                 # %if.end80
-	block
 	i32.const	$push153=, 0
 	i32.const	$push152=, 0
 	i32.const	$push151=, 1103515245
@@ -813,25 +802,21 @@ testC:                                  # @testC
 	tee_local	$push130=, $1=, $pop131
 	i32.const	$push49=, 63
 	i32.and 	$push50=, $pop130, $pop49
-	br_if   	0, $pop50       # 0: down to label5
+	br_if   	0, $pop50       # 0: down to label2
 # BB#2:                                 # %lor.lhs.false96
 	i32.add 	$push55=, $2, $0
 	i32.const	$push52=, 17
 	i32.shr_u	$push53=, $4, $pop52
 	i32.ne  	$push56=, $pop55, $pop53
-	br_if   	0, $pop56       # 0: down to label5
+	br_if   	0, $pop56       # 0: down to label2
 # BB#3:                                 # %lor.lhs.false96
 	i32.const	$push54=, 131008
 	i32.and 	$push51=, $1, $pop54
-	br_if   	0, $pop51       # 0: down to label5
+	br_if   	0, $pop51       # 0: down to label2
 # BB#4:                                 # %if.end121
 	return
 .LBB18_5:                               # %if.then120
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_6:                               # %if.then
-	end_block                       # label4:
+	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1958,9 +1943,8 @@ testG:                                  # @testG
 	i32.const	$push64=, 25
 	i32.shr_u	$push42=, $pop41, $pop64
 	i32.ne  	$push46=, $pop45, $pop42
-	br_if   	0, $pop46       # 0: down to label6
+	br_if   	0, $pop46       # 0: down to label3
 # BB#1:                                 # %if.end76
-	block
 	i32.const	$push202=, 0
 	i32.const	$push201=, 0
 	i32.const	$push47=, -2139243339
@@ -1990,7 +1974,7 @@ testG:                                  # @testG
 	i32.xor 	$push56=, $pop187, $2
 	i32.const	$push186=, 33554431
 	i32.and 	$push57=, $pop56, $pop186
-	br_if   	0, $pop57       # 0: down to label7
+	br_if   	0, $pop57       # 0: down to label3
 # BB#2:                                 # %lor.lhs.false109
 	i32.add 	$push60=, $3, $1
 	i32.const	$push61=, 127
@@ -1998,15 +1982,11 @@ testG:                                  # @testG
 	i32.const	$push58=, 25
 	i32.shr_u	$push59=, $0, $pop58
 	i32.ne  	$push63=, $pop62, $pop59
-	br_if   	0, $pop63       # 0: down to label7
+	br_if   	0, $pop63       # 0: down to label3
 # BB#3:                                 # %if.end115
 	return
 .LBB42_4:                               # %if.then114
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB42_5:                               # %if.then
-	end_block                       # label6:
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -2306,9 +2286,8 @@ testH:                                  # @testH
 	i32.const	$push64=, 23
 	i32.shr_u	$push42=, $pop41, $pop64
 	i32.ne  	$push46=, $pop45, $pop42
-	br_if   	0, $pop46       # 0: down to label8
+	br_if   	0, $pop46       # 0: down to label4
 # BB#1:                                 # %if.end76
-	block
 	i32.const	$push202=, 0
 	i32.const	$push201=, 0
 	i32.const	$push47=, -2139243339
@@ -2338,7 +2317,7 @@ testH:                                  # @testH
 	i32.xor 	$push56=, $pop187, $2
 	i32.const	$push186=, 8388607
 	i32.and 	$push57=, $pop56, $pop186
-	br_if   	0, $pop57       # 0: down to label9
+	br_if   	0, $pop57       # 0: down to label4
 # BB#2:                                 # %lor.lhs.false109
 	i32.add 	$push60=, $3, $1
 	i32.const	$push61=, 511
@@ -2346,15 +2325,11 @@ testH:                                  # @testH
 	i32.const	$push58=, 23
 	i32.shr_u	$push59=, $0, $pop58
 	i32.ne  	$push63=, $pop62, $pop59
-	br_if   	0, $pop63       # 0: down to label9
+	br_if   	0, $pop63       # 0: down to label4
 # BB#3:                                 # %if.end115
 	return
 .LBB48_4:                               # %if.then114
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB48_5:                               # %if.then
-	end_block                       # label8:
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -2837,7 +2812,7 @@ testJ:                                  # @testJ
 	i32.xor 	$push19=, $pop18, $pop17
 	i32.const	$push20=, 127
 	i32.and 	$push21=, $pop19, $pop20
-	br_if   	0, $pop21       # 0: down to label10
+	br_if   	0, $pop21       # 0: down to label5
 # BB#1:                                 # %if.end142
 	i32.const	$push89=, 0
 	i32.const	$push88=, 0
@@ -2864,7 +2839,7 @@ testJ:                                  # @testJ
 	i32.store16	$discard=, sJ($pop89):p2align=2, $pop33
 	return
 .LBB60_2:                               # %if.then
-	end_block                       # label10:
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -3249,7 +3224,7 @@ testL:                                  # @testL
 	i32.xor 	$push25=, $pop24, $pop23
 	i32.const	$push39=, 63
 	i32.and 	$push26=, $pop25, $pop39
-	br_if   	0, $pop26       # 0: down to label11
+	br_if   	0, $pop26       # 0: down to label6
 # BB#1:                                 # %if.end75
 	i32.const	$push119=, 0
 	i32.const	$push118=, 0
@@ -3276,7 +3251,7 @@ testL:                                  # @testL
 	i32.store	$discard=, sL($pop119):p2align=3, $pop38
 	return
 .LBB72_2:                               # %if.then
-	end_block                       # label11:
+	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -3491,7 +3466,7 @@ testM:                                  # @testM
 	i32.xor 	$push26=, $pop24, $pop25
 	i32.const	$push39=, 63
 	i32.and 	$push27=, $pop26, $pop39
-	br_if   	0, $pop27       # 0: down to label12
+	br_if   	0, $pop27       # 0: down to label7
 # BB#1:                                 # %if.end79
 	i32.const	$push115=, 0
 	i32.const	$push114=, 0
@@ -3516,7 +3491,7 @@ testM:                                  # @testM
 	i32.store	$discard=, sM+4($pop115), $pop38
 	return
 .LBB78_2:                               # %if.then
-	end_block                       # label12:
+	end_block                       # label7:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -3724,8 +3699,6 @@ testN:                                  # @testN
 	i32.add 	$push0=, $pop27, $pop115
 	i32.store	$1=, myrnd.s($pop121), $pop0
 	block
-	block
-	block
 	i32.const	$push114=, 0
 	i32.const	$push28=, 10
 	i32.shr_u	$push29=, $5, $pop28
@@ -3749,13 +3722,13 @@ testN:                                  # @testN
 	i64.and 	$push36=, $pop104, $pop35
 	i64.const	$push103=, 0
 	i64.ne  	$push37=, $pop36, $pop103
-	br_if   	0, $pop37       # 0: down to label15
+	br_if   	0, $pop37       # 0: down to label8
 # BB#1:                                 # %lor.lhs.false29
 	i64.const	$push41=, 63
 	i64.and 	$push42=, $4, $pop41
 	i64.const	$push168=, 0
 	i64.ne  	$push43=, $pop42, $pop168
-	br_if   	0, $pop43       # 0: down to label15
+	br_if   	0, $pop43       # 0: down to label8
 # BB#2:                                 # %lor.lhs.false29
 	i64.const	$push33=, 6
 	i64.shr_u	$push34=, $2, $pop33
@@ -3767,7 +3740,7 @@ testN:                                  # @testN
 	i32.xor 	$push39=, $pop172, $pop169
 	i32.const	$push40=, 63
 	i32.and 	$push38=, $pop39, $pop40
-	br_if   	0, $pop38       # 0: down to label15
+	br_if   	0, $pop38       # 0: down to label8
 # BB#3:                                 # %lor.lhs.false49
 	i32.const	$push177=, 16
 	i32.shr_u	$push176=, $1, $pop177
@@ -3777,7 +3750,7 @@ testN:                                  # @testN
 	i32.xor 	$push45=, $pop2, $pop44
 	i32.const	$push174=, 63
 	i32.and 	$push46=, $pop45, $pop174
-	br_if   	0, $pop46       # 0: down to label15
+	br_if   	0, $pop46       # 0: down to label8
 # BB#4:                                 # %lor.lhs.false69
 	i32.const	$push51=, 0
 	i32.const	$push47=, 1103515245
@@ -3817,13 +3790,13 @@ testN:                                  # @testN
 	i64.and 	$push64=, $pop179, $pop63
 	i64.const	$push178=, 0
 	i64.ne  	$push65=, $pop64, $pop178
-	br_if   	1, $pop65       # 1: down to label14
+	br_if   	0, $pop65       # 0: down to label8
 # BB#5:                                 # %lor.lhs.false80
 	i64.const	$push69=, 63
 	i64.and 	$push70=, $2, $pop69
 	i64.const	$push194=, 0
 	i64.ne  	$push71=, $pop70, $pop194
-	br_if   	1, $pop71       # 1: down to label14
+	br_if   	0, $pop71       # 0: down to label8
 # BB#6:                                 # %lor.lhs.false80
 	i32.const	$push197=, 16
 	i32.shr_u	$push196=, $5, $pop197
@@ -3831,7 +3804,7 @@ testN:                                  # @testN
 	i32.xor 	$push67=, $6, $pop195
 	i32.const	$push68=, 63
 	i32.and 	$push66=, $pop67, $pop68
-	br_if   	1, $pop66       # 1: down to label14
+	br_if   	0, $pop66       # 0: down to label8
 # BB#7:                                 # %lor.lhs.false100
 	i32.add 	$push72=, $7, $5
 	i32.const	$push198=, 63
@@ -3839,7 +3812,7 @@ testN:                                  # @testN
 	i32.const	$push74=, 15
 	i32.rem_u	$push75=, $pop73, $pop74
 	i32.ne  	$push76=, $pop75, $0
-	br_if   	1, $pop76       # 1: down to label14
+	br_if   	0, $pop76       # 0: down to label8
 # BB#8:                                 # %lor.lhs.false125
 	i32.const	$push84=, 0
 	i32.const	$push77=, 1103515245
@@ -3880,19 +3853,11 @@ testN:                                  # @testN
 	i32.xor 	$push101=, $pop100, $6
 	i32.const	$push199=, 63
 	i32.and 	$push102=, $pop101, $pop199
-	br_if   	2, $pop102      # 2: down to label13
+	br_if   	0, $pop102      # 0: down to label8
 # BB#9:                                 # %if.end158
 	return
-.LBB84_10:                              # %if.then
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB84_11:                              # %if.then106
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB84_12:                              # %if.then157
-	end_block                       # label13:
+.LBB84_10:                              # %if.then157
+	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -4175,7 +4140,6 @@ testO:                                  # @testO
 	i32.add 	$push0=, $pop42, $pop101
 	i32.store	$2=, myrnd.s($pop103), $pop0
 	block
-	block
 	i32.const	$push100=, 0
 	i64.extend_u/i32	$push44=, $1
 	i64.const	$push45=, -4096
@@ -4187,7 +4151,7 @@ testO:                                  # @testO
 	i32.const	$push97=, 2047
 	i32.and 	$push51=, $pop98, $pop97
 	i32.ne  	$push52=, $1, $pop51
-	br_if   	0, $pop52       # 0: down to label17
+	br_if   	0, $pop52       # 0: down to label9
 # BB#1:                                 # %entry
 	i32.const	$push208=, 16
 	i32.shr_u	$push43=, $2, $pop208
@@ -4199,7 +4163,7 @@ testO:                                  # @testO
 	i32.const	$push50=, 4095
 	i32.and 	$push3=, $pop49, $pop50
 	i32.ne  	$push53=, $pop2, $pop3
-	br_if   	0, $pop53       # 0: down to label17
+	br_if   	0, $pop53       # 0: down to label9
 # BB#2:                                 # %if.end
 	i32.const	$push54=, 1103515245
 	i32.mul 	$push55=, $2, $pop54
@@ -4216,7 +4180,6 @@ testO:                                  # @testO
 	i32.const	$push213=, 12345
 	i32.add 	$push1=, $pop58, $pop213
 	i32.store	$2=, myrnd.s($pop59), $pop1
-	block
 	i32.const	$push212=, 0
 	i64.extend_u/i32	$push61=, $1
 	i64.const	$push62=, -4096
@@ -4228,7 +4191,7 @@ testO:                                  # @testO
 	i32.const	$push209=, 2047
 	i32.and 	$push66=, $pop210, $pop209
 	i32.ne  	$push67=, $1, $pop66
-	br_if   	0, $pop67       # 0: down to label18
+	br_if   	0, $pop67       # 0: down to label9
 # BB#3:                                 # %lor.lhs.false87
 	i32.const	$push224=, 16
 	i32.shr_u	$push60=, $2, $pop224
@@ -4244,7 +4207,7 @@ testO:                                  # @testO
 	i32.const	$push219=, 15
 	i32.rem_u	$push73=, $pop72, $pop219
 	i32.ne  	$push74=, $pop71, $pop73
-	br_if   	0, $pop74       # 0: down to label18
+	br_if   	0, $pop74       # 0: down to label9
 # BB#4:                                 # %lor.lhs.false124
 	i32.const	$push83=, 0
 	i32.const	$push75=, 1103515245
@@ -4285,19 +4248,11 @@ testO:                                  # @testO
 	i32.const	$push225=, 4095
 	i32.and 	$push94=, $3, $pop225
 	i32.ne  	$push96=, $pop95, $pop94
-	br_if   	2, $pop96       # 2: down to label16
+	br_if   	0, $pop96       # 0: down to label9
 # BB#5:                                 # %if.end140
 	return
-.LBB90_6:                               # %if.then93
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB90_7:                               # %if.then
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB90_8:                               # %if.then139
-	end_block                       # label16:
+.LBB90_6:                               # %if.then139
+	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -4580,7 +4535,6 @@ testP:                                  # @testP
 	i32.add 	$push0=, $pop42, $pop101
 	i32.store	$2=, myrnd.s($pop103), $pop0
 	block
-	block
 	i32.const	$push100=, 0
 	i64.extend_u/i32	$push44=, $1
 	i64.const	$push45=, -4096
@@ -4592,7 +4546,7 @@ testP:                                  # @testP
 	i32.const	$push97=, 2047
 	i32.and 	$push51=, $pop98, $pop97
 	i32.ne  	$push52=, $1, $pop51
-	br_if   	0, $pop52       # 0: down to label20
+	br_if   	0, $pop52       # 0: down to label10
 # BB#1:                                 # %entry
 	i32.const	$push208=, 16
 	i32.shr_u	$push43=, $2, $pop208
@@ -4604,7 +4558,7 @@ testP:                                  # @testP
 	i32.const	$push50=, 4095
 	i32.and 	$push3=, $pop49, $pop50
 	i32.ne  	$push53=, $pop2, $pop3
-	br_if   	0, $pop53       # 0: down to label20
+	br_if   	0, $pop53       # 0: down to label10
 # BB#2:                                 # %if.end
 	i32.const	$push54=, 1103515245
 	i32.mul 	$push55=, $2, $pop54
@@ -4621,7 +4575,6 @@ testP:                                  # @testP
 	i32.const	$push213=, 12345
 	i32.add 	$push1=, $pop58, $pop213
 	i32.store	$2=, myrnd.s($pop59), $pop1
-	block
 	i32.const	$push212=, 0
 	i64.extend_u/i32	$push61=, $1
 	i64.const	$push62=, -4096
@@ -4633,7 +4586,7 @@ testP:                                  # @testP
 	i32.const	$push209=, 2047
 	i32.and 	$push66=, $pop210, $pop209
 	i32.ne  	$push67=, $1, $pop66
-	br_if   	0, $pop67       # 0: down to label21
+	br_if   	0, $pop67       # 0: down to label10
 # BB#3:                                 # %lor.lhs.false83
 	i32.const	$push224=, 16
 	i32.shr_u	$push60=, $2, $pop224
@@ -4649,7 +4602,7 @@ testP:                                  # @testP
 	i32.const	$push219=, 15
 	i32.rem_u	$push73=, $pop72, $pop219
 	i32.ne  	$push74=, $pop71, $pop73
-	br_if   	0, $pop74       # 0: down to label21
+	br_if   	0, $pop74       # 0: down to label10
 # BB#4:                                 # %lor.lhs.false118
 	i32.const	$push83=, 0
 	i32.const	$push75=, 1103515245
@@ -4690,19 +4643,11 @@ testP:                                  # @testP
 	i32.const	$push225=, 4095
 	i32.and 	$push94=, $3, $pop225
 	i32.ne  	$push96=, $pop95, $pop94
-	br_if   	2, $pop96       # 2: down to label19
+	br_if   	0, $pop96       # 0: down to label10
 # BB#5:                                 # %if.end134
 	return
-.LBB96_6:                               # %if.then89
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB96_7:                               # %if.then
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB96_8:                               # %if.then133
-	end_block                       # label19:
+.LBB96_6:                               # %if.then133
+	end_block                       # label10:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -5564,11 +5509,11 @@ testS:                                  # @testS
 	i32.const	$push51=, 1
 	i32.const	$push154=, 0
 	i32.eq  	$push155=, $pop51, $pop154
-	br_if   	0, $pop155      # 0: down to label22
+	br_if   	0, $pop155      # 0: down to label11
 # BB#1:                                 # %if.end134
 	return
 .LBB114_2:                              # %if.then133
-	end_block                       # label22:
+	end_block                       # label11:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -5734,7 +5679,6 @@ testT:                                  # @testT
 	i32.const	$push41=, 0
 	i32.load	$0=, sT($pop41)
 	block
-	block
 	i32.const	$push40=, 0
 	i32.const	$push39=, 1103515245
 	i32.mul 	$push12=, $3, $pop39
@@ -5750,7 +5694,7 @@ testT:                                  # @testT
 	i32.xor 	$push18=, $pop17, $pop16
 	i32.const	$push32=, 1
 	i32.and 	$push19=, $pop18, $pop32
-	br_if   	0, $pop19       # 0: down to label24
+	br_if   	0, $pop19       # 0: down to label12
 # BB#1:                                 # %if.end94
 	i32.const	$push88=, 0
 	i32.const	$push87=, 0
@@ -5778,15 +5722,11 @@ testT:                                  # @testT
 	i32.const	$push78=, 1
 	i32.const	$push89=, 0
 	i32.eq  	$push90=, $pop78, $pop89
-	br_if   	1, $pop90       # 1: down to label23
+	br_if   	0, $pop90       # 0: down to label12
 # BB#2:                                 # %if.end140
 	return
-.LBB120_3:                              # %if.then
-	end_block                       # label24:
-	call    	abort@FUNCTION
-	unreachable
-.LBB120_4:                              # %if.then139
-	end_block                       # label23:
+.LBB120_3:                              # %if.then139
+	end_block                       # label12:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -6090,8 +6030,6 @@ testU:                                  # @testU
 	tee_local	$push105=, $0=, $pop106
 	i32.store16	$discard=, sU($pop114):p2align=3, $pop105
 	block
-	block
-	block
 	i32.const	$push46=, 65472
 	i32.and 	$push47=, $0, $pop46
 	i32.const	$push104=, 6
@@ -6100,7 +6038,7 @@ testU:                                  # @testU
 	i32.xor 	$push48=, $pop102, $3
 	i32.const	$push101=, 1
 	i32.and 	$push49=, $pop48, $pop101
-	br_if   	0, $pop49       # 0: down to label27
+	br_if   	0, $pop49       # 0: down to label13
 # BB#1:                                 # %lor.lhs.false41
 	i32.const	$push220=, 16
 	i32.shr_u	$push219=, $1, $pop220
@@ -6110,7 +6048,7 @@ testU:                                  # @testU
 	i32.xor 	$push52=, $pop50, $pop51
 	i32.const	$push217=, 1
 	i32.and 	$push53=, $pop52, $pop217
-	br_if   	0, $pop53       # 0: down to label27
+	br_if   	0, $pop53       # 0: down to label13
 # BB#2:                                 # %if.end
 	i32.const	$push59=, 0
 	i32.const	$push54=, 1103515245
@@ -6145,7 +6083,7 @@ testU:                                  # @testU
 	i32.xor 	$push66=, $pop222, $0
 	i32.const	$push221=, 1
 	i32.and 	$push67=, $pop66, $pop221
-	br_if   	1, $pop67       # 1: down to label26
+	br_if   	0, $pop67       # 0: down to label13
 # BB#3:                                 # %lor.lhs.false85
 	i32.const	$push242=, 16
 	i32.shr_u	$push241=, $1, $pop242
@@ -6161,7 +6099,7 @@ testU:                                  # @testU
 	i32.const	$push237=, 15
 	i32.rem_u	$push74=, $pop73, $pop237
 	i32.ne  	$push75=, $pop71, $pop74
-	br_if   	1, $pop75       # 1: down to label26
+	br_if   	0, $pop75       # 0: down to label13
 # BB#4:                                 # %lor.lhs.false130
 	i32.const	$push83=, 0
 	i32.const	$push76=, 1103515245
@@ -6201,19 +6139,11 @@ testU:                                  # @testU
 	i32.xor 	$push98=, $pop97, $3
 	i32.const	$push99=, 1
 	i32.and 	$push100=, $pop98, $pop99
-	br_if   	2, $pop100      # 2: down to label25
+	br_if   	0, $pop100      # 0: down to label13
 # BB#5:                                 # %if.end136
 	return
-.LBB126_6:                              # %if.then
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB126_7:                              # %if.then91
-	end_block                       # label26:
-	call    	abort@FUNCTION
-	unreachable
-.LBB126_8:                              # %if.then135
-	end_block                       # label25:
+.LBB126_6:                              # %if.then135
+	end_block                       # label13:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -6386,7 +6316,6 @@ testV:                                  # @testV
 	i32.const	$push75=, 0
 	i32.load	$0=, sV($pop75)
 	block
-	block
 	i32.const	$push74=, 0
 	i32.const	$push73=, 1103515245
 	i32.mul 	$push14=, $3, $pop73
@@ -6406,7 +6335,7 @@ testV:                                  # @testV
 	i32.xor 	$push22=, $pop21, $pop20
 	i32.const	$push64=, 1
 	i32.and 	$push23=, $pop22, $pop64
-	br_if   	0, $pop23       # 0: down to label29
+	br_if   	0, $pop23       # 0: down to label14
 # BB#1:                                 # %if.end
 	i32.const	$push130=, 0
 	i32.const	$push129=, 1103515245
@@ -6435,7 +6364,6 @@ testV:                                  # @testV
 	i32.or  	$push115=, $pop28, $pop30
 	tee_local	$push114=, $2=, $pop115
 	i32.store16	$discard=, sV($pop123):p2align=2, $pop114
-	block
 	i32.const	$push31=, 65280
 	i32.and 	$push32=, $2, $pop31
 	i32.const	$push113=, 8
@@ -6444,7 +6372,7 @@ testV:                                  # @testV
 	i32.xor 	$push33=, $pop111, $1
 	i32.const	$push110=, 1
 	i32.and 	$push34=, $pop33, $pop110
-	br_if   	0, $pop34       # 0: down to label30
+	br_if   	0, $pop34       # 0: down to label14
 # BB#2:                                 # %lor.lhs.false89
 	i32.const	$push136=, 16
 	i32.shr_u	$push135=, $3, $pop136
@@ -6460,7 +6388,7 @@ testV:                                  # @testV
 	i32.const	$push131=, 15
 	i32.rem_u	$push41=, $pop40, $pop131
 	i32.ne  	$push42=, $pop38, $pop41
-	br_if   	0, $pop42       # 0: down to label30
+	br_if   	0, $pop42       # 0: down to label14
 # BB#3:                                 # %lor.lhs.false136
 	i32.const	$push50=, 0
 	i32.const	$push43=, 1103515245
@@ -6501,19 +6429,11 @@ testV:                                  # @testV
 	i32.xor 	$push62=, $pop61, $2
 	i32.const	$push137=, 1
 	i32.and 	$push63=, $pop62, $pop137
-	br_if   	2, $pop63       # 2: down to label28
+	br_if   	0, $pop63       # 0: down to label14
 # BB#4:                                 # %if.end142
 	return
-.LBB132_5:                              # %if.then95
-	end_block                       # label30:
-	call    	abort@FUNCTION
-	unreachable
-.LBB132_6:                              # %if.then
-	end_block                       # label29:
-	call    	abort@FUNCTION
-	unreachable
-.LBB132_7:                              # %if.then141
-	end_block                       # label28:
+.LBB132_5:                              # %if.then141
+	end_block                       # label14:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -6645,7 +6565,7 @@ testW:                                  # @testW
 	i32.const	$0=, -32
 .LBB138_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label31:
+	loop                            # label15:
 	i32.const	$push39=, 1103515245
 	i32.mul 	$push1=, $1, $pop39
 	i32.const	$push38=, 12345
@@ -6655,9 +6575,9 @@ testW:                                  # @testW
 	i32.store8	$discard=, sW+32($0), $pop2
 	i32.const	$push36=, 1
 	i32.add 	$0=, $0, $pop36
-	br_if   	0, $0           # 0: up to label31
+	br_if   	0, $0           # 0: up to label15
 # BB#2:                                 # %for.end
-	end_loop                        # label32:
+	end_loop                        # label16:
 	i32.const	$push3=, 0
 	i32.const	$push7=, 1103515245
 	i32.mul 	$push8=, $1, $pop7
@@ -6858,7 +6778,7 @@ testX:                                  # @testX
 	i32.const	$0=, -32
 .LBB144_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label33:
+	loop                            # label17:
 	i32.const	$push39=, 1103515245
 	i32.mul 	$push1=, $1, $pop39
 	i32.const	$push38=, 12345
@@ -6868,9 +6788,9 @@ testX:                                  # @testX
 	i32.store8	$discard=, sX+32($0), $pop2
 	i32.const	$push36=, 1
 	i32.add 	$0=, $0, $pop36
-	br_if   	0, $0           # 0: up to label33
+	br_if   	0, $0           # 0: up to label17
 # BB#2:                                 # %for.end
-	end_loop                        # label34:
+	end_loop                        # label18:
 	i32.const	$push3=, 0
 	i32.const	$push7=, 1103515245
 	i32.mul 	$push8=, $1, $pop7
@@ -7071,7 +6991,7 @@ testY:                                  # @testY
 	i32.const	$0=, -32
 .LBB150_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label35:
+	loop                            # label19:
 	i32.const	$push39=, 1103515245
 	i32.mul 	$push1=, $1, $pop39
 	i32.const	$push38=, 12345
@@ -7081,9 +7001,9 @@ testY:                                  # @testY
 	i32.store8	$discard=, sY+32($0), $pop2
 	i32.const	$push36=, 1
 	i32.add 	$0=, $0, $pop36
-	br_if   	0, $0           # 0: up to label35
+	br_if   	0, $0           # 0: up to label19
 # BB#2:                                 # %for.end
-	end_loop                        # label36:
+	end_loop                        # label20:
 	i32.const	$push3=, 0
 	i32.const	$push7=, 1103515245
 	i32.mul 	$push8=, $1, $pop7
@@ -7284,7 +7204,7 @@ testZ:                                  # @testZ
 	i32.const	$1=, -32
 .LBB156_1:                              # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label37:
+	loop                            # label21:
 	i32.const	$push47=, 1103515245
 	i32.mul 	$push3=, $2, $pop47
 	i32.const	$push46=, 12345
@@ -7294,9 +7214,9 @@ testZ:                                  # @testZ
 	i32.store8	$discard=, sZ+32($1), $pop4
 	i32.const	$push44=, 1
 	i32.add 	$1=, $1, $pop44
-	br_if   	0, $1           # 0: up to label37
+	br_if   	0, $1           # 0: up to label21
 # BB#2:                                 # %for.end
-	end_loop                        # label38:
+	end_loop                        # label22:
 	i32.const	$push71=, 0
 	i32.load	$0=, sZ+16($pop71):p2align=4
 	i32.const	$push70=, 0
@@ -7342,9 +7262,8 @@ testZ:                                  # @testZ
 	i32.const	$push48=, 20
 	i32.shr_u	$push16=, $pop15, $pop48
 	i32.ne  	$push18=, $pop17, $pop16
-	br_if   	0, $pop18       # 0: down to label39
+	br_if   	0, $pop18       # 0: down to label23
 # BB#3:                                 # %if.end80
-	block
 	i32.const	$push95=, 0
 	i32.const	$push94=, 0
 	i32.const	$push93=, 1103515245
@@ -7389,25 +7308,21 @@ testZ:                                  # @testZ
 	tee_local	$push72=, $1=, $pop73
 	i32.const	$push36=, 1040384
 	i32.and 	$push37=, $pop72, $pop36
-	br_if   	0, $pop37       # 0: down to label40
+	br_if   	0, $pop37       # 0: down to label23
 # BB#4:                                 # %lor.lhs.false98
 	i32.add 	$push42=, $4, $0
 	i32.const	$push39=, 20
 	i32.shr_u	$push40=, $3, $pop39
 	i32.ne  	$push43=, $pop42, $pop40
-	br_if   	0, $pop43       # 0: down to label40
+	br_if   	0, $pop43       # 0: down to label23
 # BB#5:                                 # %lor.lhs.false98
 	i32.const	$push41=, 8191
 	i32.and 	$push38=, $1, $pop41
-	br_if   	0, $pop38       # 0: down to label40
+	br_if   	0, $pop38       # 0: down to label23
 # BB#6:                                 # %if.end121
 	return
 .LBB156_7:                              # %if.then120
-	end_block                       # label40:
-	call    	abort@FUNCTION
-	unreachable
-.LBB156_8:                              # %if.then
-	end_block                       # label39:
+	end_block                       # label23:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20040709-2.c.s
+++ b/test/torture-s/20040709-2.c.s
@@ -3155,8 +3155,6 @@ testN:                                  # @testN
 	i32.add 	$push0=, $pop27, $pop115
 	i32.store	$1=, myrnd.s($pop121), $pop0
 	block
-	block
-	block
 	i32.const	$push114=, 0
 	i32.const	$push28=, 10
 	i32.shr_u	$push29=, $5, $pop28
@@ -3180,13 +3178,13 @@ testN:                                  # @testN
 	i64.and 	$push36=, $pop104, $pop35
 	i64.const	$push103=, 0
 	i64.ne  	$push37=, $pop36, $pop103
-	br_if   	0, $pop37       # 0: down to label5
+	br_if   	0, $pop37       # 0: down to label3
 # BB#1:                                 # %lor.lhs.false29
 	i64.const	$push41=, 63
 	i64.and 	$push42=, $4, $pop41
 	i64.const	$push168=, 0
 	i64.ne  	$push43=, $pop42, $pop168
-	br_if   	0, $pop43       # 0: down to label5
+	br_if   	0, $pop43       # 0: down to label3
 # BB#2:                                 # %lor.lhs.false29
 	i64.const	$push33=, 6
 	i64.shr_u	$push34=, $2, $pop33
@@ -3198,7 +3196,7 @@ testN:                                  # @testN
 	i32.xor 	$push39=, $pop172, $pop169
 	i32.const	$push40=, 63
 	i32.and 	$push38=, $pop39, $pop40
-	br_if   	0, $pop38       # 0: down to label5
+	br_if   	0, $pop38       # 0: down to label3
 # BB#3:                                 # %lor.lhs.false49
 	i32.const	$push177=, 16
 	i32.shr_u	$push176=, $1, $pop177
@@ -3208,7 +3206,7 @@ testN:                                  # @testN
 	i32.xor 	$push45=, $pop2, $pop44
 	i32.const	$push174=, 63
 	i32.and 	$push46=, $pop45, $pop174
-	br_if   	0, $pop46       # 0: down to label5
+	br_if   	0, $pop46       # 0: down to label3
 # BB#4:                                 # %lor.lhs.false69
 	i32.const	$push51=, 0
 	i32.const	$push47=, 1103515245
@@ -3248,13 +3246,13 @@ testN:                                  # @testN
 	i64.and 	$push64=, $pop179, $pop63
 	i64.const	$push178=, 0
 	i64.ne  	$push65=, $pop64, $pop178
-	br_if   	1, $pop65       # 1: down to label4
+	br_if   	0, $pop65       # 0: down to label3
 # BB#5:                                 # %lor.lhs.false80
 	i64.const	$push69=, 63
 	i64.and 	$push70=, $2, $pop69
 	i64.const	$push194=, 0
 	i64.ne  	$push71=, $pop70, $pop194
-	br_if   	1, $pop71       # 1: down to label4
+	br_if   	0, $pop71       # 0: down to label3
 # BB#6:                                 # %lor.lhs.false80
 	i32.const	$push197=, 16
 	i32.shr_u	$push196=, $5, $pop197
@@ -3262,7 +3260,7 @@ testN:                                  # @testN
 	i32.xor 	$push67=, $6, $pop195
 	i32.const	$push68=, 63
 	i32.and 	$push66=, $pop67, $pop68
-	br_if   	1, $pop66       # 1: down to label4
+	br_if   	0, $pop66       # 0: down to label3
 # BB#7:                                 # %lor.lhs.false100
 	i32.add 	$push72=, $7, $5
 	i32.const	$push198=, 63
@@ -3270,7 +3268,7 @@ testN:                                  # @testN
 	i32.const	$push74=, 15
 	i32.rem_u	$push75=, $pop73, $pop74
 	i32.ne  	$push76=, $pop75, $0
-	br_if   	1, $pop76       # 1: down to label4
+	br_if   	0, $pop76       # 0: down to label3
 # BB#8:                                 # %lor.lhs.false125
 	i32.const	$push84=, 0
 	i32.const	$push77=, 1103515245
@@ -3311,18 +3309,10 @@ testN:                                  # @testN
 	i32.xor 	$push101=, $pop100, $6
 	i32.const	$push199=, 63
 	i32.and 	$push102=, $pop101, $pop199
-	br_if   	2, $pop102      # 2: down to label3
+	br_if   	0, $pop102      # 0: down to label3
 # BB#9:                                 # %if.end158
 	return
-.LBB84_10:                              # %if.then
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB84_11:                              # %if.then106
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB84_12:                              # %if.then157
+.LBB84_10:                              # %if.then157
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
@@ -3606,7 +3596,6 @@ testO:                                  # @testO
 	i32.add 	$push0=, $pop42, $pop101
 	i32.store	$2=, myrnd.s($pop103), $pop0
 	block
-	block
 	i32.const	$push100=, 0
 	i64.extend_u/i32	$push44=, $1
 	i64.const	$push45=, -4096
@@ -3618,7 +3607,7 @@ testO:                                  # @testO
 	i32.const	$push97=, 2047
 	i32.and 	$push51=, $pop98, $pop97
 	i32.ne  	$push52=, $1, $pop51
-	br_if   	0, $pop52       # 0: down to label7
+	br_if   	0, $pop52       # 0: down to label4
 # BB#1:                                 # %entry
 	i32.const	$push208=, 16
 	i32.shr_u	$push43=, $2, $pop208
@@ -3630,7 +3619,7 @@ testO:                                  # @testO
 	i32.const	$push50=, 4095
 	i32.and 	$push3=, $pop49, $pop50
 	i32.ne  	$push53=, $pop2, $pop3
-	br_if   	0, $pop53       # 0: down to label7
+	br_if   	0, $pop53       # 0: down to label4
 # BB#2:                                 # %if.end
 	i32.const	$push54=, 1103515245
 	i32.mul 	$push55=, $2, $pop54
@@ -3647,7 +3636,6 @@ testO:                                  # @testO
 	i32.const	$push213=, 12345
 	i32.add 	$push1=, $pop58, $pop213
 	i32.store	$2=, myrnd.s($pop59), $pop1
-	block
 	i32.const	$push212=, 0
 	i64.extend_u/i32	$push61=, $1
 	i64.const	$push62=, -4096
@@ -3659,7 +3647,7 @@ testO:                                  # @testO
 	i32.const	$push209=, 2047
 	i32.and 	$push66=, $pop210, $pop209
 	i32.ne  	$push67=, $1, $pop66
-	br_if   	0, $pop67       # 0: down to label8
+	br_if   	0, $pop67       # 0: down to label4
 # BB#3:                                 # %lor.lhs.false87
 	i32.const	$push224=, 16
 	i32.shr_u	$push60=, $2, $pop224
@@ -3675,7 +3663,7 @@ testO:                                  # @testO
 	i32.const	$push219=, 15
 	i32.rem_u	$push73=, $pop72, $pop219
 	i32.ne  	$push74=, $pop71, $pop73
-	br_if   	0, $pop74       # 0: down to label8
+	br_if   	0, $pop74       # 0: down to label4
 # BB#4:                                 # %lor.lhs.false124
 	i32.const	$push83=, 0
 	i32.const	$push75=, 1103515245
@@ -3716,19 +3704,11 @@ testO:                                  # @testO
 	i32.const	$push225=, 4095
 	i32.and 	$push94=, $3, $pop225
 	i32.ne  	$push96=, $pop95, $pop94
-	br_if   	2, $pop96       # 2: down to label6
+	br_if   	0, $pop96       # 0: down to label4
 # BB#5:                                 # %if.end140
 	return
-.LBB90_6:                               # %if.then93
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB90_7:                               # %if.then
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB90_8:                               # %if.then139
-	end_block                       # label6:
+.LBB90_6:                               # %if.then139
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -4011,7 +3991,6 @@ testP:                                  # @testP
 	i32.add 	$push0=, $pop42, $pop101
 	i32.store	$2=, myrnd.s($pop103), $pop0
 	block
-	block
 	i32.const	$push100=, 0
 	i64.extend_u/i32	$push44=, $1
 	i64.const	$push45=, -4096
@@ -4023,7 +4002,7 @@ testP:                                  # @testP
 	i32.const	$push97=, 2047
 	i32.and 	$push51=, $pop98, $pop97
 	i32.ne  	$push52=, $1, $pop51
-	br_if   	0, $pop52       # 0: down to label10
+	br_if   	0, $pop52       # 0: down to label5
 # BB#1:                                 # %entry
 	i32.const	$push208=, 16
 	i32.shr_u	$push43=, $2, $pop208
@@ -4035,7 +4014,7 @@ testP:                                  # @testP
 	i32.const	$push50=, 4095
 	i32.and 	$push3=, $pop49, $pop50
 	i32.ne  	$push53=, $pop2, $pop3
-	br_if   	0, $pop53       # 0: down to label10
+	br_if   	0, $pop53       # 0: down to label5
 # BB#2:                                 # %if.end
 	i32.const	$push54=, 1103515245
 	i32.mul 	$push55=, $2, $pop54
@@ -4052,7 +4031,6 @@ testP:                                  # @testP
 	i32.const	$push213=, 12345
 	i32.add 	$push1=, $pop58, $pop213
 	i32.store	$2=, myrnd.s($pop59), $pop1
-	block
 	i32.const	$push212=, 0
 	i64.extend_u/i32	$push61=, $1
 	i64.const	$push62=, -4096
@@ -4064,7 +4042,7 @@ testP:                                  # @testP
 	i32.const	$push209=, 2047
 	i32.and 	$push66=, $pop210, $pop209
 	i32.ne  	$push67=, $1, $pop66
-	br_if   	0, $pop67       # 0: down to label11
+	br_if   	0, $pop67       # 0: down to label5
 # BB#3:                                 # %lor.lhs.false83
 	i32.const	$push224=, 16
 	i32.shr_u	$push60=, $2, $pop224
@@ -4080,7 +4058,7 @@ testP:                                  # @testP
 	i32.const	$push219=, 15
 	i32.rem_u	$push73=, $pop72, $pop219
 	i32.ne  	$push74=, $pop71, $pop73
-	br_if   	0, $pop74       # 0: down to label11
+	br_if   	0, $pop74       # 0: down to label5
 # BB#4:                                 # %lor.lhs.false118
 	i32.const	$push83=, 0
 	i32.const	$push75=, 1103515245
@@ -4121,19 +4099,11 @@ testP:                                  # @testP
 	i32.const	$push225=, 4095
 	i32.and 	$push94=, $3, $pop225
 	i32.ne  	$push96=, $pop95, $pop94
-	br_if   	2, $pop96       # 2: down to label9
+	br_if   	0, $pop96       # 0: down to label5
 # BB#5:                                 # %if.end134
 	return
-.LBB96_6:                               # %if.then89
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB96_7:                               # %if.then
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB96_8:                               # %if.then133
-	end_block                       # label9:
+.LBB96_6:                               # %if.then133
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -4601,11 +4571,11 @@ testR:                                  # @testR
 	i32.const	$push39=, 1
 	i32.const	$push106=, 0
 	i32.eq  	$push107=, $pop39, $pop106
-	br_if   	0, $pop107      # 0: down to label12
+	br_if   	0, $pop107      # 0: down to label6
 # BB#1:                                 # %if.end134
 	return
 .LBB108_2:                              # %if.then133
-	end_block                       # label12:
+	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -4841,11 +4811,11 @@ testS:                                  # @testS
 	i32.const	$push39=, 1
 	i32.const	$push106=, 0
 	i32.eq  	$push107=, $pop39, $pop106
-	br_if   	0, $pop107      # 0: down to label13
+	br_if   	0, $pop107      # 0: down to label7
 # BB#1:                                 # %if.end134
 	return
 .LBB114_2:                              # %if.then133
-	end_block                       # label13:
+	end_block                       # label7:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -5011,7 +4981,6 @@ testT:                                  # @testT
 	i32.const	$push41=, 0
 	i32.load	$0=, sT($pop41)
 	block
-	block
 	i32.const	$push40=, 0
 	i32.const	$push39=, 1103515245
 	i32.mul 	$push12=, $3, $pop39
@@ -5027,7 +4996,7 @@ testT:                                  # @testT
 	i32.xor 	$push18=, $pop17, $pop16
 	i32.const	$push32=, 1
 	i32.and 	$push19=, $pop18, $pop32
-	br_if   	0, $pop19       # 0: down to label15
+	br_if   	0, $pop19       # 0: down to label8
 # BB#1:                                 # %if.end94
 	i32.const	$push88=, 0
 	i32.const	$push87=, 0
@@ -5055,15 +5024,11 @@ testT:                                  # @testT
 	i32.const	$push78=, 1
 	i32.const	$push89=, 0
 	i32.eq  	$push90=, $pop78, $pop89
-	br_if   	1, $pop90       # 1: down to label14
+	br_if   	0, $pop90       # 0: down to label8
 # BB#2:                                 # %if.end140
 	return
-.LBB120_3:                              # %if.then
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB120_4:                              # %if.then139
-	end_block                       # label14:
+.LBB120_3:                              # %if.then139
+	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -5313,8 +5278,6 @@ testU:                                  # @testU
 	tee_local	$push93=, $0=, $pop94
 	i32.store16	$discard=, sU($pop102), $pop93
 	block
-	block
-	block
 	i32.const	$push34=, 65472
 	i32.and 	$push35=, $0, $pop34
 	i32.const	$push92=, 6
@@ -5323,7 +5286,7 @@ testU:                                  # @testU
 	i32.xor 	$push36=, $pop90, $3
 	i32.const	$push89=, 1
 	i32.and 	$push37=, $pop36, $pop89
-	br_if   	0, $pop37       # 0: down to label18
+	br_if   	0, $pop37       # 0: down to label9
 # BB#1:                                 # %lor.lhs.false41
 	i32.const	$push172=, 16
 	i32.shr_u	$push171=, $1, $pop172
@@ -5333,7 +5296,7 @@ testU:                                  # @testU
 	i32.xor 	$push40=, $pop38, $pop39
 	i32.const	$push169=, 1
 	i32.and 	$push41=, $pop40, $pop169
-	br_if   	0, $pop41       # 0: down to label18
+	br_if   	0, $pop41       # 0: down to label9
 # BB#2:                                 # %if.end
 	i32.const	$push47=, 0
 	i32.const	$push42=, 1103515245
@@ -5368,7 +5331,7 @@ testU:                                  # @testU
 	i32.xor 	$push54=, $pop174, $0
 	i32.const	$push173=, 1
 	i32.and 	$push55=, $pop54, $pop173
-	br_if   	1, $pop55       # 1: down to label17
+	br_if   	0, $pop55       # 0: down to label9
 # BB#3:                                 # %lor.lhs.false85
 	i32.const	$push194=, 16
 	i32.shr_u	$push193=, $1, $pop194
@@ -5384,7 +5347,7 @@ testU:                                  # @testU
 	i32.const	$push189=, 15
 	i32.rem_u	$push62=, $pop61, $pop189
 	i32.ne  	$push63=, $pop59, $pop62
-	br_if   	1, $pop63       # 1: down to label17
+	br_if   	0, $pop63       # 0: down to label9
 # BB#4:                                 # %lor.lhs.false130
 	i32.const	$push71=, 0
 	i32.const	$push64=, 1103515245
@@ -5424,19 +5387,11 @@ testU:                                  # @testU
 	i32.xor 	$push86=, $pop85, $3
 	i32.const	$push87=, 1
 	i32.and 	$push88=, $pop86, $pop87
-	br_if   	2, $pop88       # 2: down to label16
+	br_if   	0, $pop88       # 0: down to label9
 # BB#5:                                 # %if.end136
 	return
-.LBB126_6:                              # %if.then
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB126_7:                              # %if.then91
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB126_8:                              # %if.then135
-	end_block                       # label16:
+.LBB126_6:                              # %if.then135
+	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -5609,7 +5564,6 @@ testV:                                  # @testV
 	i32.const	$push75=, 0
 	i32.load	$0=, sV($pop75)
 	block
-	block
 	i32.const	$push74=, 0
 	i32.const	$push73=, 1103515245
 	i32.mul 	$push14=, $3, $pop73
@@ -5629,7 +5583,7 @@ testV:                                  # @testV
 	i32.xor 	$push22=, $pop21, $pop20
 	i32.const	$push64=, 1
 	i32.and 	$push23=, $pop22, $pop64
-	br_if   	0, $pop23       # 0: down to label20
+	br_if   	0, $pop23       # 0: down to label10
 # BB#1:                                 # %if.end
 	i32.const	$push130=, 0
 	i32.const	$push129=, 1103515245
@@ -5658,7 +5612,6 @@ testV:                                  # @testV
 	i32.or  	$push115=, $pop28, $pop30
 	tee_local	$push114=, $2=, $pop115
 	i32.store16	$discard=, sV($pop123):p2align=2, $pop114
-	block
 	i32.const	$push31=, 65280
 	i32.and 	$push32=, $2, $pop31
 	i32.const	$push113=, 8
@@ -5667,7 +5620,7 @@ testV:                                  # @testV
 	i32.xor 	$push33=, $pop111, $1
 	i32.const	$push110=, 1
 	i32.and 	$push34=, $pop33, $pop110
-	br_if   	0, $pop34       # 0: down to label21
+	br_if   	0, $pop34       # 0: down to label10
 # BB#2:                                 # %lor.lhs.false89
 	i32.const	$push136=, 16
 	i32.shr_u	$push135=, $3, $pop136
@@ -5683,7 +5636,7 @@ testV:                                  # @testV
 	i32.const	$push131=, 15
 	i32.rem_u	$push41=, $pop40, $pop131
 	i32.ne  	$push42=, $pop38, $pop41
-	br_if   	0, $pop42       # 0: down to label21
+	br_if   	0, $pop42       # 0: down to label10
 # BB#3:                                 # %lor.lhs.false136
 	i32.const	$push50=, 0
 	i32.const	$push43=, 1103515245
@@ -5724,19 +5677,11 @@ testV:                                  # @testV
 	i32.xor 	$push62=, $pop61, $2
 	i32.const	$push137=, 1
 	i32.and 	$push63=, $pop62, $pop137
-	br_if   	2, $pop63       # 2: down to label19
+	br_if   	0, $pop63       # 0: down to label10
 # BB#4:                                 # %if.end142
 	return
-.LBB132_5:                              # %if.then95
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB132_6:                              # %if.then
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB132_7:                              # %if.then141
-	end_block                       # label19:
+.LBB132_5:                              # %if.then141
+	end_block                       # label10:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -6621,9 +6566,8 @@ testZ:                                  # @testZ
 	i32.const	$push52=, 20
 	i32.shr_u	$push24=, $pop23, $pop52
 	i32.ne  	$push26=, $pop25, $pop24
-	br_if   	0, $pop26       # 0: down to label22
+	br_if   	0, $pop26       # 0: down to label11
 # BB#1:                                 # %if.end80
-	block
 	i32.const	$push122=, 0
 	i32.const	$push121=, 0
 	i32.const	$push120=, 1103515245
@@ -6668,25 +6612,21 @@ testZ:                                  # @testZ
 	tee_local	$push99=, $0=, $pop100
 	i32.const	$push44=, 1040384
 	i32.and 	$push45=, $pop99, $pop44
-	br_if   	0, $pop45       # 0: down to label23
+	br_if   	0, $pop45       # 0: down to label11
 # BB#2:                                 # %lor.lhs.false98
 	i32.add 	$push50=, $1, $4
 	i32.const	$push47=, 20
 	i32.shr_u	$push48=, $2, $pop47
 	i32.ne  	$push51=, $pop50, $pop48
-	br_if   	0, $pop51       # 0: down to label23
+	br_if   	0, $pop51       # 0: down to label11
 # BB#3:                                 # %lor.lhs.false98
 	i32.const	$push49=, 8191
 	i32.and 	$push46=, $0, $pop49
-	br_if   	0, $pop46       # 0: down to label23
+	br_if   	0, $pop46       # 0: down to label11
 # BB#4:                                 # %if.end121
 	return
 .LBB156_5:                              # %if.then120
-	end_block                       # label23:
-	call    	abort@FUNCTION
-	unreachable
-.LBB156_6:                              # %if.then
-	end_block                       # label22:
+	end_block                       # label11:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20041011-1.c.s
+++ b/test/torture-s/20041011-1.c.s
@@ -1752,153 +1752,131 @@ main:                                   # @main
 	i64.const	$push1=, 100
 	i64.store	$discard=, gull($pop0), $pop1
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push100=, 3
 	i64.const	$push2=, -1
 	i64.call	$push3=, t1@FUNCTION, $pop100, $pop2
 	i64.const	$push4=, -6145
 	i64.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label55
+	br_if   	0, $pop5        # 0: down to label33
 # BB#1:                                 # %if.end
 	i32.const	$push101=, 3
 	i64.const	$push6=, 4294967295
 	i64.call	$push7=, t1@FUNCTION, $pop101, $pop6
 	i64.const	$push8=, 4294961151
 	i64.ne  	$push9=, $pop7, $pop8
-	br_if   	1, $pop9        # 1: down to label54
+	br_if   	0, $pop9        # 0: down to label33
 # BB#2:                                 # %if.end4
 	i32.const	$push102=, 3
 	i64.const	$push10=, -1
 	i64.call	$push11=, t2@FUNCTION, $pop102, $pop10
 	i64.const	$push12=, -1540
 	i64.ne  	$push13=, $pop11, $pop12
-	br_if   	2, $pop13       # 2: down to label53
+	br_if   	0, $pop13       # 0: down to label33
 # BB#3:                                 # %if.end8
 	i32.const	$push103=, 3
 	i64.const	$push14=, 4294967295
 	i64.call	$push15=, t2@FUNCTION, $pop103, $pop14
 	i64.const	$push16=, 4294965756
 	i64.ne  	$push17=, $pop15, $pop16
-	br_if   	3, $pop17       # 3: down to label52
+	br_if   	0, $pop17       # 0: down to label33
 # BB#4:                                 # %if.end12
 	i32.const	$push104=, 3
 	i64.const	$push18=, -1
 	i64.call	$push19=, t3@FUNCTION, $pop104, $pop18
 	i64.const	$push20=, -1537
 	i64.ne  	$push21=, $pop19, $pop20
-	br_if   	4, $pop21       # 4: down to label51
+	br_if   	0, $pop21       # 0: down to label33
 # BB#5:                                 # %if.end16
 	i32.const	$push105=, 3
 	i64.const	$push22=, 4294967295
 	i64.call	$push23=, t3@FUNCTION, $pop105, $pop22
 	i64.const	$push24=, 4294965759
 	i64.ne  	$push25=, $pop23, $pop24
-	br_if   	5, $pop25       # 5: down to label50
+	br_if   	0, $pop25       # 0: down to label33
 # BB#6:                                 # %if.end20
 	i32.const	$push106=, 3
 	i64.const	$push26=, -1
 	i64.call	$push27=, t4@FUNCTION, $pop106, $pop26
 	i64.const	$push28=, -1534
 	i64.ne  	$push29=, $pop27, $pop28
-	br_if   	6, $pop29       # 6: down to label49
+	br_if   	0, $pop29       # 0: down to label33
 # BB#7:                                 # %if.end24
 	i32.const	$push107=, 3
 	i64.const	$push30=, 4294967295
 	i64.call	$push31=, t4@FUNCTION, $pop107, $pop30
 	i64.const	$push32=, 4294965762
 	i64.ne  	$push33=, $pop31, $pop32
-	br_if   	7, $pop33       # 7: down to label48
+	br_if   	0, $pop33       # 0: down to label33
 # BB#8:                                 # %if.end28
 	i32.const	$push108=, 3
 	i64.const	$push34=, -1
 	i64.call	$push35=, t5@FUNCTION, $pop108, $pop34
 	i64.const	$push36=, -4
 	i64.ne  	$push37=, $pop35, $pop36
-	br_if   	8, $pop37       # 8: down to label47
+	br_if   	0, $pop37       # 0: down to label33
 # BB#9:                                 # %if.end32
 	i32.const	$push109=, 3
 	i64.const	$push38=, 4294967295
 	i64.call	$push39=, t5@FUNCTION, $pop109, $pop38
 	i64.const	$push40=, 4294967292
 	i64.ne  	$push41=, $pop39, $pop40
-	br_if   	9, $pop41       # 9: down to label46
+	br_if   	0, $pop41       # 0: down to label33
 # BB#10:                                # %if.end36
 	i32.const	$push110=, 3
 	i64.const	$push42=, -1
 	i64.call	$push43=, t6@FUNCTION, $pop110, $pop42
 	i64.const	$push44=, 2
 	i64.ne  	$push45=, $pop43, $pop44
-	br_if   	10, $pop45      # 10: down to label45
+	br_if   	0, $pop45       # 0: down to label33
 # BB#11:                                # %if.end40
 	i32.const	$push111=, 3
 	i64.const	$push46=, 4294967295
 	i64.call	$push47=, t6@FUNCTION, $pop111, $pop46
 	i64.const	$push48=, 4294967298
 	i64.ne  	$push49=, $pop47, $pop48
-	br_if   	11, $pop49      # 11: down to label44
+	br_if   	0, $pop49       # 0: down to label33
 # BB#12:                                # %if.end44
 	i32.const	$push112=, 3
 	i64.const	$push50=, -1
 	i64.call	$push51=, t7@FUNCTION, $pop112, $pop50
 	i64.const	$push52=, 1532
 	i64.ne  	$push53=, $pop51, $pop52
-	br_if   	12, $pop53      # 12: down to label43
+	br_if   	0, $pop53       # 0: down to label33
 # BB#13:                                # %if.end48
 	i32.const	$push113=, 3
 	i64.const	$push54=, 4294967295
 	i64.call	$push55=, t7@FUNCTION, $pop113, $pop54
 	i64.const	$push56=, 4294968828
 	i64.ne  	$push57=, $pop55, $pop56
-	br_if   	13, $pop57      # 13: down to label42
+	br_if   	0, $pop57       # 0: down to label33
 # BB#14:                                # %if.end52
 	i32.const	$push114=, 3
 	i64.const	$push58=, -1
 	i64.call	$push59=, t8@FUNCTION, $pop114, $pop58
 	i64.const	$push60=, 1535
 	i64.ne  	$push61=, $pop59, $pop60
-	br_if   	14, $pop61      # 14: down to label41
+	br_if   	0, $pop61       # 0: down to label33
 # BB#15:                                # %if.end56
 	i32.const	$push115=, 3
 	i64.const	$push62=, 4294967295
 	i64.call	$push63=, t8@FUNCTION, $pop115, $pop62
 	i64.const	$push64=, 4294968831
 	i64.ne  	$push65=, $pop63, $pop64
-	br_if   	15, $pop65      # 15: down to label40
+	br_if   	0, $pop65       # 0: down to label33
 # BB#16:                                # %if.end60
 	i32.const	$push116=, 3
 	i64.const	$push66=, -1
 	i64.call	$push67=, t9@FUNCTION, $pop116, $pop66
 	i64.const	$push68=, 1538
 	i64.ne  	$push69=, $pop67, $pop68
-	br_if   	16, $pop69      # 16: down to label39
+	br_if   	0, $pop69       # 0: down to label33
 # BB#17:                                # %if.end64
 	i32.const	$push117=, 3
 	i64.const	$push70=, 4294967295
 	i64.call	$push71=, t9@FUNCTION, $pop117, $pop70
 	i64.const	$push72=, 4294968834
 	i64.ne  	$push73=, $pop71, $pop72
-	br_if   	17, $pop73      # 17: down to label38
+	br_if   	0, $pop73       # 0: down to label33
 # BB#18:                                # %if.end68
 	i32.const	$push121=, 3
 	i64.const	$push74=, -1
@@ -1910,7 +1888,7 @@ main:                                   # @main
 	i64.const	$push118=, -1
 	i64.add 	$push78=, $pop77, $pop118
 	i64.ne  	$push79=, $pop75, $pop78
-	br_if   	18, $pop79      # 18: down to label37
+	br_if   	0, $pop79       # 0: down to label33
 # BB#19:                                # %if.end72
 	i32.const	$push125=, 3
 	i64.const	$push80=, 4294967295
@@ -1922,7 +1900,7 @@ main:                                   # @main
 	i64.const	$push122=, 4294967295
 	i64.add 	$push84=, $pop83, $pop122
 	i64.ne  	$push85=, $pop81, $pop84
-	br_if   	19, $pop85      # 19: down to label36
+	br_if   	0, $pop85       # 0: down to label33
 # BB#20:                                # %if.end77
 	i32.const	$push129=, 3
 	i64.const	$push86=, -1
@@ -1934,7 +1912,7 @@ main:                                   # @main
 	i64.const	$push126=, -1
 	i64.add 	$push90=, $pop89, $pop126
 	i64.ne  	$push91=, $pop87, $pop90
-	br_if   	20, $pop91      # 20: down to label35
+	br_if   	0, $pop91       # 0: down to label33
 # BB#21:                                # %if.end84
 	i32.const	$push135=, 3
 	i64.const	$push92=, 4294967295
@@ -1947,104 +1925,16 @@ main:                                   # @main
 	i64.const	$push130=, 4294967295
 	i64.add 	$push95=, $pop94, $pop130
 	i64.ne  	$push96=, $pop93, $pop95
-	br_if   	21, $pop96      # 21: down to label34
+	br_if   	0, $pop96       # 0: down to label33
 # BB#22:                                # %if.end91
 	i64.const	$push97=, 100
 	i64.ne  	$push98=, $0, $pop97
-	br_if   	22, $pop98      # 22: down to label33
+	br_if   	0, $pop98       # 0: down to label33
 # BB#23:                                # %if.end95
 	i32.const	$push99=, 0
 	call    	exit@FUNCTION, $pop99
 	unreachable
-.LBB12_24:                              # %if.then
-	end_block                       # label55:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_25:                              # %if.then3
-	end_block                       # label54:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_26:                              # %if.then7
-	end_block                       # label53:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_27:                              # %if.then11
-	end_block                       # label52:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_28:                              # %if.then15
-	end_block                       # label51:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_29:                              # %if.then19
-	end_block                       # label50:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_30:                              # %if.then23
-	end_block                       # label49:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_31:                              # %if.then27
-	end_block                       # label48:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_32:                              # %if.then31
-	end_block                       # label47:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_33:                              # %if.then35
-	end_block                       # label46:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_34:                              # %if.then39
-	end_block                       # label45:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_35:                              # %if.then43
-	end_block                       # label44:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_36:                              # %if.then47
-	end_block                       # label43:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_37:                              # %if.then51
-	end_block                       # label42:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_38:                              # %if.then55
-	end_block                       # label41:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_39:                              # %if.then59
-	end_block                       # label40:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_40:                              # %if.then63
-	end_block                       # label39:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_41:                              # %if.then67
-	end_block                       # label38:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_42:                              # %if.then71
-	end_block                       # label37:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_43:                              # %if.then76
-	end_block                       # label36:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_44:                              # %if.then83
-	end_block                       # label35:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_45:                              # %if.then90
-	end_block                       # label34:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_46:                              # %if.then94
+.LBB12_24:                              # %if.then94
 	end_block                       # label33:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20041113-1.c.s
+++ b/test/torture-s/20041113-1.c.s
@@ -24,13 +24,10 @@ test:                                   # @test
 	i32.add 	$push2=, $pop23, $pop22
 	i32.store	$discard=, 12($5), $pop2
 	block
-	block
-	block
-	block
 	i32.load	$push3=, 0($1)
 	i32.const	$push4=, 1
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label3
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($5)
 	i32.const	$push31=, 3
@@ -44,7 +41,7 @@ test:                                   # @test
 	i32.load	$push9=, 0($1)
 	i32.const	$push10=, 2
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label2
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($5)
 	i32.const	$push37=, 3
@@ -58,7 +55,7 @@ test:                                   # @test
 	i32.load	$push15=, 0($1)
 	i32.const	$push32=, 3
 	i32.ne  	$push16=, $pop15, $pop32
-	br_if   	2, $pop16       # 2: down to label1
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.load	$push17=, 12($5)
 	i32.const	$push43=, 3
@@ -72,26 +69,14 @@ test:                                   # @test
 	i32.load	$push20=, 0($1)
 	i32.const	$push38=, 4
 	i32.ne  	$push21=, $pop20, $pop38
-	br_if   	3, $pop21       # 3: down to label0
+	br_if   	0, $pop21       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
-.LBB0_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then3
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_7:                                # %if.then6
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then9
+.LBB0_5:                                # %if.then9
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20041126-1.c.s
+++ b/test/torture-s/20041126-1.c.s
@@ -21,35 +21,36 @@ check:                                  # @check
 	i32.load	$push3=, 12($0)
 	br_if   	0, $pop3        # 0: down to label0
 # BB#4:                                 # %for.inc.3
-	i32.const	$3=, 5
 	i32.load	$push4=, 16($0)
 	br_if   	0, $pop4        # 0: down to label0
-.LBB0_5:                                # %for.cond1
+# BB#5:
+	i32.const	$3=, 5
+.LBB0_6:                                # %for.cond1
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label2:
-	i32.const	$push5=, 9
-	i32.gt_s	$push6=, $3, $pop5
-	br_if   	2, $pop6        # 2: down to label1
-# BB#6:                                 # %for.body3
-                                        #   in Loop: Header=BB0_5 Depth=1
-	i32.const	$push7=, 2
-	i32.shl 	$push8=, $3, $pop7
-	i32.add 	$push9=, $0, $pop8
-	i32.load	$1=, 0($pop9)
+	i32.const	$push9=, 9
+	i32.gt_s	$push5=, $3, $pop9
+	br_if   	2, $pop5        # 2: down to label1
+# BB#7:                                 # %for.body3
+                                        #   in Loop: Header=BB0_6 Depth=1
+	i32.const	$push11=, 2
+	i32.shl 	$push6=, $3, $pop11
+	i32.add 	$push7=, $0, $pop6
+	i32.load	$1=, 0($pop7)
 	i32.const	$push10=, 1
 	i32.add 	$2=, $3, $pop10
 	copy_local	$3=, $1
-	i32.eq  	$push11=, $1, $2
-	br_if   	0, $pop11       # 0: up to label2
-# BB#7:                                 # %if.then6
+	i32.eq  	$push8=, $1, $2
+	br_if   	0, $pop8        # 0: up to label2
+# BB#8:                                 # %if.then6
 	end_loop                        # label3:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_8:                                # %for.end10
+.LBB0_9:                                # %for.end10
 	end_block                       # label1:
 	return
-.LBB0_9:                                # %if.then
+.LBB0_10:                               # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20041213-2.c.s
+++ b/test/torture-s/20041213-2.c.s
@@ -8,45 +8,46 @@ foo:                                    # @foo
 	.param  	i32
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$3=, 1
-	i32.const	$2=, 0
 	block
 	block
 	i32.const	$push5=, 0
 	i32.eq  	$push6=, $0, $pop5
 	br_if   	0, $pop6        # 0: down to label1
-.LBB0_1:                                # %for.cond1.preheader
+# BB#1:
+	i32.const	$3=, 1
+	i32.const	$2=, 0
+.LBB0_2:                                # %for.cond1.preheader
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
 	block
 	block
 	i32.ge_s	$push0=, $2, $3
 	br_if   	0, $pop0        # 0: down to label5
-# BB#2:                                 # %for.end.thread
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push2=, 1
-	i32.shl 	$push3=, $3, $pop2
-	i32.sub 	$1=, $pop3, $2
+# BB#3:                                 # %for.end.thread
+                                        #   in Loop: Header=BB0_2 Depth=1
+	i32.const	$push4=, 1
+	i32.shl 	$push2=, $3, $pop4
+	i32.sub 	$1=, $pop2, $2
 	br      	1               # 1: down to label4
-.LBB0_3:                                # %for.end
-                                        #   in Loop: Header=BB0_1 Depth=1
+.LBB0_4:                                # %for.end
+                                        #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label5:
 	copy_local	$1=, $3
 	i32.ne  	$push1=, $2, $3
 	br_if   	4, $pop1        # 4: down to label0
-.LBB0_4:                                # %for.cond
-                                        #   in Loop: Header=BB0_1 Depth=1
+.LBB0_5:                                # %for.cond
+                                        #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label4:
-	i32.const	$push4=, -1
-	i32.add 	$0=, $0, $pop4
+	i32.const	$push3=, -1
+	i32.add 	$0=, $0, $pop3
 	copy_local	$2=, $3
 	copy_local	$3=, $1
 	br_if   	0, $0           # 0: up to label2
-.LBB0_5:                                # %for.end7
+.LBB0_6:                                # %for.end7
 	end_loop                        # label3:
 	end_block                       # label1:
 	return
-.LBB0_6:                                # %if.then
+.LBB0_7:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050119-1.c.s
+++ b/test/torture-s/20050119-1.c.s
@@ -8,23 +8,18 @@ foo:                                    # @foo
 	.param  	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.load8_u	$push0=, 0($0)
 	i32.load8_u	$push1=, 1($0)
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load8_u	$push3=, 2($0)
 	i32.const	$push4=, 2
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label0
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end7
 	return
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.then6
+.LBB0_3:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050119-2.c.s
+++ b/test/torture-s/20050119-2.c.s
@@ -9,24 +9,19 @@ foo:                                    # @foo
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.load8_u	$push0=, 0($0)
 	i32.load8_u	$push1=, 1($0)
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load8_u	$push3=, 2($0)
 	i32.const	$push4=, 2
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label0
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end7
 	i32.load8_u	$push6=, 3($0)
 	return  	$pop6
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.then6
+.LBB0_3:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050125-1.c.s
+++ b/test/torture-s/20050125-1.c.s
@@ -24,25 +24,26 @@ bracket_empty:                          # @bracket_empty
 	.local  	i32
 # BB#0:                                 # %entry
 	block
+	block
 	i32.load	$push9=, 0($0)
 	tee_local	$push8=, $1=, $pop9
 	i32.load	$push0=, 4($0)
 	i32.ge_u	$push1=, $pop8, $pop0
-	br_if   	0, $pop1        # 0: down to label0
+	br_if   	0, $pop1        # 0: down to label1
 # BB#1:                                 # %land.lhs.true
 	i32.const	$push2=, 1
 	i32.add 	$push3=, $1, $pop2
 	i32.store	$discard=, 0($0), $pop3
 	i32.load8_u	$push4=, 0($1)
 	i32.const	$push5=, 93
-	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	0, $pop6        # 0: down to label0
-# BB#2:                                 # %if.end
-	return
-.LBB1_3:                                # %lor.lhs.false
-	end_block                       # label0:
+	i32.eq  	$push6=, $pop4, $pop5
+	br_if   	1, $pop6        # 1: down to label0
+.LBB1_2:                                # %lor.lhs.false
+	end_block                       # label1:
 	i32.const	$push7=, 7
 	i32.store	$discard=, 8($0), $pop7
+.LBB1_3:                                # %if.end
+	end_block                       # label0:
 	return
 	.endfunc
 .Lfunc_end1:

--- a/test/torture-s/20050502-1.c.s
+++ b/test/torture-s/20050502-1.c.s
@@ -71,7 +71,6 @@ foo:                                    # @foo
 	br_if   	0, $4           # 0: down to label3
 # BB#4:                                 # %land.lhs.true18
                                         #   in Loop: Header=BB2_3 Depth=1
-	copy_local	$6=, $5
 	i32.const	$push23=, 24
 	i32.shl 	$push8=, $7, $pop23
 	i32.const	$push22=, 24
@@ -94,7 +93,7 @@ foo:                                    # @foo
 	i32.const	$push24=, 39
 	i32.eq  	$push13=, $pop25, $pop24
 	i32.and 	$push14=, $pop13, $2
-	br_if   	1, $pop14       # 1: down to label2
+	br_if   	2, $pop14       # 2: down to label0
 # BB#6:                                 # %while.body.backedge
                                         #   in Loop: Header=BB2_3 Depth=1
 	copy_local	$5=, $6
@@ -104,8 +103,11 @@ foo:                                    # @foo
 	i32.const	$push32=, 0
 	i32.eq  	$push33=, $pop11, $pop32
 	br_if   	0, $pop33       # 0: up to label1
-.LBB2_7:                                # %while.end
+	br      	2               # 2: down to label0
+.LBB2_7:
 	end_loop                        # label2:
+	copy_local	$6=, $5
+.LBB2_8:                                # %while.end
 	end_block                       # label0:
 	i32.add 	$push16=, $1, $6
 	i32.const	$push17=, 0
@@ -139,20 +141,16 @@ main:                                   # @main
 	i32.add 	$4=, $18, $4
 	call    	foo@FUNCTION, $3, $4, $pop2, $pop1
 	block
-	block
-	block
-	block
-	block
 	i32.load	$push3=, 12($18)
 	i32.const	$push4=, .L.str.1
 	i32.call	$push5=, strcmp@FUNCTION, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label8
+	br_if   	0, $pop5        # 0: down to label4
 # BB#1:                                 # %lor.lhs.false
 	i32.const	$push6=, .L.str.2
 	i32.const	$5=, 16
 	i32.add 	$5=, $18, $5
 	i32.call	$push7=, strcmp@FUNCTION, $5, $pop6
-	br_if   	0, $pop7        # 0: down to label8
+	br_if   	0, $pop7        # 0: down to label4
 # BB#2:                                 # %if.end
 	i32.const	$push8=, .L.str.3
 	i32.store	$discard=, 12($18), $pop8
@@ -166,13 +164,13 @@ main:                                   # @main
 	i32.load	$push11=, 12($18)
 	i32.const	$push12=, .L.str.4
 	i32.call	$push13=, strcmp@FUNCTION, $pop11, $pop12
-	br_if   	1, $pop13       # 1: down to label7
+	br_if   	0, $pop13       # 0: down to label4
 # BB#3:                                 # %lor.lhs.false7
 	i32.const	$push14=, .L.str.5
 	i32.const	$8=, 16
 	i32.add 	$8=, $18, $8
 	i32.call	$push15=, strcmp@FUNCTION, $8, $pop14
-	br_if   	1, $pop15       # 1: down to label7
+	br_if   	0, $pop15       # 0: down to label4
 # BB#4:                                 # %if.end12
 	i32.const	$push16=, .L.str.6
 	i32.store	$discard=, 12($18), $pop16
@@ -186,13 +184,13 @@ main:                                   # @main
 	i32.load	$push18=, 12($18)
 	i32.const	$push19=, .L.str.7
 	i32.call	$push20=, strcmp@FUNCTION, $pop18, $pop19
-	br_if   	2, $pop20       # 2: down to label6
+	br_if   	0, $pop20       # 0: down to label4
 # BB#5:                                 # %lor.lhs.false16
 	i32.const	$push21=, .L.str.8
 	i32.const	$11=, 16
 	i32.add 	$11=, $18, $11
 	i32.call	$push22=, strcmp@FUNCTION, $11, $pop21
-	br_if   	2, $pop22       # 2: down to label6
+	br_if   	0, $pop22       # 0: down to label4
 # BB#6:                                 # %if.end21
 	i32.const	$push23=, .L.str.9
 	i32.store	$discard=, 12($18), $pop23
@@ -206,13 +204,13 @@ main:                                   # @main
 	i32.load	$push25=, 12($18)
 	i32.const	$push26=, .L.str.10
 	i32.call	$push27=, strcmp@FUNCTION, $pop25, $pop26
-	br_if   	3, $pop27       # 3: down to label5
+	br_if   	0, $pop27       # 0: down to label4
 # BB#7:                                 # %lor.lhs.false25
 	i32.const	$push28=, .L.str.11
 	i32.const	$14=, 16
 	i32.add 	$14=, $18, $14
 	i32.call	$push29=, strcmp@FUNCTION, $14, $pop28
-	br_if   	3, $pop29       # 3: down to label5
+	br_if   	0, $pop29       # 0: down to label4
 # BB#8:                                 # %if.end30
 	i32.const	$push30=, .L.str.12
 	i32.store	$discard=, 12($18), $pop30
@@ -226,13 +224,13 @@ main:                                   # @main
 	i32.load	$push32=, 12($18)
 	i32.const	$push33=, .L.str.13
 	i32.call	$push34=, strcmp@FUNCTION, $pop32, $pop33
-	br_if   	4, $pop34       # 4: down to label4
+	br_if   	0, $pop34       # 0: down to label4
 # BB#9:                                 # %lor.lhs.false34
 	i32.const	$push35=, .L.str.14
 	i32.const	$17=, 16
 	i32.add 	$17=, $18, $17
 	i32.call	$push36=, strcmp@FUNCTION, $17, $pop35
-	br_if   	4, $pop36       # 4: down to label4
+	br_if   	0, $pop36       # 0: down to label4
 # BB#10:                                # %if.end39
 	i32.const	$push37=, 0
 	i32.const	$2=, 80
@@ -240,23 +238,7 @@ main:                                   # @main
 	i32.const	$2=, __stack_pointer
 	i32.store	$18=, 0($2), $18
 	return  	$pop37
-.LBB3_11:                               # %if.then
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_12:                               # %if.then11
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_13:                               # %if.then20
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_14:                               # %if.then29
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_15:                               # %if.then38
+.LBB3_11:                               # %if.then38
 	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050502-2.c.s
+++ b/test/torture-s/20050502-2.c.s
@@ -71,9 +71,8 @@ main:                                   # @main
 	i32.const	$8=, 4
 	i32.add 	$8=, $10, $8
 	block
-	block
 	i32.call	$push10=, memcmp@FUNCTION, $8, $pop9, $pop15
-	br_if   	0, $pop10       # 0: down to label1
+	br_if   	0, $pop10       # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push11=, 77
 	i32.store8	$discard=, 0($1):p2align=2, $pop11
@@ -83,7 +82,7 @@ main:                                   # @main
 	i32.const	$9=, 4
 	i32.add 	$9=, $10, $9
 	i32.call	$push13=, memcmp@FUNCTION, $9, $pop12, $pop21
-	br_if   	1, $pop13       # 1: down to label0
+	br_if   	0, $pop13       # 0: down to label0
 # BB#2:                                 # %if.end7
 	i32.const	$push14=, 0
 	i32.const	$4=, 16
@@ -91,11 +90,7 @@ main:                                   # @main
 	i32.const	$4=, __stack_pointer
 	i32.store	$10=, 0($4), $10
 	return  	$pop14
-.LBB2_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_4:                                # %if.then6
+.LBB2_3:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050604-1.c.s
+++ b/test/torture-s/20050604-1.c.s
@@ -125,47 +125,42 @@ main:                                   # @main
 	f32.add 	$push0=, $pop17, $pop35
 	f32.store	$4=, v($pop36):p2align=4, $pop0
 	block
-	block
 	i32.const	$push34=, 65535
 	i32.and 	$push18=, $2, $pop34
 	i32.const	$push33=, 24
 	i32.ne  	$push19=, $pop18, $pop33
-	br_if   	0, $pop19       # 0: down to label1
+	br_if   	0, $pop19       # 0: down to label0
 # BB#1:                                 # %entry
 	i32.const	$push56=, 65535
 	i32.and 	$push20=, $1, $pop56
 	i32.const	$push55=, 28
 	i32.ne  	$push21=, $pop20, $pop55
-	br_if   	0, $pop21       # 0: down to label1
+	br_if   	0, $pop21       # 0: down to label0
 # BB#2:                                 # %entry
 	i32.or  	$push5=, $3, $0
 	i32.const	$push22=, 65535
 	i32.and 	$push23=, $pop5, $pop22
-	br_if   	0, $pop23       # 0: down to label1
+	br_if   	0, $pop23       # 0: down to label0
 # BB#3:                                 # %if.end
 	f32.const	$push24=, 0x1.2p5
 	f32.ne  	$push25=, $4, $pop24
-	br_if   	1, $pop25       # 1: down to label0
+	br_if   	0, $pop25       # 0: down to label0
 # BB#4:                                 # %if.end
 	f32.const	$push26=, 0x1.4p5
 	f32.ne  	$push27=, $5, $pop26
-	br_if   	1, $pop27       # 1: down to label0
+	br_if   	0, $pop27       # 0: down to label0
 # BB#5:                                 # %if.end
 	f32.const	$push28=, 0x1.6p5
 	f32.ne  	$push29=, $6, $pop28
-	br_if   	1, $pop29       # 1: down to label0
+	br_if   	0, $pop29       # 0: down to label0
 # BB#6:                                 # %if.end
 	f32.const	$push30=, 0x0p0
 	f32.ne  	$push31=, $7, $pop30
-	br_if   	1, $pop31       # 1: down to label0
+	br_if   	0, $pop31       # 0: down to label0
 # BB#7:                                 # %if.end26
 	i32.const	$push32=, 0
 	return  	$pop32
-.LBB1_8:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_9:                                # %if.then25
+.LBB1_8:                                # %if.then25
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050713-1.c.s
+++ b/test/torture-s/20050713-1.c.s
@@ -9,44 +9,39 @@ foo2:                                   # @foo2
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.load	$push0=, 0($0)
 	i32.const	$push1=, 3
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %lor.lhs.false
 	i32.load	$push3=, 4($0)
 	i32.const	$push4=, 4
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label1
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %lor.lhs.false2
 	i32.load	$push6=, 8($0)
 	i32.const	$push7=, 5
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	0, $pop8        # 0: down to label1
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end
 	i32.load	$push9=, 0($1)
 	i32.const	$push10=, 6
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label0
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %lor.lhs.false6
 	i32.load	$push12=, 4($1)
 	i32.const	$push13=, 7
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	1, $pop14       # 1: down to label0
+	br_if   	0, $pop14       # 0: down to label0
 # BB#5:                                 # %lor.lhs.false9
 	i32.load	$push15=, 8($1)
 	i32.const	$push16=, 8
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	1, $pop17       # 1: down to label0
+	br_if   	0, $pop17       # 0: down to label0
 # BB#6:                                 # %if.end13
 	i32.const	$push18=, 0
 	return  	$pop18
-.LBB0_7:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then12
+.LBB0_7:                                # %if.then12
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -63,65 +58,55 @@ foo3:                                   # @foo3
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.load	$push2=, 0($0)
 	i32.const	$push3=, 3
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label3
+	br_if   	0, $pop4        # 0: down to label1
 # BB#1:                                 # %entry
 	i32.load	$push0=, 4($0)
 	i32.const	$push5=, 4
 	i32.ne  	$push6=, $pop0, $pop5
-	br_if   	0, $pop6        # 0: down to label3
+	br_if   	0, $pop6        # 0: down to label1
 # BB#2:                                 # %entry
 	i32.load	$push1=, 8($0)
 	i32.const	$push7=, 5
 	i32.ne  	$push8=, $pop1, $pop7
-	br_if   	0, $pop8        # 0: down to label3
+	br_if   	0, $pop8        # 0: down to label1
 # BB#3:                                 # %if.end.i
 	i32.load	$push11=, 8($1)
 	i32.const	$push12=, 8
 	i32.ne  	$push13=, $pop11, $pop12
-	br_if   	1, $pop13       # 1: down to label2
+	br_if   	0, $pop13       # 0: down to label1
 # BB#4:                                 # %if.end.i
 	i32.load	$push9=, 4($1)
 	i32.const	$push14=, 7
 	i32.ne  	$push15=, $pop9, $pop14
-	br_if   	1, $pop15       # 1: down to label2
+	br_if   	0, $pop15       # 0: down to label1
 # BB#5:                                 # %if.end.i
 	i32.load	$push10=, 0($1)
 	i32.const	$push16=, 6
 	i32.ne  	$push17=, $pop10, $pop16
-	br_if   	1, $pop17       # 1: down to label2
+	br_if   	0, $pop17       # 0: down to label1
 # BB#6:                                 # %foo2.exit
-	block
 	i32.load	$push18=, 0($2)
 	i32.const	$push19=, 9
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	0, $pop20       # 0: down to label4
+	br_if   	0, $pop20       # 0: down to label1
 # BB#7:                                 # %lor.lhs.false
 	i32.load	$push21=, 4($2)
 	i32.const	$push22=, 10
 	i32.ne  	$push23=, $pop21, $pop22
-	br_if   	0, $pop23       # 0: down to label4
+	br_if   	0, $pop23       # 0: down to label1
 # BB#8:                                 # %lor.lhs.false2
 	i32.load	$push24=, 8($2)
 	i32.const	$push25=, 11
 	i32.ne  	$push26=, $pop24, $pop25
-	br_if   	0, $pop26       # 0: down to label4
+	br_if   	0, $pop26       # 0: down to label1
 # BB#9:                                 # %if.end
 	i32.const	$push27=, 0
 	return  	$pop27
 .LBB1_10:                               # %if.then
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_11:                               # %if.then.i
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_12:                               # %if.then12.i
-	end_block                       # label2:
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -137,45 +122,40 @@ bar2:                                   # @bar2
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.load	$push2=, 0($1)
 	i32.const	$push3=, 3
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label6
+	br_if   	0, $pop4        # 0: down to label2
 # BB#1:                                 # %entry
 	i32.load	$push0=, 4($1)
 	i32.const	$push5=, 4
 	i32.ne  	$push6=, $pop0, $pop5
-	br_if   	0, $pop6        # 0: down to label6
+	br_if   	0, $pop6        # 0: down to label2
 # BB#2:                                 # %entry
 	i32.load	$push1=, 8($1)
 	i32.const	$push7=, 5
 	i32.ne  	$push8=, $pop1, $pop7
-	br_if   	0, $pop8        # 0: down to label6
+	br_if   	0, $pop8        # 0: down to label2
 # BB#3:                                 # %if.end.i
 	i32.load	$push11=, 8($0)
 	i32.const	$push12=, 8
 	i32.ne  	$push13=, $pop11, $pop12
-	br_if   	1, $pop13       # 1: down to label5
+	br_if   	0, $pop13       # 0: down to label2
 # BB#4:                                 # %if.end.i
 	i32.load	$push9=, 4($0)
 	i32.const	$push14=, 7
 	i32.ne  	$push15=, $pop9, $pop14
-	br_if   	1, $pop15       # 1: down to label5
+	br_if   	0, $pop15       # 0: down to label2
 # BB#5:                                 # %if.end.i
 	i32.load	$push10=, 0($0)
 	i32.const	$push16=, 6
 	i32.ne  	$push17=, $pop10, $pop16
-	br_if   	1, $pop17       # 1: down to label5
+	br_if   	0, $pop17       # 0: down to label2
 # BB#6:                                 # %foo2.exit
 	i32.const	$push18=, 0
 	return  	$pop18
-.LBB2_7:                                # %if.then.i
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_8:                                # %if.then12.i
-	end_block                       # label5:
+.LBB2_7:                                # %if.then12.i
+	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -191,65 +171,55 @@ bar3:                                   # @bar3
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	i32.load	$push5=, 0($1)
 	i32.const	$push6=, 3
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	0, $pop7        # 0: down to label9
+	br_if   	0, $pop7        # 0: down to label3
 # BB#1:                                 # %entry
 	i32.load	$push3=, 4($1)
 	i32.const	$push8=, 4
 	i32.ne  	$push9=, $pop3, $pop8
-	br_if   	0, $pop9        # 0: down to label9
+	br_if   	0, $pop9        # 0: down to label3
 # BB#2:                                 # %entry
 	i32.load	$push4=, 8($1)
 	i32.const	$push10=, 5
 	i32.ne  	$push11=, $pop4, $pop10
-	br_if   	0, $pop11       # 0: down to label9
+	br_if   	0, $pop11       # 0: down to label3
 # BB#3:                                 # %if.end.i.i
 	i32.load	$push14=, 8($0)
 	i32.const	$push15=, 8
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	1, $pop16       # 1: down to label8
+	br_if   	0, $pop16       # 0: down to label3
 # BB#4:                                 # %if.end.i.i
 	i32.load	$push12=, 4($0)
 	i32.const	$push17=, 7
 	i32.ne  	$push18=, $pop12, $pop17
-	br_if   	1, $pop18       # 1: down to label8
+	br_if   	0, $pop18       # 0: down to label3
 # BB#5:                                 # %if.end.i.i
 	i32.load	$push13=, 0($0)
 	i32.const	$push19=, 6
 	i32.ne  	$push20=, $pop13, $pop19
-	br_if   	1, $pop20       # 1: down to label8
+	br_if   	0, $pop20       # 0: down to label3
 # BB#6:                                 # %foo2.exit.i
 	i32.load	$push0=, 0($2)
 	i32.const	$push21=, 9
 	i32.ne  	$push22=, $pop0, $pop21
-	br_if   	2, $pop22       # 2: down to label7
+	br_if   	0, $pop22       # 0: down to label3
 # BB#7:                                 # %foo2.exit.i
 	i32.load	$push1=, 4($2)
 	i32.const	$push23=, 10
 	i32.ne  	$push24=, $pop1, $pop23
-	br_if   	2, $pop24       # 2: down to label7
+	br_if   	0, $pop24       # 0: down to label3
 # BB#8:                                 # %foo2.exit.i
 	i32.load	$push2=, 8($2)
 	i32.const	$push25=, 11
 	i32.ne  	$push26=, $pop2, $pop25
-	br_if   	2, $pop26       # 2: down to label7
+	br_if   	0, $pop26       # 0: down to label3
 # BB#9:                                 # %foo3.exit
 	i32.const	$push27=, 0
 	return  	$pop27
-.LBB3_10:                               # %if.then.i.i
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_11:                               # %if.then12.i.i
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_12:                               # %if.then.i
-	end_block                       # label7:
+.LBB3_10:                               # %if.then.i
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -265,65 +235,55 @@ baz3:                                   # @baz3
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	i32.load	$push5=, 0($1)
 	i32.const	$push6=, 3
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	0, $pop7        # 0: down to label12
+	br_if   	0, $pop7        # 0: down to label4
 # BB#1:                                 # %entry
 	i32.load	$push3=, 4($1)
 	i32.const	$push8=, 4
 	i32.ne  	$push9=, $pop3, $pop8
-	br_if   	0, $pop9        # 0: down to label12
+	br_if   	0, $pop9        # 0: down to label4
 # BB#2:                                 # %entry
 	i32.load	$push4=, 8($1)
 	i32.const	$push10=, 5
 	i32.ne  	$push11=, $pop4, $pop10
-	br_if   	0, $pop11       # 0: down to label12
+	br_if   	0, $pop11       # 0: down to label4
 # BB#3:                                 # %if.end.i.i
 	i32.load	$push14=, 8($2)
 	i32.const	$push15=, 8
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	1, $pop16       # 1: down to label11
+	br_if   	0, $pop16       # 0: down to label4
 # BB#4:                                 # %if.end.i.i
 	i32.load	$push12=, 4($2)
 	i32.const	$push17=, 7
 	i32.ne  	$push18=, $pop12, $pop17
-	br_if   	1, $pop18       # 1: down to label11
+	br_if   	0, $pop18       # 0: down to label4
 # BB#5:                                 # %if.end.i.i
 	i32.load	$push13=, 0($2)
 	i32.const	$push19=, 6
 	i32.ne  	$push20=, $pop13, $pop19
-	br_if   	1, $pop20       # 1: down to label11
+	br_if   	0, $pop20       # 0: down to label4
 # BB#6:                                 # %foo2.exit.i
 	i32.load	$push0=, 0($0)
 	i32.const	$push21=, 9
 	i32.ne  	$push22=, $pop0, $pop21
-	br_if   	2, $pop22       # 2: down to label10
+	br_if   	0, $pop22       # 0: down to label4
 # BB#7:                                 # %foo2.exit.i
 	i32.load	$push1=, 4($0)
 	i32.const	$push23=, 10
 	i32.ne  	$push24=, $pop1, $pop23
-	br_if   	2, $pop24       # 2: down to label10
+	br_if   	0, $pop24       # 0: down to label4
 # BB#8:                                 # %foo2.exit.i
 	i32.load	$push2=, 8($0)
 	i32.const	$push25=, 11
 	i32.ne  	$push26=, $pop2, $pop25
-	br_if   	2, $pop26       # 2: down to label10
+	br_if   	0, $pop26       # 0: down to label4
 # BB#9:                                 # %foo3.exit
 	i32.const	$push27=, 0
 	return  	$pop27
-.LBB4_10:                               # %if.then.i.i
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_11:                               # %if.then12.i.i
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_12:                               # %if.then.i
-	end_block                       # label10:
+.LBB4_10:                               # %if.then.i
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20050826-1.c.s
+++ b/test/torture-s/20050826-1.c.s
@@ -52,58 +52,58 @@ bar:                                    # @bar
 	.type	foo,@function
 foo:                                    # @foo
 	.result 	i32
-	.local  	i32, i32
+	.local  	i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$push0=, a
 	i32.const	$push2=, 0
 	i32.const	$push1=, 2048
 	i32.call	$discard=, memset@FUNCTION, $pop0, $pop2, $pop1
-	i32.const	$push22=, 0
-	i32.const	$push21=, 0
-	i32.load8_u	$push5=, .L.str.1+4($pop21)
-	i32.store8	$discard=, a+5($pop22), $pop5
-	i32.const	$push20=, 0
 	i32.const	$push19=, 0
-	i32.load	$push6=, .L.str.1($pop19):p2align=0
-	i32.store	$discard=, a+1($pop20):p2align=0, $pop6
 	i32.const	$push18=, 0
+	i32.load8_u	$push5=, .L.str.1+4($pop18)
+	i32.store8	$discard=, a+5($pop19), $pop5
 	i32.const	$push17=, 0
-	i32.const	$push3=, 1
-	i32.store8	$push4=, a($pop17), $pop3
-	i32.store8	$discard=, a+6($pop18), $pop4
-	i32.const	$1=, 8
-	block
 	i32.const	$push16=, 0
-	i64.load	$push7=, a($pop16):p2align=0
+	i32.load	$push6=, .L.str.1($pop16):p2align=0
+	i32.store	$discard=, a+1($pop17):p2align=0, $pop6
+	i32.const	$push15=, 0
+	i32.const	$push14=, 0
+	i32.const	$push3=, 1
+	i32.store8	$push4=, a($pop14), $pop3
+	i32.store8	$0=, a+6($pop15), $pop4
+	block
+	i32.const	$push13=, 0
+	i64.load	$push7=, a($pop13):p2align=0
 	i64.const	$push8=, 368664092428289
 	i64.ne  	$push9=, $pop7, $pop8
 	br_if   	0, $pop9        # 0: down to label4
-.LBB1_1:                                # %for.cond.i
+# BB#1:
+	i32.const	$2=, 8
+.LBB1_2:                                # %for.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label6:
-	i32.const	$push10=, -7
-	i32.add 	$push11=, $1, $pop10
-	i32.const	$push12=, 2040
-	i32.gt_u	$push13=, $pop11, $pop12
-	br_if   	2, $pop13       # 2: down to label5
-# BB#2:                                 # %for.cond.i.for.body.i_crit_edge
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load8_u	$0=, a($1)
-	i32.const	$push15=, 1
-	i32.add 	$1=, $1, $pop15
-	i32.const	$push23=, 0
-	i32.eq  	$push24=, $0, $pop23
-	br_if   	0, $pop24       # 0: up to label6
-# BB#3:                                 # %if.then2.i
+	i32.const	$push21=, -7
+	i32.add 	$push10=, $2, $pop21
+	i32.const	$push20=, 2040
+	i32.gt_u	$push11=, $pop10, $pop20
+	br_if   	2, $pop11       # 2: down to label5
+# BB#3:                                 # %for.cond.i.for.body.i_crit_edge
+                                        #   in Loop: Header=BB1_2 Depth=1
+	i32.load8_u	$1=, a($2)
+	i32.add 	$2=, $2, $0
+	i32.const	$push22=, 0
+	i32.eq  	$push23=, $1, $pop22
+	br_if   	0, $pop23       # 0: up to label6
+# BB#4:                                 # %if.then2.i
 	end_loop                        # label7:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_4:                                # %bar.exit
+.LBB1_5:                                # %bar.exit
 	end_block                       # label5:
-	i32.const	$push14=, 0
-	return  	$pop14
-.LBB1_5:                                # %if.then.i
+	i32.const	$push12=, 0
+	return  	$pop12
+.LBB1_6:                                # %if.then.i
 	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
@@ -117,58 +117,58 @@ foo:                                    # @foo
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32
+	.local  	i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$push0=, a
 	i32.const	$push2=, 0
 	i32.const	$push1=, 2048
 	i32.call	$discard=, memset@FUNCTION, $pop0, $pop2, $pop1
-	i32.const	$push22=, 0
-	i32.const	$push21=, 0
-	i32.load8_u	$push5=, .L.str.1+4($pop21)
-	i32.store8	$discard=, a+5($pop22), $pop5
-	i32.const	$push20=, 0
 	i32.const	$push19=, 0
-	i32.load	$push6=, .L.str.1($pop19):p2align=0
-	i32.store	$discard=, a+1($pop20):p2align=0, $pop6
 	i32.const	$push18=, 0
+	i32.load8_u	$push5=, .L.str.1+4($pop18)
+	i32.store8	$discard=, a+5($pop19), $pop5
 	i32.const	$push17=, 0
-	i32.const	$push3=, 1
-	i32.store8	$push4=, a($pop17), $pop3
-	i32.store8	$discard=, a+6($pop18), $pop4
-	i32.const	$1=, 8
-	block
 	i32.const	$push16=, 0
-	i64.load	$push7=, a($pop16):p2align=0
+	i32.load	$push6=, .L.str.1($pop16):p2align=0
+	i32.store	$discard=, a+1($pop17):p2align=0, $pop6
+	i32.const	$push15=, 0
+	i32.const	$push14=, 0
+	i32.const	$push3=, 1
+	i32.store8	$push4=, a($pop14), $pop3
+	i32.store8	$0=, a+6($pop15), $pop4
+	block
+	i32.const	$push13=, 0
+	i64.load	$push7=, a($pop13):p2align=0
 	i64.const	$push8=, 368664092428289
 	i64.ne  	$push9=, $pop7, $pop8
 	br_if   	0, $pop9        # 0: down to label8
-.LBB2_1:                                # %for.cond.i.i
+# BB#1:
+	i32.const	$2=, 8
+.LBB2_2:                                # %for.cond.i.i
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label10:
-	i32.const	$push10=, -7
-	i32.add 	$push11=, $1, $pop10
-	i32.const	$push12=, 2040
-	i32.gt_u	$push13=, $pop11, $pop12
-	br_if   	2, $pop13       # 2: down to label9
-# BB#2:                                 # %for.cond.i.for.body.i_crit_edge.i
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$0=, a($1)
-	i32.const	$push15=, 1
-	i32.add 	$1=, $1, $pop15
-	i32.const	$push23=, 0
-	i32.eq  	$push24=, $0, $pop23
-	br_if   	0, $pop24       # 0: up to label10
-# BB#3:                                 # %if.then2.i.i
+	i32.const	$push21=, -7
+	i32.add 	$push10=, $2, $pop21
+	i32.const	$push20=, 2040
+	i32.gt_u	$push11=, $pop10, $pop20
+	br_if   	2, $pop11       # 2: down to label9
+# BB#3:                                 # %for.cond.i.for.body.i_crit_edge.i
+                                        #   in Loop: Header=BB2_2 Depth=1
+	i32.load8_u	$1=, a($2)
+	i32.add 	$2=, $2, $0
+	i32.const	$push22=, 0
+	i32.eq  	$push23=, $1, $pop22
+	br_if   	0, $pop23       # 0: up to label10
+# BB#4:                                 # %if.then2.i.i
 	end_loop                        # label11:
 	call    	abort@FUNCTION
 	unreachable
-.LBB2_4:                                # %foo.exit
+.LBB2_5:                                # %foo.exit
 	end_block                       # label9:
-	i32.const	$push14=, 0
-	return  	$pop14
-.LBB2_5:                                # %if.then.i.i
+	i32.const	$push12=, 0
+	return  	$pop12
+.LBB2_6:                                # %if.then.i.i
 	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050826-2.c.s
+++ b/test/torture-s/20050826-2.c.s
@@ -148,79 +148,79 @@ main:                                   # @main
 	copy_local	$1=, $24
 	i32.load	$push21=, 0($39):p2align=4
 	i32.ne  	$push42=, $pop21, $0
-	br_if   	1, $pop42       # 1: down to label4
+	br_if   	2, $pop42       # 2: down to label3
 # BB#2:                                 # %for.body9.preheader
 	i32.load	$push8=, 0($2)
 	i32.ne  	$push43=, $pop8, $0
-	br_if   	1, $pop43       # 1: down to label4
+	br_if   	2, $pop43       # 2: down to label3
 # BB#3:                                 # %for.body9.preheader
 	i32.load	$push9=, 0($3):p2align=3
 	i32.ne  	$push44=, $pop9, $0
-	br_if   	1, $pop44       # 1: down to label4
+	br_if   	2, $pop44       # 2: down to label3
 # BB#4:                                 # %for.body9.preheader
 	i32.load	$push10=, 0($4)
 	i32.ne  	$push45=, $pop10, $0
-	br_if   	1, $pop45       # 1: down to label4
+	br_if   	2, $pop45       # 2: down to label3
 # BB#5:                                 # %for.body9.preheader
 	i32.const	$push22=, 16
 	i32.add 	$push23=, $39, $pop22
 	i32.load	$push11=, 0($pop23):p2align=4
 	i32.ne  	$push46=, $pop11, $0
-	br_if   	1, $pop46       # 1: down to label4
+	br_if   	2, $pop46       # 2: down to label3
 # BB#6:                                 # %for.body9.preheader
 	i32.const	$push24=, 20
 	i32.add 	$push25=, $39, $pop24
 	i32.load	$push12=, 0($pop25)
 	i32.ne  	$push47=, $pop12, $0
-	br_if   	1, $pop47       # 1: down to label4
+	br_if   	2, $pop47       # 2: down to label3
 # BB#7:                                 # %for.body9.preheader
 	i32.const	$push26=, 24
 	i32.add 	$push27=, $39, $pop26
 	i32.load	$push13=, 0($pop27):p2align=3
 	i32.ne  	$push48=, $pop13, $0
-	br_if   	1, $pop48       # 1: down to label4
+	br_if   	2, $pop48       # 2: down to label3
 # BB#8:                                 # %for.body9.preheader
 	i32.const	$push28=, 28
 	i32.add 	$push29=, $39, $pop28
 	i32.load	$push14=, 0($pop29)
 	i32.ne  	$push49=, $pop14, $1
-	br_if   	1, $pop49       # 1: down to label4
+	br_if   	2, $pop49       # 2: down to label3
 # BB#9:                                 # %for.body9.preheader
 	i32.const	$push30=, 32
 	i32.add 	$push31=, $39, $pop30
 	i32.load	$push15=, 0($pop31):p2align=4
 	i32.ne  	$push50=, $pop15, $1
-	br_if   	1, $pop50       # 1: down to label4
+	br_if   	2, $pop50       # 2: down to label3
 # BB#10:                                # %for.body9.preheader
 	i32.const	$push32=, 36
 	i32.add 	$push33=, $39, $pop32
 	i32.load	$push16=, 0($pop33)
 	i32.ne  	$push51=, $pop16, $0
-	br_if   	1, $pop51       # 1: down to label4
+	br_if   	2, $pop51       # 2: down to label3
 # BB#11:                                # %for.body9.preheader
 	i32.const	$push34=, 40
 	i32.add 	$push35=, $39, $pop34
 	i32.load	$push17=, 0($pop35):p2align=3
 	i32.ne  	$push52=, $pop17, $0
-	br_if   	1, $pop52       # 1: down to label4
+	br_if   	2, $pop52       # 2: down to label3
 # BB#12:                                # %for.body9.preheader
 	i32.const	$push36=, 44
 	i32.add 	$push37=, $39, $pop36
 	i32.load	$push18=, 0($pop37)
 	i32.ne  	$push53=, $pop18, $0
-	br_if   	1, $pop53       # 1: down to label4
+	br_if   	2, $pop53       # 2: down to label3
 # BB#13:                                # %for.body9.preheader
 	i32.const	$push38=, 48
 	i32.add 	$push39=, $39, $pop38
 	i32.load	$push19=, 0($pop39):p2align=4
 	i32.ne  	$push54=, $pop19, $0
-	br_if   	1, $pop54       # 1: down to label4
+	br_if   	2, $pop54       # 2: down to label3
 # BB#14:                                # %for.body9.preheader
 	i32.const	$push40=, 52
 	i32.add 	$push41=, $39, $pop40
 	i32.load	$push20=, 0($pop41)
 	i32.ne  	$push55=, $pop20, $0
-	br_if   	1, $pop55       # 1: down to label4
+	br_if   	2, $pop55       # 2: down to label3
 # BB#15:                                # %for.cond7.13
 	i32.const	$push78=, 4
 	i32.const	$25=, 56
@@ -305,23 +305,21 @@ main:                                   # @main
 .LBB1_17:                               # %for.body43
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	block
-	loop                            # label9:
+	loop                            # label7:
 	block
 	i32.const	$push105=, 1
 	i32.ne  	$push88=, $0, $pop105
-	br_if   	0, $pop88       # 0: down to label11
+	br_if   	0, $pop88       # 0: down to label9
 # BB#18:                                # %land.lhs.true
                                         #   in Loop: Header=BB1_17 Depth=1
 	i32.const	$0=, 2
 	i32.const	$push113=, 0
 	i32.eq  	$push114=, $2, $pop113
-	br_if   	1, $pop114      # 1: up to label9
-	br      	3               # 3: down to label8
+	br_if   	1, $pop114      # 1: up to label7
+	br      	3               # 3: down to label6
 .LBB1_19:                               # %if.else
                                         #   in Loop: Header=BB1_17 Depth=1
-	end_block                       # label11:
+	end_block                       # label9:
 	i32.const	$push107=, 2
 	i32.shl 	$push89=, $0, $pop107
 	i32.add 	$push90=, $39, $pop89
@@ -330,29 +328,29 @@ main:                                   # @main
 	block
 	i32.const	$push106=, 5
 	i32.gt_s	$push91=, $0, $pop106
-	br_if   	0, $pop91       # 0: down to label13
+	br_if   	0, $pop91       # 0: down to label11
 # BB#20:                                # %land.lhs.true55
                                         #   in Loop: Header=BB1_17 Depth=1
 	i32.eq  	$push93=, $1, $3
-	br_if   	1, $pop93       # 1: down to label12
-	br      	5               # 5: down to label7
+	br_if   	1, $pop93       # 1: down to label10
+	br      	6               # 6: down to label4
 .LBB1_21:                               # %land.lhs.true64
                                         #   in Loop: Header=BB1_17 Depth=1
-	end_block                       # label13:
+	end_block                       # label11:
 	i32.const	$38=, 56
 	i32.add 	$38=, $39, $38
 	i32.ne  	$push92=, $1, $38
-	br_if   	5, $pop92       # 5: down to label6
+	br_if   	4, $pop92       # 4: down to label5
 .LBB1_22:                               # %for.inc73
                                         #   in Loop: Header=BB1_17 Depth=1
-	end_block                       # label12:
+	end_block                       # label10:
 	i32.const	$push109=, 1
 	i32.add 	$0=, $0, $pop109
 	i32.const	$push108=, 14
 	i32.lt_s	$push94=, $0, $pop108
-	br_if   	0, $pop94       # 0: up to label9
+	br_if   	0, $pop94       # 0: up to label7
 # BB#23:                                # %for.end75
-	end_loop                        # label10:
+	end_loop                        # label8:
 	i32.const	$push95=, 0
 	i32.const	$7=, 64
 	i32.add 	$39=, $39, $7
@@ -360,26 +358,18 @@ main:                                   # @main
 	i32.store	$39=, 0($7), $39
 	return  	$pop95
 .LBB1_24:                               # %if.then49
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_25:                               # %if.then60
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_26:                               # %if.then69
 	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_27:                               # %if.then
+.LBB1_25:                               # %if.then69
 	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_28:                               # %if.then15
+.LBB1_26:                               # %if.then60
 	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_29:                               # %if.then38
+.LBB1_27:                               # %if.then38
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20050929-1.c.s
+++ b/test/torture-s/20050929-1.c.s
@@ -9,8 +9,6 @@ main:                                   # @main
 	.local  	i32, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	i32.const	$push0=, 0
 	i32.load	$push24=, e($pop0)
 	tee_local	$push23=, $1=, $pop24
@@ -19,24 +17,24 @@ main:                                   # @main
 	i32.load	$push1=, 0($pop21)
 	i32.const	$push2=, 1
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label2
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %lor.lhs.false
 	i32.load	$push4=, 4($0)
 	i32.const	$push5=, 2
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	0, $pop6        # 0: down to label2
+	br_if   	0, $pop6        # 0: down to label0
 # BB#2:                                 # %if.end
 	i32.load	$push26=, 4($1)
 	tee_local	$push25=, $0=, $pop26
 	i32.load	$push7=, 0($pop25)
 	i32.const	$push8=, 3
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	1, $pop9        # 1: down to label1
+	br_if   	0, $pop9        # 0: down to label0
 # BB#3:                                 # %lor.lhs.false5
 	i32.load	$push10=, 4($0)
 	i32.const	$push11=, 4
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	1, $pop12       # 1: down to label1
+	br_if   	0, $pop12       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.const	$push13=, 0
 	i32.load	$push28=, e+4($pop13)
@@ -44,24 +42,16 @@ main:                                   # @main
 	i32.load	$push14=, 0($pop27)
 	i32.const	$push15=, 5
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	2, $pop16       # 2: down to label0
+	br_if   	0, $pop16       # 0: down to label0
 # BB#5:                                 # %lor.lhs.false13
 	i32.load	$push17=, 4($0)
 	i32.const	$push18=, 6
 	i32.ne  	$push19=, $pop17, $pop18
-	br_if   	2, $pop19       # 2: down to label0
+	br_if   	0, $pop19       # 0: down to label0
 # BB#6:                                 # %if.end17
 	i32.const	$push20=, 0
 	return  	$pop20
-.LBB0_7:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then9
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then16
+.LBB0_7:                                # %if.then16
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20051110-1.c.s
+++ b/test/torture-s/20051110-1.c.s
@@ -8,33 +8,34 @@ add_unwind_adjustsp:                    # @add_unwind_adjustsp
 	.param  	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$1=, bytes
 	block
 	i32.const	$push0=, -516
 	i32.add 	$push1=, $0, $pop0
 	i32.const	$push2=, 2
-	i32.shr_s	$push11=, $pop1, $pop2
-	tee_local	$push10=, $0=, $pop11
+	i32.shr_s	$push7=, $pop1, $pop2
+	tee_local	$push6=, $0=, $pop7
 	i32.const	$push14=, 0
-	i32.eq  	$push15=, $pop10, $pop14
+	i32.eq  	$push15=, $pop6, $pop14
 	br_if   	0, $pop15       # 0: down to label0
-.LBB0_1:                                # %while.body
+# BB#1:
+	i32.const	$1=, bytes
+.LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push6=, 128
-	i32.or  	$push7=, $0, $pop6
-	i32.const	$push3=, 127
-	i32.and 	$push4=, $0, $pop3
-	i32.const	$push5=, 7
-	i32.shr_u	$push13=, $0, $pop5
-	tee_local	$push12=, $2=, $pop13
-	i32.select	$push8=, $pop7, $pop4, $pop12
-	i32.store8	$discard=, 0($1), $pop8
-	i32.const	$push9=, 1
-	i32.add 	$1=, $1, $pop9
+	i32.const	$push13=, 128
+	i32.or  	$push4=, $0, $pop13
+	i32.const	$push12=, 127
+	i32.and 	$push3=, $0, $pop12
+	i32.const	$push11=, 7
+	i32.shr_u	$push10=, $0, $pop11
+	tee_local	$push9=, $2=, $pop10
+	i32.select	$push5=, $pop4, $pop3, $pop9
+	i32.store8	$discard=, 0($1), $pop5
+	i32.const	$push8=, 1
+	i32.add 	$1=, $1, $pop8
 	copy_local	$0=, $2
 	br_if   	0, $2           # 0: up to label1
-.LBB0_2:                                # %while.end
+.LBB0_3:                                # %while.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	return

--- a/test/torture-s/20051113-1.c.s
+++ b/test/torture-s/20051113-1.c.s
@@ -106,24 +106,19 @@ main:                                   # @main
 	i64.store	$push9=, 70($0):p2align=0, $pop8
 	i64.store	$discard=, 78($0):p2align=0, $pop9
 	block
-	block
 	i64.call	$push10=, Sum@FUNCTION, $0
 	i64.const	$push15=, 4311811859
 	i64.ne  	$push11=, $pop10, $pop15
-	br_if   	0, $pop11       # 0: down to label7
+	br_if   	0, $pop11       # 0: down to label6
 # BB#1:                                 # %if.end
 	i64.call	$push12=, Sum2@FUNCTION, $0
 	i64.const	$push19=, 4311811859
 	i64.ne  	$push13=, $pop12, $pop19
-	br_if   	1, $pop13       # 1: down to label6
+	br_if   	0, $pop13       # 0: down to label6
 # BB#2:                                 # %if.end25
 	i32.const	$push14=, 0
 	return  	$pop14
-.LBB2_3:                                # %if.then
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_4:                                # %if.then24
+.LBB2_3:                                # %if.then24
 	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20060905-1.c.s
+++ b/test/torture-s/20060905-1.c.s
@@ -9,14 +9,14 @@ main:                                   # @main
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$0=, s-384
-	i32.const	$2=, 0
 	i32.const	$1=, 0
+	i32.const	$2=, 0
 .LBB0_1:                                # %for.body.i
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label0:
 	block
 	i32.const	$push6=, 128
-	i32.lt_s	$push0=, $1, $pop6
+	i32.lt_s	$push0=, $2, $pop6
 	br_if   	0, $pop0        # 0: down to label2
 # BB#2:                                 # %if.then.i
                                         #   in Loop: Header=BB0_1 Depth=1
@@ -24,22 +24,22 @@ main:                                   # @main
 	i32.load8_u	$push1=, 0($0)
 	i32.store8	$discard=, g($pop8), $pop1
 	i32.const	$push7=, 1
-	i32.add 	$2=, $2, $pop7
+	i32.add 	$1=, $1, $pop7
 .LBB0_3:                                # %for.inc.i
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_block                       # label2:
 	i32.const	$push11=, 1
-	i32.add 	$1=, $1, $pop11
+	i32.add 	$2=, $2, $pop11
 	i32.const	$push10=, 3
 	i32.add 	$0=, $0, $pop10
 	i32.const	$push9=, 256
-	i32.ne  	$push2=, $1, $pop9
+	i32.ne  	$push2=, $2, $pop9
 	br_if   	0, $pop2        # 0: up to label0
 # BB#4:                                 # %foo.exit
 	end_loop                        # label1:
 	block
 	i32.const	$push3=, 128
-	i32.ne  	$push4=, $2, $pop3
+	i32.ne  	$push4=, $1, $pop3
 	br_if   	0, $pop4        # 0: down to label3
 # BB#5:                                 # %if.end
 	i32.const	$push5=, 0

--- a/test/torture-s/20070623-1.c.s
+++ b/test/torture-s/20070623-1.c.s
@@ -178,225 +178,130 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push34=, -2147483648
 	i32.const	$push33=, 2147483647
 	i32.call	$push0=, nge@FUNCTION, $pop34, $pop33
-	br_if   	0, $pop0        # 0: down to label19
+	br_if   	0, $pop0        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push36=, 2147483647
 	i32.const	$push35=, -2147483648
 	i32.call	$push1=, nge@FUNCTION, $pop36, $pop35
 	i32.const	$push2=, -1
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	1, $pop3        # 1: down to label18
+	br_if   	0, $pop3        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push38=, -2147483648
 	i32.const	$push37=, 2147483647
 	i32.call	$push4=, ngt@FUNCTION, $pop38, $pop37
-	br_if   	2, $pop4        # 2: down to label17
+	br_if   	0, $pop4        # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.const	$push41=, 2147483647
 	i32.const	$push40=, -2147483648
 	i32.call	$push5=, ngt@FUNCTION, $pop41, $pop40
 	i32.const	$push39=, -1
 	i32.ne  	$push6=, $pop5, $pop39
-	br_if   	3, $pop6        # 3: down to label16
+	br_if   	0, $pop6        # 0: down to label0
 # BB#4:                                 # %if.end12
 	i32.const	$push44=, -2147483648
 	i32.const	$push43=, 2147483647
 	i32.call	$push7=, nle@FUNCTION, $pop44, $pop43
 	i32.const	$push42=, -1
 	i32.ne  	$push8=, $pop7, $pop42
-	br_if   	4, $pop8        # 4: down to label15
+	br_if   	0, $pop8        # 0: down to label0
 # BB#5:                                 # %if.end16
 	i32.const	$push46=, 2147483647
 	i32.const	$push45=, -2147483648
 	i32.call	$push9=, nle@FUNCTION, $pop46, $pop45
-	br_if   	5, $pop9        # 5: down to label14
+	br_if   	0, $pop9        # 0: down to label0
 # BB#6:                                 # %if.end20
 	i32.const	$push48=, -2147483648
 	i32.const	$push47=, 2147483647
 	i32.call	$push10=, nlt@FUNCTION, $pop48, $pop47
 	i32.const	$push11=, -1
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	6, $pop12       # 6: down to label13
+	br_if   	0, $pop12       # 0: down to label0
 # BB#7:                                 # %if.end24
 	i32.const	$push50=, 2147483647
 	i32.const	$push49=, -2147483648
 	i32.call	$push13=, nlt@FUNCTION, $pop50, $pop49
-	br_if   	7, $pop13       # 7: down to label12
+	br_if   	0, $pop13       # 0: down to label0
 # BB#8:                                 # %if.end28
 	i32.const	$push52=, -2147483648
 	i32.const	$push51=, 2147483647
 	i32.call	$push14=, neq@FUNCTION, $pop52, $pop51
-	br_if   	8, $pop14       # 8: down to label11
+	br_if   	0, $pop14       # 0: down to label0
 # BB#9:                                 # %if.end32
 	i32.const	$push54=, 2147483647
 	i32.const	$push53=, -2147483648
 	i32.call	$push15=, neq@FUNCTION, $pop54, $pop53
-	br_if   	9, $pop15       # 9: down to label10
+	br_if   	0, $pop15       # 0: down to label0
 # BB#10:                                # %if.end36
 	i32.const	$push57=, -2147483648
 	i32.const	$push56=, 2147483647
 	i32.call	$push16=, nne@FUNCTION, $pop57, $pop56
 	i32.const	$push55=, -1
 	i32.ne  	$push17=, $pop16, $pop55
-	br_if   	10, $pop17      # 10: down to label9
+	br_if   	0, $pop17       # 0: down to label0
 # BB#11:                                # %if.end40
 	i32.const	$push60=, 2147483647
 	i32.const	$push59=, -2147483648
 	i32.call	$push18=, nne@FUNCTION, $pop60, $pop59
 	i32.const	$push58=, -1
 	i32.ne  	$push19=, $pop18, $pop58
-	br_if   	11, $pop19      # 11: down to label8
+	br_if   	0, $pop19       # 0: down to label0
 # BB#12:                                # %if.end44
 	i32.const	$push62=, 0
 	i32.const	$push61=, -1
 	i32.call	$push20=, ngeu@FUNCTION, $pop62, $pop61
-	br_if   	12, $pop20      # 12: down to label7
+	br_if   	0, $pop20       # 0: down to label0
 # BB#13:                                # %if.end48
 	i32.const	$push65=, -1
 	i32.const	$push64=, 0
 	i32.call	$push21=, ngeu@FUNCTION, $pop65, $pop64
 	i32.const	$push63=, -1
 	i32.ne  	$push22=, $pop21, $pop63
-	br_if   	13, $pop22      # 13: down to label6
+	br_if   	0, $pop22       # 0: down to label0
 # BB#14:                                # %if.end52
 	i32.const	$push67=, 0
 	i32.const	$push66=, -1
 	i32.call	$push23=, ngtu@FUNCTION, $pop67, $pop66
-	br_if   	14, $pop23      # 14: down to label5
+	br_if   	0, $pop23       # 0: down to label0
 # BB#15:                                # %if.end56
 	i32.const	$push70=, -1
 	i32.const	$push69=, 0
 	i32.call	$push24=, ngtu@FUNCTION, $pop70, $pop69
 	i32.const	$push68=, -1
 	i32.ne  	$push25=, $pop24, $pop68
-	br_if   	15, $pop25      # 15: down to label4
+	br_if   	0, $pop25       # 0: down to label0
 # BB#16:                                # %if.end60
 	i32.const	$push73=, 0
 	i32.const	$push72=, -1
 	i32.call	$push26=, nleu@FUNCTION, $pop73, $pop72
 	i32.const	$push71=, -1
 	i32.ne  	$push27=, $pop26, $pop71
-	br_if   	16, $pop27      # 16: down to label3
+	br_if   	0, $pop27       # 0: down to label0
 # BB#17:                                # %if.end64
 	i32.const	$push75=, -1
 	i32.const	$push74=, 0
 	i32.call	$push28=, nleu@FUNCTION, $pop75, $pop74
-	br_if   	17, $pop28      # 17: down to label2
+	br_if   	0, $pop28       # 0: down to label0
 # BB#18:                                # %if.end68
 	i32.const	$push78=, 0
 	i32.const	$push77=, -1
 	i32.call	$push29=, nltu@FUNCTION, $pop78, $pop77
 	i32.const	$push76=, -1
 	i32.ne  	$push30=, $pop29, $pop76
-	br_if   	18, $pop30      # 18: down to label1
+	br_if   	0, $pop30       # 0: down to label0
 # BB#19:                                # %if.end72
 	i32.const	$push80=, -1
 	i32.const	$push79=, 0
 	i32.call	$push31=, nltu@FUNCTION, $pop80, $pop79
-	br_if   	19, $pop31      # 19: down to label0
+	br_if   	0, $pop31       # 0: down to label0
 # BB#20:                                # %if.end76
 	i32.const	$push32=, 0
 	call    	exit@FUNCTION, $pop32
 	unreachable
-.LBB10_21:                              # %if.then
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_22:                              # %if.then3
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_23:                              # %if.then7
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_24:                              # %if.then11
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_25:                              # %if.then15
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_26:                              # %if.then19
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_27:                              # %if.then23
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_28:                              # %if.then27
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_29:                              # %if.then31
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_30:                              # %if.then35
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_31:                              # %if.then39
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_32:                              # %if.then43
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_33:                              # %if.then47
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_34:                              # %if.then51
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_35:                              # %if.then55
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_36:                              # %if.then59
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_37:                              # %if.then63
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_38:                              # %if.then67
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_39:                              # %if.then71
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_40:                              # %if.then75
+.LBB10_21:                              # %if.then75
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20071029-1.c.s
+++ b/test/torture-s/20071029-1.c.s
@@ -21,51 +21,46 @@ test:                                   # @test
 	i32.ne  	$push3=, $1, $3
 	br_if   	0, $pop3        # 0: down to label1
 # BB#1:                                 # %if.end
-	block
 	i32.load	$push4=, 4($0)
-	br_if   	0, $pop4        # 0: down to label2
+	br_if   	0, $pop4        # 0: down to label1
 # BB#2:                                 # %lor.lhs.false
 	i32.load	$push5=, 8($0)
-	br_if   	0, $pop5        # 0: down to label2
+	br_if   	0, $pop5        # 0: down to label1
 # BB#3:                                 # %lor.lhs.false6
 	i32.load	$push6=, 12($0)
-	br_if   	0, $pop6        # 0: down to label2
+	br_if   	0, $pop6        # 0: down to label1
 # BB#4:                                 # %lor.lhs.false10
 	i32.load	$push7=, 16($0)
-	br_if   	0, $pop7        # 0: down to label2
+	br_if   	0, $pop7        # 0: down to label1
 # BB#5:                                 # %lor.lhs.false13
 	i32.load	$push8=, 20($0)
-	br_if   	0, $pop8        # 0: down to label2
+	br_if   	0, $pop8        # 0: down to label1
 # BB#6:                                 # %lor.lhs.false16
 	i32.load	$push9=, 24($0)
-	br_if   	0, $pop9        # 0: down to label2
+	br_if   	0, $pop9        # 0: down to label1
 # BB#7:                                 # %lor.lhs.false20
 	i32.load	$push10=, 28($0)
-	br_if   	0, $pop10       # 0: down to label2
+	br_if   	0, $pop10       # 0: down to label1
 # BB#8:                                 # %lor.lhs.false23
 	i32.load	$push11=, 32($0)
-	br_if   	0, $pop11       # 0: down to label2
+	br_if   	0, $pop11       # 0: down to label1
 # BB#9:                                 # %lor.lhs.false26
 	i32.load	$push12=, 36($0)
-	br_if   	0, $pop12       # 0: down to label2
+	br_if   	0, $pop12       # 0: down to label1
 # BB#10:                                # %lor.lhs.false29
 	i32.load	$push13=, 40($0)
-	br_if   	0, $pop13       # 0: down to label2
+	br_if   	0, $pop13       # 0: down to label1
 # BB#11:                                # %if.end34
 	i32.const	$push14=, 20
 	i32.eq  	$push15=, $2, $pop14
-	br_if   	2, $pop15       # 2: down to label0
+	br_if   	1, $pop15       # 1: down to label0
 # BB#12:                                # %if.end37
 	return
 .LBB0_13:                               # %if.then33
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_15:                               # %if.then36
+.LBB0_14:                               # %if.then36
 	end_block                       # label0:
 	i32.const	$push16=, 0
 	call    	exit@FUNCTION, $pop16
@@ -96,7 +91,7 @@ foo:                                    # @foo
 	i32.add 	$0=, $0, $pop1
 .LBB1_1:                                # %again
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label3:
+	loop                            # label2:
 	i32.store	$discard=, 8($6):p2align=3, $0
 	i32.const	$push4=, 0
 	i32.const	$push3=, 52
@@ -106,9 +101,9 @@ foo:                                    # @foo
 	call    	test@FUNCTION, $5
 	i32.const	$push2=, 1
 	i32.add 	$0=, $0, $pop2
-	br      	0               # 0: up to label3
+	br      	0               # 0: up to label2
 .LBB1_2:
-	end_loop                        # label4:
+	end_loop                        # label3:
 	.endfunc
 .Lfunc_end1:
 	.size	foo, .Lfunc_end1-foo

--- a/test/torture-s/20071030-1.c.s
+++ b/test/torture-s/20071030-1.c.s
@@ -9,25 +9,26 @@ CalcPing:                               # @CalcPing
 	.result 	i32
 	.local  	i32, i32, f32, i64, i32, f32
 # BB#0:                                 # %entry
-	i32.const	$2=, 0
-	i32.const	$1=, 16
-	f32.const	$3=, 0x0p0
 	block
 	block
-	i64.load	$push15=, 0($0)
-	tee_local	$push14=, $4=, $pop15
-	i32.wrap/i64	$push0=, $pop14
+	i64.load	$push13=, 0($0)
+	tee_local	$push12=, $4=, $pop13
+	i32.wrap/i64	$push0=, $pop12
 	i32.const	$push1=, 1
 	i32.ne  	$push2=, $pop0, $pop1
 	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %if.then
-	i64.const	$push12=, 32
-	i64.shr_u	$push13=, $4, $pop12
-	i32.wrap/i64	$1=, $pop13
+	i64.const	$push10=, 32
+	i64.shr_u	$push11=, $4, $pop10
+	i32.wrap/i64	$1=, $pop11
 	br      	1               # 1: down to label0
-.LBB0_2:                                # %for.body
-                                        # =>This Inner Loop Header: Depth=1
+.LBB0_2:
 	end_block                       # label1:
+	f32.const	$3=, 0x0p0
+	i32.const	$2=, 0
+	i32.const	$1=, 16
+.LBB0_3:                                # %for.body
+                                        # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
 	i32.add 	$push3=, $0, $1
 	f32.load	$push20=, 0($pop3):p2align=3
@@ -38,24 +39,24 @@ CalcPing:                               # @CalcPing
 	tee_local	$push16=, $5=, $pop17
 	f32.select	$3=, $pop4, $3, $pop16
 	i32.add 	$2=, $5, $2
-	i32.const	$push5=, 24
-	i32.add 	$1=, $1, $pop5
-	i32.const	$push6=, 1552
-	i32.ne  	$push7=, $1, $pop6
-	br_if   	0, $pop7        # 0: up to label2
-# BB#3:                                 # %for.end
+	i32.const	$push15=, 24
+	i32.add 	$1=, $1, $pop15
+	i32.const	$push14=, 1552
+	i32.ne  	$push5=, $1, $pop14
+	br_if   	0, $pop5        # 0: up to label2
+# BB#4:                                 # %for.end
 	end_loop                        # label3:
 	i32.const	$1=, 9999
 	i32.const	$push21=, 0
 	i32.eq  	$push22=, $2, $pop21
 	br_if   	0, $pop22       # 0: down to label0
-# BB#4:                                 # %if.end9
-	f32.convert_s/i32	$push8=, $2
-	f32.div 	$push9=, $3, $pop8
-	f32.const	$push10=, 0x1.f4p9
-	f32.mul 	$push11=, $pop9, $pop10
-	i32.trunc_s/f32	$1=, $pop11
-.LBB0_5:                                # %cleanup
+# BB#5:                                 # %if.end9
+	f32.convert_s/i32	$push6=, $2
+	f32.div 	$push7=, $3, $pop6
+	f32.const	$push8=, 0x1.f4p9
+	f32.mul 	$push9=, $pop7, $pop8
+	i32.trunc_s/f32	$1=, $pop9
+.LBB0_6:                                # %cleanup
 	end_block                       # label0:
 	return  	$1
 	.endfunc

--- a/test/torture-s/20071120-1.c.s
+++ b/test/torture-s/20071120-1.c.s
@@ -36,40 +36,39 @@ pop_to_parent_deferring_access_checks:  # @pop_to_parent_deferring_access_checks
 	block
 	block
 	block
-	block
 	i32.const	$push13=, 0
 	i32.load	$push12=, deferred_access_no_check($pop13)
 	tee_local	$push11=, $0=, $pop12
 	i32.const	$push20=, 0
 	i32.eq  	$push21=, $pop11, $pop20
-	br_if   	0, $pop21       # 0: down to label4
+	br_if   	0, $pop21       # 0: down to label3
 # BB#1:                                 # %if.then
 	i32.const	$push14=, 0
 	i32.const	$push0=, -1
 	i32.add 	$push1=, $0, $pop0
 	i32.store	$discard=, deferred_access_no_check($pop14), $pop1
-	br      	1               # 1: down to label3
+	br      	1               # 1: down to label2
 .LBB2_2:                                # %if.else
-	end_block                       # label4:
+	end_block                       # label3:
 	i32.const	$push17=, 0
 	i32.load	$push16=, deferred_access_stack($pop17)
 	tee_local	$push15=, $0=, $pop16
 	i32.const	$push22=, 0
 	i32.eq  	$push23=, $pop15, $pop22
-	br_if   	1, $pop23       # 1: down to label2
+	br_if   	1, $pop23       # 1: down to label1
 # BB#3:                                 # %land.lhs.true.i
 	i32.load	$push19=, 0($0)
 	tee_local	$push18=, $1=, $pop19
 	i32.const	$push24=, 0
 	i32.eq  	$push25=, $pop18, $pop24
-	br_if   	1, $pop25       # 1: down to label2
+	br_if   	1, $pop25       # 1: down to label1
 # BB#4:                                 # %land.lhs.true.i25
 	i32.const	$push2=, -1
 	i32.add 	$push3=, $1, $pop2
 	i32.store	$push4=, 0($0), $pop3
 	i32.const	$push26=, 0
 	i32.eq  	$push27=, $pop4, $pop26
-	br_if   	2, $pop27       # 2: down to label1
+	br_if   	1, $pop27       # 1: down to label1
 # BB#5:                                 # %VEC_deferred_access_base_last.exit29
 	i32.const	$push5=, 3
 	i32.shl 	$push6=, $1, $pop5
@@ -79,19 +78,15 @@ pop_to_parent_deferring_access_checks:  # @pop_to_parent_deferring_access_checks
 	i32.load	$push10=, 0($pop9)
 	i32.const	$push28=, 0
 	i32.eq  	$push29=, $pop10, $pop28
-	br_if   	3, $pop29       # 3: down to label0
+	br_if   	2, $pop29       # 2: down to label0
 .LBB2_6:                                # %if.end16
-	end_block                       # label3:
-	return
-.LBB2_7:                                # %cond.false.i
 	end_block                       # label2:
-	call    	vec_assert_fail@FUNCTION
-	unreachable
-.LBB2_8:                                # %cond.false.i26
+	return
+.LBB2_7:                                # %cond.false.i26
 	end_block                       # label1:
 	call    	vec_assert_fail@FUNCTION
 	unreachable
-.LBB2_9:                                # %if.then15
+.LBB2_8:                                # %if.then15
 	end_block                       # label0:
 	call    	perform_access_checks@FUNCTION, $0
 	unreachable

--- a/test/torture-s/20071202-1.c.s
+++ b/test/torture-s/20071202-1.c.s
@@ -52,11 +52,10 @@ main:                                   # @main
 	i32.add 	$4=, $19, $4
 	call    	foo@FUNCTION, $4
 	block
-	block
 	i32.load	$push2=, 8($19):p2align=3
 	i32.const	$push3=, 12
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label1
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %lor.lhs.false
 	i32.const	$push5=, 4
 	i32.const	$5=, 8
@@ -65,50 +64,50 @@ main:                                   # @main
 	i32.load	$push7=, 0($pop6)
 	i32.const	$push8=, 6
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	0, $pop9        # 0: down to label1
+	br_if   	0, $pop9        # 0: down to label0
 # BB#2:                                 # %lor.lhs.false2
 	i32.load	$push10=, 16($19):p2align=3
-	br_if   	0, $pop10       # 0: down to label1
+	br_if   	0, $pop10       # 0: down to label0
 # BB#3:                                 # %lor.lhs.false3
 	i32.const	$push11=, 12
 	i32.const	$6=, 8
 	i32.add 	$6=, $19, $6
 	i32.add 	$push12=, $6, $pop11
 	i32.load	$push13=, 0($pop12)
-	br_if   	0, $pop13       # 0: down to label1
+	br_if   	0, $pop13       # 0: down to label0
 # BB#4:                                 # %lor.lhs.false7
 	i32.const	$push14=, 16
 	i32.const	$7=, 8
 	i32.add 	$7=, $19, $7
 	i32.add 	$push15=, $7, $pop14
 	i32.load	$push16=, 0($pop15):p2align=3
-	br_if   	0, $pop16       # 0: down to label1
+	br_if   	0, $pop16       # 0: down to label0
 # BB#5:                                 # %lor.lhs.false11
 	i32.const	$push17=, 20
 	i32.const	$8=, 8
 	i32.add 	$8=, $19, $8
 	i32.add 	$push18=, $8, $pop17
 	i32.load	$push19=, 0($pop18)
-	br_if   	0, $pop19       # 0: down to label1
+	br_if   	0, $pop19       # 0: down to label0
 # BB#6:                                 # %lor.lhs.false15
 	i32.const	$push20=, 24
 	i32.const	$9=, 8
 	i32.add 	$9=, $19, $9
 	i32.add 	$push21=, $9, $pop20
 	i32.load	$push22=, 0($pop21):p2align=3
-	br_if   	0, $pop22       # 0: down to label1
+	br_if   	0, $pop22       # 0: down to label0
 # BB#7:                                 # %lor.lhs.false19
 	i32.const	$push23=, 28
 	i32.const	$10=, 8
 	i32.add 	$10=, $19, $10
 	i32.add 	$push24=, $10, $pop23
 	i32.load	$push25=, 0($pop24)
-	br_if   	0, $pop25       # 0: down to label1
+	br_if   	0, $pop25       # 0: down to label0
 # BB#8:                                 # %if.end
 	i32.load	$push26=, 40($19):p2align=3
 	i32.const	$push27=, 7
 	i32.ne  	$push28=, $pop26, $pop27
-	br_if   	1, $pop28       # 1: down to label0
+	br_if   	0, $pop28       # 0: down to label0
 # BB#9:                                 # %lor.lhs.false24
 	i32.const	$push29=, 36
 	i32.const	$11=, 8
@@ -117,7 +116,7 @@ main:                                   # @main
 	i32.load	$push31=, 0($pop30)
 	i32.const	$push32=, 8
 	i32.ne  	$push33=, $pop31, $pop32
-	br_if   	1, $pop33       # 1: down to label0
+	br_if   	0, $pop33       # 0: down to label0
 # BB#10:                                # %lor.lhs.false28
 	i32.const	$push34=, 40
 	i32.const	$12=, 8
@@ -126,7 +125,7 @@ main:                                   # @main
 	i32.load	$push36=, 0($pop35):p2align=3
 	i32.const	$push37=, 9
 	i32.ne  	$push38=, $pop36, $pop37
-	br_if   	1, $pop38       # 1: down to label0
+	br_if   	0, $pop38       # 0: down to label0
 # BB#11:                                # %lor.lhs.false33
 	i32.const	$push39=, 44
 	i32.const	$13=, 8
@@ -135,7 +134,7 @@ main:                                   # @main
 	i32.load	$push41=, 0($pop40)
 	i32.const	$push42=, 10
 	i32.ne  	$push43=, $pop41, $pop42
-	br_if   	1, $pop43       # 1: down to label0
+	br_if   	0, $pop43       # 0: down to label0
 # BB#12:                                # %lor.lhs.false38
 	i32.const	$push44=, 48
 	i32.const	$14=, 8
@@ -144,7 +143,7 @@ main:                                   # @main
 	i32.load	$push46=, 0($pop45):p2align=3
 	i32.const	$push47=, 11
 	i32.ne  	$push48=, $pop46, $pop47
-	br_if   	1, $pop48       # 1: down to label0
+	br_if   	0, $pop48       # 0: down to label0
 # BB#13:                                # %lor.lhs.false43
 	i32.const	$push49=, 52
 	i32.const	$15=, 8
@@ -153,7 +152,7 @@ main:                                   # @main
 	i32.load	$push51=, 0($pop50)
 	i32.const	$push52=, 12
 	i32.ne  	$push53=, $pop51, $pop52
-	br_if   	1, $pop53       # 1: down to label0
+	br_if   	0, $pop53       # 0: down to label0
 # BB#14:                                # %lor.lhs.false48
 	i32.const	$push54=, 56
 	i32.const	$16=, 8
@@ -162,7 +161,7 @@ main:                                   # @main
 	i32.load	$push56=, 0($pop55):p2align=3
 	i32.const	$push57=, 13
 	i32.ne  	$push58=, $pop56, $pop57
-	br_if   	1, $pop58       # 1: down to label0
+	br_if   	0, $pop58       # 0: down to label0
 # BB#15:                                # %lor.lhs.false53
 	i32.const	$push59=, 60
 	i32.const	$17=, 8
@@ -171,7 +170,7 @@ main:                                   # @main
 	i32.load	$push61=, 0($pop60)
 	i32.const	$push62=, 14
 	i32.ne  	$push63=, $pop61, $pop62
-	br_if   	1, $pop63       # 1: down to label0
+	br_if   	0, $pop63       # 0: down to label0
 # BB#16:                                # %lor.lhs.false58
 	i32.const	$push64=, 64
 	i32.const	$18=, 8
@@ -180,7 +179,7 @@ main:                                   # @main
 	i32.load	$push66=, 0($pop65):p2align=3
 	i32.const	$push67=, 15
 	i32.ne  	$push68=, $pop66, $pop67
-	br_if   	1, $pop68       # 1: down to label0
+	br_if   	0, $pop68       # 0: down to label0
 # BB#17:                                # %if.end64
 	i32.const	$push69=, 0
 	i32.const	$2=, 80
@@ -188,11 +187,7 @@ main:                                   # @main
 	i32.const	$2=, __stack_pointer
 	i32.store	$19=, 0($2), $19
 	return  	$pop69
-.LBB1_18:                               # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_19:                               # %if.then63
+.LBB1_18:                               # %if.then63
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20071213-1.c.s
+++ b/test/torture-s/20071213-1.c.s
@@ -18,14 +18,13 @@ h:                                      # @h
 	block
 	block
 	block
-	block
 	i32.const	$push0=, 5
 	i32.eq  	$push1=, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label3
+	br_if   	0, $pop1        # 0: down to label2
 # BB#1:                                 # %entry
 	i32.const	$push2=, 1
 	i32.ne  	$push3=, $0, $pop2
-	br_if   	2, $pop3        # 2: down to label1
+	br_if   	2, $pop3        # 2: down to label0
 # BB#2:                                 # %sw.bb
 	i32.load	$push16=, 12($5)
 	i32.const	$push31=, 3
@@ -40,7 +39,7 @@ h:                                      # @h
 	i32.load	$push19=, 0($0)
 	i32.const	$push26=, 3
 	i32.ne  	$push20=, $pop19, $pop26
-	br_if   	0, $pop20       # 0: down to label4
+	br_if   	0, $pop20       # 0: down to label3
 # BB#3:                                 # %lor.lhs.false
 	i32.load	$push21=, 12($5)
 	i32.const	$push37=, 3
@@ -54,13 +53,13 @@ h:                                      # @h
 	i32.load	$push24=, 0($0)
 	i32.const	$push32=, 4
 	i32.eq  	$push25=, $pop24, $pop32
-	br_if   	2, $pop25       # 2: down to label2
+	br_if   	2, $pop25       # 2: down to label1
 .LBB0_4:                                # %if.then
-	end_block                       # label4:
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 .LBB0_5:                                # %sw.bb2
-	end_block                       # label3:
+	end_block                       # label2:
 	i32.load	$push4=, 12($5)
 	i32.const	$push42=, 3
 	i32.add 	$push5=, $pop4, $pop42
@@ -73,7 +72,7 @@ h:                                      # @h
 	i32.load	$push7=, 0($0)
 	i32.const	$push8=, 9
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	2, $pop9        # 2: down to label0
+	br_if   	1, $pop9        # 1: down to label0
 # BB#6:                                 # %lor.lhs.false4
 	i32.load	$push10=, 12($5)
 	i32.const	$push47=, 3
@@ -87,19 +86,15 @@ h:                                      # @h
 	i32.load	$push13=, 0($0)
 	i32.const	$push14=, 10
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	2, $pop15       # 2: down to label0
+	br_if   	1, $pop15       # 1: down to label0
 .LBB0_7:                                # %return
-	end_block                       # label2:
+	end_block                       # label1:
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
 .LBB0_8:                                # %sw.default
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -126,10 +121,9 @@ f1:                                     # @f1
 	block
 	block
 	block
-	block
 	i32.const	$push1=, 1
 	i32.ne  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label8
+	br_if   	0, $pop2        # 0: down to label6
 # BB#1:                                 # %sw.bb.i
 	i32.load	$push17=, 12($6)
 	i32.const	$push34=, 3
@@ -140,11 +134,10 @@ f1:                                     # @f1
 	i32.const	$push30=, 4
 	i32.add 	$push19=, $pop31, $pop30
 	i32.store	$discard=, 12($6), $pop19
-	block
 	i32.load	$push20=, 0($0)
 	i32.const	$push29=, 3
 	i32.ne  	$push21=, $pop20, $pop29
-	br_if   	0, $pop21       # 0: down to label9
+	br_if   	1, $pop21       # 1: down to label5
 # BB#2:                                 # %lor.lhs.false.i
 	i32.load	$push22=, 12($6)
 	i32.const	$push40=, 3
@@ -158,27 +151,23 @@ f1:                                     # @f1
 	i32.load	$push25=, 0($0)
 	i32.const	$push35=, 4
 	i32.ne  	$push26=, $pop25, $pop35
-	br_if   	0, $pop26       # 0: down to label9
+	br_if   	1, $pop26       # 1: down to label5
 # BB#3:                                 # %h.exit
 	i64.const	$push27=, 2
 	i64.ne  	$push28=, $1, $pop27
-	br_if   	2, $pop28       # 2: down to label7
+	br_if   	1, $pop28       # 1: down to label5
 # BB#4:                                 # %if.end
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
-.LBB1_5:                                # %if.then.i
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_6:                                # %entry
-	end_block                       # label8:
+.LBB1_5:                                # %entry
+	end_block                       # label6:
 	i32.const	$push3=, 5
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	1, $pop4        # 1: down to label6
-# BB#7:                                 # %sw.bb2.i
+	br_if   	1, $pop4        # 1: down to label4
+# BB#6:                                 # %sw.bb2.i
 	i32.load	$push5=, 12($6)
 	i32.const	$push45=, 3
 	i32.add 	$push6=, $pop5, $pop45
@@ -191,8 +180,8 @@ f1:                                     # @f1
 	i32.load	$push8=, 0($0)
 	i32.const	$push9=, 9
 	i32.ne  	$push10=, $pop8, $pop9
-	br_if   	2, $pop10       # 2: down to label5
-# BB#8:                                 # %lor.lhs.false4.i
+	br_if   	1, $pop10       # 1: down to label4
+# BB#7:                                 # %lor.lhs.false4.i
 	i32.load	$push11=, 12($6)
 	i32.const	$push50=, 3
 	i32.add 	$push12=, $pop11, $pop50
@@ -205,17 +194,13 @@ f1:                                     # @f1
 	i32.load	$push14=, 0($0)
 	i32.const	$push15=, 10
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	2, $pop16       # 2: down to label5
-.LBB1_9:                                # %if.then
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_10:                               # %sw.default.i
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_11:                               # %if.then6.i
+	br_if   	1, $pop16       # 1: down to label4
+.LBB1_8:                                # %if.then
 	end_block                       # label5:
+	call    	abort@FUNCTION
+	unreachable
+.LBB1_9:                                # %sw.default.i
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -241,15 +226,13 @@ f2:                                     # @f2
 	block
 	block
 	block
-	block
-	block
 	i32.const	$push1=, 5
 	i32.eq  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label14
+	br_if   	0, $pop2        # 0: down to label9
 # BB#1:                                 # %entry
 	i32.const	$push3=, 1
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	2, $pop4        # 2: down to label12
+	br_if   	2, $pop4        # 2: down to label7
 # BB#2:                                 # %sw.bb.i
 	i32.load	$push17=, 12($8)
 	i32.const	$push40=, 3
@@ -264,7 +247,7 @@ f2:                                     # @f2
 	i32.load	$push20=, 0($4)
 	i32.const	$push35=, 3
 	i32.ne  	$push21=, $pop20, $pop35
-	br_if   	0, $pop21       # 0: down to label15
+	br_if   	0, $pop21       # 0: down to label10
 # BB#3:                                 # %lor.lhs.false.i
 	i32.load	$push22=, 12($8)
 	i32.const	$push46=, 3
@@ -278,13 +261,13 @@ f2:                                     # @f2
 	i32.load	$push25=, 0($4)
 	i32.const	$push41=, 4
 	i32.eq  	$push26=, $pop25, $pop41
-	br_if   	2, $pop26       # 2: down to label13
+	br_if   	2, $pop26       # 2: down to label8
 .LBB2_4:                                # %if.then.i
-	end_block                       # label15:
+	end_block                       # label10:
 	call    	abort@FUNCTION
 	unreachable
 .LBB2_5:                                # %sw.bb2.i
-	end_block                       # label14:
+	end_block                       # label9:
 	i32.load	$push5=, 12($8)
 	i32.const	$push51=, 3
 	i32.add 	$push6=, $pop5, $pop51
@@ -297,7 +280,7 @@ f2:                                     # @f2
 	i32.load	$push8=, 0($4)
 	i32.const	$push9=, 9
 	i32.ne  	$push10=, $pop8, $pop9
-	br_if   	2, $pop10       # 2: down to label11
+	br_if   	1, $pop10       # 1: down to label7
 # BB#6:                                 # %lor.lhs.false4.i
 	i32.load	$push11=, 12($8)
 	i32.const	$push56=, 3
@@ -311,40 +294,32 @@ f2:                                     # @f2
 	i32.load	$push14=, 0($4)
 	i32.const	$push15=, 10
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	2, $pop16       # 2: down to label11
+	br_if   	1, $pop16       # 1: down to label7
 .LBB2_7:                                # %h.exit
-	end_block                       # label13:
+	end_block                       # label8:
 	i32.const	$push27=, 5
 	i32.ne  	$push28=, $0, $pop27
-	br_if   	2, $pop28       # 2: down to label10
+	br_if   	0, $pop28       # 0: down to label7
 # BB#8:                                 # %h.exit
 	i32.const	$push29=, 6
 	i32.ne  	$push30=, $1, $pop29
-	br_if   	2, $pop30       # 2: down to label10
+	br_if   	0, $pop30       # 0: down to label7
 # BB#9:                                 # %h.exit
 	i32.const	$push31=, 7
 	i32.ne  	$push32=, $2, $pop31
-	br_if   	2, $pop32       # 2: down to label10
+	br_if   	0, $pop32       # 0: down to label7
 # BB#10:                                # %h.exit
 	i64.const	$push33=, 8
 	i64.ne  	$push34=, $3, $pop33
-	br_if   	2, $pop34       # 2: down to label10
+	br_if   	0, $pop34       # 0: down to label7
 # BB#11:                                # %if.end
 	i32.const	$7=, 16
 	i32.add 	$8=, $8, $7
 	i32.const	$7=, __stack_pointer
 	i32.store	$8=, 0($7), $8
 	return
-.LBB2_12:                               # %sw.default.i
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_13:                               # %if.then6.i
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_14:                               # %if.then
-	end_block                       # label10:
+.LBB2_12:                               # %if.then
+	end_block                       # label7:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/20071216-1.c.s
+++ b/test/torture-s/20071216-1.c.s
@@ -49,8 +49,6 @@ main:                                   # @main
 	i32.store	$0=, x($pop25), $pop0
 	i32.call	$1=, bar@FUNCTION
 	block
-	block
-	block
 	i32.const	$push24=, -37
 	i32.const	$push23=, -1
 	i32.const	$push22=, -38
@@ -60,7 +58,7 @@ main:                                   # @main
 	i32.lt_u	$push1=, $1, $pop21
 	i32.select	$push4=, $1, $pop3, $pop1
 	i32.ne  	$push5=, $0, $pop4
-	br_if   	0, $pop5        # 0: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push31=, 0
 	i32.const	$push6=, -39
@@ -76,7 +74,7 @@ main:                                   # @main
 	i32.select	$push10=, $1, $pop9, $pop7
 	i32.const	$push26=, -1
 	i32.ne  	$push11=, $pop10, $pop26
-	br_if   	1, $pop11       # 1: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push33=, 0
 	i32.const	$push12=, -38
@@ -91,19 +89,11 @@ main:                                   # @main
 	i32.select	$push19=, $1, $pop18, $pop14
 	i32.const	$push32=, -37
 	i32.ne  	$push20=, $pop19, $pop32
-	br_if   	2, $pop20       # 2: down to label0
+	br_if   	0, $pop20       # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.const	$push34=, 0
 	return  	$pop34
-.LBB2_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_5:                                # %if.then3
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_6:                                # %if.then7
+.LBB2_4:                                # %if.then7
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20080519-1.c.s
+++ b/test/torture-s/20080519-1.c.s
@@ -41,23 +41,24 @@ regrename_optimize:                     # @regrename_optimize
 	i32.sub 	$11=, $6, $7
 	i32.const	$7=, __stack_pointer
 	i32.store	$11=, 0($7), $11
-	i32.const	$push1=, 0
-	i32.store	$3=, 8($11), $pop1
 	i32.load	$2=, 0($0)
-	i32.store	$discard=, 12($11), $3
+	i32.const	$push1=, 0
+	i32.store	$push2=, 8($11), $pop1
+	i32.store	$3=, 12($11), $pop2
+	block
+	i32.const	$push30=, 0
+	i32.eq  	$push31=, $2, $pop30
+	br_if   	0, $pop31       # 0: down to label1
+# BB#1:
 	i32.const	$1=, -1
 	copy_local	$4=, $3
-	block
-	i32.const	$push29=, 0
-	i32.eq  	$push30=, $2, $pop29
-	br_if   	0, $pop30       # 0: down to label1
-.LBB1_1:                                # %for.body
+.LBB1_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
 	copy_local	$push0=, $0
-	i32.load	$push2=, 4($pop0)
-	i32.const	$push3=, 3
-	i32.shl 	$push23=, $pop2, $pop3
+	i32.load	$push3=, 4($pop0)
+	i32.const	$push24=, 3
+	i32.shl 	$push23=, $pop3, $pop24
 	tee_local	$push22=, $5=, $pop23
 	i32.load	$push4=, reg_class_contents($pop22):p2align=3
 	i32.const	$push21=, -1
@@ -69,40 +70,40 @@ regrename_optimize:                     # @regrename_optimize
 	i32.const	$push20=, -1
 	i32.xor 	$push7=, $pop6, $pop20
 	i32.or  	$3=, $3, $pop7
-	i32.const	$push8=, 1
-	i32.add 	$1=, $1, $pop8
+	i32.const	$push19=, 1
+	i32.add 	$1=, $1, $pop19
 	br_if   	0, $2           # 0: up to label2
-# BB#2:                                 # %for.end
+# BB#3:                                 # %for.end
 	end_loop                        # label3:
 	i32.store	$2=, 8($11), $4
-	i32.const	$push9=, 4
+	i32.const	$push8=, 4
 	i32.const	$9=, 8
 	i32.add 	$9=, $11, $9
-	i32.add 	$push25=, $9, $pop9
-	tee_local	$push24=, $4=, $pop25
-	i32.store	$discard=, 0($pop24), $3
-	i32.const	$push10=, 0
-	i32.lt_s	$push11=, $1, $pop10
-	br_if   	0, $pop11       # 0: down to label1
-# BB#3:                                 # %if.end
-	i32.load	$push12=, 4($0)
-	i32.const	$push13=, 3
-	i32.shl 	$push28=, $pop12, $pop13
-	tee_local	$push27=, $0=, $pop28
-	i32.load	$1=, reg_class_contents($pop27):p2align=3
-	i32.load	$push17=, reg_class_contents+4($0)
-	i32.const	$push14=, -1
-	i32.xor 	$push18=, $pop17, $pop14
-	i32.or  	$push19=, $3, $pop18
-	i32.store	$discard=, 0($4), $pop19
-	i32.const	$push26=, -1
-	i32.xor 	$push15=, $1, $pop26
-	i32.or  	$push16=, $2, $pop15
-	i32.store	$discard=, 8($11), $pop16
+	i32.add 	$push26=, $9, $pop8
+	tee_local	$push25=, $4=, $pop26
+	i32.store	$discard=, 0($pop25), $3
+	i32.const	$push9=, 0
+	i32.lt_s	$push10=, $1, $pop9
+	br_if   	0, $pop10       # 0: down to label1
+# BB#4:                                 # %if.end
+	i32.load	$push11=, 4($0)
+	i32.const	$push12=, 3
+	i32.shl 	$push29=, $pop11, $pop12
+	tee_local	$push28=, $0=, $pop29
+	i32.load	$1=, reg_class_contents($pop28):p2align=3
+	i32.load	$push16=, reg_class_contents+4($0)
+	i32.const	$push13=, -1
+	i32.xor 	$push17=, $pop16, $pop13
+	i32.or  	$push18=, $3, $pop17
+	i32.store	$discard=, 0($4), $pop18
+	i32.const	$push27=, -1
+	i32.xor 	$push14=, $1, $pop27
+	i32.or  	$push15=, $2, $pop14
+	i32.store	$discard=, 8($11), $pop15
 	i32.const	$10=, 8
 	i32.add 	$10=, $11, $10
 	call    	merge_overlapping_regs@FUNCTION, $10
-.LBB1_4:                                # %cleanup
+.LBB1_5:                                # %cleanup
 	end_block                       # label1:
 	i32.const	$8=, 16
 	i32.add 	$11=, $11, $8

--- a/test/torture-s/20080522-1.c.s
+++ b/test/torture-s/20080522-1.c.s
@@ -56,46 +56,41 @@ main:                                   # @main
 	i32.const	$push0=, 0
 	i32.store	$discard=, 12($5), $pop0
 	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push16=, i
 	i32.call	$push1=, foo@FUNCTION, $pop16
 	i32.const	$push2=, 2
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label5
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push18=, i
 	i32.call	$push4=, bar@FUNCTION, $pop18
 	i32.const	$push17=, 1
 	i32.ne  	$push5=, $pop4, $pop17
-	br_if   	1, $pop5        # 1: down to label4
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$3=, 12
 	i32.add 	$3=, $5, $3
 	i32.call	$push6=, foo@FUNCTION, $3
 	i32.const	$push19=, 1
 	i32.ne  	$push7=, $pop6, $pop19
-	br_if   	2, $pop7        # 2: down to label3
+	br_if   	0, $pop7        # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.load	$push8=, 12($5)
 	i32.const	$push20=, 2
 	i32.ne  	$push9=, $pop8, $pop20
-	br_if   	3, $pop9        # 3: down to label2
+	br_if   	0, $pop9        # 0: down to label0
 # BB#4:                                 # %if.end11
 	i32.const	$4=, 12
 	i32.add 	$4=, $5, $4
 	i32.call	$push10=, bar@FUNCTION, $4
 	i32.const	$push21=, 2
 	i32.ne  	$push11=, $pop10, $pop21
-	br_if   	4, $pop11       # 4: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#5:                                 # %if.end15
 	i32.load	$push12=, 12($5)
 	i32.const	$push13=, 2
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	5, $pop14       # 5: down to label0
+	br_if   	0, $pop14       # 0: down to label0
 # BB#6:                                 # %if.end18
 	i32.const	$push15=, 0
 	i32.const	$2=, 16
@@ -103,27 +98,7 @@ main:                                   # @main
 	i32.const	$2=, __stack_pointer
 	i32.store	$5=, 0($2), $5
 	return  	$pop15
-.LBB2_7:                                # %if.then
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_8:                                # %if.then3
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_9:                                # %if.then7
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_10:                               # %if.then10
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_11:                               # %if.then14
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_12:                               # %if.then17
+.LBB2_7:                                # %if.then17
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20081218-1.c.s
+++ b/test/torture-s/20081218-1.c.s
@@ -43,73 +43,74 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$0=, 0
 	block
 	block
 	i32.call	$push0=, foo@FUNCTION
 	i32.const	$push1=, 640034342
 	i32.ne  	$push2=, $pop0, $pop1
 	br_if   	0, $pop2        # 0: down to label1
-.LBB2_1:                                # %for.body
+# BB#1:
+	i32.const	$0=, 0
+.LBB2_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block
 	block
 	loop                            # label4:
 	i32.load8_u	$push3=, a($0)
-	i32.const	$push4=, 38
-	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	2, $pop5        # 2: down to label3
-# BB#2:                                 # %for.cond
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push6=, 1
-	i32.add 	$0=, $0, $pop6
-	i32.const	$push7=, 519
-	i32.le_u	$push8=, $0, $pop7
-	br_if   	0, $pop8        # 0: up to label4
-# BB#3:                                 # %for.end
+	i32.const	$push16=, 38
+	i32.ne  	$push4=, $pop3, $pop16
+	br_if   	2, $pop4        # 2: down to label3
+# BB#3:                                 # %for.cond
+                                        #   in Loop: Header=BB2_2 Depth=1
+	i32.const	$push15=, 1
+	i32.add 	$0=, $0, $pop15
+	i32.const	$push14=, 519
+	i32.le_u	$push5=, $0, $pop14
+	br_if   	0, $pop5        # 0: up to label4
+# BB#4:                                 # %for.end
 	end_loop                        # label5:
 	call    	bar@FUNCTION
 	i32.const	$0=, 0
 	i32.const	$push17=, 0
-	i32.load	$push9=, a+4($pop17)
-	i32.const	$push10=, 909588022
-	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label0
-# BB#4:                                 # %if.end9
+	i32.load	$push6=, a+4($pop17)
+	i32.const	$push7=, 909588022
+	i32.ne  	$push8=, $pop6, $pop7
+	br_if   	3, $pop8        # 3: down to label0
+# BB#5:                                 # %if.end9
 	i32.const	$push18=, 0
-	i32.const	$push12=, 909522486
-	i32.store	$discard=, a+4($pop18), $pop12
-.LBB2_5:                                # %for.body13
+	i32.const	$push9=, 909522486
+	i32.store	$discard=, a+4($pop18), $pop9
+.LBB2_6:                                # %for.body13
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label6:
-	i32.load8_u	$push13=, a($0)
+	i32.load8_u	$push10=, a($0)
 	i32.const	$push21=, 54
-	i32.ne  	$push14=, $pop13, $pop21
-	br_if   	3, $pop14       # 3: down to label2
-# BB#6:                                 # %for.cond10
-                                        #   in Loop: Header=BB2_5 Depth=1
+	i32.ne  	$push11=, $pop10, $pop21
+	br_if   	3, $pop11       # 3: down to label2
+# BB#7:                                 # %for.cond10
+                                        #   in Loop: Header=BB2_6 Depth=1
 	i32.const	$push20=, 1
 	i32.add 	$0=, $0, $pop20
 	i32.const	$push19=, 519
-	i32.le_u	$push15=, $0, $pop19
-	br_if   	0, $pop15       # 0: up to label6
-# BB#7:                                 # %for.end22
+	i32.le_u	$push12=, $0, $pop19
+	br_if   	0, $pop12       # 0: up to label6
+# BB#8:                                 # %for.end22
 	end_loop                        # label7:
-	i32.const	$push16=, 0
-	return  	$pop16
-.LBB2_8:                                # %if.then4
+	i32.const	$push13=, 0
+	return  	$pop13
+.LBB2_9:                                # %if.then4
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
-.LBB2_9:                                # %if.then18
+.LBB2_10:                               # %if.then18
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
-.LBB2_10:                               # %if.then
+.LBB2_11:                               # %if.then
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB2_11:                               # %if.then8
+.LBB2_12:                               # %if.then8
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/20090113-3.c.s
+++ b/test/torture-s/20090113-3.c.s
@@ -73,8 +73,8 @@ foobar:                                 # @foobar
 	i32.const	$9=, 12
 	i32.add 	$9=, $13, $9
 	call    	bmp_iter_set_init@FUNCTION, $8, $0, $9
-	i32.load	$3=, 24($13):p2align=3
-	i32.load	$2=, 16($13):p2align=3
+	i32.load	$2=, 24($13):p2align=3
+	i32.load	$1=, 16($13):p2align=3
 	i32.load	$0=, 28($13)
 .LBB1_1:                                # %for.cond
                                         # =>This Loop Header: Depth=1
@@ -117,7 +117,7 @@ foobar:                                 # @foobar
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label3:
 	i32.const	$push15=, 1
-	i32.add 	$3=, $3, $pop15
+	i32.add 	$2=, $2, $pop15
 .LBB1_6:                                # %while.cond7.i.outer
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Loop Header: Depth=2
@@ -125,15 +125,15 @@ foobar:                                 # @foobar
 	loop                            # label6:
 	block
 	i32.const	$push16=, 2
-	i32.eq  	$push5=, $3, $pop16
+	i32.eq  	$push5=, $2, $pop16
 	br_if   	0, $pop5        # 0: down to label8
 # BB#7:                                 # %while.body9.i.preheader
                                         #   in Loop: Header=BB1_6 Depth=2
 	i32.const	$push18=, 2
-	i32.shl 	$push6=, $3, $pop18
-	i32.add 	$push7=, $2, $pop6
+	i32.shl 	$push6=, $2, $pop18
+	i32.add 	$push7=, $1, $pop6
 	i32.const	$push17=, 12
-	i32.add 	$1=, $pop7, $pop17
+	i32.add 	$3=, $pop7, $pop17
 .LBB1_8:                                # %while.body9.i
                                         #   Parent Loop BB1_1 Depth=1
                                         #     Parent Loop BB1_6 Depth=2
@@ -144,25 +144,25 @@ foobar:                                 # @foobar
 	i32.add 	$10=, $13, $10
 	i32.add 	$push20=, $10, $pop21
 	tee_local	$push19=, $4=, $pop20
-	i32.load	$push0=, 0($1)
+	i32.load	$push0=, 0($3)
 	i32.store	$0=, 0($pop19), $pop0
 	br_if   	4, $0           # 4: down to label7
 # BB#9:                                 # %if.end26.i
                                         #   in Loop: Header=BB1_8 Depth=3
 	i32.const	$push27=, 1
-	i32.add 	$3=, $3, $pop27
+	i32.add 	$2=, $2, $pop27
 	i32.const	$push26=, 4
-	i32.add 	$1=, $1, $pop26
+	i32.add 	$3=, $3, $pop26
 	i32.const	$push25=, 2
-	i32.ne  	$push11=, $3, $pop25
+	i32.ne  	$push11=, $2, $pop25
 	br_if   	0, $pop11       # 0: up to label9
 .LBB1_10:                               # %while.end30.i
                                         #   in Loop: Header=BB1_6 Depth=2
 	end_loop                        # label10:
 	end_block                       # label8:
-	i32.load	$2=, 0($2)
-	i32.const	$3=, 0
-	br_if   	0, $2           # 0: up to label6
+	i32.load	$1=, 0($1)
+	i32.const	$2=, 0
+	br_if   	0, $1           # 0: up to label6
 	br      	4               # 4: down to label1
 .LBB1_11:                               # %while.cond16.preheader.i
                                         #   in Loop: Header=BB1_1 Depth=1

--- a/test/torture-s/20100805-1.c.s
+++ b/test/torture-s/20100805-1.c.s
@@ -8,8 +8,8 @@ foo:                                    # @foo
 	.param  	i32, i32
 	.result 	i32
 # BB#0:                                 # %entry
-	i32.const	$push4=, 1
-	i32.and 	$0=, $0, $pop4
+	i32.const	$push2=, 1
+	i32.and 	$0=, $0, $pop2
 	block
 	i32.const	$push6=, 0
 	i32.eq  	$push7=, $1, $pop6
@@ -19,9 +19,9 @@ foo:                                    # @foo
 	loop                            # label1:
 	i32.const	$push5=, 1
 	i32.shl 	$push0=, $0, $pop5
-	i32.const	$push1=, 31
-	i32.shr_u	$push2=, $0, $pop1
-	i32.or  	$0=, $pop0, $pop2
+	i32.const	$push4=, 31
+	i32.shr_u	$push1=, $0, $pop4
+	i32.or  	$0=, $pop0, $pop1
 	i32.const	$push3=, -1
 	i32.add 	$1=, $1, $pop3
 	br_if   	0, $1           # 0: up to label1

--- a/test/torture-s/20100827-1.c.s
+++ b/test/torture-s/20100827-1.c.s
@@ -19,19 +19,19 @@ foo:                                    # @foo
 .LBB0_1:                                # %if.end
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.add 	$push5=, $0, $1
-	tee_local	$push4=, $2=, $pop5
+	i32.add 	$push4=, $0, $1
+	tee_local	$push3=, $2=, $pop4
 	i32.const	$push9=, 0
-	i32.eq  	$push10=, $pop4, $pop9
+	i32.eq  	$push10=, $pop3, $pop9
 	br_if   	3, $pop10       # 3: down to label0
 # BB#2:                                 # %if.end5
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push1=, 1
-	i32.add 	$1=, $1, $pop1
 	i32.const	$push6=, 1
-	i32.add 	$push2=, $2, $pop6
-	i32.load8_u	$push3=, 0($pop2)
-	br_if   	0, $pop3        # 0: up to label2
+	i32.add 	$1=, $1, $pop6
+	i32.const	$push5=, 1
+	i32.add 	$push1=, $2, $pop5
+	i32.load8_u	$push2=, 0($pop1)
+	br_if   	0, $pop2        # 0: up to label2
 .LBB0_3:                                # %do.end
 	end_loop                        # label3:
 	end_block                       # label1:

--- a/test/torture-s/20111227-2.c.s
+++ b/test/torture-s/20111227-2.c.s
@@ -9,11 +9,9 @@ bar:                                    # @bar
 # BB#0:                                 # %entry
 	block
 	block
-	block
-	block
 	i32.const	$push1=, 2
 	i32.ne  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push16=, 0
 	i32.load16_u	$push0=, s($pop16)
@@ -21,41 +19,33 @@ bar:                                    # @bar
 	i32.and 	$push4=, $pop0, $pop3
 	i32.const	$push5=, 255
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	1, $pop6        # 1: down to label2
+	br_if   	1, $pop6        # 1: down to label0
 .LBB0_2:                                # %if.end
-	end_block                       # label3:
+	end_block                       # label1:
 	block
 	i32.const	$push8=, 1
 	i32.ne  	$push9=, $0, $pop8
-	br_if   	0, $pop9        # 0: down to label4
+	br_if   	0, $pop9        # 0: down to label2
 # BB#3:                                 # %if.end
 	i32.const	$push17=, 0
 	i32.load	$push7=, i($pop17)
 	i32.const	$push10=, 255
 	i32.ne  	$push11=, $pop7, $pop10
-	br_if   	2, $pop11       # 2: down to label1
+	br_if   	1, $pop11       # 1: down to label0
 .LBB0_4:                                # %if.end9
-	end_block                       # label4:
+	end_block                       # label2:
 	block
-	br_if   	0, $0           # 0: down to label5
+	br_if   	0, $0           # 0: down to label3
 # BB#5:                                 # %if.end9
 	i32.const	$push13=, 0
 	i32.load	$push12=, l($pop13)
 	i32.const	$push14=, 255
 	i32.ne  	$push15=, $pop12, $pop14
-	br_if   	3, $pop15       # 3: down to label0
+	br_if   	1, $pop15       # 1: down to label0
 .LBB0_6:                                # %if.end16
-	end_block                       # label5:
+	end_block                       # label3:
 	return
-.LBB0_7:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then8
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then15
+.LBB0_7:                                # %if.then15
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -78,30 +68,30 @@ foo:                                    # @foo
 	block
 	i32.const	$push8=, 0
 	i32.eq  	$push9=, $1, $pop8
-	br_if   	0, $pop9        # 0: down to label8
+	br_if   	0, $pop9        # 0: down to label6
 # BB#1:                                 # %entry
 	i32.const	$push0=, 1
 	i32.eq  	$push1=, $1, $pop0
-	br_if   	1, $pop1        # 1: down to label7
+	br_if   	1, $pop1        # 1: down to label5
 # BB#2:                                 # %entry
 	i32.const	$push2=, 2
 	i32.ne  	$push3=, $1, $pop2
-	br_if   	2, $pop3        # 2: down to label6
+	br_if   	2, $pop3        # 2: down to label4
 # BB#3:                                 # %if.then
 	i32.const	$push5=, 0
 	i32.store16	$discard=, s($pop5), $2
-	br      	2               # 2: down to label6
+	br      	2               # 2: down to label4
 .LBB1_4:                                # %if.then8
-	end_block                       # label8:
+	end_block                       # label6:
 	i32.const	$push7=, 0
 	i32.store	$discard=, l($pop7), $2
-	br      	1               # 1: down to label6
+	br      	1               # 1: down to label4
 .LBB1_5:                                # %if.then3
-	end_block                       # label7:
+	end_block                       # label5:
 	i32.const	$push4=, 0
 	i32.store	$discard=, i($pop4), $2
 .LBB1_6:                                # %if.end11
-	end_block                       # label6:
+	end_block                       # label4:
 	call    	bar@FUNCTION, $1
 	return
 	.endfunc

--- a/test/torture-s/20111227-3.c.s
+++ b/test/torture-s/20111227-3.c.s
@@ -9,11 +9,9 @@ bar:                                    # @bar
 # BB#0:                                 # %entry
 	block
 	block
-	block
-	block
 	i32.const	$push1=, 2
 	i32.ne  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push16=, 0
 	i32.load16_u	$push0=, s($pop16)
@@ -21,41 +19,33 @@ bar:                                    # @bar
 	i32.and 	$push4=, $pop0, $pop3
 	i32.const	$push15=, 65535
 	i32.ne  	$push5=, $pop4, $pop15
-	br_if   	1, $pop5        # 1: down to label2
+	br_if   	1, $pop5        # 1: down to label0
 .LBB0_2:                                # %if.end
-	end_block                       # label3:
+	end_block                       # label1:
 	block
 	i32.const	$push7=, 1
 	i32.ne  	$push8=, $0, $pop7
-	br_if   	0, $pop8        # 0: down to label4
+	br_if   	0, $pop8        # 0: down to label2
 # BB#3:                                 # %if.end
 	i32.const	$push17=, 0
 	i32.load	$push6=, i($pop17)
 	i32.const	$push9=, -1
 	i32.ne  	$push10=, $pop6, $pop9
-	br_if   	2, $pop10       # 2: down to label1
+	br_if   	1, $pop10       # 1: down to label0
 .LBB0_4:                                # %if.end9
-	end_block                       # label4:
+	end_block                       # label2:
 	block
-	br_if   	0, $0           # 0: down to label5
+	br_if   	0, $0           # 0: down to label3
 # BB#5:                                 # %if.end9
 	i32.const	$push12=, 0
 	i32.load	$push11=, l($pop12)
 	i32.const	$push13=, -1
 	i32.ne  	$push14=, $pop11, $pop13
-	br_if   	3, $pop14       # 3: down to label0
+	br_if   	1, $pop14       # 1: down to label0
 .LBB0_6:                                # %if.end16
-	end_block                       # label5:
+	end_block                       # label3:
 	return
-.LBB0_7:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then8
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then15
+.LBB0_7:                                # %if.then15
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -78,30 +68,30 @@ foo:                                    # @foo
 	block
 	i32.const	$push8=, 0
 	i32.eq  	$push9=, $1, $pop8
-	br_if   	0, $pop9        # 0: down to label8
+	br_if   	0, $pop9        # 0: down to label6
 # BB#1:                                 # %entry
 	i32.const	$push0=, 1
 	i32.eq  	$push1=, $1, $pop0
-	br_if   	1, $pop1        # 1: down to label7
+	br_if   	1, $pop1        # 1: down to label5
 # BB#2:                                 # %entry
 	i32.const	$push2=, 2
 	i32.ne  	$push3=, $1, $pop2
-	br_if   	2, $pop3        # 2: down to label6
+	br_if   	2, $pop3        # 2: down to label4
 # BB#3:                                 # %if.then
 	i32.const	$push5=, 0
 	i32.store16	$discard=, s($pop5), $2
-	br      	2               # 2: down to label6
+	br      	2               # 2: down to label4
 .LBB1_4:                                # %if.then8
-	end_block                       # label8:
+	end_block                       # label6:
 	i32.const	$push7=, 0
 	i32.store	$discard=, l($pop7), $2
-	br      	1               # 1: down to label6
+	br      	1               # 1: down to label4
 .LBB1_5:                                # %if.then3
-	end_block                       # label7:
+	end_block                       # label5:
 	i32.const	$push4=, 0
 	i32.store	$discard=, i($pop4), $2
 .LBB1_6:                                # %if.end11
-	end_block                       # label6:
+	end_block                       # label4:
 	call    	bar@FUNCTION, $1
 	return
 	.endfunc

--- a/test/torture-s/20120427-1.c.s
+++ b/test/torture-s/20120427-1.c.s
@@ -50,30 +50,28 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$6=, 0
-	i32.const	$push52=, 0
-	i32.load	$0=, a+4($pop52)
-	i32.const	$push51=, 0
-	i32.load	$1=, a($pop51):p2align=4
-	i32.const	$push50=, 0
-	i32.load	$2=, a+12($pop50)
-	i32.const	$push49=, 0
-	i32.load	$3=, a+8($pop49):p2align=3
-	i32.const	$push48=, 0
-	i32.load	$4=, a+20($pop48)
 	i32.const	$push47=, 0
-	i32.load	$5=, a+16($pop47):p2align=4
-.LBB1_1:                                # %for.cond1.preheader
+	i32.load	$0=, a+4($pop47)
+	i32.const	$push46=, 0
+	i32.load	$1=, a($pop46):p2align=4
+	i32.const	$push45=, 0
+	i32.load	$2=, a+12($pop45)
+	i32.const	$push44=, 0
+	i32.load	$3=, a+8($pop44):p2align=3
+	i32.const	$push43=, 0
+	i32.load	$4=, a+20($pop43)
+	i32.const	$push42=, 0
+	i32.load	$5=, a+16($pop42):p2align=4
+.LBB1_1:                                # %if.end
                                         # =>This Inner Loop Header: Depth=1
-	block
-	loop                            # label2:
-	i32.const	$push58=, 3
-	i32.shl 	$push57=, $6, $pop58
-	tee_local	$push56=, $8=, $pop57
-	i32.const	$push55=, a+4
-	i32.add 	$7=, $pop56, $pop55
-	i32.const	$push54=, a
-	i32.add 	$8=, $8, $pop54
-	block
+	loop                            # label1:
+	i32.const	$push52=, 3
+	i32.shl 	$push51=, $6, $pop52
+	tee_local	$push50=, $8=, $pop51
+	i32.const	$push49=, a+4
+	i32.add 	$7=, $pop50, $pop49
+	i32.const	$push48=, a
+	i32.add 	$8=, $8, $pop48
 	block
 	block
 	block
@@ -81,202 +79,182 @@ main:                                   # @main
 	block
 	block
 	block
-	i32.const	$push53=, -1
-	i32.le_s	$push0=, $6, $pop53
-	br_if   	0, $pop0        # 0: down to label11
-# BB#2:                                 # %if.end
+	block
+	block
+	i32.const	$push72=, 0
+	i32.eq  	$push73=, $6, $pop72
+	br_if   	0, $pop73       # 0: down to label11
+# BB#2:                                 # %if.end14
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push80=, 0
-	i32.eq  	$push81=, $6, $pop80
-	br_if   	1, $pop81       # 1: down to label10
-# BB#3:                                 # %if.end14
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push61=, 1
-	i32.lt_s	$push1=, $6, $pop61
-	br_if   	2, $pop1        # 2: down to label9
-# BB#4:                                 # %land.lhs.true16
+	i32.const	$push53=, 1
+	i32.lt_s	$push0=, $6, $pop53
+	br_if   	1, $pop0        # 1: down to label10
+# BB#3:                                 # %land.lhs.true16
                                         #   in Loop: Header=BB1_1 Depth=1
 	block
-	i32.load	$push63=, 0($7)
-	tee_local	$push62=, $9=, $pop63
-	i32.gt_s	$push2=, $pop62, $0
-	br_if   	0, $pop2        # 0: down to label12
-# BB#5:                                 # %if.end.i45
+	i32.load	$push55=, 0($7)
+	tee_local	$push54=, $9=, $pop55
+	i32.gt_s	$push1=, $pop54, $0
+	br_if   	0, $pop1        # 0: down to label12
+# BB#4:                                 # %if.end.i45
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push3=, $9, $0
-	br_if   	6, $pop3        # 6: down to label6
-# BB#6:                                 # %if.end6.i49
+	i32.lt_s	$push2=, $9, $0
+	br_if   	8, $pop2        # 8: down to label4
+# BB#5:                                 # %if.end6.i49
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push4=, 0($8):p2align=3
-	i32.le_u	$push5=, $pop4, $1
-	br_if   	6, $pop5        # 6: down to label6
-.LBB1_7:                                # %if.end.1
+	i32.load	$push3=, 0($8):p2align=3
+	i32.le_u	$push4=, $pop3, $1
+	br_if   	8, $pop4        # 8: down to label4
+.LBB1_6:                                # %if.end.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label12:
-	i32.const	$push66=, 1
-	i32.ne  	$push6=, $6, $pop66
-	br_if   	3, $pop6        # 3: down to label8
-# BB#8:                                 # %land.lhs.true8.1
+	i32.const	$push58=, 1
+	i32.ne  	$push5=, $6, $pop58
+	br_if   	2, $pop5        # 2: down to label9
+# BB#7:                                 # %land.lhs.true8.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push25=, 0($7)
-	i32.ne  	$push26=, $pop25, $2
-	br_if   	4, $pop26       # 4: down to label7
-# BB#9:                                 # %if.end6.i63.1
+	i32.load	$push24=, 0($7)
+	i32.ne  	$push25=, $pop24, $2
+	br_if   	6, $pop25       # 6: down to label5
+# BB#8:                                 # %if.end6.i63.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push27=, 0($8):p2align=3
-	i32.eq  	$push28=, $pop27, $3
-	br_if   	6, $pop28       # 6: down to label5
-	br      	4               # 4: down to label7
-.LBB1_10:                               # %land.lhs.true
+	i32.load	$push26=, 0($8):p2align=3
+	i32.eq  	$push27=, $pop26, $3
+	br_if   	3, $pop27       # 3: down to label8
+	br      	6               # 6: down to label5
+.LBB1_9:                                # %land.lhs.true8
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label11:
-	i32.load	$push60=, 0($7)
-	tee_local	$push59=, $9=, $pop60
-	i32.gt_s	$push33=, $pop59, $0
-	br_if   	9, $pop33       # 9: down to label1
-# BB#11:                                # %if.end.i
+	i32.load	$push28=, 0($7)
+	i32.ne  	$push29=, $pop28, $0
+	br_if   	5, $pop29       # 5: down to label5
+# BB#10:                                # %if.end6.i63
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push34=, $9, $0
-	br_if   	1, $pop34       # 1: down to label9
-# BB#12:                                # %if.end6.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push35=, 0($8):p2align=3
-	i32.lt_u	$push36=, $pop35, $1
-	br_if   	1, $pop36       # 1: down to label9
-	br      	9               # 9: down to label1
-.LBB1_13:                               # %land.lhs.true8
+	i32.load	$push30=, 0($8):p2align=3
+	i32.ne  	$push31=, $pop30, $1
+	br_if   	5, $pop31       # 5: down to label5
+.LBB1_11:                               # %land.lhs.true.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label10:
-	i32.load	$push29=, 0($7)
-	i32.ne  	$push30=, $pop29, $0
-	br_if   	2, $pop30       # 2: down to label7
-# BB#14:                                # %if.end6.i63
+	i32.load	$push57=, 0($7)
+	tee_local	$push56=, $9=, $pop57
+	i32.gt_s	$push32=, $pop56, $2
+	br_if   	3, $pop32       # 3: down to label6
+# BB#12:                                # %if.end.i.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push31=, 0($8):p2align=3
-	i32.ne  	$push32=, $pop31, $1
-	br_if   	2, $pop32       # 2: down to label7
-.LBB1_15:                               # %land.lhs.true.1
+	i32.lt_s	$push33=, $9, $2
+	br_if   	1, $pop33       # 1: down to label8
+# BB#13:                                # %if.end6.i.1
+                                        #   in Loop: Header=BB1_1 Depth=1
+	i32.load	$push34=, 0($8):p2align=3
+	i32.lt_u	$push35=, $pop34, $3
+	br_if   	1, $pop35       # 1: down to label8
+	br      	3               # 3: down to label6
+.LBB1_14:                               # %if.end14.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label9:
-	i32.load	$push65=, 0($7)
-	tee_local	$push64=, $9=, $pop65
-	i32.gt_s	$push37=, $pop64, $2
-	br_if   	7, $pop37       # 7: down to label1
-# BB#16:                                # %if.end.i.1
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push38=, $9, $2
-	br_if   	3, $pop38       # 3: down to label5
-# BB#17:                                # %if.end6.i.1
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push39=, 0($8):p2align=3
-	i32.ge_u	$push40=, $pop39, $3
-	br_if   	7, $pop40       # 7: down to label1
-	br      	3               # 3: down to label5
-.LBB1_18:                               # %if.end14.1
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label8:
-	i32.const	$push67=, 2
-	i32.lt_s	$push7=, $6, $pop67
-	br_if   	2, $pop7        # 2: down to label5
-# BB#19:                                # %land.lhs.true16.1
+	i32.const	$push59=, 2
+	i32.lt_s	$push6=, $6, $pop59
+	br_if   	0, $pop6        # 0: down to label8
+# BB#15:                                # %land.lhs.true16.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	block
-	i32.load	$push69=, 0($7)
-	tee_local	$push68=, $9=, $pop69
-	i32.gt_s	$push8=, $pop68, $2
-	br_if   	0, $pop8        # 0: down to label13
-# BB#20:                                # %if.end.i45.1
+	i32.load	$push61=, 0($7)
+	tee_local	$push60=, $9=, $pop61
+	i32.gt_s	$push7=, $pop60, $2
+	br_if   	0, $pop7        # 0: down to label13
+# BB#16:                                # %if.end.i45.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push9=, $9, $2
-	br_if   	2, $pop9        # 2: down to label6
-# BB#21:                                # %if.end6.i49.1
+	i32.lt_s	$push8=, $9, $2
+	br_if   	5, $pop8        # 5: down to label4
+# BB#17:                                # %if.end6.i49.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push10=, 0($8):p2align=3
-	i32.le_u	$push11=, $pop10, $3
-	br_if   	2, $pop11       # 2: down to label6
-.LBB1_22:                               # %if.end.2
+	i32.load	$push9=, 0($8):p2align=3
+	i32.le_u	$push10=, $pop9, $3
+	br_if   	5, $pop10       # 5: down to label4
+.LBB1_18:                               # %if.end.2
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label13:
-	block
-	i32.const	$push72=, 2
-	i32.ne  	$push12=, $6, $pop72
-	br_if   	0, $pop12       # 0: down to label14
-# BB#23:                                # %land.lhs.true8.2
+	i32.const	$push64=, 2
+	i32.ne  	$push11=, $6, $pop64
+	br_if   	1, $pop11       # 1: down to label7
+# BB#19:                                # %land.lhs.true8.2
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push21=, 0($7)
-	i32.ne  	$push22=, $pop21, $4
-	br_if   	1, $pop22       # 1: down to label7
-# BB#24:                                # %if.end6.i63.2
+	i32.load	$push20=, 0($7)
+	i32.ne  	$push21=, $pop20, $4
+	br_if   	3, $pop21       # 3: down to label5
+# BB#20:                                # %if.end6.i63.2
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$6=, 3
-	i32.load	$push23=, 0($8):p2align=3
-	i32.eq  	$push24=, $pop23, $5
-	br_if   	5, $pop24       # 5: up to label2
-	br      	1               # 1: down to label7
-.LBB1_25:                               # %if.end14.2
+	i32.load	$push22=, 0($8):p2align=3
+	i32.eq  	$push23=, $pop22, $5
+	br_if   	6, $pop23       # 6: up to label1
+	br      	3               # 3: down to label5
+.LBB1_21:                               # %land.lhs.true.2
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label14:
-	i32.const	$push73=, 3
-	i32.lt_s	$push13=, $6, $pop73
-	br_if   	3, $pop13       # 3: down to label4
-# BB#26:                                # %land.lhs.true16.2
-	i32.load	$push77=, 0($7)
-	tee_local	$push76=, $6=, $pop77
-	i32.const	$push14=, 0
-	i32.load	$push75=, a+20($pop14)
-	tee_local	$push74=, $7=, $pop75
-	i32.gt_s	$push15=, $pop76, $pop74
-	br_if   	5, $pop15       # 5: down to label3
-# BB#27:                                # %if.end.i45.2
-	i32.lt_s	$push16=, $6, $7
-	br_if   	1, $pop16       # 1: down to label6
-# BB#28:                                # %if.end6.i49.2
-	i32.load	$push17=, 0($8):p2align=3
-	i32.const	$push18=, 0
-	i32.load	$push19=, a+16($pop18):p2align=4
-	i32.le_u	$push20=, $pop17, $pop19
-	br_if   	1, $pop20       # 1: down to label6
-	br      	5               # 5: down to label3
-.LBB1_29:                               # %if.then13
+	end_block                       # label8:
+	i32.load	$push63=, 0($7)
+	tee_local	$push62=, $7=, $pop63
+	i32.gt_s	$push36=, $pop62, $4
+	br_if   	1, $pop36       # 1: down to label6
+# BB#22:                                # %if.end.i.2
+                                        #   in Loop: Header=BB1_1 Depth=1
+	i32.lt_s	$push37=, $7, $4
+	br_if   	4, $pop37       # 4: down to label3
+# BB#23:                                # %if.end6.i.2
+                                        #   in Loop: Header=BB1_1 Depth=1
+	i32.load	$push38=, 0($8):p2align=3
+	i32.ge_u	$push39=, $pop38, $5
+	br_if   	1, $pop39       # 1: down to label6
+	br      	4               # 4: down to label3
+.LBB1_24:                               # %if.end14.2
+                                        #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_30:                               # %if.then21
+	i32.const	$push65=, 3
+	i32.lt_s	$push12=, $6, $pop65
+	br_if   	3, $pop12       # 3: down to label3
+# BB#25:                                # %land.lhs.true16.2
+	i32.load	$push69=, 0($7)
+	tee_local	$push68=, $6=, $pop69
+	i32.const	$push13=, 0
+	i32.load	$push67=, a+20($pop13)
+	tee_local	$push66=, $7=, $pop67
+	i32.gt_s	$push14=, $pop68, $pop66
+	br_if   	5, $pop14       # 5: down to label2
+# BB#26:                                # %if.end.i45.2
+	i32.lt_s	$push15=, $6, $7
+	br_if   	2, $pop15       # 2: down to label4
+# BB#27:                                # %if.end6.i49.2
+	i32.load	$push16=, 0($8):p2align=3
+	i32.const	$push17=, 0
+	i32.load	$push18=, a+16($pop17):p2align=4
+	i32.le_u	$push19=, $pop16, $pop18
+	br_if   	2, $pop19       # 2: down to label4
+	br      	5               # 5: down to label2
+.LBB1_28:                               # %if.then
 	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_31:                               # %land.lhs.true.2
-                                        #   in Loop: Header=BB1_1 Depth=1
+.LBB1_29:                               # %if.then13
 	end_block                       # label5:
-	i32.load	$push71=, 0($7)
-	tee_local	$push70=, $7=, $pop71
-	i32.gt_s	$push41=, $pop70, $4
-	br_if   	3, $pop41       # 3: down to label1
-# BB#32:                                # %if.end.i.2
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push42=, $7, $4
-	br_if   	0, $pop42       # 0: down to label4
-# BB#33:                                # %if.end6.i.2
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push43=, 0($8):p2align=3
-	i32.ge_u	$push44=, $pop43, $5
-	br_if   	3, $pop44       # 3: down to label1
-.LBB1_34:                               # %for.inc.2
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label4:
-	i32.const	$push79=, 1
-	i32.add 	$6=, $6, $pop79
-	i32.const	$push78=, 4
-	i32.lt_s	$push45=, $6, $pop78
-	br_if   	0, $pop45       # 0: up to label2
-.LBB1_35:                               # %for.end25
-	end_loop                        # label3:
-	i32.const	$push46=, 0
-	return  	$pop46
-.LBB1_36:                               # %if.then
-	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
+.LBB1_30:                               # %if.then21
+	end_block                       # label4:
+	call    	abort@FUNCTION
+	unreachable
+.LBB1_31:                               # %for.inc.2
+                                        #   in Loop: Header=BB1_1 Depth=1
+	end_block                       # label3:
+	i32.const	$push71=, 1
+	i32.add 	$6=, $6, $pop71
+	i32.const	$push70=, 4
+	i32.lt_s	$push40=, $6, $pop70
+	br_if   	0, $pop40       # 0: up to label1
+.LBB1_32:                               # %for.end25
+	end_loop                        # label2:
+	i32.const	$push41=, 0
+	return  	$pop41
 	.endfunc
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main

--- a/test/torture-s/20120427-2.c.s
+++ b/test/torture-s/20120427-2.c.s
@@ -50,30 +50,28 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$6=, 0
-	i32.const	$push52=, 0
-	i32.load	$0=, a+4($pop52)
-	i32.const	$push51=, 0
-	i32.load	$1=, a($pop51):p2align=4
-	i32.const	$push50=, 0
-	i32.load	$2=, a+12($pop50)
-	i32.const	$push49=, 0
-	i32.load	$3=, a+8($pop49):p2align=3
-	i32.const	$push48=, 0
-	i32.load	$4=, a+20($pop48)
 	i32.const	$push47=, 0
-	i32.load	$5=, a+16($pop47):p2align=4
-.LBB1_1:                                # %for.cond1.preheader
+	i32.load	$0=, a+4($pop47)
+	i32.const	$push46=, 0
+	i32.load	$1=, a($pop46):p2align=4
+	i32.const	$push45=, 0
+	i32.load	$2=, a+12($pop45)
+	i32.const	$push44=, 0
+	i32.load	$3=, a+8($pop44):p2align=3
+	i32.const	$push43=, 0
+	i32.load	$4=, a+20($pop43)
+	i32.const	$push42=, 0
+	i32.load	$5=, a+16($pop42):p2align=4
+.LBB1_1:                                # %if.end
                                         # =>This Inner Loop Header: Depth=1
-	block
-	loop                            # label2:
-	i32.const	$push58=, 3
-	i32.shl 	$push57=, $6, $pop58
-	tee_local	$push56=, $8=, $pop57
-	i32.const	$push55=, a+4
-	i32.add 	$7=, $pop56, $pop55
-	i32.const	$push54=, a
-	i32.add 	$8=, $8, $pop54
-	block
+	loop                            # label1:
+	i32.const	$push52=, 3
+	i32.shl 	$push51=, $6, $pop52
+	tee_local	$push50=, $8=, $pop51
+	i32.const	$push49=, a+4
+	i32.add 	$7=, $pop50, $pop49
+	i32.const	$push48=, a
+	i32.add 	$8=, $8, $pop48
 	block
 	block
 	block
@@ -81,202 +79,182 @@ main:                                   # @main
 	block
 	block
 	block
-	i32.const	$push53=, -1
-	i32.le_s	$push0=, $6, $pop53
-	br_if   	0, $pop0        # 0: down to label11
-# BB#2:                                 # %if.end
+	block
+	block
+	i32.const	$push72=, 0
+	i32.eq  	$push73=, $6, $pop72
+	br_if   	0, $pop73       # 0: down to label11
+# BB#2:                                 # %if.end14
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push80=, 0
-	i32.eq  	$push81=, $6, $pop80
-	br_if   	1, $pop81       # 1: down to label10
-# BB#3:                                 # %if.end14
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push61=, 1
-	i32.lt_s	$push1=, $6, $pop61
-	br_if   	2, $pop1        # 2: down to label9
-# BB#4:                                 # %land.lhs.true16
+	i32.const	$push53=, 1
+	i32.lt_s	$push0=, $6, $pop53
+	br_if   	1, $pop0        # 1: down to label10
+# BB#3:                                 # %land.lhs.true16
                                         #   in Loop: Header=BB1_1 Depth=1
 	block
-	i32.load	$push63=, 0($7)
-	tee_local	$push62=, $9=, $pop63
-	i32.gt_s	$push2=, $pop62, $0
-	br_if   	0, $pop2        # 0: down to label12
-# BB#5:                                 # %if.end.i45
+	i32.load	$push55=, 0($7)
+	tee_local	$push54=, $9=, $pop55
+	i32.gt_s	$push1=, $pop54, $0
+	br_if   	0, $pop1        # 0: down to label12
+# BB#4:                                 # %if.end.i45
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push3=, $9, $0
-	br_if   	6, $pop3        # 6: down to label6
-# BB#6:                                 # %if.end6.i49
+	i32.lt_s	$push2=, $9, $0
+	br_if   	8, $pop2        # 8: down to label4
+# BB#5:                                 # %if.end6.i49
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push4=, 0($8):p2align=3
-	i32.le_u	$push5=, $pop4, $1
-	br_if   	6, $pop5        # 6: down to label6
-.LBB1_7:                                # %if.end.1
+	i32.load	$push3=, 0($8):p2align=3
+	i32.le_u	$push4=, $pop3, $1
+	br_if   	8, $pop4        # 8: down to label4
+.LBB1_6:                                # %if.end.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label12:
-	i32.const	$push66=, 1
-	i32.ne  	$push6=, $6, $pop66
-	br_if   	3, $pop6        # 3: down to label8
-# BB#8:                                 # %land.lhs.true8.1
+	i32.const	$push58=, 1
+	i32.ne  	$push5=, $6, $pop58
+	br_if   	2, $pop5        # 2: down to label9
+# BB#7:                                 # %land.lhs.true8.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push25=, 0($7)
-	i32.ne  	$push26=, $pop25, $2
-	br_if   	4, $pop26       # 4: down to label7
-# BB#9:                                 # %if.end6.i63.1
+	i32.load	$push24=, 0($7)
+	i32.ne  	$push25=, $pop24, $2
+	br_if   	6, $pop25       # 6: down to label5
+# BB#8:                                 # %if.end6.i63.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push27=, 0($8):p2align=3
-	i32.eq  	$push28=, $pop27, $3
-	br_if   	6, $pop28       # 6: down to label5
-	br      	4               # 4: down to label7
-.LBB1_10:                               # %land.lhs.true
+	i32.load	$push26=, 0($8):p2align=3
+	i32.eq  	$push27=, $pop26, $3
+	br_if   	3, $pop27       # 3: down to label8
+	br      	6               # 6: down to label5
+.LBB1_9:                                # %land.lhs.true8
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label11:
-	i32.load	$push60=, 0($7)
-	tee_local	$push59=, $9=, $pop60
-	i32.gt_s	$push33=, $pop59, $0
-	br_if   	9, $pop33       # 9: down to label1
-# BB#11:                                # %if.end.i
+	i32.load	$push28=, 0($7)
+	i32.ne  	$push29=, $pop28, $0
+	br_if   	5, $pop29       # 5: down to label5
+# BB#10:                                # %if.end6.i63
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push34=, $9, $0
-	br_if   	1, $pop34       # 1: down to label9
-# BB#12:                                # %if.end6.i
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push35=, 0($8):p2align=3
-	i32.lt_u	$push36=, $pop35, $1
-	br_if   	1, $pop36       # 1: down to label9
-	br      	9               # 9: down to label1
-.LBB1_13:                               # %land.lhs.true8
+	i32.load	$push30=, 0($8):p2align=3
+	i32.ne  	$push31=, $pop30, $1
+	br_if   	5, $pop31       # 5: down to label5
+.LBB1_11:                               # %land.lhs.true.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label10:
-	i32.load	$push29=, 0($7)
-	i32.ne  	$push30=, $pop29, $0
-	br_if   	2, $pop30       # 2: down to label7
-# BB#14:                                # %if.end6.i63
+	i32.load	$push57=, 0($7)
+	tee_local	$push56=, $9=, $pop57
+	i32.gt_s	$push32=, $pop56, $2
+	br_if   	3, $pop32       # 3: down to label6
+# BB#12:                                # %if.end.i.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push31=, 0($8):p2align=3
-	i32.ne  	$push32=, $pop31, $1
-	br_if   	2, $pop32       # 2: down to label7
-.LBB1_15:                               # %land.lhs.true.1
+	i32.lt_s	$push33=, $9, $2
+	br_if   	1, $pop33       # 1: down to label8
+# BB#13:                                # %if.end6.i.1
+                                        #   in Loop: Header=BB1_1 Depth=1
+	i32.load	$push34=, 0($8):p2align=3
+	i32.lt_u	$push35=, $pop34, $3
+	br_if   	1, $pop35       # 1: down to label8
+	br      	3               # 3: down to label6
+.LBB1_14:                               # %if.end14.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label9:
-	i32.load	$push65=, 0($7)
-	tee_local	$push64=, $9=, $pop65
-	i32.gt_s	$push37=, $pop64, $2
-	br_if   	7, $pop37       # 7: down to label1
-# BB#16:                                # %if.end.i.1
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push38=, $9, $2
-	br_if   	3, $pop38       # 3: down to label5
-# BB#17:                                # %if.end6.i.1
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push39=, 0($8):p2align=3
-	i32.ge_u	$push40=, $pop39, $3
-	br_if   	7, $pop40       # 7: down to label1
-	br      	3               # 3: down to label5
-.LBB1_18:                               # %if.end14.1
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label8:
-	i32.const	$push67=, 2
-	i32.lt_s	$push7=, $6, $pop67
-	br_if   	2, $pop7        # 2: down to label5
-# BB#19:                                # %land.lhs.true16.1
+	i32.const	$push59=, 2
+	i32.lt_s	$push6=, $6, $pop59
+	br_if   	0, $pop6        # 0: down to label8
+# BB#15:                                # %land.lhs.true16.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	block
-	i32.load	$push69=, 0($7)
-	tee_local	$push68=, $9=, $pop69
-	i32.gt_s	$push8=, $pop68, $2
-	br_if   	0, $pop8        # 0: down to label13
-# BB#20:                                # %if.end.i45.1
+	i32.load	$push61=, 0($7)
+	tee_local	$push60=, $9=, $pop61
+	i32.gt_s	$push7=, $pop60, $2
+	br_if   	0, $pop7        # 0: down to label13
+# BB#16:                                # %if.end.i45.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push9=, $9, $2
-	br_if   	2, $pop9        # 2: down to label6
-# BB#21:                                # %if.end6.i49.1
+	i32.lt_s	$push8=, $9, $2
+	br_if   	5, $pop8        # 5: down to label4
+# BB#17:                                # %if.end6.i49.1
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push10=, 0($8):p2align=3
-	i32.le_u	$push11=, $pop10, $3
-	br_if   	2, $pop11       # 2: down to label6
-.LBB1_22:                               # %if.end.2
+	i32.load	$push9=, 0($8):p2align=3
+	i32.le_u	$push10=, $pop9, $3
+	br_if   	5, $pop10       # 5: down to label4
+.LBB1_18:                               # %if.end.2
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label13:
-	block
-	i32.const	$push72=, 2
-	i32.ne  	$push12=, $6, $pop72
-	br_if   	0, $pop12       # 0: down to label14
-# BB#23:                                # %land.lhs.true8.2
+	i32.const	$push64=, 2
+	i32.ne  	$push11=, $6, $pop64
+	br_if   	1, $pop11       # 1: down to label7
+# BB#19:                                # %land.lhs.true8.2
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push21=, 0($7)
-	i32.ne  	$push22=, $pop21, $4
-	br_if   	1, $pop22       # 1: down to label7
-# BB#24:                                # %if.end6.i63.2
+	i32.load	$push20=, 0($7)
+	i32.ne  	$push21=, $pop20, $4
+	br_if   	3, $pop21       # 3: down to label5
+# BB#20:                                # %if.end6.i63.2
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$6=, 3
-	i32.load	$push23=, 0($8):p2align=3
-	i32.eq  	$push24=, $pop23, $5
-	br_if   	5, $pop24       # 5: up to label2
-	br      	1               # 1: down to label7
-.LBB1_25:                               # %if.end14.2
+	i32.load	$push22=, 0($8):p2align=3
+	i32.eq  	$push23=, $pop22, $5
+	br_if   	6, $pop23       # 6: up to label1
+	br      	3               # 3: down to label5
+.LBB1_21:                               # %land.lhs.true.2
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label14:
-	i32.const	$push73=, 3
-	i32.lt_s	$push13=, $6, $pop73
-	br_if   	3, $pop13       # 3: down to label4
-# BB#26:                                # %land.lhs.true16.2
-	i32.load	$push77=, 0($7)
-	tee_local	$push76=, $6=, $pop77
-	i32.const	$push14=, 0
-	i32.load	$push75=, a+20($pop14)
-	tee_local	$push74=, $7=, $pop75
-	i32.gt_s	$push15=, $pop76, $pop74
-	br_if   	5, $pop15       # 5: down to label3
-# BB#27:                                # %if.end.i45.2
-	i32.lt_s	$push16=, $6, $7
-	br_if   	1, $pop16       # 1: down to label6
-# BB#28:                                # %if.end6.i49.2
-	i32.load	$push17=, 0($8):p2align=3
-	i32.const	$push18=, 0
-	i32.load	$push19=, a+16($pop18):p2align=4
-	i32.le_u	$push20=, $pop17, $pop19
-	br_if   	1, $pop20       # 1: down to label6
-	br      	5               # 5: down to label3
-.LBB1_29:                               # %if.then13
+	end_block                       # label8:
+	i32.load	$push63=, 0($7)
+	tee_local	$push62=, $7=, $pop63
+	i32.gt_s	$push36=, $pop62, $4
+	br_if   	1, $pop36       # 1: down to label6
+# BB#22:                                # %if.end.i.2
+                                        #   in Loop: Header=BB1_1 Depth=1
+	i32.lt_s	$push37=, $7, $4
+	br_if   	4, $pop37       # 4: down to label3
+# BB#23:                                # %if.end6.i.2
+                                        #   in Loop: Header=BB1_1 Depth=1
+	i32.load	$push38=, 0($8):p2align=3
+	i32.ge_u	$push39=, $pop38, $5
+	br_if   	1, $pop39       # 1: down to label6
+	br      	4               # 4: down to label3
+.LBB1_24:                               # %if.end14.2
+                                        #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_30:                               # %if.then21
+	i32.const	$push65=, 3
+	i32.lt_s	$push12=, $6, $pop65
+	br_if   	3, $pop12       # 3: down to label3
+# BB#25:                                # %land.lhs.true16.2
+	i32.load	$push69=, 0($7)
+	tee_local	$push68=, $6=, $pop69
+	i32.const	$push13=, 0
+	i32.load	$push67=, a+20($pop13)
+	tee_local	$push66=, $7=, $pop67
+	i32.gt_s	$push14=, $pop68, $pop66
+	br_if   	5, $pop14       # 5: down to label2
+# BB#26:                                # %if.end.i45.2
+	i32.lt_s	$push15=, $6, $7
+	br_if   	2, $pop15       # 2: down to label4
+# BB#27:                                # %if.end6.i49.2
+	i32.load	$push16=, 0($8):p2align=3
+	i32.const	$push17=, 0
+	i32.load	$push18=, a+16($pop17):p2align=4
+	i32.le_u	$push19=, $pop16, $pop18
+	br_if   	2, $pop19       # 2: down to label4
+	br      	5               # 5: down to label2
+.LBB1_28:                               # %if.then
 	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_31:                               # %land.lhs.true.2
-                                        #   in Loop: Header=BB1_1 Depth=1
+.LBB1_29:                               # %if.then13
 	end_block                       # label5:
-	i32.load	$push71=, 0($7)
-	tee_local	$push70=, $7=, $pop71
-	i32.gt_s	$push41=, $pop70, $4
-	br_if   	3, $pop41       # 3: down to label1
-# BB#32:                                # %if.end.i.2
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.lt_s	$push42=, $7, $4
-	br_if   	0, $pop42       # 0: down to label4
-# BB#33:                                # %if.end6.i.2
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push43=, 0($8):p2align=3
-	i32.ge_u	$push44=, $pop43, $5
-	br_if   	3, $pop44       # 3: down to label1
-.LBB1_34:                               # %for.inc.2
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label4:
-	i32.const	$push79=, 1
-	i32.add 	$6=, $6, $pop79
-	i32.const	$push78=, 4
-	i32.lt_s	$push45=, $6, $pop78
-	br_if   	0, $pop45       # 0: up to label2
-.LBB1_35:                               # %for.end25
-	end_loop                        # label3:
-	i32.const	$push46=, 0
-	return  	$pop46
-.LBB1_36:                               # %if.then
-	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
+.LBB1_30:                               # %if.then21
+	end_block                       # label4:
+	call    	abort@FUNCTION
+	unreachable
+.LBB1_31:                               # %for.inc.2
+                                        #   in Loop: Header=BB1_1 Depth=1
+	end_block                       # label3:
+	i32.const	$push71=, 1
+	i32.add 	$6=, $6, $pop71
+	i32.const	$push70=, 4
+	i32.lt_s	$push40=, $6, $pop70
+	br_if   	0, $pop40       # 0: up to label1
+.LBB1_32:                               # %for.end25
+	end_loop                        # label2:
+	i32.const	$push41=, 0
+	return  	$pop41
 	.endfunc
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main

--- a/test/torture-s/20120919-1.c.s
+++ b/test/torture-s/20120919-1.c.s
@@ -34,7 +34,7 @@ main:                                   # @main
 	i32.const	$9=, __stack_pointer
 	i32.store	$13=, 0($9), $13
 	i32.const	$push0=, 1
-	i32.store	$3=, 12($13), $pop0
+	i32.store	$4=, 12($13), $pop0
 	i32.const	$11=, 12
 	i32.add 	$11=, $13, $11
 	i32.const	$12=, 16
@@ -51,16 +51,16 @@ main:                                   # @main
 	i32.load	$0=, pd($pop16)
 	i32.const	$push15=, 0
 	i32.load	$1=, pi($pop15)
-	i32.const	$4=, -1
-	i32.const	$5=, 0
+	i32.const	$5=, -1
+	i32.const	$2=, 0
 .LBB1_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
 	block
-	br_if   	0, $4           # 0: down to label4
+	br_if   	0, $5           # 0: down to label4
 # BB#3:                                 # %if.then
                                         #   in Loop: Header=BB1_2 Depth=1
-	i32.load	$2=, 0($1)
+	i32.load	$3=, 0($1)
 	block
 	f64.load	$push19=, 0($0)
 	tee_local	$push18=, $7=, $pop19
@@ -73,24 +73,24 @@ main:                                   # @main
                                         #   in Loop: Header=BB1_2 Depth=1
 	i32.const	$push21=, 0
 	i32.const	$push20=, 0
-	i32.gt_s	$push5=, $2, $pop20
-	i32.select	$push6=, $2, $pop21, $pop5
-	i32.add 	$5=, $pop6, $5
+	i32.gt_s	$push5=, $3, $pop20
+	i32.select	$push6=, $3, $pop21, $pop5
+	i32.add 	$2=, $pop6, $2
 .LBB1_5:                                # %if.end8
                                         #   in Loop: Header=BB1_2 Depth=1
 	end_block                       # label5:
-	f64.convert_s/i32	$push7=, $2
+	f64.convert_s/i32	$push7=, $3
 	f64.store	$discard=, 0($0), $pop7
 .LBB1_6:                                # %if.end11
                                         #   in Loop: Header=BB1_2 Depth=1
 	end_block                       # label4:
-	i32.add 	$4=, $4, $3
-	i32.lt_s	$push8=, $4, $6
+	i32.add 	$5=, $5, $4
+	i32.lt_s	$push8=, $5, $6
 	br_if   	0, $pop8        # 0: up to label2
 # BB#7:                                 # %while.end
 	end_loop                        # label3:
 	i32.const	$push9=, 1234567890
-	i32.ne  	$push10=, $5, $pop9
+	i32.ne  	$push10=, $2, $pop9
 	br_if   	0, $pop10       # 0: down to label1
 # BB#8:                                 # %if.end15
 	i32.const	$push11=, 0

--- a/test/torture-s/920501-2.c.s
+++ b/test/torture-s/920501-2.c.s
@@ -7,33 +7,32 @@
 gcd_ll:                                 # @gcd_ll
 	.param  	i64, i64
 	.result 	i32
-	.local  	i64
 # BB#0:                                 # %entry
-	copy_local	$2=, $0
 	block
-	i64.const	$push5=, 0
-	i64.eq  	$push0=, $1, $pop5
+	i64.const	$push4=, 0
+	i64.eq  	$push0=, $1, $pop4
 	br_if   	0, $pop0        # 0: down to label0
 .LBB0_1:                                # %if.end
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	i64.rem_u	$0=, $0, $1
-	copy_local	$2=, $1
-	i64.const	$push6=, 0
-	i64.eq  	$push1=, $0, $pop6
+	i64.const	$push5=, 0
+	i64.eq  	$push1=, $0, $pop5
 	br_if   	1, $pop1        # 1: down to label2
 # BB#2:                                 # %if.end5
                                         #   in Loop: Header=BB0_1 Depth=1
 	i64.rem_u	$1=, $1, $0
-	copy_local	$2=, $0
-	i64.const	$push2=, 0
-	i64.ne  	$push3=, $1, $pop2
-	br_if   	0, $pop3        # 0: up to label1
-.LBB0_3:                                # %return
+	i64.const	$push6=, 0
+	i64.ne  	$push2=, $1, $pop6
+	br_if   	0, $pop2        # 0: up to label1
+	br      	2               # 2: down to label0
+.LBB0_3:
 	end_loop                        # label2:
+	copy_local	$0=, $1
+.LBB0_4:                                # %return
 	end_block                       # label0:
-	i32.wrap/i64	$push4=, $2
-	return  	$pop4
+	i32.wrap/i64	$push3=, $0
+	return  	$pop3
 	.endfunc
 .Lfunc_end0:
 	.size	gcd_ll, .Lfunc_end0-gcd_ll
@@ -48,13 +47,14 @@ powmod_ll:                              # @powmod_ll
 	.local  	i32, i32, i64
 # BB#0:                                 # %entry
 	i64.const	$5=, 1
-	i32.const	$3=, -1
-	copy_local	$4=, $1
 	block
 	i32.const	$push15=, 0
 	i32.eq  	$push16=, $1, $pop15
 	br_if   	0, $pop16       # 0: down to label3
-.LBB1_1:                                # %for.body
+# BB#1:
+	i32.const	$3=, -1
+	copy_local	$4=, $1
+.LBB1_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label4:
 	i32.const	$push8=, 1
@@ -62,19 +62,19 @@ powmod_ll:                              # @powmod_ll
 	i32.const	$push7=, 1
 	i32.add 	$3=, $3, $pop7
 	br_if   	0, $4           # 0: up to label4
-# BB#2:                                 # %for.end
+# BB#3:                                 # %for.end
 	end_loop                        # label5:
-	copy_local	$5=, $0
+	block
 	i32.const	$push9=, 1
 	i32.lt_s	$push0=, $3, $pop9
-	br_if   	0, $pop0        # 0: down to label3
-# BB#3:                                 # %for.body4.preheader
+	br_if   	0, $pop0        # 0: down to label6
+# BB#4:                                 # %for.body4.preheader
 	i32.const	$push10=, 1
 	i32.add 	$4=, $3, $pop10
 	copy_local	$5=, $0
-.LBB1_4:                                # %for.body4
+.LBB1_5:                                # %for.body4
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label6:
+	loop                            # label7:
 	i64.mul 	$push1=, $5, $5
 	i64.rem_u	$5=, $pop1, $2
 	block
@@ -85,21 +85,25 @@ powmod_ll:                              # @powmod_ll
 	i32.and 	$push4=, $pop3, $1
 	i32.const	$push17=, 0
 	i32.eq  	$push18=, $pop4, $pop17
-	br_if   	0, $pop18       # 0: down to label8
-# BB#5:                                 # %if.then5
-                                        #   in Loop: Header=BB1_4 Depth=1
+	br_if   	0, $pop18       # 0: down to label9
+# BB#6:                                 # %if.then5
+                                        #   in Loop: Header=BB1_5 Depth=1
 	i64.mul 	$push5=, $5, $0
 	i64.rem_u	$5=, $pop5, $2
-.LBB1_6:                                # %for.inc9
-                                        #   in Loop: Header=BB1_4 Depth=1
-	end_block                       # label8:
+.LBB1_7:                                # %for.inc9
+                                        #   in Loop: Header=BB1_5 Depth=1
+	end_block                       # label9:
 	i32.const	$push14=, -1
 	i32.add 	$4=, $4, $pop14
 	i32.const	$push13=, 1
 	i32.gt_s	$push6=, $4, $pop13
-	br_if   	0, $pop6        # 0: up to label6
-.LBB1_7:                                # %cleanup
-	end_loop                        # label7:
+	br_if   	0, $pop6        # 0: up to label7
+	br      	3               # 3: down to label3
+.LBB1_8:
+	end_loop                        # label8:
+	end_block                       # label6:
+	copy_local	$5=, $0
+.LBB1_9:                                # %cleanup
 	end_block                       # label3:
 	return  	$5
 	.endfunc
@@ -112,66 +116,66 @@ powmod_ll:                              # @powmod_ll
 	.type	facts,@function
 facts:                                  # @facts
 	.param  	i64, i32, i32, i32
-	.local  	i64, i32, i64, i64, i64, i64, i64, i64, i32, i32, i32, i64
+	.local  	i64, i32, i64, i32, i32, i32, i64, i64, i64, i64, i64, i64
 # BB#0:                                 # %entry
-	i64.extend_s/i32	$7=, $2
+	i64.extend_s/i32	$11=, $2
 	i64.extend_s/i32	$push38=, $1
 	tee_local	$push37=, $15=, $pop38
 	i64.const	$push36=, 1
 	i64.add 	$4=, $pop37, $pop36
-	i64.const	$6=, 1
-	copy_local	$8=, $7
-	i32.const	$12=, factab
-	i32.const	$14=, 0
-	i32.const	$13=, 1
-	i32.const	$5=, 1
+	i64.const	$10=, 1
+	copy_local	$13=, $11
+	i32.const	$5=, factab
+	i32.const	$7=, 0
+	i32.const	$8=, 1
+	i32.const	$9=, 1
 .LBB2_1:                                # %for.body
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB2_2 Depth 2
                                         #     Child Loop BB2_5 Depth 2
-                                        #     Child Loop BB2_9 Depth 2
-                                        #     Child Loop BB2_12 Depth 2
-                                        #     Child Loop BB2_16 Depth 2
-                                        #     Child Loop BB2_19 Depth 2
-                                        #     Child Loop BB2_24 Depth 2
-	loop                            # label9:
-	copy_local	$10=, $8
-	copy_local	$8=, $4
-	i64.const	$9=, 1
+                                        #     Child Loop BB2_10 Depth 2
+                                        #     Child Loop BB2_13 Depth 2
+                                        #     Child Loop BB2_18 Depth 2
+                                        #     Child Loop BB2_21 Depth 2
+                                        #     Child Loop BB2_27 Depth 2
+	loop                            # label10:
+	copy_local	$6=, $13
+	copy_local	$13=, $4
+	i64.const	$14=, 1
 	i32.const	$1=, -1
 	copy_local	$2=, $3
 	block
 	i32.const	$push78=, 0
 	i32.eq  	$push79=, $3, $pop78
-	br_if   	0, $pop79       # 0: down to label11
+	br_if   	0, $pop79       # 0: down to label12
 .LBB2_2:                                # %for.body.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label12:
+	loop                            # label13:
 	i32.const	$push40=, 1
 	i32.shr_u	$2=, $2, $pop40
 	i32.const	$push39=, 1
 	i32.add 	$1=, $1, $pop39
-	br_if   	0, $2           # 0: up to label12
+	br_if   	0, $2           # 0: up to label13
 # BB#3:                                 # %for.end.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label13:
-	copy_local	$9=, $10
+	end_loop                        # label14:
+	block
 	block
 	i32.const	$push41=, 1
 	i32.lt_s	$push0=, $1, $pop41
-	br_if   	0, $pop0        # 0: down to label14
+	br_if   	0, $pop0        # 0: down to label16
 # BB#4:                                 # %for.body4.i.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push42=, 1
 	i32.add 	$2=, $1, $pop42
-	copy_local	$9=, $10
+	copy_local	$12=, $6
 .LBB2_5:                                # %for.body4.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label15:
-	i64.mul 	$push1=, $9, $9
-	i64.rem_u	$9=, $pop1, $0
+	loop                            # label17:
+	i64.mul 	$push1=, $12, $12
+	i64.rem_u	$12=, $pop1, $0
 	block
 	i32.const	$push44=, 1
 	i32.const	$push43=, -2
@@ -180,54 +184,58 @@ facts:                                  # @facts
 	i32.and 	$push4=, $pop3, $3
 	i32.const	$push80=, 0
 	i32.eq  	$push81=, $pop4, $pop80
-	br_if   	0, $pop81       # 0: down to label17
+	br_if   	0, $pop81       # 0: down to label19
 # BB#6:                                 # %if.then5.i
                                         #   in Loop: Header=BB2_5 Depth=2
-	i64.mul 	$push5=, $9, $10
-	i64.rem_u	$9=, $pop5, $0
+	i64.mul 	$push5=, $12, $6
+	i64.rem_u	$12=, $pop5, $0
 .LBB2_7:                                # %for.inc9.i
                                         #   in Loop: Header=BB2_5 Depth=2
-	end_block                       # label17:
+	end_block                       # label19:
 	i32.const	$push46=, -1
 	i32.add 	$2=, $2, $pop46
 	i32.const	$push45=, 1
 	i32.gt_s	$push6=, $2, $pop45
-	br_if   	0, $pop6        # 0: up to label15
-.LBB2_8:                                # %for.body.i114.preheader
+	br_if   	0, $pop6        # 0: up to label17
+	br      	3               # 3: down to label15
+.LBB2_8:                                #   in Loop: Header=BB2_1 Depth=1
+	end_loop                        # label18:
+	end_block                       # label16:
+	copy_local	$12=, $6
+.LBB2_9:                                # %for.body.i114.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label16:
-	end_block                       # label14:
-	i64.add 	$8=, $9, $15
+	end_block                       # label15:
+	i64.add 	$13=, $12, $15
 	i32.const	$1=, -1
 	copy_local	$2=, $3
-.LBB2_9:                                # %for.body.i114
+.LBB2_10:                               # %for.body.i114
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label18:
+	loop                            # label20:
 	i32.const	$push48=, 1
 	i32.shr_u	$2=, $2, $pop48
 	i32.const	$push47=, 1
 	i32.add 	$1=, $1, $pop47
-	br_if   	0, $2           # 0: up to label18
-# BB#10:                                # %for.end.i116
+	br_if   	0, $2           # 0: up to label20
+# BB#11:                                # %for.end.i116
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label19:
-	copy_local	$9=, $7
+	end_loop                        # label21:
+	block
 	block
 	i32.const	$push49=, 1
 	i32.lt_s	$push7=, $1, $pop49
-	br_if   	0, $pop7        # 0: down to label20
-# BB#11:                                # %for.body4.i125.preheader
+	br_if   	0, $pop7        # 0: down to label23
+# BB#12:                                # %for.body4.i125.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push50=, 1
 	i32.add 	$2=, $1, $pop50
-	copy_local	$9=, $7
-.LBB2_12:                               # %for.body4.i125
+	copy_local	$12=, $11
+.LBB2_13:                               # %for.body4.i125
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label21:
-	i64.mul 	$push8=, $9, $9
-	i64.rem_u	$9=, $pop8, $0
+	loop                            # label24:
+	i64.mul 	$push8=, $12, $12
+	i64.rem_u	$12=, $pop8, $0
 	block
 	i32.const	$push52=, 1
 	i32.const	$push51=, -2
@@ -236,53 +244,56 @@ facts:                                  # @facts
 	i32.and 	$push11=, $pop10, $3
 	i32.const	$push82=, 0
 	i32.eq  	$push83=, $pop11, $pop82
-	br_if   	0, $pop83       # 0: down to label23
-# BB#13:                                # %if.then5.i128
-                                        #   in Loop: Header=BB2_12 Depth=2
-	i64.mul 	$push12=, $9, $7
-	i64.rem_u	$9=, $pop12, $0
-.LBB2_14:                               # %for.inc9.i131
-                                        #   in Loop: Header=BB2_12 Depth=2
-	end_block                       # label23:
+	br_if   	0, $pop83       # 0: down to label26
+# BB#14:                                # %if.then5.i128
+                                        #   in Loop: Header=BB2_13 Depth=2
+	i64.mul 	$push12=, $12, $11
+	i64.rem_u	$12=, $pop12, $0
+.LBB2_15:                               # %for.inc9.i131
+                                        #   in Loop: Header=BB2_13 Depth=2
+	end_block                       # label26:
 	i32.const	$push54=, -1
 	i32.add 	$2=, $2, $pop54
 	i32.const	$push53=, 1
 	i32.gt_s	$push13=, $2, $pop53
-	br_if   	0, $pop13       # 0: up to label21
-.LBB2_15:                               # %for.body.i88.preheader
+	br_if   	0, $pop13       # 0: up to label24
+	br      	3               # 3: down to label22
+.LBB2_16:                               #   in Loop: Header=BB2_1 Depth=1
+	end_loop                        # label25:
+	end_block                       # label23:
+	copy_local	$12=, $11
+.LBB2_17:                               # %for.body.i88.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label22:
-	end_block                       # label20:
-	i64.add 	$10=, $9, $15
+	end_block                       # label22:
+	i64.add 	$14=, $12, $15
 	i32.const	$1=, -1
 	copy_local	$2=, $3
-.LBB2_16:                               # %for.body.i88
+.LBB2_18:                               # %for.body.i88
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label24:
+	loop                            # label27:
 	i32.const	$push56=, 1
 	i32.shr_u	$2=, $2, $pop56
 	i32.const	$push55=, 1
 	i32.add 	$1=, $1, $pop55
-	br_if   	0, $2           # 0: up to label24
-# BB#17:                                # %for.end.i90
+	br_if   	0, $2           # 0: up to label27
+# BB#19:                                # %for.end.i90
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label25:
-	copy_local	$9=, $10
+	end_loop                        # label28:
 	i32.const	$push57=, 1
 	i32.lt_s	$push14=, $1, $pop57
-	br_if   	0, $pop14       # 0: down to label11
-# BB#18:                                # %for.body4.i99.preheader
+	br_if   	0, $pop14       # 0: down to label12
+# BB#20:                                # %for.body4.i99.preheader
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push58=, 1
 	i32.add 	$2=, $1, $pop58
-	copy_local	$9=, $10
-.LBB2_19:                               # %for.body4.i99
+	copy_local	$12=, $14
+.LBB2_21:                               # %for.body4.i99
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label26:
-	i64.mul 	$push15=, $9, $9
-	i64.rem_u	$9=, $pop15, $0
+	loop                            # label29:
+	i64.mul 	$push15=, $12, $12
+	i64.rem_u	$12=, $pop15, $0
 	block
 	i32.const	$push60=, 1
 	i32.const	$push59=, -2
@@ -291,97 +302,99 @@ facts:                                  # @facts
 	i32.and 	$push18=, $pop17, $3
 	i32.const	$push84=, 0
 	i32.eq  	$push85=, $pop18, $pop84
-	br_if   	0, $pop85       # 0: down to label28
-# BB#20:                                # %if.then5.i102
-                                        #   in Loop: Header=BB2_19 Depth=2
-	i64.mul 	$push19=, $9, $10
-	i64.rem_u	$9=, $pop19, $0
-.LBB2_21:                               # %for.inc9.i105
-                                        #   in Loop: Header=BB2_19 Depth=2
-	end_block                       # label28:
+	br_if   	0, $pop85       # 0: down to label31
+# BB#22:                                # %if.then5.i102
+                                        #   in Loop: Header=BB2_21 Depth=2
+	i64.mul 	$push19=, $12, $14
+	i64.rem_u	$12=, $pop19, $0
+.LBB2_23:                               # %for.inc9.i105
+                                        #   in Loop: Header=BB2_21 Depth=2
+	end_block                       # label31:
 	i32.const	$push62=, -1
 	i32.add 	$2=, $2, $pop62
 	i32.const	$push61=, 1
 	i32.gt_s	$push20=, $2, $pop61
-	br_if   	0, $pop20       # 0: up to label26
-.LBB2_22:                               # %powmod_ll.exit107
+	br_if   	0, $pop20       # 0: up to label29
+# BB#24:                                #   in Loop: Header=BB2_1 Depth=1
+	end_loop                        # label30:
+	copy_local	$14=, $12
+.LBB2_25:                               # %powmod_ll.exit107
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label27:
-	end_block                       # label11:
-	i64.add 	$7=, $9, $15
-	i64.sub 	$push22=, $8, $7
-	i64.sub 	$push23=, $7, $8
-	i64.gt_u	$push21=, $8, $7
+	end_block                       # label12:
+	i64.add 	$11=, $14, $15
+	i64.sub 	$push22=, $13, $11
+	i64.sub 	$push23=, $11, $13
+	i64.gt_u	$push21=, $13, $11
 	i64.select	$push24=, $pop22, $pop23, $pop21
 	i64.const	$push64=, 4294967295
 	i64.and 	$push26=, $pop24, $pop64
 	i64.const	$push63=, 4294967295
-	i64.and 	$push25=, $6, $pop63
+	i64.and 	$push25=, $10, $pop63
 	i64.mul 	$push27=, $pop26, $pop25
-	i64.rem_u	$6=, $pop27, $0
+	i64.rem_u	$10=, $pop27, $0
 	block
-	i32.ne  	$push28=, $5, $13
-	br_if   	0, $pop28       # 0: down to label29
-# BB#23:                                # %if.then19
+	i32.ne  	$push28=, $9, $8
+	br_if   	0, $pop28       # 0: down to label32
+# BB#26:                                # %if.then19
                                         #   in Loop: Header=BB2_1 Depth=1
-	i64.const	$push67=, 4294967295
-	i64.and 	$9=, $6, $pop67
-	i32.const	$push66=, 1
-	i32.add 	$14=, $14, $pop66
-	copy_local	$10=, $0
-	copy_local	$11=, $9
+	i32.const	$push67=, 1
+	i32.add 	$7=, $7, $pop67
+	i64.const	$push66=, 4294967295
+	i64.and 	$12=, $10, $pop66
+	copy_local	$14=, $0
 	block
 	i64.const	$push65=, 0
 	i64.eq  	$push29=, $0, $pop65
-	br_if   	0, $pop29       # 0: down to label30
-.LBB2_24:                               # %if.end.i
+	br_if   	0, $pop29       # 0: down to label33
+.LBB2_27:                               # %if.end.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label31:
-	i64.rem_u	$9=, $9, $10
-	copy_local	$11=, $10
+	loop                            # label34:
+	i64.rem_u	$12=, $12, $14
 	i64.const	$push68=, 0
-	i64.eq  	$push30=, $9, $pop68
-	br_if   	1, $pop30       # 1: down to label32
-# BB#25:                                # %if.end5.i
-                                        #   in Loop: Header=BB2_24 Depth=2
-	i64.rem_u	$10=, $10, $9
-	copy_local	$11=, $9
+	i64.eq  	$push30=, $12, $pop68
+	br_if   	1, $pop30       # 1: down to label35
+# BB#28:                                # %if.end5.i
+                                        #   in Loop: Header=BB2_27 Depth=2
+	i64.rem_u	$14=, $14, $12
 	i64.const	$push69=, 0
-	i64.ne  	$push31=, $10, $pop69
-	br_if   	0, $pop31       # 0: up to label31
-.LBB2_26:                               # %gcd_ll.exit
+	i64.ne  	$push31=, $14, $pop69
+	br_if   	0, $pop31       # 0: up to label34
+	br      	2               # 2: down to label33
+.LBB2_29:                               #   in Loop: Header=BB2_1 Depth=1
+	end_loop                        # label35:
+	copy_local	$12=, $14
+.LBB2_30:                               # %gcd_ll.exit
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label32:
-	end_block                       # label30:
-	i32.add 	$13=, $14, $13
-	i32.wrap/i64	$push72=, $11
+	end_block                       # label33:
+	i32.add 	$8=, $7, $8
+	i32.wrap/i64	$push72=, $12
 	tee_local	$push71=, $2=, $pop72
 	i32.const	$push70=, 1
 	i32.eq  	$push32=, $pop71, $pop70
-	br_if   	0, $pop32       # 0: down to label29
-# BB#27:                                # %if.then26
+	br_if   	0, $pop32       # 0: down to label32
+# BB#31:                                # %if.then26
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.store	$discard=, 0($12), $2
-	i32.const	$push75=, 4
-	i32.add 	$2=, $12, $pop75
+	i32.store	$discard=, 0($5), $2
 	i64.const	$push74=, 4294967295
-	i64.and 	$push33=, $11, $pop74
+	i64.and 	$push33=, $12, $pop74
 	i64.div_u	$0=, $0, $pop33
-	copy_local	$12=, $2
 	i64.const	$push73=, 1
 	i64.eq  	$push34=, $0, $pop73
-	br_if   	2, $pop34       # 2: down to label10
-.LBB2_28:                               # %for.inc
+	br_if   	2, $pop34       # 2: down to label11
+# BB#32:                                #   in Loop: Header=BB2_1 Depth=1
+	i32.const	$push75=, 4
+	i32.add 	$5=, $5, $pop75
+.LBB2_33:                               # %for.inc
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label29:
+	end_block                       # label32:
 	i32.const	$push77=, 1
-	i32.add 	$5=, $5, $pop77
+	i32.add 	$9=, $9, $pop77
 	i32.const	$push76=, 10000
-	i32.lt_s	$push35=, $5, $pop76
-	br_if   	0, $pop35       # 0: up to label9
-.LBB2_29:                               # %cleanup
-	end_loop                        # label10:
+	i32.lt_s	$push35=, $9, $pop76
+	br_if   	0, $pop35       # 0: up to label10
+.LBB2_34:                               # %cleanup
+	end_loop                        # label11:
 	return
 	.endfunc
 .Lfunc_end2:
@@ -407,25 +420,25 @@ main:                                   # @main
 	i32.wrap/i64	$push6=, $pop15
 	i32.const	$push7=, 7
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	0, $pop8        # 0: down to label33
+	br_if   	0, $pop8        # 0: down to label36
 # BB#1:                                 # %entry
 	i64.const	$push9=, -4294967296
 	i64.and 	$push0=, $0, $pop9
 	i64.const	$push10=, 313532612608
 	i64.ne  	$push11=, $pop0, $pop10
-	br_if   	0, $pop11       # 0: down to label33
+	br_if   	0, $pop11       # 0: down to label36
 # BB#2:                                 # %entry
 	i32.const	$push18=, 0
 	i32.load	$push1=, factab+8($pop18):p2align=3
 	i32.const	$push12=, 262657
 	i32.ne  	$push13=, $pop1, $pop12
-	br_if   	0, $pop13       # 0: down to label33
+	br_if   	0, $pop13       # 0: down to label36
 # BB#3:                                 # %if.end
 	i32.const	$push14=, 0
 	call    	exit@FUNCTION, $pop14
 	unreachable
 .LBB3_4:                                # %if.then
-	end_block                       # label33:
+	end_block                       # label36:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/920501-6.c.s
+++ b/test/torture-s/920501-6.c.s
@@ -112,102 +112,104 @@ plist:                                  # @plist
 	block
 	i64.gt_u	$push0=, $0, $1
 	br_if   	0, $pop0        # 0: down to label7
-.LBB2_1:                                # %for.cond.i.preheader
+# BB#1:
+	copy_local	$3=, $2
+.LBB2_2:                                # %for.cond.i.preheader
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB2_2 Depth 2
-                                        #     Child Loop BB2_4 Depth 2
-                                        #     Child Loop BB2_6 Depth 2
+                                        #     Child Loop BB2_3 Depth 2
+                                        #     Child Loop BB2_5 Depth 2
+                                        #     Child Loop BB2_7 Depth 2
 	loop                            # label8:
 	copy_local	$5=, $0
 	i64.const	$4=, 0
-.LBB2_2:                                # %for.cond.i
-                                        #   Parent Loop BB2_1 Depth=1
+.LBB2_3:                                # %for.cond.i
+                                        #   Parent Loop BB2_2 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop                            # label10:
-	i64.const	$push27=, 1
-	i64.add 	$4=, $4, $pop27
-	i64.const	$push26=, 1
-	i64.shr_u	$5=, $5, $pop26
-	i64.const	$push25=, 0
-	i64.ne  	$push1=, $5, $pop25
+	i64.const	$push21=, 1
+	i64.add 	$4=, $4, $pop21
+	i64.const	$push20=, 1
+	i64.shr_u	$5=, $5, $pop20
+	i64.const	$push19=, 0
+	i64.ne  	$push1=, $5, $pop19
 	br_if   	0, $pop1        # 0: up to label10
-# BB#3:                                 # %for.end.i
-                                        #   in Loop: Header=BB2_1 Depth=1
+# BB#4:                                 # %for.end.i
+                                        #   in Loop: Header=BB2_2 Depth=1
 	end_loop                        # label11:
-	i64.const	$push3=, 63
-	i64.shl 	$push4=, $4, $pop3
-	i64.const	$push33=, 63
-	i64.shr_s	$push5=, $pop4, $pop33
-	i64.const	$push32=, 1
-	i64.const	$push31=, 1
-	i64.shr_u	$push2=, $4, $pop31
-	i64.shl 	$push30=, $pop32, $pop2
-	tee_local	$push29=, $5=, $pop30
-	i64.const	$push28=, 1
-	i64.shr_u	$push6=, $pop29, $pop28
-	i64.and 	$push7=, $pop5, $pop6
-	i64.add 	$5=, $pop7, $5
-.LBB2_4:                                # %do.body.i
-                                        #   Parent Loop BB2_1 Depth=1
+	i64.const	$push28=, 63
+	i64.shl 	$push3=, $4, $pop28
+	i64.const	$push27=, 63
+	i64.shr_s	$push4=, $pop3, $pop27
+	i64.const	$push26=, 1
+	i64.const	$push25=, 1
+	i64.shr_u	$push2=, $4, $pop25
+	i64.shl 	$push24=, $pop26, $pop2
+	tee_local	$push23=, $5=, $pop24
+	i64.const	$push22=, 1
+	i64.shr_u	$push5=, $pop23, $pop22
+	i64.and 	$push6=, $pop4, $pop5
+	i64.add 	$5=, $pop6, $5
+.LBB2_5:                                # %do.body.i
+                                        #   Parent Loop BB2_2 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop                            # label12:
-	i64.div_u	$push35=, $0, $5
-	tee_local	$push34=, $4=, $pop35
-	i64.add 	$push8=, $pop34, $5
-	i64.const	$push9=, 1
-	i64.shr_u	$5=, $pop8, $pop9
-	i64.lt_u	$push10=, $4, $5
-	br_if   	0, $pop10       # 0: up to label12
-# BB#5:                                 # %sqrtllu.exit
-                                        #   in Loop: Header=BB2_1 Depth=1
+	i64.div_u	$push31=, $0, $5
+	tee_local	$push30=, $4=, $pop31
+	i64.add 	$push7=, $pop30, $5
+	i64.const	$push29=, 1
+	i64.shr_u	$5=, $pop7, $pop29
+	i64.lt_u	$push8=, $4, $5
+	br_if   	0, $pop8        # 0: up to label12
+# BB#6:                                 # %sqrtllu.exit
+                                        #   in Loop: Header=BB2_2 Depth=1
 	end_loop                        # label13:
 	i32.const	$6=, 3
 	block
 	block
-	i32.wrap/i64	$push38=, $5
-	tee_local	$push37=, $7=, $pop38
-	i32.const	$push36=, 3
-	i32.lt_u	$push11=, $pop37, $pop36
-	br_if   	0, $pop11       # 0: down to label15
-.LBB2_6:                                # %for.body3
-                                        #   Parent Loop BB2_1 Depth=1
+	i32.wrap/i64	$push34=, $5
+	tee_local	$push33=, $7=, $pop34
+	i32.const	$push32=, 3
+	i32.lt_u	$push9=, $pop33, $pop32
+	br_if   	0, $pop9        # 0: down to label15
+.LBB2_7:                                # %for.body3
+                                        #   Parent Loop BB2_2 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop                            # label16:
-	i64.extend_u/i32	$push12=, $6
-	i64.rem_u	$push13=, $0, $pop12
-	i64.const	$push14=, 0
-	i64.eq  	$push15=, $pop13, $pop14
-	br_if   	3, $pop15       # 3: down to label14
-# BB#7:                                 # %for.cond1
-                                        #   in Loop: Header=BB2_6 Depth=2
-	i32.const	$push16=, 2
-	i32.add 	$6=, $6, $pop16
-	i32.le_u	$push17=, $6, $7
-	br_if   	0, $pop17       # 0: up to label16
-.LBB2_8:                                # %for.end
-                                        #   in Loop: Header=BB2_1 Depth=1
+	i64.extend_u/i32	$push10=, $6
+	i64.rem_u	$push11=, $0, $pop10
+	i64.const	$push36=, 0
+	i64.eq  	$push12=, $pop11, $pop36
+	br_if   	3, $pop12       # 3: down to label14
+# BB#8:                                 # %for.cond1
+                                        #   in Loop: Header=BB2_7 Depth=2
+	i32.const	$push35=, 2
+	i32.add 	$6=, $6, $pop35
+	i32.le_u	$push13=, $6, $7
+	br_if   	0, $pop13       # 0: up to label16
+.LBB2_9:                                # %for.end
+                                        #   in Loop: Header=BB2_2 Depth=1
 	end_loop                        # label17:
 	end_block                       # label15:
-	i32.const	$push18=, 8
-	i32.add 	$6=, $3, $pop18
+	i32.const	$push37=, 8
+	i32.add 	$6=, $3, $pop37
 	i64.store	$discard=, 0($3), $0
 	copy_local	$3=, $6
-.LBB2_9:                                # %for.inc6
-                                        #   in Loop: Header=BB2_1 Depth=1
+.LBB2_10:                               # %for.inc6
+                                        #   in Loop: Header=BB2_2 Depth=1
 	end_block                       # label14:
-	i64.const	$push19=, 2
-	i64.add 	$0=, $0, $pop19
-	i64.le_u	$push20=, $0, $1
-	br_if   	0, $pop20       # 0: up to label8
-.LBB2_10:                               # %for.end8
+	i64.const	$push38=, 2
+	i64.add 	$0=, $0, $pop38
+	i64.le_u	$push14=, $0, $1
+	br_if   	0, $pop14       # 0: up to label8
+.LBB2_11:                               # %for.end8
 	end_loop                        # label9:
 	end_block                       # label7:
-	i64.const	$push21=, 0
-	i64.store	$discard=, 0($3), $pop21
-	i32.sub 	$push22=, $3, $2
-	i32.const	$push23=, 3
-	i32.shr_s	$push24=, $pop22, $pop23
-	return  	$pop24
+	i64.const	$push15=, 0
+	i64.store	$discard=, 0($3), $pop15
+	i32.sub 	$push16=, $3, $2
+	i32.const	$push17=, 3
+	i32.shr_s	$push18=, $pop16, $pop17
+	return  	$pop18
 	.endfunc
 .Lfunc_end2:
 	.size	plist, .Lfunc_end2-plist

--- a/test/torture-s/920501-9.c.s
+++ b/test/torture-s/920501-9.c.s
@@ -144,12 +144,8 @@ main:                                   # @main
 	i32.const	$4=, 80
 	i32.add 	$4=, $16, $4
 	block
-	block
-	block
-	block
-	block
 	i32.call	$push2=, strcmp@FUNCTION, $pop1, $4
-	br_if   	0, $pop2        # 0: down to label6
+	br_if   	0, $pop2        # 0: down to label2
 # BB#1:                                 # %if.end
 	i32.const	$push3=, 305419896
 	i32.store	$discard=, 48($16):p2align=4, $pop3
@@ -163,7 +159,7 @@ main:                                   # @main
 	i32.const	$7=, 80
 	i32.add 	$7=, $16, $7
 	i32.call	$push5=, strcmp@FUNCTION, $pop4, $7
-	br_if   	1, $pop5        # 1: down to label5
+	br_if   	0, $pop5        # 0: down to label2
 # BB#2:                                 # %if.end11
 	i64.const	$push6=, 1311768467732155613
 	i64.store	$discard=, 32($16):p2align=4, $pop6
@@ -177,7 +173,7 @@ main:                                   # @main
 	i32.const	$10=, 80
 	i32.add 	$10=, $16, $10
 	i32.call	$push8=, strcmp@FUNCTION, $pop7, $10
-	br_if   	2, $pop8        # 2: down to label4
+	br_if   	0, $pop8        # 0: down to label2
 # BB#3:                                 # %if.end19
 	i64.const	$push9=, -1
 	i64.store	$discard=, 16($16):p2align=4, $pop9
@@ -191,7 +187,7 @@ main:                                   # @main
 	i32.const	$13=, 80
 	i32.add 	$13=, $16, $13
 	i32.call	$push11=, strcmp@FUNCTION, $pop10, $13
-	br_if   	3, $pop11       # 3: down to label3
+	br_if   	0, $pop11       # 0: down to label2
 # BB#4:                                 # %if.end27
 	i32.const	$push12=, -1430532899
 	i32.store	$discard=, 0($16):p2align=4, $pop12
@@ -203,28 +199,12 @@ main:                                   # @main
 	i32.const	$15=, 80
 	i32.add 	$15=, $16, $15
 	i32.call	$push15=, strcmp@FUNCTION, $pop14, $15
-	br_if   	4, $pop15       # 4: down to label2
+	br_if   	0, $pop15       # 0: down to label2
 # BB#5:                                 # %if.end35
 	i32.const	$push16=, 0
 	call    	exit@FUNCTION, $pop16
 	unreachable
-.LBB6_6:                                # %if.then
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_7:                                # %if.then10
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_8:                                # %if.then18
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_9:                                # %if.then26
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_10:                               # %if.then34
+.LBB6_6:                                # %if.then34
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/920721-3.c.s
+++ b/test/torture-s/920721-3.c.s
@@ -9,12 +9,11 @@ ru:                                     # @ru
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push8=, 65535
 	i32.and 	$push0=, $0, $pop8
 	i32.const	$push1=, 5
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push3=, 2
 	i32.add 	$push4=, $0, $pop3
@@ -22,14 +21,10 @@ ru:                                     # @ru
 	i32.and 	$push5=, $pop4, $pop9
 	i32.const	$push6=, 7
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label0
+	br_if   	0, $pop7        # 0: down to label0
 # BB#2:                                 # %if.end8
 	return  	$0
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.then7
+.LBB0_3:                                # %if.then7
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -50,11 +45,11 @@ rs:                                     # @rs
 	i32.and 	$push1=, $0, $pop0
 	i32.const	$push2=, 5
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label2
+	br_if   	0, $pop3        # 0: down to label1
 # BB#1:                                 # %if.end8
 	return  	$0
 .LBB1_2:                                # %if.then
-	end_block                       # label2:
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/920731-1.c.s
+++ b/test/torture-s/920731-1.c.s
@@ -11,17 +11,17 @@ f:                                      # @f
 # BB#0:                                 # %entry
 	i32.const	$1=, 0
 	block
-	i32.const	$push4=, 1
-	i32.and 	$push0=, $0, $pop4
+	i32.const	$push3=, 1
+	i32.and 	$push0=, $0, $pop3
 	br_if   	0, $pop0        # 0: down to label0
 .LBB0_1:                                # %for.inc
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	i32.const	$push5=, 1
 	i32.add 	$1=, $1, $pop5
-	i32.const	$push2=, 7
-	i32.gt_s	$push3=, $1, $pop2
-	br_if   	1, $pop3        # 1: down to label2
+	i32.const	$push4=, 7
+	i32.gt_s	$push2=, $1, $pop4
+	br_if   	1, $pop2        # 1: down to label2
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push7=, 1

--- a/test/torture-s/921013-1.c.s
+++ b/test/torture-s/921013-1.c.s
@@ -15,18 +15,18 @@ f:                                      # @f
 .LBB0_1:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	f32.load	$push2=, 0($1)
-	f32.load	$push3=, 0($2)
-	f32.eq  	$push4=, $pop2, $pop3
-	i32.store	$discard=, 0($0), $pop4
-	i32.const	$push1=, 4
-	i32.add 	$1=, $1, $pop1
+	f32.load	$push0=, 0($1)
+	f32.load	$push1=, 0($2)
+	f32.eq  	$push2=, $pop0, $pop1
+	i32.store	$discard=, 0($0), $pop2
 	i32.const	$push6=, 4
-	i32.add 	$2=, $2, $pop6
+	i32.add 	$1=, $1, $pop6
 	i32.const	$push5=, 4
-	i32.add 	$0=, $0, $pop5
-	i32.const	$push0=, -1
-	i32.add 	$3=, $3, $pop0
+	i32.add 	$2=, $2, $pop5
+	i32.const	$push4=, 4
+	i32.add 	$0=, $0, $pop4
+	i32.const	$push3=, -1
+	i32.add 	$3=, $3, $pop3
 	br_if   	0, $3           # 0: up to label1
 .LBB0_2:                                # %while.end
 	end_loop                        # label2:

--- a/test/torture-s/921113-1.c.s
+++ b/test/torture-s/921113-1.c.s
@@ -78,28 +78,27 @@ gitter:                                 # @gitter
 	.local  	f32, f64, f64
 # BB#0:                                 # %entry
 	block
-	block
 	f32.load	$push1=, 0($4)
 	f32.const	$push23=, 0x0p0
 	f32.ne  	$push2=, $pop1, $pop23
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label2
 # BB#1:                                 # %entry
 	f32.load	$push0=, 4($4)
 	f32.const	$push24=, 0x0p0
 	f32.ne  	$push3=, $pop0, $pop24
-	br_if   	0, $pop3        # 0: down to label3
+	br_if   	0, $pop3        # 0: down to label2
 # BB#2:                                 # %f1.exit
 	f32.load	$push5=, 8($4)
 	f32.const	$push25=, 0x1p0
 	f32.ne  	$push8=, $pop5, $pop25
-	br_if   	1, $pop8        # 1: down to label2
+	br_if   	0, $pop8        # 0: down to label2
 # BB#3:                                 # %f1.exit
 	i32.const	$push6=, 12
 	i32.add 	$push7=, $4, $pop6
 	f32.load	$push4=, 0($pop7)
 	f32.const	$push26=, 0x1p0
 	f32.ne  	$push9=, $pop4, $pop26
-	br_if   	1, $pop9        # 1: down to label2
+	br_if   	0, $pop9        # 0: down to label2
 # BB#4:                                 # %f2.exit
 	f32.load	$6=, 0($1)
 	i32.const	$push10=, 0
@@ -109,7 +108,7 @@ gitter:                                 # @gitter
 	f32.gt  	$push12=, $6, $pop11
 	f32.ne  	$push13=, $6, $6
 	i32.or  	$push14=, $pop12, $pop13
-	br_if   	0, $pop14       # 0: down to label4
+	br_if   	0, $pop14       # 0: down to label3
 # BB#5:                                 # %if.then
 	f64.promote/f32	$push30=, $6
 	tee_local	$push29=, $8=, $pop30
@@ -122,18 +121,14 @@ gitter:                                 # @gitter
 	f64.ne  	$push18=, $7, $7
 	i32.or  	$push20=, $pop19, $pop18
 	i32.or  	$push21=, $pop17, $pop20
-	br_if   	0, $pop21       # 0: down to label4
+	br_if   	0, $pop21       # 0: down to label3
 # BB#6:                                 # %if.then15
 	i32.const	$push22=, 1065353216
 	i32.store	$discard=, 0($2), $pop22
 .LBB3_7:                                # %if.end18
-	end_block                       # label4:
-	return  	$4
-.LBB3_8:                                # %if.then.i
 	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_9:                                # %if.then.i32
+	return  	$4
+.LBB3_8:                                # %if.then.i32
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
@@ -149,40 +144,35 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push10=, 0
 	f32.load	$push1=, limit($pop10):p2align=4
 	f32.const	$push9=, 0x0p0
 	f32.ne  	$push2=, $pop1, $pop9
-	br_if   	0, $pop2        # 0: down to label6
+	br_if   	0, $pop2        # 0: down to label4
 # BB#1:                                 # %entry
 	i32.const	$push12=, 0
 	f32.load	$push0=, limit+4($pop12)
 	f32.const	$push11=, 0x0p0
 	f32.ne  	$push3=, $pop0, $pop11
-	br_if   	0, $pop3        # 0: down to label6
+	br_if   	0, $pop3        # 0: down to label4
 # BB#2:                                 # %f1.exit.i
 	i32.const	$push14=, 0
 	f32.load	$push5=, limit+8($pop14):p2align=3
 	f32.const	$push13=, 0x1p0
 	f32.ne  	$push6=, $pop5, $pop13
-	br_if   	1, $pop6        # 1: down to label5
+	br_if   	0, $pop6        # 0: down to label4
 # BB#3:                                 # %f1.exit.i
 	i32.const	$push16=, 0
 	f32.load	$push4=, limit+12($pop16)
 	f32.const	$push15=, 0x1p0
 	f32.ne  	$push7=, $pop4, $pop15
-	br_if   	1, $pop7        # 1: down to label5
+	br_if   	0, $pop7        # 0: down to label4
 # BB#4:                                 # %f2.exit.i
 	i32.const	$push8=, 0
 	call    	exit@FUNCTION, $pop8
 	unreachable
-.LBB4_5:                                # %if.then.i.i
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_6:                                # %if.then.i32.i
-	end_block                       # label5:
+.LBB4_5:                                # %if.then.i32.i
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/930518-1.c.s
+++ b/test/torture-s/930518-1.c.s
@@ -7,30 +7,30 @@
 f:                                      # @f
 	.param  	i32
 	.result 	i32
-	.local  	i32, i32, i32
+	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$2=, 2
 	block
 	i32.const	$push7=, 0
 	i32.load	$push6=, bar($pop7)
-	tee_local	$push5=, $3=, $pop6
-	i32.const	$push4=, 1
-	i32.gt_s	$push1=, $pop5, $pop4
-	br_if   	0, $pop1        # 0: down to label0
-.LBB0_1:                                # %while.body
+	tee_local	$push5=, $2=, $pop6
+	i32.const	$push1=, 1
+	i32.gt_s	$push2=, $pop5, $pop1
+	br_if   	0, $pop2        # 0: down to label0
+# BB#1:
+	i32.const	$1=, 2
+.LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push2=, 4
-	i32.add 	$1=, $0, $pop2
-	i32.sub 	$push0=, $2, $3
-	i32.store	$2=, 0($0), $pop0
-	copy_local	$0=, $1
-	i32.const	$push9=, 0
-	i32.const	$push8=, 1
-	i32.store	$3=, bar($pop9), $pop8
-	i32.gt_s	$push3=, $2, $3
-	br_if   	0, $pop3        # 0: up to label1
-.LBB0_2:                                # %while.end
+	i32.sub 	$push0=, $1, $2
+	i32.store	$1=, 0($0), $pop0
+	i32.const	$push9=, 4
+	i32.add 	$0=, $0, $pop9
+	i32.const	$push8=, 0
+	i32.const	$push3=, 1
+	i32.store	$2=, bar($pop8), $pop3
+	i32.gt_s	$push4=, $1, $2
+	br_if   	0, $pop4        # 0: up to label1
+.LBB0_3:                                # %while.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	return  	$0
@@ -44,60 +44,60 @@ f:                                      # @f
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$4=, __stack_pointer
+	i32.load	$4=, 0($4)
+	i32.const	$5=, 16
+	i32.sub 	$8=, $4, $5
 	i32.const	$5=, __stack_pointer
-	i32.load	$5=, 0($5)
-	i32.const	$6=, 16
-	i32.sub 	$9=, $5, $6
-	i32.const	$6=, __stack_pointer
-	i32.store	$9=, 0($6), $9
+	i32.store	$8=, 0($5), $8
 	i32.const	$push1=, 0
-	i32.store	$3=, 12($9), $pop1
-	i32.const	$7=, 8
-	i32.add 	$7=, $9, $7
-	copy_local	$2=, $7
-	i32.const	$1=, 2
+	i32.store	$2=, 12($8), $pop1
+	i32.const	$6=, 8
+	i32.add 	$6=, $8, $6
+	copy_local	$1=, $6
 	block
-	i32.store	$push16=, 8($9), $3
-	tee_local	$push15=, $4=, $pop16
-	i32.load	$push14=, bar($pop15)
-	tee_local	$push13=, $3=, $pop14
-	i32.const	$push12=, 1
-	i32.gt_s	$push2=, $pop13, $pop12
-	br_if   	0, $pop2        # 0: down to label3
-.LBB1_1:                                # %while.body.i
+	i32.store	$push18=, 8($8), $2
+	tee_local	$push17=, $3=, $pop18
+	i32.load	$push16=, bar($pop17)
+	tee_local	$push15=, $2=, $pop16
+	i32.const	$push2=, 1
+	i32.gt_s	$push3=, $pop15, $pop2
+	br_if   	0, $pop3        # 0: down to label3
+# BB#1:
+	i32.const	$0=, 2
+.LBB1_2:                                # %while.body.i
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label4:
-	i32.const	$push18=, 4
-	i32.add 	$0=, $2, $pop18
-	i32.sub 	$push0=, $1, $3
-	i32.store	$1=, 0($2), $pop0
-	copy_local	$2=, $0
-	i32.const	$push17=, 1
-	i32.store	$3=, bar($4), $pop17
-	i32.gt_s	$push3=, $1, $3
-	br_if   	0, $pop3        # 0: up to label4
-# BB#2:                                 # %f.exit
-	end_loop                        # label5:
-	i32.load	$push5=, 8($9)
-	i32.const	$push7=, 2
-	i32.ne  	$push8=, $pop5, $pop7
-	br_if   	0, $pop8        # 0: down to label3
-# BB#3:                                 # %f.exit
+	i32.sub 	$push0=, $0, $2
+	i32.store	$0=, 0($1), $pop0
 	i32.const	$push19=, 4
-	i32.const	$8=, 8
-	i32.add 	$8=, $9, $8
-	i32.add 	$push6=, $8, $pop19
-	i32.load	$push4=, 0($pop6)
-	i32.const	$push9=, 1
-	i32.ne  	$push10=, $pop4, $pop9
-	br_if   	0, $pop10       # 0: down to label3
-# BB#4:                                 # %if.end
-	i32.const	$push11=, 0
-	call    	exit@FUNCTION, $pop11
+	i32.add 	$1=, $1, $pop19
+	i32.const	$push4=, 1
+	i32.store	$2=, bar($3), $pop4
+	i32.gt_s	$push5=, $0, $2
+	br_if   	0, $pop5        # 0: up to label4
+# BB#3:                                 # %f.exit
+	end_loop                        # label5:
+	i32.load	$push7=, 8($8)
+	i32.const	$push10=, 2
+	i32.ne  	$push11=, $pop7, $pop10
+	br_if   	0, $pop11       # 0: down to label3
+# BB#4:                                 # %f.exit
+	i32.const	$push8=, 4
+	i32.const	$7=, 8
+	i32.add 	$7=, $8, $7
+	i32.add 	$push9=, $7, $pop8
+	i32.load	$push6=, 0($pop9)
+	i32.const	$push12=, 1
+	i32.ne  	$push13=, $pop6, $pop12
+	br_if   	0, $pop13       # 0: down to label3
+# BB#5:                                 # %if.end
+	i32.const	$push14=, 0
+	call    	exit@FUNCTION, $pop14
 	unreachable
-.LBB1_5:                                # %if.then
+.LBB1_6:                                # %if.then
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/930628-1.c.s
+++ b/test/torture-s/930628-1.c.s
@@ -27,114 +27,117 @@ f:                                      # @f
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32
+	.local  	i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$2=, 0
 	i32.const	$0=, 0
-	i32.const	$1=, 0
 .LBB1_1:                                # %for.cond4.preheader
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label2:
 	block
 	i32.const	$push17=, 0
-	i32.eq  	$push18=, $0, $pop17
+	i32.eq  	$push18=, $2, $pop17
 	br_if   	0, $pop18       # 0: down to label4
 # BB#2:                                 # %for.cond15.preheader
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push19=, 0
-	i32.eq  	$push20=, $0, $pop19
+	i32.eq  	$push20=, $2, $pop19
 	br_if   	3, $pop20       # 3: down to label1
 .LBB1_3:                                # %for.inc36.1.1
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label4:
-	i32.const	$3=, 1
-	i32.const	$push16=, 1
-	i32.add 	$1=, $1, $pop16
-	i32.const	$push15=, -64
-	i32.add 	$0=, $0, $pop15
-	i32.const	$2=, 0
-	i32.const	$push14=, 4
-	i32.lt_s	$push0=, $1, $pop14
+	i32.const	$1=, 1
+	i32.const	$push7=, 1
+	i32.add 	$0=, $0, $pop7
+	i32.const	$push6=, -64
+	i32.add 	$2=, $2, $pop6
+	i32.const	$push5=, 4
+	i32.lt_s	$push0=, $0, $pop5
 	br_if   	0, $pop0        # 0: up to label2
-.LBB1_4:                                # %for.cond4.preheader.1
-                                        # =>This Inner Loop Header: Depth=1
+# BB#4:
 	end_loop                        # label3:
+	i32.const	$2=, 0
+.LBB1_5:                                # %for.cond4.preheader.1
+                                        # =>This Inner Loop Header: Depth=1
 	loop                            # label5:
 	block
 	i32.const	$push21=, 0
 	i32.eq  	$push22=, $2, $pop21
 	br_if   	0, $pop22       # 0: down to label7
-# BB#5:                                 # %for.cond15.preheader.1
-                                        #   in Loop: Header=BB1_4 Depth=1
+# BB#6:                                 # %for.cond15.preheader.1
+                                        #   in Loop: Header=BB1_5 Depth=1
 	i32.const	$push23=, 0
 	i32.eq  	$push24=, $2, $pop23
 	br_if   	3, $pop24       # 3: down to label1
-.LBB1_6:                                # %for.inc36.1.1.1
-                                        #   in Loop: Header=BB1_4 Depth=1
+.LBB1_7:                                # %for.inc36.1.1.1
+                                        #   in Loop: Header=BB1_5 Depth=1
 	end_block                       # label7:
-	i32.const	$push1=, 1
-	i32.add 	$3=, $3, $pop1
-	i32.const	$push2=, -64
-	i32.add 	$2=, $2, $pop2
-	i32.const	$1=, 2
-	i32.const	$0=, 0
-	i32.const	$push3=, 4
-	i32.lt_s	$push4=, $3, $pop3
-	br_if   	0, $pop4        # 0: up to label5
-.LBB1_7:                                # %for.cond4.preheader.2
-                                        # =>This Inner Loop Header: Depth=1
+	i32.const	$push10=, 1
+	i32.add 	$1=, $1, $pop10
+	i32.const	$push9=, -64
+	i32.add 	$2=, $2, $pop9
+	i32.const	$push8=, 4
+	i32.lt_s	$push1=, $1, $pop8
+	br_if   	0, $pop1        # 0: up to label5
+# BB#8:
 	end_loop                        # label6:
+	i32.const	$2=, 2
+	i32.const	$1=, 0
+.LBB1_9:                                # %for.cond4.preheader.2
+                                        # =>This Inner Loop Header: Depth=1
 	loop                            # label8:
 	block
 	i32.const	$push25=, 0
-	i32.eq  	$push26=, $0, $pop25
+	i32.eq  	$push26=, $1, $pop25
 	br_if   	0, $pop26       # 0: down to label10
-# BB#8:                                 # %for.cond15.preheader.2
-                                        #   in Loop: Header=BB1_7 Depth=1
+# BB#10:                                # %for.cond15.preheader.2
+                                        #   in Loop: Header=BB1_9 Depth=1
 	i32.const	$push27=, 0
-	i32.eq  	$push28=, $0, $pop27
+	i32.eq  	$push28=, $1, $pop27
 	br_if   	3, $pop28       # 3: down to label1
-.LBB1_9:                                # %for.inc36.1.1.2
-                                        #   in Loop: Header=BB1_7 Depth=1
+.LBB1_11:                               # %for.inc36.1.1.2
+                                        #   in Loop: Header=BB1_9 Depth=1
 	end_block                       # label10:
-	i32.const	$push5=, 1
-	i32.add 	$1=, $1, $pop5
-	i32.const	$push6=, -64
-	i32.add 	$0=, $0, $pop6
-	i32.const	$3=, 3
-	i32.const	$2=, 0
-	i32.const	$push7=, 4
-	i32.lt_s	$push8=, $1, $pop7
-	br_if   	0, $pop8        # 0: up to label8
-.LBB1_10:                               # %for.cond4.preheader.3
-                                        # =>This Inner Loop Header: Depth=1
+	i32.const	$push13=, 1
+	i32.add 	$2=, $2, $pop13
+	i32.const	$push12=, -64
+	i32.add 	$1=, $1, $pop12
+	i32.const	$push11=, 4
+	i32.lt_s	$push2=, $2, $pop11
+	br_if   	0, $pop2        # 0: up to label8
+# BB#12:
 	end_loop                        # label9:
+	i32.const	$2=, 3
+	i32.const	$1=, 0
+.LBB1_13:                               # %for.cond4.preheader.3
+                                        # =>This Inner Loop Header: Depth=1
 	loop                            # label11:
 	block
 	i32.const	$push29=, 0
-	i32.eq  	$push30=, $2, $pop29
+	i32.eq  	$push30=, $1, $pop29
 	br_if   	0, $pop30       # 0: down to label13
-# BB#11:                                # %for.cond15.preheader.3
-                                        #   in Loop: Header=BB1_10 Depth=1
+# BB#14:                                # %for.cond15.preheader.3
+                                        #   in Loop: Header=BB1_13 Depth=1
 	i32.const	$push31=, 0
-	i32.eq  	$push32=, $2, $pop31
+	i32.eq  	$push32=, $1, $pop31
 	br_if   	3, $pop32       # 3: down to label1
-.LBB1_12:                               # %for.inc36.1.1.3
-                                        #   in Loop: Header=BB1_10 Depth=1
+.LBB1_15:                               # %for.inc36.1.1.3
+                                        #   in Loop: Header=BB1_13 Depth=1
 	end_block                       # label13:
-	i32.const	$push9=, 1
-	i32.add 	$3=, $3, $pop9
-	i32.const	$push10=, -64
-	i32.add 	$2=, $2, $pop10
-	i32.const	$push11=, 4
-	i32.lt_s	$push12=, $3, $pop11
-	br_if   	0, $pop12       # 0: up to label11
-# BB#13:                                # %for.inc45.3
+	i32.const	$push16=, 1
+	i32.add 	$2=, $2, $pop16
+	i32.const	$push15=, -64
+	i32.add 	$1=, $1, $pop15
+	i32.const	$push14=, 4
+	i32.lt_s	$push3=, $2, $pop14
+	br_if   	0, $pop3        # 0: up to label11
+# BB#16:                                # %for.inc45.3
 	end_loop                        # label12:
-	i32.const	$push13=, 0
-	call    	exit@FUNCTION, $pop13
+	i32.const	$push4=, 0
+	call    	exit@FUNCTION, $pop4
 	unreachable
-.LBB1_14:                               # %if.then.i
+.LBB1_17:                               # %if.then.i
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/930930-1.c.s
+++ b/test/torture-s/930930-1.c.s
@@ -9,43 +9,44 @@ f:                                      # @f
 	.result 	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	copy_local	$5=, $0
 	block
 	block
 	i32.lt_u	$push0=, $3, $4
 	br_if   	0, $pop0        # 0: down to label1
-.LBB0_1:                                # %if.end
+# BB#1:
+	copy_local	$5=, $0
+.LBB0_2:                                # %if.end
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
 	block
-	i32.load	$push8=, 0($3)
-	tee_local	$push7=, $6=, $pop8
-	i32.ge_u	$push1=, $pop7, $2
+	i32.load	$push6=, 0($3)
+	tee_local	$push5=, $6=, $pop6
+	i32.ge_u	$push1=, $pop5, $2
 	br_if   	0, $pop1        # 0: down to label4
-# BB#2:                                 # %if.end
-                                        #   in Loop: Header=BB0_1 Depth=1
+# BB#3:                                 # %if.end
+                                        #   in Loop: Header=BB0_2 Depth=1
 	i32.lt_u	$push2=, $6, $1
 	br_if   	0, $pop2        # 0: down to label4
-# BB#3:                                 # %if.then3
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push3=, -4
-	i32.add 	$5=, $5, $pop3
+# BB#4:                                 # %if.then3
+                                        #   in Loop: Header=BB0_2 Depth=1
+	i32.const	$push7=, -4
+	i32.add 	$5=, $5, $pop7
 	i32.store	$discard=, 0($5), $6
-.LBB0_4:                                # %if.end4
-                                        #   in Loop: Header=BB0_1 Depth=1
+.LBB0_5:                                # %if.end4
+                                        #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label4:
-	i32.const	$push4=, -4
-	i32.add 	$3=, $3, $pop4
-	i32.ge_u	$push5=, $3, $4
-	br_if   	0, $pop5        # 0: up to label2
-# BB#5:                                 # %out
+	i32.const	$push8=, -4
+	i32.add 	$3=, $3, $pop8
+	i32.ge_u	$push3=, $3, $4
+	br_if   	0, $pop3        # 0: up to label2
+# BB#6:                                 # %out
 	end_loop                        # label3:
-	i32.ne  	$push6=, $5, $0
-	br_if   	1, $pop6        # 1: down to label0
-.LBB0_6:                                # %if.end8
+	i32.ne  	$push4=, $5, $0
+	br_if   	1, $pop4        # 1: down to label0
+.LBB0_7:                                # %if.end8
 	end_block                       # label1:
 	return  	$3
-.LBB0_7:                                # %if.then7
+.LBB0_8:                                # %if.then7
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931004-1.c.s
+++ b/test/torture-s/931004-1.c.s
@@ -9,39 +9,24 @@ f:                                      # @f
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
 	i32.const	$push0=, 10
 	i32.ne  	$push1=, $1, $pop0
-	br_if   	0, $pop1        # 0: down to label3
+	br_if   	0, $pop1        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push2=, 11
 	i32.ne  	$push3=, $2, $pop2
-	br_if   	1, $pop3        # 1: down to label2
+	br_if   	0, $pop3        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.const	$push4=, 12
 	i32.ne  	$push5=, $3, $pop4
-	br_if   	2, $pop5        # 2: down to label1
+	br_if   	0, $pop5        # 0: down to label0
 # BB#3:                                 # %if.end10
 	i32.const	$push6=, 123
 	i32.ne  	$push7=, $4, $pop6
-	br_if   	3, $pop7        # 3: down to label0
+	br_if   	0, $pop7        # 0: down to label0
 # BB#4:                                 # %if.end13
 	return  	$1
-.LBB0_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then5
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_7:                                # %if.then9
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then12
+.LBB0_5:                                # %if.then12
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931004-11.c.s
+++ b/test/torture-s/931004-11.c.s
@@ -9,102 +9,57 @@ f:                                      # @f
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load8_u	$push0=, 0($1)
 	i32.const	$push1=, 10
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label9
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load8_u	$push3=, 1($1)
 	i32.const	$push4=, 20
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label8
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.load8_u	$push6=, 2($1)
 	i32.const	$push7=, 30
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label7
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end11
 	i32.load8_u	$push9=, 0($2)
 	i32.const	$push10=, 11
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label6
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end17
 	i32.load8_u	$push12=, 1($2)
 	i32.const	$push13=, 21
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	4, $pop14       # 4: down to label5
+	br_if   	0, $pop14       # 0: down to label0
 # BB#5:                                 # %if.end23
 	i32.load8_u	$push15=, 2($2)
 	i32.const	$push16=, 31
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	5, $pop17       # 5: down to label4
+	br_if   	0, $pop17       # 0: down to label0
 # BB#6:                                 # %if.end29
 	i32.load8_u	$push18=, 0($3)
 	i32.const	$push19=, 12
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	6, $pop20       # 6: down to label3
+	br_if   	0, $pop20       # 0: down to label0
 # BB#7:                                 # %if.end35
 	i32.load8_u	$push21=, 1($3)
 	i32.const	$push22=, 22
 	i32.ne  	$push23=, $pop21, $pop22
-	br_if   	7, $pop23       # 7: down to label2
+	br_if   	0, $pop23       # 0: down to label0
 # BB#8:                                 # %if.end41
 	i32.load8_u	$push24=, 2($3)
 	i32.const	$push25=, 32
 	i32.ne  	$push26=, $pop24, $pop25
-	br_if   	8, $pop26       # 8: down to label1
+	br_if   	0, $pop26       # 0: down to label0
 # BB#9:                                 # %if.end47
 	i32.const	$push27=, 123
 	i32.ne  	$push28=, $4, $pop27
-	br_if   	9, $pop28       # 9: down to label0
+	br_if   	0, $pop28       # 0: down to label0
 # BB#10:                                # %if.end51
 	return  	$1
-.LBB0_11:                               # %if.then
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then5
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then10
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then16
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then22
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then28
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then34
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then40
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then46
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_20:                               # %if.then50
+.LBB0_11:                               # %if.then50
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931004-13.c.s
+++ b/test/torture-s/931004-13.c.s
@@ -9,132 +9,72 @@ f:                                      # @f
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load8_u	$push0=, 0($1)
 	i32.const	$push1=, 10
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label12
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load8_u	$push3=, 1($1)
 	i32.const	$push4=, 20
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label11
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.load8_u	$push6=, 2($1)
 	i32.const	$push7=, 30
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label10
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end11
 	i32.load8_u	$push9=, 3($1)
 	i32.const	$push10=, 40
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label9
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end16
 	i32.load8_u	$push12=, 0($2)
 	i32.const	$push13=, 11
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	4, $pop14       # 4: down to label8
+	br_if   	0, $pop14       # 0: down to label0
 # BB#5:                                 # %if.end22
 	i32.load8_u	$push15=, 1($2)
 	i32.const	$push16=, 21
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	5, $pop17       # 5: down to label7
+	br_if   	0, $pop17       # 0: down to label0
 # BB#6:                                 # %if.end28
 	i32.load8_u	$push18=, 2($2)
 	i32.const	$push19=, 31
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	6, $pop20       # 6: down to label6
+	br_if   	0, $pop20       # 0: down to label0
 # BB#7:                                 # %if.end34
 	i32.load8_u	$push21=, 3($2)
 	i32.const	$push22=, 41
 	i32.ne  	$push23=, $pop21, $pop22
-	br_if   	7, $pop23       # 7: down to label5
+	br_if   	0, $pop23       # 0: down to label0
 # BB#8:                                 # %if.end40
 	i32.load8_u	$push24=, 0($3)
 	i32.const	$push25=, 12
 	i32.ne  	$push26=, $pop24, $pop25
-	br_if   	8, $pop26       # 8: down to label4
+	br_if   	0, $pop26       # 0: down to label0
 # BB#9:                                 # %if.end46
 	i32.load8_u	$push27=, 1($3)
 	i32.const	$push28=, 22
 	i32.ne  	$push29=, $pop27, $pop28
-	br_if   	9, $pop29       # 9: down to label3
+	br_if   	0, $pop29       # 0: down to label0
 # BB#10:                                # %if.end52
 	i32.load8_u	$push30=, 2($3)
 	i32.const	$push31=, 32
 	i32.ne  	$push32=, $pop30, $pop31
-	br_if   	10, $pop32      # 10: down to label2
+	br_if   	0, $pop32       # 0: down to label0
 # BB#11:                                # %if.end58
 	i32.load8_u	$push33=, 3($3)
 	i32.const	$push34=, 42
 	i32.ne  	$push35=, $pop33, $pop34
-	br_if   	11, $pop35      # 11: down to label1
+	br_if   	0, $pop35       # 0: down to label0
 # BB#12:                                # %if.end64
 	i32.const	$push36=, 123
 	i32.ne  	$push37=, $4, $pop36
-	br_if   	12, $pop37      # 12: down to label0
+	br_if   	0, $pop37       # 0: down to label0
 # BB#13:                                # %if.end68
 	return  	$1
-.LBB0_14:                               # %if.then
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then5
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then10
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then15
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then21
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then27
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_20:                               # %if.then33
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_21:                               # %if.then39
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_22:                               # %if.then45
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_23:                               # %if.then51
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then57
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then63
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then67
+.LBB0_14:                               # %if.then67
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931004-3.c.s
+++ b/test/torture-s/931004-3.c.s
@@ -9,45 +9,30 @@ f:                                      # @f
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
 	i32.const	$push12=, 65535
 	i32.and 	$push0=, $1, $pop12
 	i32.const	$push1=, 10
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push13=, 65535
 	i32.and 	$push3=, $2, $pop13
 	i32.const	$push4=, 11
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end9
 	i32.const	$push6=, 65535
 	i32.and 	$push7=, $3, $pop6
 	i32.const	$push8=, 12
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	2, $pop9        # 2: down to label1
+	br_if   	0, $pop9        # 0: down to label0
 # BB#3:                                 # %if.end15
 	i32.const	$push10=, 123
 	i32.ne  	$push11=, $4, $pop10
-	br_if   	3, $pop11       # 3: down to label0
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end19
 	return  	$1
-.LBB0_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then8
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_7:                                # %if.then14
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then18
+.LBB0_5:                                # %if.then18
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931004-5.c.s
+++ b/test/torture-s/931004-5.c.s
@@ -9,72 +9,42 @@ f:                                      # @f
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load16_u	$push0=, 0($1)
 	i32.const	$push1=, 10
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label6
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load16_u	$push3=, 2($1)
 	i32.const	$push4=, 20
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label5
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.load16_u	$push6=, 0($2)
 	i32.const	$push7=, 11
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label4
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end12
 	i32.load16_u	$push9=, 2($2)
 	i32.const	$push10=, 21
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label3
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end18
 	i32.load16_u	$push12=, 0($3)
 	i32.const	$push13=, 12
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	4, $pop14       # 4: down to label2
+	br_if   	0, $pop14       # 0: down to label0
 # BB#5:                                 # %if.end24
 	i32.load16_u	$push15=, 2($3)
 	i32.const	$push16=, 22
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	5, $pop17       # 5: down to label1
+	br_if   	0, $pop17       # 0: down to label0
 # BB#6:                                 # %if.end30
 	i32.const	$push18=, 123
 	i32.ne  	$push19=, $4, $pop18
-	br_if   	6, $pop19       # 6: down to label0
+	br_if   	0, $pop19       # 0: down to label0
 # BB#7:                                 # %if.end34
 	return  	$1
-.LBB0_8:                                # %if.then
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then5
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.then11
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then17
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then23
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then29
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then33
+.LBB0_8:                                # %if.then33
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931004-7.c.s
+++ b/test/torture-s/931004-7.c.s
@@ -9,45 +9,30 @@ f:                                      # @f
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
 	i32.const	$push12=, 255
 	i32.and 	$push0=, $1, $pop12
 	i32.const	$push1=, 10
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push13=, 255
 	i32.and 	$push3=, $2, $pop13
 	i32.const	$push4=, 11
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end9
 	i32.const	$push6=, 255
 	i32.and 	$push7=, $3, $pop6
 	i32.const	$push8=, 12
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	2, $pop9        # 2: down to label1
+	br_if   	0, $pop9        # 0: down to label0
 # BB#3:                                 # %if.end15
 	i32.const	$push10=, 123
 	i32.ne  	$push11=, $4, $pop10
-	br_if   	3, $pop11       # 3: down to label0
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end19
 	return  	$1
-.LBB0_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then8
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_7:                                # %if.then14
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then18
+.LBB0_5:                                # %if.then18
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931004-9.c.s
+++ b/test/torture-s/931004-9.c.s
@@ -9,72 +9,42 @@ f:                                      # @f
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load8_u	$push0=, 0($1)
 	i32.const	$push1=, 10
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label6
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load8_u	$push3=, 1($1)
 	i32.const	$push4=, 20
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label5
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.load8_u	$push6=, 0($2)
 	i32.const	$push7=, 11
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label4
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end12
 	i32.load8_u	$push9=, 1($2)
 	i32.const	$push10=, 21
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label3
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end18
 	i32.load8_u	$push12=, 0($3)
 	i32.const	$push13=, 12
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	4, $pop14       # 4: down to label2
+	br_if   	0, $pop14       # 0: down to label0
 # BB#5:                                 # %if.end24
 	i32.load8_u	$push15=, 1($3)
 	i32.const	$push16=, 22
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	5, $pop17       # 5: down to label1
+	br_if   	0, $pop17       # 0: down to label0
 # BB#6:                                 # %if.end30
 	i32.const	$push18=, 123
 	i32.ne  	$push19=, $4, $pop18
-	br_if   	6, $pop19       # 6: down to label0
+	br_if   	0, $pop19       # 0: down to label0
 # BB#7:                                 # %if.end34
 	return  	$1
-.LBB0_8:                                # %if.then
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then5
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.then11
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then17
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then23
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then29
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then33
+.LBB0_8:                                # %if.then33
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/931102-1.c.s
+++ b/test/torture-s/931102-1.c.s
@@ -11,22 +11,22 @@ f:                                      # @f
 # BB#0:                                 # %entry
 	i32.const	$1=, 0
 	block
-	i32.const	$push5=, 1
-	i32.and 	$push0=, $0, $pop5
+	i32.const	$push3=, 1
+	i32.and 	$push0=, $0, $pop3
 	br_if   	0, $pop0        # 0: down to label0
 .LBB0_1:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push1=, 24
-	i32.shl 	$push2=, $0, $pop1
-	i32.const	$push3=, 25
-	i32.shr_s	$0=, $pop2, $pop3
 	i32.const	$push7=, 1
 	i32.add 	$1=, $1, $pop7
-	i32.const	$push6=, 1
-	i32.and 	$push4=, $0, $pop6
+	i32.const	$push6=, 24
+	i32.shl 	$push1=, $0, $pop6
+	i32.const	$push5=, 25
+	i32.shr_s	$0=, $pop1, $pop5
+	i32.const	$push4=, 1
+	i32.and 	$push2=, $0, $pop4
 	i32.const	$push8=, 0
-	i32.eq  	$push9=, $pop4, $pop8
+	i32.eq  	$push9=, $pop2, $pop8
 	br_if   	0, $pop9        # 0: up to label1
 .LBB0_2:                                # %while.end
 	end_loop                        # label2:

--- a/test/torture-s/931102-2.c.s
+++ b/test/torture-s/931102-2.c.s
@@ -11,22 +11,22 @@ f:                                      # @f
 # BB#0:                                 # %entry
 	i32.const	$1=, 0
 	block
-	i32.const	$push5=, 1
-	i32.and 	$push0=, $0, $pop5
+	i32.const	$push3=, 1
+	i32.and 	$push0=, $0, $pop3
 	br_if   	0, $pop0        # 0: down to label0
 .LBB0_1:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push1=, 16
-	i32.shl 	$push2=, $0, $pop1
-	i32.const	$push3=, 17
-	i32.shr_s	$0=, $pop2, $pop3
 	i32.const	$push7=, 1
 	i32.add 	$1=, $1, $pop7
-	i32.const	$push6=, 1
-	i32.and 	$push4=, $0, $pop6
+	i32.const	$push6=, 16
+	i32.shl 	$push1=, $0, $pop6
+	i32.const	$push5=, 17
+	i32.shr_s	$0=, $pop1, $pop5
+	i32.const	$push4=, 1
+	i32.and 	$push2=, $0, $pop4
 	i32.const	$push8=, 0
-	i32.eq  	$push9=, $pop4, $pop8
+	i32.eq  	$push9=, $pop2, $pop8
 	br_if   	0, $pop9        # 0: up to label1
 .LBB0_2:                                # %while.end
 	end_loop                        # label2:

--- a/test/torture-s/950221-1.c.s
+++ b/test/torture-s/950221-1.c.s
@@ -120,8 +120,8 @@ el:
 	.globl	filler
 	.p2align	4
 filler:
-	.skip	49152
-	.size	filler, 49152
+	.skip	522240
+	.size	filler, 522240
 
 
 	.ident	"clang version 3.9.0 "

--- a/test/torture-s/960521-1.c.s
+++ b/test/torture-s/960521-1.c.s
@@ -37,7 +37,7 @@ foo:                                    # @foo
 	i32.const	$push10=, 0
 	i32.load	$push4=, b($pop10)
 	i32.const	$push6=, 255
-	i32.const	$push5=, 131068
+	i32.const	$push5=, 522236
 	i32.call	$discard=, memset@FUNCTION, $pop4, $pop6, $pop5
 	return  	$0
 	.endfunc
@@ -53,13 +53,13 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %for.body.lr.ph.i
 	i32.const	$push2=, 0
-	i32.const	$push3=, 32768
+	i32.const	$push3=, 130560
 	i32.store	$discard=, n($pop2), $pop3
 	i32.const	$push17=, 0
-	i32.const	$push4=, 131072
+	i32.const	$push4=, 522240
 	i32.call	$push0=, malloc@FUNCTION, $pop4
 	i32.store	$2=, a($pop17), $pop0
-	i32.const	$push16=, 131072
+	i32.const	$push16=, 522240
 	i32.call	$push15=, malloc@FUNCTION, $pop16
 	tee_local	$push14=, $4=, $pop15
 	i32.const	$push13=, 0
@@ -85,7 +85,7 @@ main:                                   # @main
 	end_loop                        # label4:
 	i32.load	$2=, 0($4)
 	i32.const	$push7=, 255
-	i32.const	$push6=, 131068
+	i32.const	$push6=, 522236
 	i32.call	$discard=, memset@FUNCTION, $1, $pop7, $pop6
 	block
 	br_if   	0, $2           # 0: down to label5

--- a/test/torture-s/960909-1.c.s
+++ b/test/torture-s/960909-1.c.s
@@ -16,13 +16,15 @@ ffs:                                    # @ffs
 	br_if   	0, $pop6        # 0: down to label0
 # BB#1:                                 # %for.cond.preheader
 	i32.const	$1=, 1
-	i32.const	$2=, 1
+	block
 	i32.const	$push2=, 1
 	i32.and 	$push0=, $0, $pop2
-	br_if   	0, $pop0        # 0: down to label0
-.LBB0_2:                                # %for.inc
+	br_if   	0, $pop0        # 0: down to label1
+# BB#2:
+	i32.const	$2=, 1
+.LBB0_3:                                # %for.inc
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label1:
+	loop                            # label2:
 	i32.const	$push4=, 1
 	i32.add 	$2=, $2, $pop4
 	i32.const	$push3=, 1
@@ -30,9 +32,13 @@ ffs:                                    # @ffs
 	i32.and 	$push1=, $1, $0
 	i32.const	$push7=, 0
 	i32.eq  	$push8=, $pop1, $pop7
-	br_if   	0, $pop8        # 0: up to label1
-.LBB0_3:                                # %cleanup
-	end_loop                        # label2:
+	br_if   	0, $pop8        # 0: up to label2
+	br      	3               # 3: down to label0
+.LBB0_4:
+	end_loop                        # label3:
+	end_block                       # label1:
+	i32.const	$2=, 1
+.LBB0_5:                                # %cleanup
 	end_block                       # label0:
 	return  	$2
 	.endfunc
@@ -50,11 +56,11 @@ f:                                      # @f
 	block
 	i32.const	$push0=, 0
 	i32.eq  	$push1=, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label3
+	br_if   	0, $pop1        # 0: down to label4
 # BB#1:                                 # %if.end
 	return  	$0
 .LBB1_2:                                # %if.then
-	end_block                       # label3:
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/980608-1.c.s
+++ b/test/torture-s/980608-1.c.s
@@ -36,15 +36,10 @@ debug:                                  # @debug
 	i32.add 	$push2=, $pop37, $pop36
 	i32.store	$discard=, 12($5), $pop2
 	block
-	block
-	block
-	block
-	block
-	block
 	i32.load	$push3=, 0($1)
 	i32.const	$push4=, 101
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label5
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($5)
 	i32.const	$push45=, 3
@@ -58,7 +53,7 @@ debug:                                  # @debug
 	i32.load	$push9=, 0($1)
 	i32.const	$push10=, 102
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label4
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($5)
 	i32.const	$push50=, 3
@@ -72,7 +67,7 @@ debug:                                  # @debug
 	i32.load	$push15=, 0($1)
 	i32.const	$push16=, 103
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	2, $pop17       # 2: down to label3
+	br_if   	0, $pop17       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.load	$push18=, 12($5)
 	i32.const	$push55=, 3
@@ -86,7 +81,7 @@ debug:                                  # @debug
 	i32.load	$push21=, 0($1)
 	i32.const	$push22=, 104
 	i32.ne  	$push23=, $pop21, $pop22
-	br_if   	3, $pop23       # 3: down to label2
+	br_if   	0, $pop23       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.load	$push24=, 12($5)
 	i32.const	$push60=, 3
@@ -100,7 +95,7 @@ debug:                                  # @debug
 	i32.load	$push27=, 0($1)
 	i32.const	$push28=, 105
 	i32.ne  	$push29=, $pop27, $pop28
-	br_if   	4, $pop29       # 4: down to label1
+	br_if   	0, $pop29       # 0: down to label0
 # BB#5:                                 # %if.end13
 	i32.load	$push30=, 12($5)
 	i32.const	$push65=, 3
@@ -114,34 +109,14 @@ debug:                                  # @debug
 	i32.load	$push33=, 0($1)
 	i32.const	$push34=, 106
 	i32.ne  	$push35=, $pop33, $pop34
-	br_if   	5, $pop35       # 5: down to label0
+	br_if   	0, $pop35       # 0: down to label0
 # BB#6:                                 # %if.end16
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
-.LBB1_7:                                # %if.then
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_8:                                # %if.then3
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_9:                                # %if.then6
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_10:                               # %if.then9
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_11:                               # %if.then12
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_12:                               # %if.then15
+.LBB1_7:                                # %if.then15
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/980707-1.c.s
+++ b/test/torture-s/980707-1.c.s
@@ -7,70 +7,71 @@
 buildargv:                              # @buildargv
 	.param  	i32
 	.result 	i32
-	.local  	i32, i32, i32
+	.local  	i32, i32
 # BB#0:                                 # %entry
 	i32.const	$1=, 0
 .LBB0_1:                                # %while.cond1
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_5 Depth 2
-	loop                            # label0:
+	block
+	loop                            # label1:
 	block
 	i32.load8_u	$push9=, 0($0)
-	tee_local	$push8=, $3=, $pop9
+	tee_local	$push8=, $2=, $pop9
 	i32.const	$push7=, 32
 	i32.ne  	$push0=, $pop8, $pop7
-	br_if   	0, $pop0        # 0: down to label2
+	br_if   	0, $pop0        # 0: down to label3
 # BB#2:                                 # %while.body3
                                         #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push10=, 1
 	i32.add 	$0=, $0, $pop10
-	br      	1               # 1: up to label0
+	br      	1               # 1: up to label1
 .LBB0_3:                                # %while.cond1
                                         #   in Loop: Header=BB0_1 Depth=1
-	end_block                       # label2:
-	copy_local	$2=, $1
+	end_block                       # label3:
 	i32.const	$push19=, 0
-	i32.eq  	$push20=, $3, $pop19
-	br_if   	1, $pop20       # 1: down to label1
+	i32.eq  	$push20=, $2, $pop19
+	br_if   	2, $pop20       # 2: down to label0
 # BB#4:                                 # %if.end
                                         #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push12=, 2
 	i32.shl 	$push1=, $1, $pop12
 	i32.store	$discard=, buildargv.arglist($pop1), $0
 	i32.const	$push11=, 1
-	i32.add 	$2=, $1, $pop11
+	i32.add 	$1=, $1, $pop11
 .LBB0_5:                                # %while.cond7
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label3:
+	loop                            # label4:
 	i32.load8_u	$push14=, 0($0)
-	tee_local	$push13=, $3=, $pop14
+	tee_local	$push13=, $2=, $pop14
 	i32.const	$push21=, 0
 	i32.eq  	$push22=, $pop13, $pop21
-	br_if   	3, $pop22       # 3: down to label1
+	br_if   	3, $pop22       # 3: down to label2
 # BB#6:                                 # %while.cond7
                                         #   in Loop: Header=BB0_5 Depth=2
 	i32.const	$push15=, 32
-	i32.eq  	$push2=, $3, $pop15
-	br_if   	1, $pop2        # 1: down to label4
+	i32.eq  	$push2=, $2, $pop15
+	br_if   	1, $pop2        # 1: down to label5
 # BB#7:                                 # %while.body14
                                         #   in Loop: Header=BB0_5 Depth=2
 	i32.const	$push16=, 1
 	i32.add 	$0=, $0, $pop16
-	br      	0               # 0: up to label3
+	br      	0               # 0: up to label4
 .LBB0_8:                                # %if.end21
                                         #   in Loop: Header=BB0_1 Depth=1
-	end_loop                        # label4:
+	end_loop                        # label5:
 	i32.const	$push18=, 0
 	i32.store8	$discard=, 0($0), $pop18
 	i32.const	$push17=, 1
 	i32.add 	$0=, $0, $pop17
-	copy_local	$1=, $2
-	br      	0               # 0: up to label0
-.LBB0_9:                                # %while.end23
-	end_loop                        # label1:
+	br      	0               # 0: up to label1
+.LBB0_9:
+	end_loop                        # label2:
+.LBB0_10:                               # %while.end23
+	end_block                       # label0:
 	i32.const	$push3=, 2
-	i32.shl 	$push4=, $2, $pop3
+	i32.shl 	$push4=, $1, $pop3
 	i32.const	$push6=, 0
 	i32.store	$discard=, buildargv.arglist($pop4), $pop6
 	i32.const	$push5=, buildargv.arglist
@@ -85,128 +86,126 @@ buildargv:                              # @buildargv
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$3=, __stack_pointer
+	i32.load	$3=, 0($3)
+	i32.const	$4=, 256
+	i32.sub 	$5=, $3, $4
 	i32.const	$4=, __stack_pointer
-	i32.load	$4=, 0($4)
-	i32.const	$5=, 256
-	i32.sub 	$6=, $4, $5
-	i32.const	$5=, __stack_pointer
-	i32.store	$6=, 0($5), $6
-	copy_local	$1=, $6
+	i32.store	$5=, 0($4), $5
+	copy_local	$0=, $5
 	i32.const	$push1=, 4
-	i32.or  	$push2=, $6, $pop1
+	i32.or  	$push2=, $5, $pop1
 	i32.const	$push22=, 0
 	i32.load8_u	$push0=, .L.str+4($pop22)
 	i32.store8	$discard=, 0($pop2):p2align=2, $pop0
 	i32.const	$push21=, 0
 	i32.load	$push3=, .L.str($pop21):p2align=0
-	i32.store	$discard=, 0($6):p2align=4, $pop3
-	i32.const	$0=, 0
+	i32.store	$discard=, 0($5):p2align=4, $pop3
+	i32.const	$1=, 0
 .LBB1_1:                                # %while.cond1.i
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB1_5 Depth 2
-	loop                            # label5:
 	block
-	i32.load8_u	$push25=, 0($1)
-	tee_local	$push24=, $3=, $pop25
+	loop                            # label7:
+	block
+	i32.load8_u	$push25=, 0($0)
+	tee_local	$push24=, $2=, $pop25
 	i32.const	$push23=, 32
 	i32.ne  	$push4=, $pop24, $pop23
-	br_if   	0, $pop4        # 0: down to label7
+	br_if   	0, $pop4        # 0: down to label9
 # BB#2:                                 # %while.body3.i
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push26=, 1
-	i32.add 	$1=, $1, $pop26
-	br      	1               # 1: up to label5
+	i32.add 	$0=, $0, $pop26
+	br      	1               # 1: up to label7
 .LBB1_3:                                # %while.cond1.i
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label7:
-	copy_local	$2=, $0
+	end_block                       # label9:
 	i32.const	$push41=, 0
-	i32.eq  	$push42=, $3, $pop41
-	br_if   	1, $pop42       # 1: down to label6
+	i32.eq  	$push42=, $2, $pop41
+	br_if   	2, $pop42       # 2: down to label6
 # BB#4:                                 # %if.end.i
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push28=, 2
-	i32.shl 	$push5=, $0, $pop28
-	i32.store	$discard=, buildargv.arglist($pop5), $1
+	i32.shl 	$push5=, $1, $pop28
+	i32.store	$discard=, buildargv.arglist($pop5), $0
 	i32.const	$push27=, 1
-	i32.add 	$2=, $0, $pop27
+	i32.add 	$2=, $1, $pop27
 .LBB1_5:                                # %while.cond7.i
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label8:
-	i32.load8_u	$push31=, 0($1)
-	tee_local	$push30=, $0=, $pop31
+	loop                            # label10:
+	i32.load8_u	$push31=, 0($0)
+	tee_local	$push30=, $1=, $pop31
 	i32.const	$push29=, 32
 	i32.eq  	$push6=, $pop30, $pop29
-	br_if   	1, $pop6        # 1: down to label9
+	br_if   	1, $pop6        # 1: down to label11
 # BB#6:                                 # %while.cond7.i
                                         #   in Loop: Header=BB1_5 Depth=2
 	i32.const	$push43=, 0
-	i32.eq  	$push44=, $0, $pop43
-	br_if   	3, $pop44       # 3: down to label6
+	i32.eq  	$push44=, $1, $pop43
+	br_if   	3, $pop44       # 3: down to label8
 # BB#7:                                 # %while.body14.i
                                         #   in Loop: Header=BB1_5 Depth=2
 	i32.const	$push32=, 1
-	i32.add 	$1=, $1, $pop32
-	br      	0               # 0: up to label8
+	i32.add 	$0=, $0, $pop32
+	br      	0               # 0: up to label10
 .LBB1_8:                                # %if.end21.i
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_loop                        # label9:
+	end_loop                        # label11:
 	i32.const	$push34=, 0
-	i32.store8	$discard=, 0($1), $pop34
+	i32.store8	$discard=, 0($0), $pop34
 	i32.const	$push33=, 1
-	i32.add 	$1=, $1, $pop33
-	copy_local	$0=, $2
-	br      	0               # 0: up to label5
-.LBB1_9:                                # %buildargv.exit
-	end_loop                        # label6:
-	block
+	i32.add 	$0=, $0, $pop33
+	copy_local	$1=, $2
+	br      	0               # 0: up to label7
+.LBB1_9:
+	end_loop                        # label8:
+	copy_local	$1=, $2
+.LBB1_10:                               # %buildargv.exit
+	end_block                       # label6:
 	block
 	block
 	i32.const	$push7=, 2
-	i32.shl 	$push8=, $2, $pop7
+	i32.shl 	$push8=, $1, $pop7
 	i32.const	$push9=, 0
 	i32.store	$push10=, buildargv.arglist($pop8), $pop9
 	i32.load	$push36=, buildargv.arglist($pop10):p2align=4
-	tee_local	$push35=, $1=, $pop36
+	tee_local	$push35=, $0=, $pop36
 	i32.load8_u	$push11=, 0($pop35)
 	i32.const	$push12=, 97
 	i32.ne  	$push13=, $pop11, $pop12
-	br_if   	0, $pop13       # 0: down to label12
-# BB#10:                                # %if.end37
-	i32.load8_u	$push14=, 1($1)
-	br_if   	0, $pop14       # 0: down to label12
-# BB#11:                                # %cond.true52
+	br_if   	0, $pop13       # 0: down to label13
+# BB#11:                                # %if.end37
+	i32.load8_u	$push14=, 1($0)
+	br_if   	0, $pop14       # 0: down to label13
+# BB#12:                                # %cond.true52
 	i32.const	$push15=, 0
 	i32.load	$push38=, buildargv.arglist+4($pop15)
-	tee_local	$push37=, $1=, $pop38
+	tee_local	$push37=, $0=, $pop38
 	i32.load8_u	$push16=, 0($pop37)
 	i32.const	$push17=, 98
 	i32.ne  	$push18=, $pop16, $pop17
-	br_if   	1, $pop18       # 1: down to label11
-# BB#12:                                # %if.end94
-	i32.load8_u	$push19=, 1($1)
-	br_if   	1, $pop19       # 1: down to label11
-# BB#13:                                # %if.end104
+	br_if   	1, $pop18       # 1: down to label12
+# BB#13:                                # %if.end94
+	i32.load8_u	$push19=, 1($0)
+	br_if   	1, $pop19       # 1: down to label12
+# BB#14:                                # %if.end104
 	i32.const	$push39=, 0
 	i32.load	$push20=, buildargv.arglist+8($pop39):p2align=3
-	br_if   	2, $pop20       # 2: down to label10
-# BB#14:                                # %if.end109
+	br_if   	1, $pop20       # 1: down to label12
+# BB#15:                                # %if.end109
 	i32.const	$push40=, 0
 	call    	exit@FUNCTION, $pop40
 	unreachable
-.LBB1_15:                               # %if.then42
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_16:                               # %if.then103
-	end_block                       # label11:
+.LBB1_16:                               # %if.then42
+	end_block                       # label13:
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_17:                               # %if.then108
-	end_block                       # label10:
+	end_block                       # label12:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/981019-1.c.s
+++ b/test/torture-s/981019-1.c.s
@@ -10,48 +10,43 @@ ff:                                     # @ff
 # BB#0:                                 # %entry
 	block
 	block
-	block
 	i32.const	$push6=, 0
 	i32.eq  	$push7=, $0, $pop6
-	br_if   	0, $pop7        # 0: down to label2
+	br_if   	0, $pop7        # 0: down to label1
 # BB#1:                                 # %entry
-	br_if   	1, $2           # 1: down to label1
+	br_if   	1, $2           # 1: down to label0
 .LBB0_2:                                # %while.cond.preheader
-	end_block                       # label2:
+	end_block                       # label1:
 	i32.const	$push2=, 0
 	i32.load	$0=, f3.x($pop2)
 .LBB0_3:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	loop                            # label4:
+	loop                            # label3:
 	copy_local	$push5=, $0
 	tee_local	$push4=, $3=, $pop5
 	i32.const	$push3=, 0
 	i32.eq  	$0=, $pop4, $pop3
-	br_if   	2, $3           # 2: down to label3
+	br_if   	2, $3           # 2: down to label2
 # BB#4:                                 # %while.body
                                         #   in Loop: Header=BB0_3 Depth=1
 	i32.const	$push8=, 0
 	i32.eq  	$push9=, $2, $pop8
-	br_if   	0, $pop9        # 0: up to label4
+	br_if   	0, $pop9        # 0: up to label3
 # BB#5:                                 # %land.lhs.true
-	end_loop                        # label5:
+	end_loop                        # label4:
 	i32.const	$push1=, 0
 	i32.store	$discard=, f3.x($pop1), $0
 	i32.call	$discard=, f2@FUNCTION
 	unreachable
 .LBB0_6:                                # %while.end
-	end_block                       # label3:
+	end_block                       # label2:
 	i32.const	$push0=, 0
 	i32.store	$discard=, f3.x($pop0), $0
-	br_if   	1, $2           # 1: down to label0
+	br_if   	0, $2           # 0: down to label0
 # BB#7:                                 # %if.end16
 	return
-.LBB0_8:                                # %if.then2
-	end_block                       # label1:
-	call    	f1@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then15
+.LBB0_8:                                # %if.then15
 	end_block                       # label0:
 	call    	f1@FUNCTION
 	unreachable
@@ -114,16 +109,16 @@ main:                                   # @main
 	i32.load	$0=, f3.x($pop1)
 .LBB4_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label6:
+	loop                            # label5:
 	copy_local	$push4=, $0
 	tee_local	$push3=, $1=, $pop4
 	i32.const	$push2=, 0
 	i32.eq  	$0=, $pop3, $pop2
 	i32.const	$push6=, 0
 	i32.eq  	$push7=, $1, $pop6
-	br_if   	0, $pop7        # 0: up to label6
+	br_if   	0, $pop7        # 0: up to label5
 # BB#2:                                 # %ff.exit
-	end_loop                        # label7:
+	end_loop                        # label6:
 	i32.const	$push0=, 0
 	i32.store	$discard=, f3.x($pop0), $0
 	i32.const	$push5=, 0

--- a/test/torture-s/990128-1.c.s
+++ b/test/torture-s/990128-1.c.s
@@ -94,12 +94,12 @@ sub:                                    # @sub
 	.param  	i32, i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push5=, 0
-	i32.load	$2=, count($pop5)
+	i32.const	$push4=, 0
+	i32.load	$2=, count($pop4)
 	block
-	i32.const	$push7=, 0
-	i32.eq  	$push8=, $0, $pop7
-	br_if   	0, $pop8        # 0: down to label5
+	i32.const	$push8=, 0
+	i32.eq  	$push9=, $0, $pop8
+	br_if   	0, $pop9        # 0: down to label5
 .LBB1_1:                                # %for.inc.i.preheader
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB1_2 Depth 2
@@ -114,22 +114,23 @@ sub:                                    # @sub
 # BB#3:                                 # %if.then
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_loop                        # label9:
-	i32.const	$push0=, 0
-	i32.store	$3=, 0($1), $pop0
+	i32.const	$push6=, 0
+	i32.store	$discard=, 0($1), $pop6
 	i32.load	$0=, 0($0)
-	i32.const	$push1=, 1
-	i32.add 	$2=, $2, $pop1
+	i32.const	$push5=, 1
+	i32.add 	$2=, $2, $pop5
 	br_if   	0, $0           # 0: up to label6
 # BB#4:                                 # %for.cond.look.exit.thread_crit_edge
 	end_loop                        # label7:
-	i32.store	$discard=, count($3), $2
+	i32.const	$push0=, 0
+	i32.store	$discard=, count($pop0), $2
 .LBB1_5:                                # %for.end
 	end_block                       # label5:
-	i32.const	$push6=, 0
-	i32.store	$push2=, 0($1), $pop6
-	i32.const	$push3=, 1
-	i32.add 	$push4=, $2, $pop3
-	i32.store	$discard=, count($pop2), $pop4
+	i32.const	$push7=, 0
+	i32.store	$push1=, 0($1), $pop7
+	i32.const	$push2=, 1
+	i32.add 	$push3=, $2, $pop2
+	i32.store	$discard=, count($pop1), $pop3
 	return
 	.endfunc
 .Lfunc_end1:

--- a/test/torture-s/990222-1.c.s
+++ b/test/torture-s/990222-1.c.s
@@ -8,74 +8,75 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$push29=, 0
-	i32.const	$push28=, 0
-	i32.load8_u	$push0=, line+2($pop28)
-	i32.const	$push27=, 1
-	i32.add 	$push26=, $pop0, $pop27
-	tee_local	$push25=, $0=, $pop26
-	i32.store8	$discard=, line+2($pop29), $pop25
-	i32.const	$1=, line+1
+	i32.const	$push26=, 0
+	i32.const	$push25=, 0
+	i32.load8_u	$push0=, line+2($pop25)
+	i32.const	$push24=, 1
+	i32.add 	$push23=, $pop0, $pop24
+	tee_local	$push22=, $1=, $pop23
+	i32.store8	$discard=, line+2($pop26), $pop22
 	block
-	i32.const	$push24=, 24
-	i32.shl 	$push1=, $0, $pop24
-	i32.const	$push23=, 24
-	i32.shr_s	$push22=, $pop1, $pop23
-	tee_local	$push21=, $0=, $pop22
+	i32.const	$push21=, 24
+	i32.shl 	$push1=, $1, $pop21
+	i32.const	$push20=, 24
+	i32.shr_s	$push19=, $pop1, $pop20
+	tee_local	$push18=, $1=, $pop19
 	i32.const	$push2=, 58
-	i32.lt_s	$push3=, $pop21, $pop2
+	i32.lt_s	$push3=, $pop18, $pop2
 	br_if   	0, $pop3        # 0: down to label0
-.LBB0_1:                                # %while.body
+# BB#1:
+	i32.const	$1=, line+1
+.LBB0_2:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	i32.load8_u	$0=, 0($1)
 	i32.const	$push35=, 1
 	i32.add 	$push4=, $1, $pop35
-	i32.const	$push5=, 48
-	i32.store8	$discard=, 0($pop4), $pop5
-	i32.const	$push34=, 1
-	i32.add 	$push33=, $0, $pop34
-	tee_local	$push32=, $0=, $pop33
-	i32.store8	$discard=, 0($1), $pop32
-	i32.const	$push10=, -1
-	i32.add 	$1=, $1, $pop10
-	i32.const	$push31=, 24
-	i32.shl 	$push6=, $0, $pop31
-	i32.const	$push30=, 24
-	i32.shr_s	$push7=, $pop6, $pop30
-	i32.const	$push8=, 57
-	i32.gt_s	$push9=, $pop7, $pop8
-	br_if   	0, $pop9        # 0: up to label1
-# BB#2:                                 # %while.end.loopexit
+	i32.const	$push34=, 48
+	i32.store8	$discard=, 0($pop4), $pop34
+	i32.const	$push33=, 1
+	i32.add 	$push32=, $0, $pop33
+	tee_local	$push31=, $0=, $pop32
+	i32.store8	$discard=, 0($1), $pop31
+	i32.const	$push30=, -1
+	i32.add 	$1=, $1, $pop30
+	i32.const	$push29=, 24
+	i32.shl 	$push5=, $0, $pop29
+	i32.const	$push28=, 24
+	i32.shr_s	$push6=, $pop5, $pop28
+	i32.const	$push27=, 57
+	i32.gt_s	$push7=, $pop6, $pop27
+	br_if   	0, $pop7        # 0: up to label1
+# BB#3:                                 # %while.end.loopexit
 	end_loop                        # label2:
-	i32.const	$push11=, 0
-	i32.load8_u	$0=, line+2($pop11)
-.LBB0_3:                                # %while.end
+	i32.const	$push8=, 0
+	i32.load8_u	$1=, line+2($pop8)
+.LBB0_4:                                # %while.end
 	end_block                       # label0:
 	block
 	i32.const	$push36=, 0
-	i32.load8_u	$push13=, line($pop36)
-	i32.const	$push14=, 50
-	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	0, $pop15       # 0: down to label3
-# BB#4:                                 # %while.end
-	i32.const	$push39=, 0
-	i32.load8_u	$push12=, line+1($pop39)
-	i32.const	$push38=, 255
-	i32.and 	$push16=, $pop12, $pop38
-	i32.const	$push37=, 48
-	i32.ne  	$push17=, $pop16, $pop37
-	br_if   	0, $pop17       # 0: down to label3
+	i32.load8_u	$push10=, line($pop36)
+	i32.const	$push11=, 50
+	i32.ne  	$push12=, $pop10, $pop11
+	br_if   	0, $pop12       # 0: down to label3
 # BB#5:                                 # %while.end
+	i32.const	$push39=, 0
+	i32.load8_u	$push9=, line+1($pop39)
+	i32.const	$push38=, 255
+	i32.and 	$push13=, $pop9, $pop38
+	i32.const	$push37=, 48
+	i32.ne  	$push14=, $pop13, $pop37
+	br_if   	0, $pop14       # 0: down to label3
+# BB#6:                                 # %while.end
 	i32.const	$push41=, 255
-	i32.and 	$push18=, $0, $pop41
+	i32.and 	$push15=, $1, $pop41
 	i32.const	$push40=, 48
-	i32.ne  	$push19=, $pop18, $pop40
-	br_if   	0, $pop19       # 0: down to label3
-# BB#6:                                 # %if.end
-	i32.const	$push20=, 0
-	return  	$pop20
-.LBB0_7:                                # %if.then
+	i32.ne  	$push16=, $pop15, $pop40
+	br_if   	0, $pop16       # 0: down to label3
+# BB#7:                                 # %if.end
+	i32.const	$push17=, 0
+	return  	$pop17
+.LBB0_8:                                # %if.then
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/991112-1.c.s
+++ b/test/torture-s/991112-1.c.s
@@ -39,24 +39,19 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push0=, 97
 	i32.call	$push1=, isprint@FUNCTION, $pop0
 	i32.const	$push5=, 0
 	i32.eq  	$push6=, $pop1, $pop5
-	br_if   	0, $pop6        # 0: down to label1
+	br_if   	0, $pop6        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push2=, 2
 	i32.call	$push3=, isprint@FUNCTION, $pop2
-	br_if   	1, $pop3        # 1: down to label0
+	br_if   	0, $pop3        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push4=, 0
 	return  	$pop4
-.LBB2_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_4:                                # %if.then3
+.LBB2_3:                                # %if.then3
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/991118-1.c.s
+++ b/test/torture-s/991118-1.c.s
@@ -86,14 +86,11 @@ main:                                   # @main
 	i64.xor 	$push0=, $0, $pop6
 	i64.store	$2=, tmp2($pop45), $pop0
 	block
-	block
-	block
-	block
 	i64.const	$push10=, -4096
 	i64.and 	$push11=, $1, $pop10
 	i64.const	$push12=, -7687337405579571200
 	i64.ne  	$push13=, $pop11, $pop12
-	br_if   	0, $pop13       # 0: down to label3
+	br_if   	0, $pop13       # 0: down to label0
 # BB#1:                                 # %entry
 	i64.const	$push7=, 52
 	i64.shl 	$push8=, $3, $pop7
@@ -102,20 +99,20 @@ main:                                   # @main
 	i32.wrap/i64	$push2=, $pop9
 	i32.const	$push50=, 291
 	i32.ne  	$push14=, $pop2, $pop50
-	br_if   	0, $pop14       # 0: down to label3
+	br_if   	0, $pop14       # 0: down to label0
 # BB#2:                                 # %if.end
 	i64.const	$push16=, 52
 	i64.shr_s	$push17=, $0, $pop16
 	i32.wrap/i64	$push18=, $pop17
 	i32.const	$push52=, 291
 	i32.ne  	$push20=, $pop18, $pop52
-	br_if   	1, $pop20       # 1: down to label2
+	br_if   	0, $pop20       # 0: down to label0
 # BB#3:                                 # %if.end
 	i64.const	$push19=, 4503599627370495
 	i64.and 	$push15=, $2, $pop19
 	i64.const	$push21=, 2626808268586421
 	i64.ne  	$push22=, $pop15, $pop21
-	br_if   	1, $pop22       # 1: down to label2
+	br_if   	0, $pop22       # 0: down to label0
 # BB#4:                                 # %if.end19
 	i32.const	$push24=, 0
 	i64.load	$0=, tmp4($pop24)
@@ -134,7 +131,7 @@ main:                                   # @main
 	i64.and 	$push32=, $1, $pop31
 	i64.const	$push33=, -3725223934242340864
 	i64.ne  	$push34=, $pop32, $pop33
-	br_if   	2, $pop34       # 2: down to label1
+	br_if   	0, $pop34       # 0: down to label0
 # BB#5:                                 # %if.end19
 	i64.const	$push28=, 53
 	i64.shl 	$push29=, $3, $pop28
@@ -143,37 +140,25 @@ main:                                   # @main
 	i32.wrap/i64	$push23=, $pop30
 	i32.const	$push58=, 291
 	i32.ne  	$push35=, $pop23, $pop58
-	br_if   	2, $pop35       # 2: down to label1
+	br_if   	0, $pop35       # 0: down to label0
 # BB#6:                                 # %if.end34
 	i64.const	$push37=, 53
 	i64.shr_s	$push38=, $0, $pop37
 	i32.wrap/i64	$push39=, $pop38
 	i32.const	$push60=, 291
 	i32.ne  	$push41=, $pop39, $pop60
-	br_if   	3, $pop41       # 3: down to label0
+	br_if   	0, $pop41       # 0: down to label0
 # BB#7:                                 # %if.end34
 	i64.const	$push40=, 9007199254740991
 	i64.and 	$push36=, $2, $pop40
 	i64.const	$push42=, 7188242255599224
 	i64.ne  	$push43=, $pop36, $pop42
-	br_if   	3, $pop43       # 3: down to label0
+	br_if   	0, $pop43       # 0: down to label0
 # BB#8:                                 # %if.end47
 	i32.const	$push44=, 0
 	call    	exit@FUNCTION, $pop44
 	unreachable
-.LBB4_9:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_10:                               # %if.then18
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_11:                               # %if.then33
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_12:                               # %if.then46
+.LBB4_9:                                # %if.then46
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/991216-2.c.s
+++ b/test/torture-s/991216-2.c.s
@@ -15,78 +15,72 @@ test:                                   # @test
 	i32.const	$4=, __stack_pointer
 	i32.store	$6=, 0($4), $6
 	i32.store	$discard=, 12($6), $1
-	i32.const	$1=, 1
-	block
 	block
 	block
 	block
 	i32.const	$push0=, 2
 	i32.lt_s	$push1=, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label3
-.LBB0_1:                                # %for.body
+	br_if   	0, $pop1        # 0: down to label2
+# BB#1:
+	i32.const	$1=, 1
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label4:
+	loop                            # label3:
 	i32.load	$push2=, 12($6)
-	i32.const	$push3=, 3
-	i32.add 	$push4=, $pop2, $pop3
-	i32.const	$push5=, -4
-	i32.and 	$push33=, $pop4, $pop5
-	tee_local	$push32=, $2=, $pop33
-	i32.const	$push6=, 4
-	i32.add 	$push7=, $pop32, $pop6
-	i32.store	$discard=, 12($6), $pop7
-	i32.const	$push31=, 1
-	i32.add 	$push9=, $1, $pop31
-	i32.load	$push8=, 0($2)
-	i32.ne  	$push10=, $pop9, $pop8
-	br_if   	3, $pop10       # 3: down to label2
-# BB#2:                                 # %for.cond
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$1=, $1, $pop11
-	i32.lt_s	$push12=, $1, $0
-	br_if   	0, $pop12       # 0: up to label4
-.LBB0_3:                                # %for.end
-	end_loop                        # label5:
-	end_block                       # label3:
-	i32.load	$push13=, 12($6)
-	i32.const	$push14=, 7
-	i32.add 	$push15=, $pop13, $pop14
-	i32.const	$push16=, -8
-	i32.and 	$push35=, $pop15, $pop16
+	i32.const	$push31=, 3
+	i32.add 	$push3=, $pop2, $pop31
+	i32.const	$push30=, -4
+	i32.and 	$push29=, $pop3, $pop30
+	tee_local	$push28=, $2=, $pop29
+	i32.const	$push27=, 4
+	i32.add 	$push4=, $pop28, $pop27
+	i32.store	$discard=, 12($6), $pop4
+	i32.const	$push26=, 1
+	i32.add 	$1=, $1, $pop26
+	i32.load	$push5=, 0($2)
+	i32.ne  	$push6=, $1, $pop5
+	br_if   	3, $pop6        # 3: down to label1
+# BB#3:                                 # %for.cond
+                                        #   in Loop: Header=BB0_2 Depth=1
+	i32.lt_s	$push7=, $1, $0
+	br_if   	0, $pop7        # 0: up to label3
+.LBB0_4:                                # %for.end
+	end_loop                        # label4:
+	end_block                       # label2:
+	i32.load	$push8=, 12($6)
+	i32.const	$push9=, 7
+	i32.add 	$push10=, $pop8, $pop9
+	i32.const	$push11=, -8
+	i32.and 	$push33=, $pop10, $pop11
+	tee_local	$push32=, $1=, $pop33
+	i32.const	$push12=, 8
+	i32.add 	$push13=, $pop32, $pop12
+	i32.store	$discard=, 12($6), $pop13
+	i64.load	$push14=, 0($1)
+	i64.const	$push15=, 81985529216486895
+	i64.ne  	$push16=, $pop14, $pop15
+	br_if   	1, $pop16       # 1: down to label0
+# BB#5:                                 # %if.end5
+	i32.load	$push17=, 12($6)
+	i32.const	$push18=, 3
+	i32.add 	$push19=, $pop17, $pop18
+	i32.const	$push20=, -4
+	i32.and 	$push35=, $pop19, $pop20
 	tee_local	$push34=, $1=, $pop35
-	i32.const	$push17=, 8
-	i32.add 	$push18=, $pop34, $pop17
-	i32.store	$discard=, 12($6), $pop18
-	i64.load	$push19=, 0($1)
-	i64.const	$push20=, 81985529216486895
-	i64.ne  	$push21=, $pop19, $pop20
-	br_if   	1, $pop21       # 1: down to label1
-# BB#4:                                 # %if.end5
-	i32.load	$push22=, 12($6)
-	i32.const	$push23=, 3
-	i32.add 	$push24=, $pop22, $pop23
-	i32.const	$push25=, -4
-	i32.and 	$push37=, $pop24, $pop25
-	tee_local	$push36=, $1=, $pop37
-	i32.const	$push26=, 4
-	i32.add 	$push27=, $pop36, $pop26
-	i32.store	$discard=, 12($6), $pop27
-	i32.load	$push28=, 0($1)
-	i32.const	$push29=, 85
-	i32.ne  	$push30=, $pop28, $pop29
-	br_if   	2, $pop30       # 2: down to label0
-# BB#5:                                 # %if.end8
+	i32.const	$push21=, 4
+	i32.add 	$push22=, $pop34, $pop21
+	i32.store	$discard=, 12($6), $pop22
+	i32.load	$push23=, 0($1)
+	i32.const	$push24=, 85
+	i32.ne  	$push25=, $pop23, $pop24
+	br_if   	1, $pop25       # 1: down to label0
+# BB#6:                                 # %if.end8
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
-.LBB0_6:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_7:                                # %if.then4
+.LBB0_7:                                # %if.then
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/align-2.c.s
+++ b/test/torture-s/align-2.c.s
@@ -8,146 +8,119 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push95=, 0
 	i32.load8_u	$push0=, s_c_s($pop95):p2align=1
 	i32.const	$push1=, 97
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label27
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push96=, 0
 	i32.load16_u	$push3=, s_c_s+2($pop96)
 	i32.const	$push4=, 13
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label26
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.const	$push97=, 0
 	i32.load8_u	$push6=, s_c_i($pop97):p2align=2
 	i32.const	$push7=, 98
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label25
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end11
 	i32.const	$push98=, 0
 	i32.load	$push9=, s_c_i+4($pop98)
 	i32.const	$push10=, 14
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label24
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end15
 	i32.const	$push99=, 0
 	i32.load16_u	$push12=, s_s_i($pop99):p2align=2
 	i32.const	$push13=, 15
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	4, $pop14       # 4: down to label23
+	br_if   	0, $pop14       # 0: down to label0
 # BB#5:                                 # %if.end20
 	i32.const	$push100=, 0
 	i32.load	$push15=, s_s_i+4($pop100)
 	i32.const	$push16=, 16
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	5, $pop17       # 5: down to label22
+	br_if   	0, $pop17       # 0: down to label0
 # BB#6:                                 # %if.end24
 	i32.const	$push101=, 0
 	i32.load8_u	$push18=, s_c_f($pop101):p2align=2
 	i32.const	$push19=, 99
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	6, $pop20       # 6: down to label21
+	br_if   	0, $pop20       # 0: down to label0
 # BB#7:                                 # %if.end29
 	i32.const	$push102=, 0
 	f32.load	$push21=, s_c_f+4($pop102)
 	f32.const	$push22=, 0x1.1p4
 	f32.ne  	$push23=, $pop21, $pop22
-	br_if   	7, $pop23       # 7: down to label20
+	br_if   	0, $pop23       # 0: down to label0
 # BB#8:                                 # %if.end34
 	i32.const	$push103=, 0
 	i32.load16_u	$push24=, s_s_f($pop103):p2align=2
 	i32.const	$push25=, 18
 	i32.ne  	$push26=, $pop24, $pop25
-	br_if   	8, $pop26       # 8: down to label19
+	br_if   	0, $pop26       # 0: down to label0
 # BB#9:                                 # %if.end39
 	i32.const	$push104=, 0
 	f32.load	$push27=, s_s_f+4($pop104)
 	f32.const	$push28=, 0x1.3p4
 	f32.ne  	$push29=, $pop27, $pop28
-	br_if   	9, $pop29       # 9: down to label18
+	br_if   	0, $pop29       # 0: down to label0
 # BB#10:                                # %if.end44
 	i32.const	$push105=, 0
 	i32.load8_u	$push30=, s_c_d($pop105):p2align=3
 	i32.const	$push31=, 100
 	i32.ne  	$push32=, $pop30, $pop31
-	br_if   	10, $pop32      # 10: down to label17
+	br_if   	0, $pop32       # 0: down to label0
 # BB#11:                                # %if.end49
 	i32.const	$push106=, 0
 	f64.load	$push33=, s_c_d+8($pop106)
 	f64.const	$push34=, 0x1.4p4
 	f64.ne  	$push35=, $pop33, $pop34
-	br_if   	11, $pop35      # 11: down to label16
+	br_if   	0, $pop35       # 0: down to label0
 # BB#12:                                # %if.end53
 	i32.const	$push107=, 0
 	i32.load16_u	$push36=, s_s_d($pop107):p2align=3
 	i32.const	$push37=, 21
 	i32.ne  	$push38=, $pop36, $pop37
-	br_if   	12, $pop38      # 12: down to label15
+	br_if   	0, $pop38       # 0: down to label0
 # BB#13:                                # %if.end58
 	i32.const	$push108=, 0
 	f64.load	$push39=, s_s_d+8($pop108)
 	f64.const	$push40=, 0x1.6p4
 	f64.ne  	$push41=, $pop39, $pop40
-	br_if   	13, $pop41      # 13: down to label14
+	br_if   	0, $pop41       # 0: down to label0
 # BB#14:                                # %if.end62
 	i32.const	$push109=, 0
 	i32.load	$push42=, s_i_d($pop109):p2align=3
 	i32.const	$push43=, 23
 	i32.ne  	$push44=, $pop42, $pop43
-	br_if   	14, $pop44      # 14: down to label13
+	br_if   	0, $pop44       # 0: down to label0
 # BB#15:                                # %if.end66
 	i32.const	$push110=, 0
 	f64.load	$push45=, s_i_d+8($pop110)
 	f64.const	$push46=, 0x1.8p4
 	f64.ne  	$push47=, $pop45, $pop46
-	br_if   	15, $pop47      # 15: down to label12
+	br_if   	0, $pop47       # 0: down to label0
 # BB#16:                                # %if.end70
 	i32.const	$push111=, 0
 	f32.load	$push48=, s_f_d($pop111):p2align=3
 	f32.const	$push49=, 0x1.9p4
 	f32.ne  	$push50=, $pop48, $pop49
-	br_if   	16, $pop50      # 16: down to label11
+	br_if   	0, $pop50       # 0: down to label0
 # BB#17:                                # %if.end75
 	i32.const	$push112=, 0
 	f64.load	$push51=, s_f_d+8($pop112)
 	f64.const	$push52=, 0x1.ap4
 	f64.ne  	$push53=, $pop51, $pop52
-	br_if   	17, $pop53      # 17: down to label10
+	br_if   	0, $pop53       # 0: down to label0
 # BB#18:                                # %if.end79
 	i32.const	$push113=, 0
 	i32.load8_u	$push54=, s_c_ld($pop113):p2align=4
 	i32.const	$push55=, 101
 	i32.ne  	$push56=, $pop54, $pop55
-	br_if   	18, $pop56      # 18: down to label9
+	br_if   	0, $pop56       # 0: down to label0
 # BB#19:                                # %if.end84
 	i32.const	$push115=, 0
 	i64.load	$push58=, s_c_ld+16($pop115):p2align=4
@@ -156,13 +129,13 @@ main:                                   # @main
 	i64.const	$push60=, 0
 	i64.const	$push59=, 4612723957404008448
 	i32.call	$push61=, __eqtf2@FUNCTION, $pop58, $pop57, $pop60, $pop59
-	br_if   	19, $pop61      # 19: down to label8
+	br_if   	0, $pop61       # 0: down to label0
 # BB#20:                                # %if.end88
 	i32.const	$push116=, 0
 	i32.load16_u	$push62=, s_s_ld($pop116):p2align=4
 	i32.const	$push63=, 28
 	i32.ne  	$push64=, $pop62, $pop63
-	br_if   	20, $pop64      # 20: down to label7
+	br_if   	0, $pop64       # 0: down to label0
 # BB#21:                                # %if.end93
 	i32.const	$push118=, 0
 	i64.load	$push66=, s_s_ld+16($pop118):p2align=4
@@ -171,13 +144,13 @@ main:                                   # @main
 	i64.const	$push68=, 0
 	i64.const	$push67=, 4612759141776097280
 	i32.call	$push69=, __eqtf2@FUNCTION, $pop66, $pop65, $pop68, $pop67
-	br_if   	21, $pop69      # 21: down to label6
+	br_if   	0, $pop69       # 0: down to label0
 # BB#22:                                # %if.end97
 	i32.const	$push119=, 0
 	i32.load	$push70=, s_i_ld($pop119):p2align=4
 	i32.const	$push71=, 30
 	i32.ne  	$push72=, $pop70, $pop71
-	br_if   	22, $pop72      # 22: down to label5
+	br_if   	0, $pop72       # 0: down to label0
 # BB#23:                                # %if.end101
 	i32.const	$push121=, 0
 	i64.load	$push74=, s_i_ld+16($pop121):p2align=4
@@ -186,13 +159,13 @@ main:                                   # @main
 	i64.const	$push76=, 0
 	i64.const	$push75=, 4612794326148186112
 	i32.call	$push77=, __eqtf2@FUNCTION, $pop74, $pop73, $pop76, $pop75
-	br_if   	23, $pop77      # 23: down to label4
+	br_if   	0, $pop77       # 0: down to label0
 # BB#24:                                # %if.end105
 	i32.const	$push122=, 0
 	f32.load	$push78=, s_f_ld($pop122):p2align=4
 	f32.const	$push79=, 0x1p5
 	f32.ne  	$push80=, $pop78, $pop79
-	br_if   	24, $pop80      # 24: down to label3
+	br_if   	0, $pop80       # 0: down to label0
 # BB#25:                                # %if.end110
 	i32.const	$push124=, 0
 	i64.load	$push82=, s_f_ld+16($pop124):p2align=4
@@ -201,13 +174,13 @@ main:                                   # @main
 	i64.const	$push84=, 0
 	i64.const	$push83=, 4612820714427252736
 	i32.call	$push85=, __eqtf2@FUNCTION, $pop82, $pop81, $pop84, $pop83
-	br_if   	25, $pop85      # 25: down to label2
+	br_if   	0, $pop85       # 0: down to label0
 # BB#26:                                # %if.end114
 	i32.const	$push125=, 0
 	f64.load	$push86=, s_d_ld($pop125):p2align=4
 	f64.const	$push87=, 0x1.1p5
 	f64.ne  	$push88=, $pop86, $pop87
-	br_if   	26, $pop88      # 26: down to label1
+	br_if   	0, $pop88       # 0: down to label0
 # BB#27:                                # %if.end118
 	i32.const	$push127=, 0
 	i64.load	$push90=, s_d_ld+16($pop127):p2align=4
@@ -216,119 +189,11 @@ main:                                   # @main
 	i64.const	$push92=, 0
 	i64.const	$push91=, 4612838306613297152
 	i32.call	$push93=, __eqtf2@FUNCTION, $pop90, $pop89, $pop92, $pop91
-	br_if   	27, $pop93      # 27: down to label0
+	br_if   	0, $pop93       # 0: down to label0
 # BB#28:                                # %if.end122
 	i32.const	$push94=, 0
 	return  	$pop94
-.LBB0_29:                               # %if.then
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_30:                               # %if.then5
-	end_block                       # label26:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_31:                               # %if.then10
-	end_block                       # label25:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_32:                               # %if.then14
-	end_block                       # label24:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_33:                               # %if.then19
-	end_block                       # label23:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_34:                               # %if.then23
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_35:                               # %if.then28
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_36:                               # %if.then33
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_37:                               # %if.then38
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_38:                               # %if.then43
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_39:                               # %if.then48
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_40:                               # %if.then52
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_41:                               # %if.then57
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_42:                               # %if.then61
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_43:                               # %if.then65
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_44:                               # %if.then69
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_45:                               # %if.then74
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_46:                               # %if.then78
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_47:                               # %if.then83
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_48:                               # %if.then87
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_49:                               # %if.then92
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_50:                               # %if.then96
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_51:                               # %if.then100
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_52:                               # %if.then104
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_53:                               # %if.then109
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_54:                               # %if.then113
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_55:                               # %if.then117
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_56:                               # %if.then121
+.LBB0_29:                               # %if.then121
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/arith-rand-ll.c.s
+++ b/test/torture-s/arith-rand-ll.c.s
@@ -28,12 +28,12 @@ simple_rand:                            # @simple_rand
 	.type	random_bitstring,@function
 random_bitstring:                       # @random_bitstring
 	.result 	i64
-	.local  	i64, i32, i64, i32, i64
+	.local  	i64, i64, i32, i32, i64
 # BB#0:                                 # %entry
-	i32.const	$1=, 0
+	i32.const	$2=, 0
 	i32.const	$push10=, 0
 	i64.load	$0=, simple_rand.seed($pop10)
-	i64.const	$2=, 0
+	i64.const	$1=, 0
 .LBB1_1:                                # %for.cond
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label0:
@@ -55,8 +55,8 @@ random_bitstring:                       # @random_bitstring
                                         #   in Loop: Header=BB1_1 Depth=1
 	i64.const	$push21=, 15
 	i64.and 	$push2=, $4, $pop21
-	i64.shl 	$2=, $2, $pop2
-	i32.add 	$1=, $3, $1
+	i64.shl 	$1=, $1, $pop2
+	i32.add 	$2=, $3, $2
 	block
 	i64.const	$push20=, 256
 	i64.and 	$push3=, $0, $pop20
@@ -70,18 +70,18 @@ random_bitstring:                       # @random_bitstring
 	i32.const	$push22=, -1
 	i32.add 	$push6=, $pop5, $pop22
 	i64.extend_s/i32	$push7=, $pop6
-	i64.or  	$2=, $pop7, $2
+	i64.or  	$1=, $pop7, $1
 .LBB1_4:                                # %if.end
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label2:
 	i32.const	$push24=, 71
-	i32.lt_u	$push8=, $1, $pop24
+	i32.lt_u	$push8=, $2, $pop24
 	br_if   	0, $pop8        # 0: up to label0
 .LBB1_5:                                # %cleanup
 	end_loop                        # label1:
 	i32.const	$push9=, 0
 	i64.store	$discard=, simple_rand.seed($pop9), $0
-	return  	$2
+	return  	$1
 	.endfunc
 .Lfunc_end1:
 	.size	random_bitstring, .Lfunc_end1-random_bitstring
@@ -92,7 +92,7 @@ random_bitstring:                       # @random_bitstring
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i64, i64, i32, i32, i32, i64, i64, i32, i64, i64, i32, i32, i32
+	.local  	i64, i64, i32, i32, i64, i32, i64, i32, i64, i64, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$push76=, 0
 	i64.load	$1=, simple_rand.seed($pop76)
@@ -106,8 +106,8 @@ main:                                   # @main
 	block
 	block
 	loop                            # label7:
-	i64.const	$5=, 0
-	i32.const	$4=, 0
+	i64.const	$4=, 0
+	i32.const	$5=, 0
 .LBB2_2:                                # %for.cond.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
@@ -130,8 +130,8 @@ main:                                   # @main
                                         #   in Loop: Header=BB2_2 Depth=2
 	i64.const	$push87=, 15
 	i64.and 	$push2=, $6, $pop87
-	i64.shl 	$5=, $5, $pop2
-	i32.add 	$4=, $7, $4
+	i64.shl 	$4=, $4, $pop2
+	i32.add 	$5=, $7, $5
 	block
 	i64.const	$push86=, 256
 	i64.and 	$push3=, $1, $pop86
@@ -145,18 +145,18 @@ main:                                   # @main
 	i32.const	$push88=, -1
 	i32.add 	$push6=, $pop5, $pop88
 	i64.extend_s/i32	$push7=, $pop6
-	i64.or  	$5=, $pop7, $5
+	i64.or  	$4=, $pop7, $4
 .LBB2_5:                                # %if.end.i
                                         #   in Loop: Header=BB2_2 Depth=2
 	end_block                       # label11:
 	i32.const	$push90=, 71
-	i32.lt_u	$push8=, $4, $pop90
+	i32.lt_u	$push8=, $5, $pop90
 	br_if   	0, $pop8        # 0: up to label9
 .LBB2_6:                                # %random_bitstring.exit
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_loop                        # label10:
 	i64.const	$6=, 0
-	i32.const	$4=, 0
+	i32.const	$5=, 0
 .LBB2_7:                                # %for.cond.i452
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
@@ -180,7 +180,7 @@ main:                                   # @main
 	i64.const	$push101=, 15
 	i64.and 	$push11=, $8, $pop101
 	i64.shl 	$6=, $6, $pop11
-	i32.add 	$4=, $7, $4
+	i32.add 	$5=, $7, $5
 	block
 	i64.const	$push100=, 256
 	i64.and 	$push12=, $1, $pop100
@@ -199,7 +199,7 @@ main:                                   # @main
                                         #   in Loop: Header=BB2_7 Depth=2
 	end_block                       # label14:
 	i32.const	$push104=, 71
-	i32.lt_u	$push17=, $4, $pop104
+	i32.lt_u	$push17=, $5, $pop104
 	br_if   	0, $pop17       # 0: up to label12
 .LBB2_11:                               # %random_bitstring.exit467
                                         #   in Loop: Header=BB2_1 Depth=1
@@ -212,7 +212,7 @@ main:                                   # @main
                                         #   in Loop: Header=BB2_1 Depth=1
 	block
 	i64.const	$push107=, 9223372036854775807
-	i64.and 	$push19=, $5, $pop107
+	i64.and 	$push19=, $4, $pop107
 	i64.const	$push106=, 0
 	i64.ne  	$push20=, $pop19, $pop106
 	br_if   	0, $pop20       # 0: down to label16
@@ -224,7 +224,7 @@ main:                                   # @main
 .LBB2_14:                               # %if.end17
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_block                       # label16:
-	i64.rem_s	$8=, $5, $6
+	i64.rem_s	$8=, $4, $6
 	i64.const	$push114=, 63
 	i64.shr_s	$push113=, $8, $pop114
 	tee_local	$push112=, $9=, $pop113
@@ -240,14 +240,14 @@ main:                                   # @main
 # BB#15:                                # %save_time
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.wrap/i64	$push116=, $6
-	tee_local	$push115=, $4=, $pop116
+	tee_local	$push115=, $5=, $pop116
 	i32.const	$push179=, 0
 	i32.eq  	$push180=, $pop115, $pop179
 	br_if   	0, $pop180      # 0: down to label15
 # BB#16:                                # %cleanup.cont65
                                         #   in Loop: Header=BB2_1 Depth=1
 	block
-	i32.wrap/i64	$push119=, $5
+	i32.wrap/i64	$push119=, $4
 	tee_local	$push118=, $7=, $pop119
 	i32.const	$push117=, 2147483647
 	i32.and 	$push28=, $pop118, $pop117
@@ -255,21 +255,21 @@ main:                                   # @main
 # BB#17:                                # %cleanup.cont65
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push120=, -1
-	i32.eq  	$push29=, $4, $pop120
+	i32.eq  	$push29=, $5, $pop120
 	br_if   	1, $pop29       # 1: down to label15
 .LBB2_18:                               # %if.end79
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_block                       # label17:
-	i32.rem_s	$2=, $7, $4
+	i32.rem_s	$2=, $7, $5
 	i32.const	$push126=, 31
 	i32.shr_s	$push125=, $2, $pop126
 	tee_local	$push124=, $3=, $pop125
 	i32.add 	$push32=, $2, $pop124
 	i32.xor 	$push33=, $pop32, $3
 	i32.const	$push123=, 31
-	i32.shr_s	$push122=, $4, $pop123
+	i32.shr_s	$push122=, $5, $pop123
 	tee_local	$push121=, $3=, $pop122
-	i32.add 	$push30=, $4, $pop121
+	i32.add 	$push30=, $5, $pop121
 	i32.xor 	$push31=, $pop30, $3
 	i32.ge_u	$push34=, $pop33, $pop31
 	br_if   	4, $pop34       # 4: down to label5
@@ -289,7 +289,7 @@ main:                                   # @main
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_block                       # label18:
 	i32.const	$push128=, 65535
-	i32.and 	$push37=, $4, $pop128
+	i32.and 	$push37=, $5, $pop128
 	i32.const	$push183=, 0
 	i32.eq  	$push184=, $pop37, $pop183
 	br_if   	0, $pop184      # 0: down to label15
@@ -301,7 +301,7 @@ main:                                   # @main
 	i32.shr_s	$push145=, $pop38, $pop146
 	tee_local	$push144=, $12=, $pop145
 	i32.const	$push143=, 16
-	i32.shl 	$push142=, $4, $pop143
+	i32.shl 	$push142=, $5, $pop143
 	tee_local	$push141=, $11=, $pop142
 	i32.const	$push140=, 16
 	i32.shr_s	$push139=, $pop141, $pop140
@@ -340,7 +340,7 @@ main:                                   # @main
 # BB#24:                                # %if.end209
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push150=, 255
-	i32.and 	$push55=, $4, $pop150
+	i32.and 	$push55=, $5, $pop150
 	i32.const	$push185=, 0
 	i32.eq  	$push186=, $pop55, $pop185
 	br_if   	0, $pop186      # 0: down to label15
@@ -352,11 +352,11 @@ main:                                   # @main
 	i32.shr_s	$push167=, $pop56, $pop168
 	tee_local	$push166=, $2=, $pop167
 	i32.const	$push165=, 24
-	i32.shl 	$push164=, $4, $pop165
+	i32.shl 	$push164=, $5, $pop165
 	tee_local	$push163=, $3=, $pop164
 	i32.const	$push162=, 24
 	i32.shr_s	$push161=, $pop163, $pop162
-	tee_local	$push160=, $4=, $pop161
+	tee_local	$push160=, $5=, $pop161
 	i32.rem_s	$push57=, $pop166, $pop160
 	i32.const	$push159=, 24
 	i32.shl 	$push158=, $pop57, $pop159
@@ -369,18 +369,18 @@ main:                                   # @main
 	i32.gt_s	$push58=, $12, $pop154
 	i32.select	$push60=, $7, $pop59, $pop58
 	i32.const	$push153=, 0
-	i32.sub 	$push62=, $pop153, $4
+	i32.sub 	$push62=, $pop153, $5
 	i32.const	$push152=, -16777216
 	i32.gt_s	$push61=, $3, $pop152
-	i32.select	$push63=, $4, $pop62, $pop61
+	i32.select	$push63=, $5, $pop62, $pop61
 	i32.const	$push151=, 255
 	i32.and 	$push64=, $pop63, $pop151
 	i32.ge_s	$push65=, $pop60, $pop64
 	br_if   	6, $pop65       # 6: down to label3
 # BB#26:                                # %lor.lhs.false288
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.div_s	$push66=, $2, $4
-	i32.mul 	$push67=, $pop66, $4
+	i32.div_s	$push66=, $2, $5
+	i32.mul 	$push67=, $pop66, $5
 	i32.add 	$push68=, $pop67, $7
 	i32.const	$push171=, 24
 	i32.shl 	$push69=, $pop68, $pop171

--- a/test/torture-s/arith-rand.c.s
+++ b/test/torture-s/arith-rand.c.s
@@ -30,10 +30,10 @@ random_bitstring:                       # @random_bitstring
 	.result 	i32
 	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$2=, 0
+	i32.const	$1=, 0
 	i32.const	$push7=, 0
 	i32.load	$0=, simple_rand.seed($pop7)
-	i32.const	$1=, 0
+	i32.const	$2=, 0
 .LBB1_1:                                # %for.cond
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label0:
@@ -51,8 +51,8 @@ random_bitstring:                       # @random_bitstring
 	br_if   	1, $pop19       # 1: down to label1
 # BB#2:                                 # %if.else
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.add 	$1=, $3, $1
-	i32.shl 	$2=, $2, $3
+	i32.add 	$2=, $3, $2
+	i32.shl 	$1=, $1, $3
 	block
 	i32.const	$push14=, 256
 	i32.and 	$push2=, $0, $pop14
@@ -65,18 +65,18 @@ random_bitstring:                       # @random_bitstring
 	i32.shl 	$push3=, $pop16, $3
 	i32.const	$push15=, -1
 	i32.add 	$push4=, $pop3, $pop15
-	i32.or  	$2=, $pop4, $2
+	i32.or  	$1=, $pop4, $1
 .LBB1_4:                                # %if.end
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_block                       # label2:
 	i32.const	$push17=, 39
-	i32.lt_u	$push5=, $1, $pop17
+	i32.lt_u	$push5=, $2, $pop17
 	br_if   	0, $pop5        # 0: up to label0
 .LBB1_5:                                # %cleanup
 	end_loop                        # label1:
 	i32.const	$push6=, 0
 	i32.store	$discard=, simple_rand.seed($pop6), $0
-	return  	$2
+	return  	$1
 	.endfunc
 .Lfunc_end1:
 	.size	random_bitstring, .Lfunc_end1-random_bitstring
@@ -101,7 +101,7 @@ main:                                   # @main
 	block
 	loop                            # label6:
 	i32.const	$2=, 0
-	i32.const	$4=, 0
+	i32.const	$3=, 0
 .LBB2_2:                                # %for.cond.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
@@ -120,7 +120,7 @@ main:                                   # @main
 	br_if   	1, $pop135      # 1: down to label9
 # BB#3:                                 # %if.else.i
                                         #   in Loop: Header=BB2_2 Depth=2
-	i32.add 	$4=, $5, $4
+	i32.add 	$3=, $5, $3
 	i32.shl 	$2=, $2, $5
 	block
 	i32.const	$push65=, 256
@@ -139,13 +139,13 @@ main:                                   # @main
                                         #   in Loop: Header=BB2_2 Depth=2
 	end_block                       # label10:
 	i32.const	$push68=, 39
-	i32.lt_u	$push5=, $4, $pop68
+	i32.lt_u	$push5=, $3, $pop68
 	br_if   	0, $pop5        # 0: up to label8
 .LBB2_6:                                # %random_bitstring.exit
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_loop                        # label9:
-	i32.const	$4=, 0
 	i32.const	$3=, 0
+	i32.const	$4=, 0
 .LBB2_7:                                # %for.cond.i339
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
@@ -164,8 +164,8 @@ main:                                   # @main
 	br_if   	1, $pop139      # 1: down to label12
 # BB#8:                                 # %if.else.i343
                                         #   in Loop: Header=BB2_7 Depth=2
-	i32.add 	$3=, $5, $3
-	i32.shl 	$4=, $4, $5
+	i32.add 	$4=, $5, $4
+	i32.shl 	$3=, $3, $5
 	block
 	i32.const	$push75=, 256
 	i32.and 	$push8=, $1, $pop75
@@ -178,19 +178,19 @@ main:                                   # @main
 	i32.shl 	$push9=, $pop77, $5
 	i32.const	$push76=, -1
 	i32.add 	$push10=, $pop9, $pop76
-	i32.or  	$4=, $pop10, $4
+	i32.or  	$3=, $pop10, $3
 .LBB2_10:                               # %if.end.i350
                                         #   in Loop: Header=BB2_7 Depth=2
 	end_block                       # label13:
 	i32.const	$push78=, 39
-	i32.lt_u	$push11=, $3, $pop78
+	i32.lt_u	$push11=, $4, $pop78
 	br_if   	0, $pop11       # 0: up to label11
 .LBB2_11:                               # %random_bitstring.exit352
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_loop                        # label12:
 	block
 	i32.const	$push142=, 0
-	i32.eq  	$push143=, $4, $pop142
+	i32.eq  	$push143=, $3, $pop142
 	br_if   	0, $pop143      # 0: down to label14
 # BB#12:                                # %cleanup.cont
                                         #   in Loop: Header=BB2_1 Depth=1
@@ -201,28 +201,28 @@ main:                                   # @main
 # BB#13:                                # %cleanup.cont
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push80=, -1
-	i32.eq  	$push13=, $4, $pop80
+	i32.eq  	$push13=, $3, $pop80
 	br_if   	1, $pop13       # 1: down to label14
 .LBB2_14:                               # %if.end25
                                         #   in Loop: Header=BB2_1 Depth=1
 	end_block                       # label15:
-	i32.rem_s	$5=, $2, $4
+	i32.rem_s	$5=, $2, $3
 	i32.const	$push86=, 31
 	i32.shr_s	$push85=, $5, $pop86
-	tee_local	$push84=, $3=, $pop85
+	tee_local	$push84=, $4=, $pop85
 	i32.add 	$push16=, $5, $pop84
-	i32.xor 	$push17=, $pop16, $3
+	i32.xor 	$push17=, $pop16, $4
 	i32.const	$push83=, 31
-	i32.shr_s	$push82=, $4, $pop83
+	i32.shr_s	$push82=, $3, $pop83
 	tee_local	$push81=, $5=, $pop82
-	i32.add 	$push14=, $4, $pop81
+	i32.add 	$push14=, $3, $pop81
 	i32.xor 	$push15=, $pop14, $5
 	i32.ge_u	$push18=, $pop17, $pop15
 	br_if   	4, $pop18       # 4: down to label4
 # BB#15:                                # %cleanup.cont47
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push87=, 65535
-	i32.and 	$push20=, $4, $pop87
+	i32.and 	$push20=, $3, $pop87
 	i32.const	$push144=, 0
 	i32.eq  	$push145=, $pop20, $pop144
 	br_if   	0, $pop145      # 0: down to label14
@@ -234,7 +234,7 @@ main:                                   # @main
 	i32.shr_s	$push104=, $pop21, $pop105
 	tee_local	$push103=, $8=, $pop104
 	i32.const	$push102=, 16
-	i32.shl 	$push101=, $4, $pop102
+	i32.shl 	$push101=, $3, $pop102
 	tee_local	$push100=, $7=, $pop101
 	i32.const	$push99=, 16
 	i32.shr_s	$push98=, $pop100, $pop99
@@ -244,12 +244,12 @@ main:                                   # @main
 	i32.shl 	$push95=, $pop22, $pop96
 	tee_local	$push94=, $6=, $pop95
 	i32.const	$push93=, 16
-	i32.shr_s	$3=, $pop94, $pop93
+	i32.shr_s	$4=, $pop94, $pop93
 	i32.const	$push92=, 0
-	i32.sub 	$push24=, $pop92, $3
+	i32.sub 	$push24=, $pop92, $4
 	i32.const	$push91=, -65536
 	i32.gt_s	$push23=, $6, $pop91
-	i32.select	$push25=, $3, $pop24, $pop23
+	i32.select	$push25=, $4, $pop24, $pop23
 	i32.const	$push90=, 0
 	i32.sub 	$push27=, $pop90, $5
 	i32.const	$push89=, -65536
@@ -263,7 +263,7 @@ main:                                   # @main
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.div_s	$push31=, $8, $5
 	i32.mul 	$push32=, $pop31, $5
-	i32.add 	$push33=, $pop32, $3
+	i32.add 	$push33=, $pop32, $4
 	i32.const	$push108=, 16
 	i32.shl 	$push34=, $pop33, $pop108
 	i32.const	$push107=, 16
@@ -273,7 +273,7 @@ main:                                   # @main
 # BB#18:                                # %if.end137
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push109=, 255
-	i32.and 	$push38=, $4, $pop109
+	i32.and 	$push38=, $3, $pop109
 	i32.const	$push146=, 0
 	i32.eq  	$push147=, $pop38, $pop146
 	br_if   	0, $pop147      # 0: down to label14
@@ -285,8 +285,8 @@ main:                                   # @main
 	i32.shr_s	$push126=, $pop39, $pop127
 	tee_local	$push125=, $2=, $pop126
 	i32.const	$push124=, 24
-	i32.shl 	$push123=, $4, $pop124
-	tee_local	$push122=, $3=, $pop123
+	i32.shl 	$push123=, $3, $pop124
+	tee_local	$push122=, $4=, $pop123
 	i32.const	$push121=, 24
 	i32.shr_s	$push120=, $pop122, $pop121
 	tee_local	$push119=, $5=, $pop120
@@ -295,16 +295,16 @@ main:                                   # @main
 	i32.shl 	$push117=, $pop40, $pop118
 	tee_local	$push116=, $8=, $pop117
 	i32.const	$push115=, 24
-	i32.shr_s	$4=, $pop116, $pop115
+	i32.shr_s	$3=, $pop116, $pop115
 	i32.const	$push114=, 0
-	i32.sub 	$push42=, $pop114, $4
+	i32.sub 	$push42=, $pop114, $3
 	i32.const	$push113=, -16777216
 	i32.gt_s	$push41=, $8, $pop113
-	i32.select	$push43=, $4, $pop42, $pop41
+	i32.select	$push43=, $3, $pop42, $pop41
 	i32.const	$push112=, 0
 	i32.sub 	$push45=, $pop112, $5
 	i32.const	$push111=, -16777216
-	i32.gt_s	$push44=, $3, $pop111
+	i32.gt_s	$push44=, $4, $pop111
 	i32.select	$push46=, $5, $pop45, $pop44
 	i32.const	$push110=, 255
 	i32.and 	$push47=, $pop46, $pop110
@@ -314,7 +314,7 @@ main:                                   # @main
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.div_s	$push49=, $2, $5
 	i32.mul 	$push50=, $pop49, $5
-	i32.add 	$push51=, $pop50, $4
+	i32.add 	$push51=, $pop50, $3
 	i32.const	$push130=, 24
 	i32.shl 	$push52=, $pop51, $pop130
 	i32.const	$push129=, 24

--- a/test/torture-s/ashldi-1.c.s
+++ b/test/torture-s/ashldi-1.c.s
@@ -6,58 +6,59 @@
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i64, i32, i32
+	.local  	i64, i32, i32
 # BB#0:                                 # %entry
-	i64.const	$1=, 0
-	i32.const	$0=, .Lswitch.table
+	i64.const	$0=, 0
+	i32.const	$2=, .Lswitch.table
 .LBB0_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label1:
-	i64.const	$push12=, 81985529216486895
-	i64.shl 	$push0=, $pop12, $1
-	i64.load	$push1=, 0($0)
+	i64.const	$push9=, 81985529216486895
+	i64.shl 	$push0=, $pop9, $0
+	i64.load	$push1=, 0($2)
 	i64.ne  	$push2=, $pop0, $pop1
 	br_if   	2, $pop2        # 2: down to label0
 # BB#2:                                 # %for.cond
                                         #   in Loop: Header=BB0_1 Depth=1
-	i64.const	$push11=, 1
-	i64.add 	$1=, $1, $pop11
-	i32.const	$push10=, 8
-	i32.add 	$0=, $0, $pop10
-	i32.const	$3=, 0
-	i32.const	$2=, .Lswitch.table
-	i64.const	$push9=, 63
-	i64.le_s	$push3=, $1, $pop9
+	i64.const	$push8=, 1
+	i64.add 	$0=, $0, $pop8
+	i32.const	$push7=, 8
+	i32.add 	$2=, $2, $pop7
+	i64.const	$push6=, 63
+	i64.le_s	$push3=, $0, $pop6
 	br_if   	0, $pop3        # 0: up to label1
-.LBB0_3:                                # %constant_shift.exit
-                                        # =>This Inner Loop Header: Depth=1
+# BB#3:
 	end_loop                        # label2:
+	i32.const	$2=, 0
+	i32.const	$1=, .Lswitch.table
+.LBB0_4:                                # %constant_shift.exit
+                                        # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label4:
-	i32.const	$push4=, 1
-	i32.const	$push14=, 0
-	i32.eq  	$push15=, $pop4, $pop14
-	br_if   	2, $pop15       # 2: down to label3
-# BB#4:                                 # %for.cond2
-                                        #   in Loop: Header=BB0_3 Depth=1
 	i32.const	$push13=, 1
-	i32.add 	$3=, $3, $pop13
-	i32.const	$push5=, 8
-	i32.add 	$2=, $2, $pop5
-	i32.const	$push6=, 63
-	i32.le_s	$push7=, $3, $pop6
-	br_if   	0, $pop7        # 0: up to label4
-# BB#5:                                 # %for.end13
+	i32.const	$push14=, 0
+	i32.eq  	$push15=, $pop13, $pop14
+	br_if   	2, $pop15       # 2: down to label3
+# BB#5:                                 # %for.cond2
+                                        #   in Loop: Header=BB0_4 Depth=1
+	i32.const	$push12=, 1
+	i32.add 	$2=, $2, $pop12
+	i32.const	$push11=, 8
+	i32.add 	$1=, $1, $pop11
+	i32.const	$push10=, 63
+	i32.le_s	$push4=, $2, $pop10
+	br_if   	0, $pop4        # 0: up to label4
+# BB#6:                                 # %for.end13
 	end_loop                        # label5:
-	i32.const	$push8=, 0
-	call    	exit@FUNCTION, $pop8
+	i32.const	$push5=, 0
+	call    	exit@FUNCTION, $pop5
 	unreachable
-.LBB0_6:                                # %if.then9
+.LBB0_7:                                # %if.then9
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_7:                                # %if.then
+.LBB0_8:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/ashrdi-1.c.s
+++ b/test/torture-s/ashrdi-1.c.s
@@ -6,109 +6,107 @@
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i64, i64, i32, i32, i32, i32
+	.local  	i64, i32, i32
 # BB#0:                                 # %entry
 	i64.const	$0=, 0
-	i32.const	$4=, zext
+	i32.const	$2=, zext
 .LBB0_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block
 	block
-	block
-	loop                            # label3:
-	i64.const	$push32=, 8526495107234113920
-	i64.shr_u	$push0=, $pop32, $0
-	i64.load	$push1=, 0($4)
+	loop                            # label2:
+	i64.const	$push20=, 8526495107234113920
+	i64.shr_u	$push0=, $pop20, $0
+	i64.load	$push1=, 0($2)
 	i64.ne  	$push2=, $pop0, $pop1
-	br_if   	2, $pop2        # 2: down to label2
+	br_if   	2, $pop2        # 2: down to label1
 # BB#2:                                 # %for.cond
                                         #   in Loop: Header=BB0_1 Depth=1
-	i64.const	$push31=, 1
-	i64.add 	$0=, $0, $pop31
-	i32.const	$push30=, 8
-	i32.add 	$4=, $4, $pop30
-	i64.const	$1=, 0
-	i32.const	$5=, sext
-	i64.const	$push29=, 63
-	i64.le_s	$push3=, $0, $pop29
-	br_if   	0, $pop3        # 0: up to label3
-.LBB0_3:                                # %for.body4
+	i64.const	$push19=, 1
+	i64.add 	$0=, $0, $pop19
+	i32.const	$push18=, 8
+	i32.add 	$2=, $2, $pop18
+	i64.const	$push17=, 63
+	i64.le_s	$push3=, $0, $pop17
+	br_if   	0, $pop3        # 0: up to label2
+# BB#3:
+	end_loop                        # label3:
+	i64.const	$0=, 0
+	i32.const	$2=, sext
+.LBB0_4:                                # %for.body4
                                         # =>This Inner Loop Header: Depth=1
-	end_loop                        # label4:
-	loop                            # label5:
-	i64.const	$push4=, -8152436031399644656
-	i64.shr_s	$push5=, $pop4, $1
-	i64.load	$push6=, 0($5)
-	i64.ne  	$push7=, $pop5, $pop6
-	br_if   	3, $pop7        # 3: down to label1
-# BB#4:                                 # %for.cond2
-                                        #   in Loop: Header=BB0_3 Depth=1
-	i32.const	$push9=, 8
-	i32.add 	$5=, $5, $pop9
-	i64.const	$push8=, 1
-	i64.add 	$1=, $1, $pop8
-	i32.const	$3=, 0
-	i32.const	$2=, zext
-	i64.const	$push10=, 63
-	i64.le_s	$push11=, $1, $pop10
-	br_if   	0, $pop11       # 0: up to label5
-.LBB0_5:                                # %for.body16
+	loop                            # label4:
+	i64.const	$push24=, -8152436031399644656
+	i64.shr_s	$push4=, $pop24, $0
+	i64.load	$push5=, 0($2)
+	i64.ne  	$push6=, $pop4, $pop5
+	br_if   	2, $pop6        # 2: down to label1
+# BB#5:                                 # %for.cond2
+                                        #   in Loop: Header=BB0_4 Depth=1
+	i64.const	$push23=, 1
+	i64.add 	$0=, $0, $pop23
+	i32.const	$push22=, 8
+	i32.add 	$2=, $2, $pop22
+	i64.const	$push21=, 63
+	i64.le_s	$push7=, $0, $pop21
+	br_if   	0, $pop7        # 0: up to label4
+# BB#6:
+	end_loop                        # label5:
+	i32.const	$2=, 0
+	i32.const	$1=, zext
+.LBB0_7:                                # %for.body16
                                         # =>This Inner Loop Header: Depth=1
-	end_loop                        # label6:
-	loop                            # label7:
-	i64.const	$push12=, 8526495107234113920
-	i64.call	$push13=, constant_shift@FUNCTION, $pop12, $3
-	i64.load	$push14=, 0($2)
-	i64.ne  	$push15=, $pop13, $pop14
-	br_if   	4, $pop15       # 4: down to label0
-# BB#6:                                 # %for.cond14
-                                        #   in Loop: Header=BB0_5 Depth=1
-	i32.const	$push16=, 1
-	i32.add 	$3=, $3, $pop16
-	i32.const	$push17=, 8
-	i32.add 	$2=, $2, $pop17
-	i32.const	$5=, 0
-	i32.const	$4=, sext
-	i32.const	$push18=, 63
-	i32.le_s	$push19=, $3, $pop18
-	br_if   	0, $pop19       # 0: up to label7
-.LBB0_7:                                # %for.body28
-                                        # =>This Inner Loop Header: Depth=1
-	end_loop                        # label8:
-	block
-	loop                            # label10:
-	i64.const	$push20=, -8152436031399644656
-	i64.call	$push21=, constant_shift@FUNCTION, $pop20, $5
-	i64.load	$push22=, 0($4)
-	i64.ne  	$push23=, $pop21, $pop22
-	br_if   	2, $pop23       # 2: down to label9
-# BB#8:                                 # %for.cond26
+	loop                            # label6:
+	i64.const	$push28=, 8526495107234113920
+	i64.call	$push8=, constant_shift@FUNCTION, $pop28, $2
+	i64.load	$push9=, 0($1)
+	i64.ne  	$push10=, $pop8, $pop9
+	br_if   	3, $pop10       # 3: down to label0
+# BB#8:                                 # %for.cond14
                                         #   in Loop: Header=BB0_7 Depth=1
-	i32.const	$push24=, 1
-	i32.add 	$5=, $5, $pop24
-	i32.const	$push25=, 8
-	i32.add 	$4=, $4, $pop25
-	i32.const	$push26=, 63
-	i32.le_s	$push27=, $5, $pop26
-	br_if   	0, $pop27       # 0: up to label10
-# BB#9:                                 # %for.end37
-	end_loop                        # label11:
-	i32.const	$push28=, 0
-	call    	exit@FUNCTION, $pop28
+	i32.const	$push27=, 1
+	i32.add 	$2=, $2, $pop27
+	i32.const	$push26=, 8
+	i32.add 	$1=, $1, $pop26
+	i32.const	$push25=, 63
+	i32.le_s	$push11=, $2, $pop25
+	br_if   	0, $pop11       # 0: up to label6
+# BB#9:
+	end_loop                        # label7:
+	i32.const	$2=, 0
+	i32.const	$1=, sext
+.LBB0_10:                               # %for.body28
+                                        # =>This Inner Loop Header: Depth=1
+	block
+	loop                            # label9:
+	i64.const	$push32=, -8152436031399644656
+	i64.call	$push12=, constant_shift@FUNCTION, $pop32, $2
+	i64.load	$push13=, 0($1)
+	i64.ne  	$push14=, $pop12, $pop13
+	br_if   	2, $pop14       # 2: down to label8
+# BB#11:                                # %for.cond26
+                                        #   in Loop: Header=BB0_10 Depth=1
+	i32.const	$push31=, 1
+	i32.add 	$2=, $2, $pop31
+	i32.const	$push30=, 8
+	i32.add 	$1=, $1, $pop30
+	i32.const	$push29=, 63
+	i32.le_s	$push15=, $2, $pop29
+	br_if   	0, $pop15       # 0: up to label9
+# BB#12:                                # %for.end37
+	end_loop                        # label10:
+	i32.const	$push16=, 0
+	call    	exit@FUNCTION, $pop16
 	unreachable
-.LBB0_10:                               # %if.then33
-	end_block                       # label9:
+.LBB0_13:                               # %if.then33
+	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_11:                               # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then9
+.LBB0_14:                               # %if.then
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_13:                               # %if.then21
+.LBB0_15:                               # %if.then21
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -125,7 +123,7 @@ constant_shift:                         # @constant_shift
 	block
 	i32.const	$push0=, 63
 	i32.gt_u	$push1=, $1, $pop0
-	br_if   	0, $pop1        # 0: down to label12
+	br_if   	0, $pop1        # 0: down to label11
 # BB#1:                                 # %entry
 	block
 	block
@@ -191,389 +189,389 @@ constant_shift:                         # @constant_shift
 	block
 	block
 	block
-	tableswitch	$1, 63, 63, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62 # 63: down to label13
-                                        # 0: down to label76
-                                        # 1: down to label75
-                                        # 2: down to label74
-                                        # 3: down to label73
-                                        # 4: down to label72
-                                        # 5: down to label71
-                                        # 6: down to label70
-                                        # 7: down to label69
-                                        # 8: down to label68
-                                        # 9: down to label67
-                                        # 10: down to label66
-                                        # 11: down to label65
-                                        # 12: down to label64
-                                        # 13: down to label63
-                                        # 14: down to label62
-                                        # 15: down to label61
-                                        # 16: down to label60
-                                        # 17: down to label59
-                                        # 18: down to label58
-                                        # 19: down to label57
-                                        # 20: down to label56
-                                        # 21: down to label55
-                                        # 22: down to label54
-                                        # 23: down to label53
-                                        # 24: down to label52
-                                        # 25: down to label51
-                                        # 26: down to label50
-                                        # 27: down to label49
-                                        # 28: down to label48
-                                        # 29: down to label47
-                                        # 30: down to label46
-                                        # 31: down to label45
-                                        # 32: down to label44
-                                        # 33: down to label43
-                                        # 34: down to label42
-                                        # 35: down to label41
-                                        # 36: down to label40
-                                        # 37: down to label39
-                                        # 38: down to label38
-                                        # 39: down to label37
-                                        # 40: down to label36
-                                        # 41: down to label35
-                                        # 42: down to label34
-                                        # 43: down to label33
-                                        # 44: down to label32
-                                        # 45: down to label31
-                                        # 46: down to label30
-                                        # 47: down to label29
-                                        # 48: down to label28
-                                        # 49: down to label27
-                                        # 50: down to label26
-                                        # 51: down to label25
-                                        # 52: down to label24
-                                        # 53: down to label23
-                                        # 54: down to label22
-                                        # 55: down to label21
-                                        # 56: down to label20
-                                        # 57: down to label19
-                                        # 58: down to label18
-                                        # 59: down to label17
-                                        # 60: down to label16
-                                        # 61: down to label15
-                                        # 62: down to label14
+	tableswitch	$1, 63, 63, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62 # 63: down to label12
+                                        # 0: down to label75
+                                        # 1: down to label74
+                                        # 2: down to label73
+                                        # 3: down to label72
+                                        # 4: down to label71
+                                        # 5: down to label70
+                                        # 6: down to label69
+                                        # 7: down to label68
+                                        # 8: down to label67
+                                        # 9: down to label66
+                                        # 10: down to label65
+                                        # 11: down to label64
+                                        # 12: down to label63
+                                        # 13: down to label62
+                                        # 14: down to label61
+                                        # 15: down to label60
+                                        # 16: down to label59
+                                        # 17: down to label58
+                                        # 18: down to label57
+                                        # 19: down to label56
+                                        # 20: down to label55
+                                        # 21: down to label54
+                                        # 22: down to label53
+                                        # 23: down to label52
+                                        # 24: down to label51
+                                        # 25: down to label50
+                                        # 26: down to label49
+                                        # 27: down to label48
+                                        # 28: down to label47
+                                        # 29: down to label46
+                                        # 30: down to label45
+                                        # 31: down to label44
+                                        # 32: down to label43
+                                        # 33: down to label42
+                                        # 34: down to label41
+                                        # 35: down to label40
+                                        # 36: down to label39
+                                        # 37: down to label38
+                                        # 38: down to label37
+                                        # 39: down to label36
+                                        # 40: down to label35
+                                        # 41: down to label34
+                                        # 42: down to label33
+                                        # 43: down to label32
+                                        # 44: down to label31
+                                        # 45: down to label30
+                                        # 46: down to label29
+                                        # 47: down to label28
+                                        # 48: down to label27
+                                        # 49: down to label26
+                                        # 50: down to label25
+                                        # 51: down to label24
+                                        # 52: down to label23
+                                        # 53: down to label22
+                                        # 54: down to label21
+                                        # 55: down to label20
+                                        # 56: down to label19
+                                        # 57: down to label18
+                                        # 58: down to label17
+                                        # 59: down to label16
+                                        # 60: down to label15
+                                        # 61: down to label14
+                                        # 62: down to label13
 .LBB1_2:                                # %sw.bb1
-	end_block                       # label76:
+	end_block                       # label75:
 	i64.const	$push64=, 1
 	i64.shr_s	$0=, $0, $pop64
-	br      	62              # 62: down to label13
+	br      	62              # 62: down to label12
 .LBB1_3:                                # %sw.bb3
-	end_block                       # label75:
+	end_block                       # label74:
 	i64.const	$push63=, 2
 	i64.shr_s	$0=, $0, $pop63
-	br      	61              # 61: down to label13
+	br      	61              # 61: down to label12
 .LBB1_4:                                # %sw.bb5
-	end_block                       # label74:
+	end_block                       # label73:
 	i64.const	$push62=, 3
 	i64.shr_s	$0=, $0, $pop62
-	br      	60              # 60: down to label13
+	br      	60              # 60: down to label12
 .LBB1_5:                                # %sw.bb7
-	end_block                       # label73:
+	end_block                       # label72:
 	i64.const	$push61=, 4
 	i64.shr_s	$0=, $0, $pop61
-	br      	59              # 59: down to label13
+	br      	59              # 59: down to label12
 .LBB1_6:                                # %sw.bb9
-	end_block                       # label72:
+	end_block                       # label71:
 	i64.const	$push60=, 5
 	i64.shr_s	$0=, $0, $pop60
-	br      	58              # 58: down to label13
+	br      	58              # 58: down to label12
 .LBB1_7:                                # %sw.bb11
-	end_block                       # label71:
+	end_block                       # label70:
 	i64.const	$push59=, 6
 	i64.shr_s	$0=, $0, $pop59
-	br      	57              # 57: down to label13
+	br      	57              # 57: down to label12
 .LBB1_8:                                # %sw.bb13
-	end_block                       # label70:
+	end_block                       # label69:
 	i64.const	$push58=, 7
 	i64.shr_s	$0=, $0, $pop58
-	br      	56              # 56: down to label13
+	br      	56              # 56: down to label12
 .LBB1_9:                                # %sw.bb15
-	end_block                       # label69:
+	end_block                       # label68:
 	i64.const	$push57=, 8
 	i64.shr_s	$0=, $0, $pop57
-	br      	55              # 55: down to label13
+	br      	55              # 55: down to label12
 .LBB1_10:                               # %sw.bb17
-	end_block                       # label68:
+	end_block                       # label67:
 	i64.const	$push56=, 9
 	i64.shr_s	$0=, $0, $pop56
-	br      	54              # 54: down to label13
+	br      	54              # 54: down to label12
 .LBB1_11:                               # %sw.bb19
-	end_block                       # label67:
+	end_block                       # label66:
 	i64.const	$push55=, 10
 	i64.shr_s	$0=, $0, $pop55
-	br      	53              # 53: down to label13
+	br      	53              # 53: down to label12
 .LBB1_12:                               # %sw.bb21
-	end_block                       # label66:
+	end_block                       # label65:
 	i64.const	$push54=, 11
 	i64.shr_s	$0=, $0, $pop54
-	br      	52              # 52: down to label13
+	br      	52              # 52: down to label12
 .LBB1_13:                               # %sw.bb23
-	end_block                       # label65:
+	end_block                       # label64:
 	i64.const	$push53=, 12
 	i64.shr_s	$0=, $0, $pop53
-	br      	51              # 51: down to label13
+	br      	51              # 51: down to label12
 .LBB1_14:                               # %sw.bb25
-	end_block                       # label64:
+	end_block                       # label63:
 	i64.const	$push52=, 13
 	i64.shr_s	$0=, $0, $pop52
-	br      	50              # 50: down to label13
+	br      	50              # 50: down to label12
 .LBB1_15:                               # %sw.bb27
-	end_block                       # label63:
+	end_block                       # label62:
 	i64.const	$push51=, 14
 	i64.shr_s	$0=, $0, $pop51
-	br      	49              # 49: down to label13
+	br      	49              # 49: down to label12
 .LBB1_16:                               # %sw.bb29
-	end_block                       # label62:
+	end_block                       # label61:
 	i64.const	$push50=, 15
 	i64.shr_s	$0=, $0, $pop50
-	br      	48              # 48: down to label13
+	br      	48              # 48: down to label12
 .LBB1_17:                               # %sw.bb31
-	end_block                       # label61:
+	end_block                       # label60:
 	i64.const	$push49=, 16
 	i64.shr_s	$0=, $0, $pop49
-	br      	47              # 47: down to label13
+	br      	47              # 47: down to label12
 .LBB1_18:                               # %sw.bb33
-	end_block                       # label60:
+	end_block                       # label59:
 	i64.const	$push48=, 17
 	i64.shr_s	$0=, $0, $pop48
-	br      	46              # 46: down to label13
+	br      	46              # 46: down to label12
 .LBB1_19:                               # %sw.bb35
-	end_block                       # label59:
+	end_block                       # label58:
 	i64.const	$push47=, 18
 	i64.shr_s	$0=, $0, $pop47
-	br      	45              # 45: down to label13
+	br      	45              # 45: down to label12
 .LBB1_20:                               # %sw.bb37
-	end_block                       # label58:
+	end_block                       # label57:
 	i64.const	$push46=, 19
 	i64.shr_s	$0=, $0, $pop46
-	br      	44              # 44: down to label13
+	br      	44              # 44: down to label12
 .LBB1_21:                               # %sw.bb39
-	end_block                       # label57:
+	end_block                       # label56:
 	i64.const	$push45=, 20
 	i64.shr_s	$0=, $0, $pop45
-	br      	43              # 43: down to label13
+	br      	43              # 43: down to label12
 .LBB1_22:                               # %sw.bb41
-	end_block                       # label56:
+	end_block                       # label55:
 	i64.const	$push44=, 21
 	i64.shr_s	$0=, $0, $pop44
-	br      	42              # 42: down to label13
+	br      	42              # 42: down to label12
 .LBB1_23:                               # %sw.bb43
-	end_block                       # label55:
+	end_block                       # label54:
 	i64.const	$push43=, 22
 	i64.shr_s	$0=, $0, $pop43
-	br      	41              # 41: down to label13
+	br      	41              # 41: down to label12
 .LBB1_24:                               # %sw.bb45
-	end_block                       # label54:
+	end_block                       # label53:
 	i64.const	$push42=, 23
 	i64.shr_s	$0=, $0, $pop42
-	br      	40              # 40: down to label13
+	br      	40              # 40: down to label12
 .LBB1_25:                               # %sw.bb47
-	end_block                       # label53:
+	end_block                       # label52:
 	i64.const	$push41=, 24
 	i64.shr_s	$0=, $0, $pop41
-	br      	39              # 39: down to label13
+	br      	39              # 39: down to label12
 .LBB1_26:                               # %sw.bb49
-	end_block                       # label52:
+	end_block                       # label51:
 	i64.const	$push40=, 25
 	i64.shr_s	$0=, $0, $pop40
-	br      	38              # 38: down to label13
+	br      	38              # 38: down to label12
 .LBB1_27:                               # %sw.bb51
-	end_block                       # label51:
+	end_block                       # label50:
 	i64.const	$push39=, 26
 	i64.shr_s	$0=, $0, $pop39
-	br      	37              # 37: down to label13
+	br      	37              # 37: down to label12
 .LBB1_28:                               # %sw.bb53
-	end_block                       # label50:
+	end_block                       # label49:
 	i64.const	$push38=, 27
 	i64.shr_s	$0=, $0, $pop38
-	br      	36              # 36: down to label13
+	br      	36              # 36: down to label12
 .LBB1_29:                               # %sw.bb55
-	end_block                       # label49:
+	end_block                       # label48:
 	i64.const	$push37=, 28
 	i64.shr_s	$0=, $0, $pop37
-	br      	35              # 35: down to label13
+	br      	35              # 35: down to label12
 .LBB1_30:                               # %sw.bb57
-	end_block                       # label48:
+	end_block                       # label47:
 	i64.const	$push36=, 29
 	i64.shr_s	$0=, $0, $pop36
-	br      	34              # 34: down to label13
+	br      	34              # 34: down to label12
 .LBB1_31:                               # %sw.bb59
-	end_block                       # label47:
+	end_block                       # label46:
 	i64.const	$push35=, 30
 	i64.shr_s	$0=, $0, $pop35
-	br      	33              # 33: down to label13
+	br      	33              # 33: down to label12
 .LBB1_32:                               # %sw.bb61
-	end_block                       # label46:
+	end_block                       # label45:
 	i64.const	$push34=, 31
 	i64.shr_s	$0=, $0, $pop34
-	br      	32              # 32: down to label13
+	br      	32              # 32: down to label12
 .LBB1_33:                               # %sw.bb63
-	end_block                       # label45:
+	end_block                       # label44:
 	i64.const	$push33=, 32
 	i64.shr_s	$0=, $0, $pop33
-	br      	31              # 31: down to label13
+	br      	31              # 31: down to label12
 .LBB1_34:                               # %sw.bb65
-	end_block                       # label44:
+	end_block                       # label43:
 	i64.const	$push32=, 33
 	i64.shr_s	$0=, $0, $pop32
-	br      	30              # 30: down to label13
+	br      	30              # 30: down to label12
 .LBB1_35:                               # %sw.bb67
-	end_block                       # label43:
+	end_block                       # label42:
 	i64.const	$push31=, 34
 	i64.shr_s	$0=, $0, $pop31
-	br      	29              # 29: down to label13
+	br      	29              # 29: down to label12
 .LBB1_36:                               # %sw.bb69
-	end_block                       # label42:
+	end_block                       # label41:
 	i64.const	$push30=, 35
 	i64.shr_s	$0=, $0, $pop30
-	br      	28              # 28: down to label13
+	br      	28              # 28: down to label12
 .LBB1_37:                               # %sw.bb71
-	end_block                       # label41:
+	end_block                       # label40:
 	i64.const	$push29=, 36
 	i64.shr_s	$0=, $0, $pop29
-	br      	27              # 27: down to label13
+	br      	27              # 27: down to label12
 .LBB1_38:                               # %sw.bb73
-	end_block                       # label40:
+	end_block                       # label39:
 	i64.const	$push28=, 37
 	i64.shr_s	$0=, $0, $pop28
-	br      	26              # 26: down to label13
+	br      	26              # 26: down to label12
 .LBB1_39:                               # %sw.bb75
-	end_block                       # label39:
+	end_block                       # label38:
 	i64.const	$push27=, 38
 	i64.shr_s	$0=, $0, $pop27
-	br      	25              # 25: down to label13
+	br      	25              # 25: down to label12
 .LBB1_40:                               # %sw.bb77
-	end_block                       # label38:
+	end_block                       # label37:
 	i64.const	$push26=, 39
 	i64.shr_s	$0=, $0, $pop26
-	br      	24              # 24: down to label13
+	br      	24              # 24: down to label12
 .LBB1_41:                               # %sw.bb79
-	end_block                       # label37:
+	end_block                       # label36:
 	i64.const	$push25=, 40
 	i64.shr_s	$0=, $0, $pop25
-	br      	23              # 23: down to label13
+	br      	23              # 23: down to label12
 .LBB1_42:                               # %sw.bb81
-	end_block                       # label36:
+	end_block                       # label35:
 	i64.const	$push24=, 41
 	i64.shr_s	$0=, $0, $pop24
-	br      	22              # 22: down to label13
+	br      	22              # 22: down to label12
 .LBB1_43:                               # %sw.bb83
-	end_block                       # label35:
+	end_block                       # label34:
 	i64.const	$push23=, 42
 	i64.shr_s	$0=, $0, $pop23
-	br      	21              # 21: down to label13
+	br      	21              # 21: down to label12
 .LBB1_44:                               # %sw.bb85
-	end_block                       # label34:
+	end_block                       # label33:
 	i64.const	$push22=, 43
 	i64.shr_s	$0=, $0, $pop22
-	br      	20              # 20: down to label13
+	br      	20              # 20: down to label12
 .LBB1_45:                               # %sw.bb87
-	end_block                       # label33:
+	end_block                       # label32:
 	i64.const	$push21=, 44
 	i64.shr_s	$0=, $0, $pop21
-	br      	19              # 19: down to label13
+	br      	19              # 19: down to label12
 .LBB1_46:                               # %sw.bb89
-	end_block                       # label32:
+	end_block                       # label31:
 	i64.const	$push20=, 45
 	i64.shr_s	$0=, $0, $pop20
-	br      	18              # 18: down to label13
+	br      	18              # 18: down to label12
 .LBB1_47:                               # %sw.bb91
-	end_block                       # label31:
+	end_block                       # label30:
 	i64.const	$push19=, 46
 	i64.shr_s	$0=, $0, $pop19
-	br      	17              # 17: down to label13
+	br      	17              # 17: down to label12
 .LBB1_48:                               # %sw.bb93
-	end_block                       # label30:
+	end_block                       # label29:
 	i64.const	$push18=, 47
 	i64.shr_s	$0=, $0, $pop18
-	br      	16              # 16: down to label13
+	br      	16              # 16: down to label12
 .LBB1_49:                               # %sw.bb95
-	end_block                       # label29:
+	end_block                       # label28:
 	i64.const	$push17=, 48
 	i64.shr_s	$0=, $0, $pop17
-	br      	15              # 15: down to label13
+	br      	15              # 15: down to label12
 .LBB1_50:                               # %sw.bb97
-	end_block                       # label28:
+	end_block                       # label27:
 	i64.const	$push16=, 49
 	i64.shr_s	$0=, $0, $pop16
-	br      	14              # 14: down to label13
+	br      	14              # 14: down to label12
 .LBB1_51:                               # %sw.bb99
-	end_block                       # label27:
+	end_block                       # label26:
 	i64.const	$push15=, 50
 	i64.shr_s	$0=, $0, $pop15
-	br      	13              # 13: down to label13
+	br      	13              # 13: down to label12
 .LBB1_52:                               # %sw.bb101
-	end_block                       # label26:
+	end_block                       # label25:
 	i64.const	$push14=, 51
 	i64.shr_s	$0=, $0, $pop14
-	br      	12              # 12: down to label13
+	br      	12              # 12: down to label12
 .LBB1_53:                               # %sw.bb103
-	end_block                       # label25:
+	end_block                       # label24:
 	i64.const	$push13=, 52
 	i64.shr_s	$0=, $0, $pop13
-	br      	11              # 11: down to label13
+	br      	11              # 11: down to label12
 .LBB1_54:                               # %sw.bb105
-	end_block                       # label24:
+	end_block                       # label23:
 	i64.const	$push12=, 53
 	i64.shr_s	$0=, $0, $pop12
-	br      	10              # 10: down to label13
+	br      	10              # 10: down to label12
 .LBB1_55:                               # %sw.bb107
-	end_block                       # label23:
+	end_block                       # label22:
 	i64.const	$push11=, 54
 	i64.shr_s	$0=, $0, $pop11
-	br      	9               # 9: down to label13
+	br      	9               # 9: down to label12
 .LBB1_56:                               # %sw.bb109
-	end_block                       # label22:
+	end_block                       # label21:
 	i64.const	$push10=, 55
 	i64.shr_s	$0=, $0, $pop10
-	br      	8               # 8: down to label13
+	br      	8               # 8: down to label12
 .LBB1_57:                               # %sw.bb111
-	end_block                       # label21:
+	end_block                       # label20:
 	i64.const	$push9=, 56
 	i64.shr_s	$0=, $0, $pop9
-	br      	7               # 7: down to label13
+	br      	7               # 7: down to label12
 .LBB1_58:                               # %sw.bb113
-	end_block                       # label20:
+	end_block                       # label19:
 	i64.const	$push8=, 57
 	i64.shr_s	$0=, $0, $pop8
-	br      	6               # 6: down to label13
+	br      	6               # 6: down to label12
 .LBB1_59:                               # %sw.bb115
-	end_block                       # label19:
+	end_block                       # label18:
 	i64.const	$push7=, 58
 	i64.shr_s	$0=, $0, $pop7
-	br      	5               # 5: down to label13
+	br      	5               # 5: down to label12
 .LBB1_60:                               # %sw.bb117
-	end_block                       # label18:
+	end_block                       # label17:
 	i64.const	$push6=, 59
 	i64.shr_s	$0=, $0, $pop6
-	br      	4               # 4: down to label13
+	br      	4               # 4: down to label12
 .LBB1_61:                               # %sw.bb119
-	end_block                       # label17:
+	end_block                       # label16:
 	i64.const	$push5=, 60
 	i64.shr_s	$0=, $0, $pop5
-	br      	3               # 3: down to label13
+	br      	3               # 3: down to label12
 .LBB1_62:                               # %sw.bb121
-	end_block                       # label16:
+	end_block                       # label15:
 	i64.const	$push4=, 61
 	i64.shr_s	$0=, $0, $pop4
-	br      	2               # 2: down to label13
+	br      	2               # 2: down to label12
 .LBB1_63:                               # %sw.bb123
-	end_block                       # label15:
+	end_block                       # label14:
 	i64.const	$push3=, 62
 	i64.shr_s	$0=, $0, $pop3
-	br      	1               # 1: down to label13
+	br      	1               # 1: down to label12
 .LBB1_64:                               # %sw.bb125
-	end_block                       # label14:
+	end_block                       # label13:
 	i64.const	$push2=, 63
 	i64.shr_s	$0=, $0, $pop2
 .LBB1_65:                               # %sw.epilog
-	end_block                       # label13:
+	end_block                       # label12:
 	return  	$0
 .LBB1_66:                               # %sw.default
-	end_block                       # label12:
+	end_block                       # label11:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/bf-pack-1.c.s
+++ b/test/torture-s/bf-pack-1.c.s
@@ -10,27 +10,22 @@ f:                                      # @f
 	.local  	i64
 # BB#0:                                 # %entry
 	block
-	block
 	i64.load	$push9=, 0($0):p2align=2
 	tee_local	$push8=, $1=, $pop9
 	i64.const	$push0=, 65535
 	i64.and 	$push1=, $pop8, $pop0
 	i64.const	$push2=, 4660
 	i64.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label1
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.end
 	i64.const	$push4=, 281474976645120
 	i64.and 	$push5=, $1, $pop4
 	i64.const	$push6=, 95075992076288
 	i64.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label0
+	br_if   	0, $pop7        # 0: down to label0
 # BB#2:                                 # %if.end6
 	return  	$0
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.then5
+.LBB0_3:                                # %if.then5
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/bf-sign-2.c.s
+++ b/test/torture-s/bf-sign-2.c.s
@@ -9,6 +9,7 @@ main:                                   # @main
 	.local  	i64
 # BB#0:                                 # %entry
 	block
+	block
 	i32.const	$push40=, 0
 	i64.load	$push39=, x($pop40)
 	tee_local	$push38=, $0=, $pop39
@@ -18,14 +19,9 @@ main:                                   # @main
 	i32.const	$push37=, -2
 	i32.add 	$push3=, $pop2, $pop37
 	i32.const	$push36=, 0
-	i32.lt_s	$push4=, $pop3, $pop36
-	br_if   	0, $pop4        # 0: down to label0
-# BB#1:                                 # %if.then
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_2:                                # %if.end
-	end_block                       # label0:
-	block
+	i32.ge_s	$push4=, $pop3, $pop36
+	br_if   	0, $pop4        # 0: down to label1
+# BB#1:                                 # %if.end
 	i64.const	$push5=, 31
 	i64.shr_u	$push6=, $0, $pop5
 	i32.wrap/i64	$push7=, $pop6
@@ -34,14 +30,9 @@ main:                                   # @main
 	i32.const	$push42=, -2
 	i32.add 	$push10=, $pop9, $pop42
 	i32.const	$push41=, 0
-	i32.lt_s	$push11=, $pop10, $pop41
+	i32.ge_s	$push11=, $pop10, $pop41
 	br_if   	0, $pop11       # 0: down to label1
-# BB#3:                                 # %if.then4
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.end5
-	end_block                       # label1:
-	block
+# BB#2:                                 # %if.end5
 	i32.const	$push47=, 0
 	i64.load	$push46=, x+8($pop47)
 	tee_local	$push45=, $0=, $pop46
@@ -49,14 +40,9 @@ main:                                   # @main
 	i32.const	$push44=, -2
 	i32.add 	$push13=, $pop12, $pop44
 	i32.const	$push43=, 0
-	i32.lt_s	$push14=, $pop13, $pop43
-	br_if   	0, $pop14       # 0: down to label2
-# BB#5:                                 # %if.then12
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.end13
-	end_block                       # label2:
-	block
+	i32.ge_s	$push14=, $pop13, $pop43
+	br_if   	0, $pop14       # 0: down to label1
+# BB#3:                                 # %if.end13
 	i32.const	$push50=, 0
 	i64.load	$push15=, x+24($pop50)
 	i64.const	$push16=, 35
@@ -67,14 +53,9 @@ main:                                   # @main
 	i32.const	$push49=, -2
 	i32.add 	$push21=, $pop20, $pop49
 	i32.const	$push48=, 0
-	i32.lt_s	$push22=, $pop21, $pop48
-	br_if   	0, $pop22       # 0: down to label3
-# BB#7:                                 # %if.then19
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.end20
-	end_block                       # label3:
-	block
+	i32.ge_s	$push22=, $pop21, $pop48
+	br_if   	0, $pop22       # 0: down to label1
+# BB#4:                                 # %if.end20
 	i64.const	$push23=, 32
 	i64.shr_u	$push24=, $0, $pop23
 	i32.wrap/i64	$push25=, $pop24
@@ -83,14 +64,9 @@ main:                                   # @main
 	i32.const	$push52=, -2
 	i32.add 	$push28=, $pop27, $pop52
 	i32.const	$push51=, 0
-	i32.lt_s	$push29=, $pop28, $pop51
-	br_if   	0, $pop29       # 0: down to label4
-# BB#9:                                 # %if.then27
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.end35
-	end_block                       # label4:
-	block
+	i32.ge_s	$push29=, $pop28, $pop51
+	br_if   	0, $pop29       # 0: down to label1
+# BB#5:                                 # %if.end35
 	i32.const	$push55=, 0
 	i32.load	$push30=, x+20($pop55)
 	i32.const	$push31=, 7
@@ -99,12 +75,13 @@ main:                                   # @main
 	i32.add 	$push33=, $pop32, $pop54
 	i32.const	$push53=, 0
 	i32.lt_s	$push34=, $pop33, $pop53
-	br_if   	0, $pop34       # 0: down to label5
-# BB#11:                                # %if.then42
+	br_if   	1, $pop34       # 1: down to label0
+.LBB0_6:                                # %if.then42
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_12:                               # %if.end50
-	end_block                       # label5:
+.LBB0_7:                                # %if.end50
+	end_block                       # label0:
 	i32.const	$push35=, 0
 	call    	exit@FUNCTION, $pop35
 	unreachable

--- a/test/torture-s/bitfld-3.c.s
+++ b/test/torture-s/bitfld-3.c.s
@@ -9,31 +9,27 @@ main:                                   # @main
 	.local  	i64, i64
 # BB#0:                                 # %entry
 	block
-	i32.const	$push13=, 0
-	i64.load	$push0=, a($pop13)
+	i32.const	$push12=, 0
+	i64.load	$push0=, a($pop12)
 	i64.const	$push1=, 8589934591
-	i64.and 	$push12=, $pop0, $pop1
-	tee_local	$push11=, $0=, $pop12
-	i64.mul 	$push2=, $pop11, $0
-	i64.const	$push10=, 0
-	i64.ne  	$push3=, $pop2, $pop10
+	i64.and 	$push11=, $pop0, $pop1
+	tee_local	$push10=, $0=, $pop11
+	i64.mul 	$push2=, $pop10, $0
+	i64.const	$push9=, 0
+	i64.ne  	$push3=, $pop2, $pop9
 	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %lor.lhs.false
-	i32.const	$push17=, 0
-	i64.load	$push4=, a+8($pop17)
+	i32.const	$push16=, 0
+	i64.load	$push4=, a+8($pop16)
 	i64.const	$push5=, 1099511627775
-	i64.and 	$push16=, $pop4, $pop5
-	tee_local	$push15=, $1=, $pop16
-	i64.mul 	$push6=, $pop15, $0
+	i64.and 	$push15=, $pop4, $pop5
+	tee_local	$push14=, $1=, $pop15
+	i64.mul 	$push6=, $pop14, $0
 	i64.mul 	$push7=, $1, $1
 	i64.or  	$push8=, $pop6, $pop7
-	i64.const	$push14=, 0
-	i64.ne  	$push9=, $pop8, $pop14
-	br_if   	0, $pop9        # 0: down to label0
-# BB#2:                                 # %if.end
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_3:                                # %if.then
+	i64.const	$push13=, 0
+	i64.eq  	$discard=, $pop8, $pop13
+.LBB0_2:                                # %if.end
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/bswap-1.c.s
+++ b/test/torture-s/bswap-1.c.s
@@ -104,92 +104,57 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i64.const	$push0=, 18
 	i64.call	$push1=, g@FUNCTION, $pop0
 	i64.const	$push2=, 1297036692682702848
 	i64.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label7
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.end
 	i64.const	$push4=, 4660
 	i64.call	$push5=, g@FUNCTION, $pop4
 	i64.const	$push6=, 3752061439553044480
 	i64.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label6
+	br_if   	0, $pop7        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i64.const	$push8=, 1193046
 	i64.call	$push9=, g@FUNCTION, $pop8
 	i64.const	$push10=, 6211609577260056576
 	i64.ne  	$push11=, $pop9, $pop10
-	br_if   	2, $pop11       # 2: down to label5
+	br_if   	0, $pop11       # 0: down to label0
 # BB#3:                                 # %if.end11
 	i64.const	$push12=, 305419896
 	i64.call	$push13=, g@FUNCTION, $pop12
 	i64.const	$push14=, 8671175384462524416
 	i64.ne  	$push15=, $pop13, $pop14
-	br_if   	3, $pop15       # 3: down to label4
+	br_if   	0, $pop15       # 0: down to label0
 # BB#4:                                 # %if.end16
 	i64.const	$push16=, 78187493520
 	i64.call	$push17=, g@FUNCTION, $pop16
 	i64.const	$push18=, -8036578753402372096
 	i64.ne  	$push19=, $pop17, $pop18
-	br_if   	4, $pop19       # 4: down to label3
+	br_if   	0, $pop19       # 0: down to label0
 # BB#5:                                 # %if.end21
 	i64.const	$push20=, 20015998341138
 	i64.call	$push21=, g@FUNCTION, $pop20
 	i64.const	$push22=, 1337701400965152768
 	i64.ne  	$push23=, $pop21, $pop22
-	br_if   	5, $pop23       # 5: down to label2
+	br_if   	0, $pop23       # 0: down to label0
 # BB#6:                                 # %if.end26
 	i64.const	$push24=, 5124095575331380
 	i64.call	$push25=, g@FUNCTION, $pop24
 	i64.const	$push26=, 3752220286069772800
 	i64.ne  	$push27=, $pop25, $pop26
-	br_if   	6, $pop27       # 6: down to label1
+	br_if   	0, $pop27       # 0: down to label0
 # BB#7:                                 # %if.end31
 	i64.const	$push28=, 1311768467284833366
 	i64.call	$push29=, g@FUNCTION, $pop28
 	i64.const	$push30=, 6211610197754262546
 	i64.ne  	$push31=, $pop29, $pop30
-	br_if   	7, $pop31       # 7: down to label0
+	br_if   	0, $pop31       # 0: down to label0
 # BB#8:                                 # %if.end36
 	i32.const	$push32=, 0
 	return  	$pop32
-.LBB2_9:                                # %if.then
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_10:                               # %if.then5
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_11:                               # %if.then10
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_12:                               # %if.then15
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_13:                               # %if.then20
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_14:                               # %if.then25
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_15:                               # %if.then30
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_16:                               # %if.then35
+.LBB2_9:                                # %if.then35
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/builtin-bitops-1.c.s
+++ b/test/torture-s/builtin-bitops-1.c.s
@@ -23,15 +23,15 @@ my_ffs:                                 # @my_ffs
 	br_if   	1, $pop1        # 1: down to label2
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push5=, 1
-	i32.add 	$1=, $1, $pop5
-	i32.const	$push2=, 32
-	i32.lt_u	$push3=, $1, $pop2
-	br_if   	0, $pop3        # 0: up to label1
-.LBB0_3:                                # %for.end
-	end_loop                        # label2:
 	i32.const	$push6=, 1
 	i32.add 	$1=, $1, $pop6
+	i32.const	$push5=, 32
+	i32.lt_u	$push2=, $1, $pop5
+	br_if   	0, $pop2        # 0: up to label1
+.LBB0_3:                                # %for.end
+	end_loop                        # label2:
+	i32.const	$push3=, 1
+	i32.add 	$1=, $1, $pop3
 .LBB0_4:                                # %cleanup
 	end_block                       # label0:
 	return  	$1
@@ -232,15 +232,15 @@ my_ffsl:                                # @my_ffsl
 	br_if   	1, $pop1        # 1: down to label15
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB6_1 Depth=1
-	i32.const	$push5=, 1
-	i32.add 	$1=, $1, $pop5
-	i32.const	$push2=, 32
-	i32.lt_u	$push3=, $1, $pop2
-	br_if   	0, $pop3        # 0: up to label14
-.LBB6_3:                                # %for.end
-	end_loop                        # label15:
 	i32.const	$push6=, 1
 	i32.add 	$1=, $1, $pop6
+	i32.const	$push5=, 32
+	i32.lt_u	$push2=, $1, $pop5
+	br_if   	0, $pop2        # 0: up to label14
+.LBB6_3:                                # %for.end
+	end_loop                        # label15:
+	i32.const	$push3=, 1
+	i32.add 	$1=, $1, $pop3
 .LBB6_4:                                # %cleanup
 	end_block                       # label13:
 	return  	$1
@@ -430,31 +430,31 @@ my_ffsll:                               # @my_ffsll
 	i64.const	$1=, 0
 	i32.const	$2=, 0
 	block
-	i64.const	$push8=, 0
-	i64.eq  	$push0=, $0, $pop8
+	i64.const	$push6=, 0
+	i64.eq  	$push0=, $0, $pop6
 	br_if   	0, $pop0        # 0: down to label26
 .LBB12_1:                               # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label27:
-	i64.const	$push10=, 1
-	i64.shl 	$push1=, $pop10, $1
+	i64.const	$push8=, 1
+	i64.shl 	$push1=, $pop8, $1
 	i64.and 	$push2=, $pop1, $0
-	i64.const	$push9=, 0
-	i64.ne  	$push3=, $pop2, $pop9
+	i64.const	$push7=, 0
+	i64.ne  	$push3=, $pop2, $pop7
 	br_if   	1, $pop3        # 1: down to label28
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB12_1 Depth=1
-	i32.const	$push4=, 1
-	i32.add 	$2=, $2, $pop4
 	i64.const	$push11=, 1
 	i64.add 	$1=, $1, $pop11
-	i64.const	$push5=, 64
-	i64.lt_u	$push6=, $1, $pop5
-	br_if   	0, $pop6        # 0: up to label27
+	i32.const	$push10=, 1
+	i32.add 	$2=, $2, $pop10
+	i64.const	$push9=, 64
+	i64.lt_u	$push4=, $1, $pop9
+	br_if   	0, $pop4        # 0: up to label27
 .LBB12_3:                               # %for.end
 	end_loop                        # label28:
-	i32.const	$push7=, 1
-	i32.add 	$2=, $2, $pop7
+	i32.const	$push5=, 1
+	i32.add 	$2=, $2, $pop5
 .LBB12_4:                               # %cleanup
 	end_block                       # label26:
 	return  	$2
@@ -653,7 +653,7 @@ my_parityll:                            # @my_parityll
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i64, i32, i32, i64, i64, i64, i32, i32
+	.local  	i32, i32, i64, i32, i32, i64, i64, i64, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$0=, 0
 .LBB18_1:                               # %for.body
@@ -666,1167 +666,950 @@ main:                                   # @main
                                         #     Child Loop BB18_21 Depth 2
 	block
 	block
+	loop                            # label41:
+	i32.const	$push221=, 2
+	i32.shl 	$push220=, $0, $pop221
+	tee_local	$push219=, $9=, $pop220
+	i32.load	$push218=, ints($pop219)
+	tee_local	$push217=, $10=, $pop218
+	i32.ctz 	$push216=, $pop217
+	tee_local	$push215=, $1=, $pop216
+	i32.const	$push214=, 1
+	i32.add 	$push3=, $pop215, $pop214
+	i32.const	$push213=, 0
+	i32.select	$4=, $pop3, $pop213, $10
+	i32.const	$8=, 0
+	i32.const	$3=, 0
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label84:
-	i32.const	$push272=, 2
-	i32.shl 	$push271=, $0, $pop272
-	tee_local	$push270=, $2=, $pop271
-	i32.load	$push269=, ints($pop270)
-	tee_local	$push268=, $10=, $pop269
-	i32.ctz 	$push267=, $pop268
-	tee_local	$push266=, $1=, $pop267
-	i32.const	$push265=, 1
-	i32.add 	$push3=, $pop266, $pop265
-	i32.const	$push264=, 0
-	i32.select	$5=, $pop3, $pop264, $10
-	i32.const	$9=, 0
-	i32.const	$4=, 0
-	block
-	i32.const	$push382=, 0
-	i32.eq  	$push383=, $10, $pop382
-	br_if   	0, $pop383      # 0: down to label86
+	i32.const	$push380=, 0
+	i32.eq  	$push381=, $10, $pop380
+	br_if   	0, $pop381      # 0: down to label43
 .LBB18_2:                               # %for.body.i
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label87:
-	i32.const	$push273=, 1
-	i32.shl 	$push4=, $pop273, $9
+	loop                            # label44:
+	i32.const	$push222=, 1
+	i32.shl 	$push4=, $pop222, $8
 	i32.and 	$push5=, $pop4, $10
-	br_if   	1, $pop5        # 1: down to label88
+	br_if   	1, $pop5        # 1: down to label45
 # BB#3:                                 # %for.inc.i
                                         #   in Loop: Header=BB18_2 Depth=2
-	i32.const	$push275=, 1
-	i32.add 	$9=, $9, $pop275
-	i32.const	$push274=, 32
-	i32.lt_u	$push6=, $9, $pop274
-	br_if   	0, $pop6        # 0: up to label87
+	i32.const	$push224=, 1
+	i32.add 	$8=, $8, $pop224
+	i32.const	$push223=, 32
+	i32.lt_u	$push6=, $8, $pop223
+	br_if   	0, $pop6        # 0: up to label44
 .LBB18_4:                               # %for.end.i
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_loop                        # label88:
-	i32.const	$push276=, 1
-	i32.add 	$4=, $9, $pop276
+	end_loop                        # label45:
+	i32.const	$push225=, 1
+	i32.add 	$3=, $8, $pop225
 .LBB18_5:                               # %my_ffs.exit
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_block                       # label86:
-	i32.ne  	$push7=, $5, $4
-	br_if   	2, $pop7        # 2: down to label83
+	end_block                       # label43:
+	i32.ne  	$push7=, $4, $3
+	br_if   	2, $pop7        # 2: down to label40
 # BB#6:                                 # %if.end
                                         #   in Loop: Header=BB18_1 Depth=1
 	block
-	i32.const	$push384=, 0
-	i32.eq  	$push385=, $10, $pop384
-	br_if   	0, $pop385      # 0: down to label89
+	i32.const	$push382=, 0
+	i32.eq  	$push383=, $10, $pop382
+	br_if   	0, $pop383      # 0: down to label46
 # BB#7:                                 # %land.lhs.true
                                         #   in Loop: Header=BB18_1 Depth=1
-	i32.clz 	$5=, $10
-	i32.const	$9=, 0
-	i32.const	$4=, 31
+	i32.clz 	$4=, $10
+	i32.const	$8=, 0
+	i32.const	$3=, 31
 .LBB18_8:                               # %for.body.i822
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label90:
-	i32.const	$push277=, 1
-	i32.shl 	$push8=, $pop277, $4
+	loop                            # label47:
+	i32.const	$push226=, 1
+	i32.shl 	$push8=, $pop226, $3
 	i32.and 	$push9=, $pop8, $10
-	br_if   	1, $pop9        # 1: down to label91
+	br_if   	1, $pop9        # 1: down to label48
 # BB#9:                                 # %for.inc.i825
                                         #   in Loop: Header=BB18_8 Depth=2
-	i32.const	$push280=, 1
-	i32.add 	$9=, $9, $pop280
-	i32.const	$push279=, -1
-	i32.add 	$4=, $4, $pop279
-	i32.const	$push278=, 32
-	i32.lt_u	$push10=, $9, $pop278
-	br_if   	0, $pop10       # 0: up to label90
+	i32.const	$push229=, 1
+	i32.add 	$8=, $8, $pop229
+	i32.const	$push228=, -1
+	i32.add 	$3=, $3, $pop228
+	i32.const	$push227=, 32
+	i32.lt_u	$push10=, $8, $pop227
+	br_if   	0, $pop10       # 0: up to label47
 .LBB18_10:                              # %my_clz.exit
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_loop                        # label91:
-	i32.ne  	$push11=, $5, $9
-	br_if   	15, $pop11      # 15: down to label71
+	end_loop                        # label48:
+	i32.ne  	$push11=, $4, $8
+	br_if   	3, $pop11       # 3: down to label40
 # BB#11:                                # %land.lhs.true13
                                         #   in Loop: Header=BB18_1 Depth=1
-	i32.const	$9=, 0
+	i32.const	$8=, 0
 .LBB18_12:                              # %for.body.i889
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label92:
-	i32.const	$push281=, 1
-	i32.shl 	$push12=, $pop281, $9
+	loop                            # label49:
+	i32.const	$push230=, 1
+	i32.shl 	$push12=, $pop230, $8
 	i32.and 	$push13=, $pop12, $10
-	br_if   	1, $pop13       # 1: down to label93
+	br_if   	1, $pop13       # 1: down to label50
 # BB#13:                                # %for.inc.i892
                                         #   in Loop: Header=BB18_12 Depth=2
-	i32.const	$push283=, 1
-	i32.add 	$9=, $9, $pop283
-	i32.const	$push282=, 32
-	i32.lt_u	$push14=, $9, $pop282
-	br_if   	0, $pop14       # 0: up to label92
+	i32.const	$push232=, 1
+	i32.add 	$8=, $8, $pop232
+	i32.const	$push231=, 32
+	i32.lt_u	$push14=, $8, $pop231
+	br_if   	0, $pop14       # 0: up to label49
 .LBB18_14:                              # %my_ctz.exit
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_loop                        # label93:
-	i32.ne  	$push15=, $1, $9
-	br_if   	16, $pop15      # 16: down to label70
+	end_loop                        # label50:
+	i32.ne  	$push15=, $1, $8
+	br_if   	3, $pop15       # 3: down to label40
 .LBB18_15:                              # %if.end19
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_block                       # label89:
+	end_block                       # label46:
 	i32.call	$1=, __builtin_clrsb@FUNCTION, $10
-	i32.const	$push287=, ints
-	i32.add 	$push0=, $2, $pop287
-	i32.load	$push286=, 0($pop0)
-	tee_local	$push285=, $10=, $pop286
-	i32.const	$push284=, 31
-	i32.shr_u	$4=, $pop285, $pop284
-	i32.const	$5=, 1
-	i32.const	$9=, 30
+	i32.const	$push236=, ints
+	i32.add 	$push0=, $9, $pop236
+	i32.load	$push235=, 0($pop0)
+	tee_local	$push234=, $10=, $pop235
+	i32.const	$push233=, 31
+	i32.shr_u	$3=, $pop234, $pop233
+	i32.const	$4=, 1
+	i32.const	$8=, 30
 .LBB18_16:                              # %for.body.i974
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label94:
-	i32.shr_u	$push16=, $10, $9
-	i32.const	$push288=, 1
-	i32.and 	$push17=, $pop16, $pop288
-	i32.ne  	$push18=, $pop17, $4
-	br_if   	1, $pop18       # 1: down to label95
+	loop                            # label51:
+	i32.shr_u	$push16=, $10, $8
+	i32.const	$push237=, 1
+	i32.and 	$push17=, $pop16, $pop237
+	i32.ne  	$push18=, $pop17, $3
+	br_if   	1, $pop18       # 1: down to label52
 # BB#17:                                # %for.inc.i977
                                         #   in Loop: Header=BB18_16 Depth=2
-	i32.const	$push291=, 1
-	i32.add 	$5=, $5, $pop291
-	i32.const	$push290=, -1
-	i32.add 	$9=, $9, $pop290
-	i32.const	$push289=, 32
-	i32.lt_u	$push19=, $5, $pop289
-	br_if   	0, $pop19       # 0: up to label94
+	i32.const	$push240=, 1
+	i32.add 	$4=, $4, $pop240
+	i32.const	$push239=, -1
+	i32.add 	$8=, $8, $pop239
+	i32.const	$push238=, 32
+	i32.lt_u	$push19=, $4, $pop238
+	br_if   	0, $pop19       # 0: up to label51
 .LBB18_18:                              # %my_clrsb.exit
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_loop                        # label95:
-	i32.const	$4=, 0
-	i32.const	$9=, 0
-	i32.const	$push292=, -1
-	i32.add 	$push20=, $5, $pop292
+	end_loop                        # label52:
+	i32.const	$3=, 0
+	i32.const	$8=, 0
+	i32.const	$push241=, -1
+	i32.add 	$push20=, $4, $pop241
 	i32.ne  	$push21=, $1, $pop20
-	br_if   	3, $pop21       # 3: down to label82
+	br_if   	2, $pop21       # 2: down to label40
 .LBB18_19:                              # %for.body.i1069
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label96:
-	i32.const	$push296=, 1
-	i32.shl 	$push22=, $pop296, $9
+	loop                            # label53:
+	i32.const	$push245=, 1
+	i32.shl 	$push22=, $pop245, $8
 	i32.and 	$push23=, $pop22, $10
-	i32.const	$push295=, 0
-	i32.ne  	$push24=, $pop23, $pop295
-	i32.add 	$4=, $pop24, $4
-	i32.const	$push294=, 1
-	i32.add 	$9=, $9, $pop294
-	i32.const	$push293=, 32
-	i32.ne  	$push25=, $9, $pop293
-	br_if   	0, $pop25       # 0: up to label96
+	i32.const	$push244=, 0
+	i32.ne  	$push24=, $pop23, $pop244
+	i32.add 	$3=, $pop24, $3
+	i32.const	$push243=, 1
+	i32.add 	$8=, $8, $pop243
+	i32.const	$push242=, 32
+	i32.ne  	$push25=, $8, $pop242
+	br_if   	0, $pop25       # 0: up to label53
 # BB#20:                                # %my_popcount.exit
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_loop                        # label97:
-	i32.const	$5=, 0
-	i32.const	$9=, 0
+	end_loop                        # label54:
+	i32.const	$4=, 0
+	i32.const	$8=, 0
 	i32.popcnt	$push26=, $10
-	i32.ne  	$push27=, $pop26, $4
-	br_if   	4, $pop27       # 4: down to label81
+	i32.ne  	$push27=, $pop26, $3
+	br_if   	2, $pop27       # 2: down to label40
 .LBB18_21:                              # %for.body.i1161
                                         #   Parent Loop BB18_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label98:
-	i32.const	$push300=, 1
-	i32.shl 	$push28=, $pop300, $9
+	loop                            # label55:
+	i32.const	$push249=, 1
+	i32.shl 	$push28=, $pop249, $8
 	i32.and 	$push29=, $pop28, $10
-	i32.const	$push299=, 0
-	i32.ne  	$push30=, $pop29, $pop299
-	i32.add 	$5=, $pop30, $5
-	i32.const	$push298=, 1
-	i32.add 	$9=, $9, $pop298
-	i32.const	$push297=, 32
-	i32.ne  	$push31=, $9, $pop297
-	br_if   	0, $pop31       # 0: up to label98
+	i32.const	$push248=, 0
+	i32.ne  	$push30=, $pop29, $pop248
+	i32.add 	$4=, $pop30, $4
+	i32.const	$push247=, 1
+	i32.add 	$8=, $8, $pop247
+	i32.const	$push246=, 32
+	i32.ne  	$push31=, $8, $pop246
+	br_if   	0, $pop31       # 0: up to label55
 # BB#22:                                # %my_parity.exit
                                         #   in Loop: Header=BB18_1 Depth=1
-	end_loop                        # label99:
-	i32.xor 	$push32=, $5, $4
-	i32.const	$push301=, 1
-	i32.and 	$push33=, $pop32, $pop301
-	br_if   	5, $pop33       # 5: down to label80
+	end_loop                        # label56:
+	i32.xor 	$push32=, $4, $3
+	i32.const	$push250=, 1
+	i32.and 	$push33=, $pop32, $pop250
+	br_if   	2, $pop33       # 2: down to label40
 # BB#23:                                # %for.cond
                                         #   in Loop: Header=BB18_1 Depth=1
-	i32.const	$push263=, 1
-	i32.add 	$0=, $0, $pop263
-	i32.const	$2=, 0
-	i32.const	$push262=, 12
-	i32.le_u	$push34=, $0, $pop262
-	br_if   	0, $pop34       # 0: up to label84
-.LBB18_24:                              # %for.body41
+	i32.const	$push212=, 1
+	i32.add 	$0=, $0, $pop212
+	i32.const	$push211=, 12
+	i32.le_u	$push34=, $0, $pop211
+	br_if   	0, $pop34       # 0: up to label41
+# BB#24:
+	end_loop                        # label42:
+	i32.const	$0=, 0
+.LBB18_25:                              # %for.body41
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB18_25 Depth 2
-                                        #     Child Loop BB18_31 Depth 2
-                                        #     Child Loop BB18_35 Depth 2
-                                        #     Child Loop BB18_39 Depth 2
-                                        #     Child Loop BB18_42 Depth 2
-                                        #     Child Loop BB18_44 Depth 2
-	end_loop                        # label85:
-	loop                            # label100:
-	i32.const	$push35=, 2
-	i32.shl 	$push310=, $2, $pop35
-	tee_local	$push309=, $0=, $pop310
-	i32.load	$push308=, longs($pop309)
-	tee_local	$push307=, $10=, $pop308
-	i32.ctz 	$push306=, $pop307
-	tee_local	$push305=, $1=, $pop306
-	i32.const	$push304=, 1
-	i32.add 	$push37=, $pop305, $pop304
-	i32.const	$push303=, 0
-	i32.select	$5=, $pop37, $pop303, $10
-	i32.const	$9=, 0
-	i32.const	$4=, 0
+                                        #     Child Loop BB18_26 Depth 2
+                                        #     Child Loop BB18_32 Depth 2
+                                        #     Child Loop BB18_36 Depth 2
+                                        #     Child Loop BB18_40 Depth 2
+                                        #     Child Loop BB18_43 Depth 2
+                                        #     Child Loop BB18_45 Depth 2
+	loop                            # label57:
+	i32.const	$push261=, 2
+	i32.shl 	$push260=, $0, $pop261
+	tee_local	$push259=, $9=, $pop260
+	i32.load	$push258=, longs($pop259)
+	tee_local	$push257=, $10=, $pop258
+	i32.ctz 	$push256=, $pop257
+	tee_local	$push255=, $1=, $pop256
+	i32.const	$push254=, 1
+	i32.add 	$push35=, $pop255, $pop254
+	i32.const	$push253=, 0
+	i32.select	$4=, $pop35, $pop253, $10
+	i32.const	$8=, 0
+	i32.const	$3=, 0
+	block
+	i32.const	$push384=, 0
+	i32.eq  	$push385=, $10, $pop384
+	br_if   	0, $pop385      # 0: down to label59
+.LBB18_26:                              # %for.body.i1251
+                                        #   Parent Loop BB18_25 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label60:
+	i32.const	$push262=, 1
+	i32.shl 	$push36=, $pop262, $8
+	i32.and 	$push37=, $pop36, $10
+	br_if   	1, $pop37       # 1: down to label61
+# BB#27:                                # %for.inc.i1254
+                                        #   in Loop: Header=BB18_26 Depth=2
+	i32.const	$push264=, 1
+	i32.add 	$8=, $8, $pop264
+	i32.const	$push263=, 32
+	i32.lt_u	$push38=, $8, $pop263
+	br_if   	0, $pop38       # 0: up to label60
+.LBB18_28:                              # %for.end.i1257
+                                        #   in Loop: Header=BB18_25 Depth=1
+	end_loop                        # label61:
+	i32.const	$push265=, 1
+	i32.add 	$3=, $8, $pop265
+.LBB18_29:                              # %my_ffsl.exit
+                                        #   in Loop: Header=BB18_25 Depth=1
+	end_block                       # label59:
+	i32.ne  	$push39=, $4, $3
+	br_if   	2, $pop39       # 2: down to label40
+# BB#30:                                # %if.end49
+                                        #   in Loop: Header=BB18_25 Depth=1
 	block
 	i32.const	$push386=, 0
 	i32.eq  	$push387=, $10, $pop386
-	br_if   	0, $pop387      # 0: down to label102
-.LBB18_25:                              # %for.body.i1251
-                                        #   Parent Loop BB18_24 Depth=1
+	br_if   	0, $pop387      # 0: down to label62
+# BB#31:                                # %land.lhs.true52
+                                        #   in Loop: Header=BB18_25 Depth=1
+	i32.clz 	$4=, $10
+	i32.const	$8=, 0
+	i32.const	$3=, 31
+.LBB18_32:                              # %for.body.i1346
+                                        #   Parent Loop BB18_25 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label103:
-	i32.const	$push311=, 1
-	i32.shl 	$push38=, $pop311, $9
-	i32.and 	$push39=, $pop38, $10
-	br_if   	1, $pop39       # 1: down to label104
-# BB#26:                                # %for.inc.i1254
-                                        #   in Loop: Header=BB18_25 Depth=2
-	i32.const	$push40=, 1
-	i32.add 	$9=, $9, $pop40
-	i32.const	$push41=, 32
-	i32.lt_u	$push42=, $9, $pop41
-	br_if   	0, $pop42       # 0: up to label103
-.LBB18_27:                              # %for.end.i1257
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_loop                        # label104:
-	i32.const	$push43=, 1
-	i32.add 	$4=, $9, $pop43
-.LBB18_28:                              # %my_ffsl.exit
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_block                       # label102:
-	i32.ne  	$push44=, $5, $4
-	br_if   	6, $pop44       # 6: down to label79
-# BB#29:                                # %if.end49
-                                        #   in Loop: Header=BB18_24 Depth=1
-	block
-	i32.const	$push388=, 0
-	i32.eq  	$push389=, $10, $pop388
-	br_if   	0, $pop389      # 0: down to label105
-# BB#30:                                # %land.lhs.true52
-                                        #   in Loop: Header=BB18_24 Depth=1
-	i32.clz 	$5=, $10
-	i32.const	$9=, 0
-	i32.const	$4=, 31
-.LBB18_31:                              # %for.body.i1346
-                                        #   Parent Loop BB18_24 Depth=1
+	loop                            # label63:
+	i32.const	$push266=, 1
+	i32.shl 	$push40=, $pop266, $3
+	i32.and 	$push41=, $pop40, $10
+	br_if   	1, $pop41       # 1: down to label64
+# BB#33:                                # %for.inc.i1349
+                                        #   in Loop: Header=BB18_32 Depth=2
+	i32.const	$push269=, 1
+	i32.add 	$8=, $8, $pop269
+	i32.const	$push268=, -1
+	i32.add 	$3=, $3, $pop268
+	i32.const	$push267=, 32
+	i32.lt_u	$push42=, $8, $pop267
+	br_if   	0, $pop42       # 0: up to label63
+.LBB18_34:                              # %my_clzl.exit
+                                        #   in Loop: Header=BB18_25 Depth=1
+	end_loop                        # label64:
+	i32.ne  	$push43=, $4, $8
+	br_if   	3, $pop43       # 3: down to label40
+# BB#35:                                # %land.lhs.true61
+                                        #   in Loop: Header=BB18_25 Depth=1
+	i32.const	$8=, 0
+.LBB18_36:                              # %for.body.i1438
+                                        #   Parent Loop BB18_25 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label106:
-	i32.const	$push312=, 1
-	i32.shl 	$push45=, $pop312, $4
-	i32.and 	$push46=, $pop45, $10
-	br_if   	1, $pop46       # 1: down to label107
-# BB#32:                                # %for.inc.i1349
-                                        #   in Loop: Header=BB18_31 Depth=2
-	i32.const	$push313=, 1
-	i32.add 	$9=, $9, $pop313
-	i32.const	$push47=, -1
-	i32.add 	$4=, $4, $pop47
-	i32.const	$push48=, 32
-	i32.lt_u	$push49=, $9, $pop48
-	br_if   	0, $pop49       # 0: up to label106
-.LBB18_33:                              # %my_clzl.exit
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_loop                        # label107:
-	i32.ne  	$push50=, $5, $9
-	br_if   	17, $pop50      # 17: down to label69
-# BB#34:                                # %land.lhs.true61
-                                        #   in Loop: Header=BB18_24 Depth=1
-	i32.const	$9=, 0
-.LBB18_35:                              # %for.body.i1438
-                                        #   Parent Loop BB18_24 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label108:
-	i32.const	$push314=, 1
-	i32.shl 	$push51=, $pop314, $9
-	i32.and 	$push52=, $pop51, $10
-	br_if   	1, $pop52       # 1: down to label109
-# BB#36:                                # %for.inc.i1441
-                                        #   in Loop: Header=BB18_35 Depth=2
-	i32.const	$push315=, 1
-	i32.add 	$9=, $9, $pop315
-	i32.const	$push53=, 32
-	i32.lt_u	$push54=, $9, $pop53
-	br_if   	0, $pop54       # 0: up to label108
-.LBB18_37:                              # %my_ctzl.exit
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_loop                        # label109:
-	i32.ne  	$push55=, $1, $9
-	br_if   	18, $pop55      # 18: down to label68
-.LBB18_38:                              # %if.end67
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_block                       # label105:
-	i32.call	$1=, __builtin_clrsbl@FUNCTION, $10
-	i32.const	$push36=, longs
-	i32.add 	$push1=, $0, $pop36
-	i32.load	$push317=, 0($pop1)
-	tee_local	$push316=, $10=, $pop317
-	i32.const	$push56=, 31
-	i32.shr_u	$4=, $pop316, $pop56
-	i32.const	$9=, 30
-	i32.const	$5=, 1
-.LBB18_39:                              # %for.body.i1532
-                                        #   Parent Loop BB18_24 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label110:
-	i32.shr_u	$push57=, $10, $9
-	i32.const	$push318=, 1
-	i32.and 	$push58=, $pop57, $pop318
-	i32.ne  	$push59=, $pop58, $4
-	br_if   	1, $pop59       # 1: down to label111
-# BB#40:                                # %for.inc.i1535
-                                        #   in Loop: Header=BB18_39 Depth=2
-	i32.const	$push60=, 1
-	i32.add 	$5=, $5, $pop60
-	i32.const	$push61=, -1
-	i32.add 	$9=, $9, $pop61
-	i32.const	$push62=, 32
-	i32.lt_u	$push63=, $5, $pop62
-	br_if   	0, $pop63       # 0: up to label110
-.LBB18_41:                              # %my_clrsbl.exit
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_loop                        # label111:
-	i32.const	$4=, 0
-	i32.const	$9=, 0
-	i32.const	$push64=, -1
-	i32.add 	$push65=, $5, $pop64
-	i32.ne  	$push66=, $1, $pop65
-	br_if   	7, $pop66       # 7: down to label78
-.LBB18_42:                              # %for.body.i1630
-                                        #   Parent Loop BB18_24 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label112:
-	i32.const	$push67=, 1
-	i32.shl 	$push68=, $pop67, $9
-	i32.and 	$push69=, $pop68, $10
-	i32.const	$push320=, 0
-	i32.ne  	$push70=, $pop69, $pop320
-	i32.add 	$4=, $pop70, $4
-	i32.const	$push319=, 1
-	i32.add 	$9=, $9, $pop319
-	i32.const	$push71=, 32
-	i32.ne  	$push72=, $9, $pop71
-	br_if   	0, $pop72       # 0: up to label112
-# BB#43:                                # %my_popcountl.exit
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_loop                        # label113:
-	i32.const	$5=, 0
-	i32.const	$9=, 0
-	i32.popcnt	$push73=, $10
-	i32.ne  	$push74=, $pop73, $4
-	br_if   	8, $pop74       # 8: down to label77
-.LBB18_44:                              # %for.body.i1723
-                                        #   Parent Loop BB18_24 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label114:
-	i32.const	$push323=, 1
-	i32.shl 	$push75=, $pop323, $9
-	i32.and 	$push76=, $pop75, $10
-	i32.const	$push322=, 0
-	i32.ne  	$push77=, $pop76, $pop322
-	i32.add 	$5=, $pop77, $5
-	i32.const	$push321=, 1
-	i32.add 	$9=, $9, $pop321
-	i32.const	$push78=, 32
-	i32.ne  	$push79=, $9, $pop78
-	br_if   	0, $pop79       # 0: up to label114
-# BB#45:                                # %my_parityl.exit
-                                        #   in Loop: Header=BB18_24 Depth=1
-	end_loop                        # label115:
-	i32.xor 	$push80=, $5, $4
-	i32.const	$push324=, 1
-	i32.and 	$push81=, $pop80, $pop324
-	br_if   	9, $pop81       # 9: down to label76
-# BB#46:                                # %for.cond39
-                                        #   in Loop: Header=BB18_24 Depth=1
-	i32.const	$push302=, 1
-	i32.add 	$2=, $2, $pop302
-	i32.const	$4=, 0
-	i32.const	$push82=, 12
-	i32.le_u	$push83=, $2, $pop82
-	br_if   	0, $pop83       # 0: up to label100
-.LBB18_47:                              # %for.body92
-                                        # =>This Loop Header: Depth=1
-                                        #     Child Loop BB18_48 Depth 2
-                                        #     Child Loop BB18_54 Depth 2
-                                        #     Child Loop BB18_58 Depth 2
-                                        #     Child Loop BB18_62 Depth 2
-                                        #     Child Loop BB18_66 Depth 2
-                                        #     Child Loop BB18_68 Depth 2
-	end_loop                        # label101:
-	loop                            # label116:
-	i32.const	$push336=, 0
-	i32.const	$push84=, 3
-	i32.shl 	$push335=, $4, $pop84
-	tee_local	$push334=, $0=, $pop335
-	i64.load	$push333=, longlongs($pop334)
-	tee_local	$push332=, $8=, $pop333
-	i64.ctz 	$push331=, $pop332
-	tee_local	$push330=, $3=, $pop331
-	i64.const	$push329=, 1
-	i64.add 	$push86=, $pop330, $pop329
-	i32.wrap/i64	$push87=, $pop86
-	i64.const	$push328=, 0
-	i64.eq  	$push327=, $8, $pop328
-	tee_local	$push326=, $5=, $pop327
-	i32.select	$2=, $pop336, $pop87, $pop326
-	i64.const	$7=, 0
-	i32.const	$9=, 0
-	i32.const	$10=, 0
-	block
-	br_if   	0, $5           # 0: down to label118
-.LBB18_48:                              # %for.body.i1814
-                                        #   Parent Loop BB18_47 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label119:
-	i64.const	$push338=, 1
-	i64.shl 	$push88=, $pop338, $7
-	i64.and 	$push89=, $pop88, $8
-	i64.const	$push337=, 0
-	i64.ne  	$push90=, $pop89, $pop337
-	br_if   	1, $pop90       # 1: down to label120
-# BB#49:                                # %for.inc.i1818
-                                        #   in Loop: Header=BB18_48 Depth=2
-	i32.const	$push92=, 1
-	i32.add 	$9=, $9, $pop92
-	i64.const	$push91=, 1
-	i64.add 	$7=, $7, $pop91
-	i64.const	$push93=, 64
-	i64.lt_u	$push94=, $7, $pop93
-	br_if   	0, $pop94       # 0: up to label119
-.LBB18_50:                              # %for.end.i1821
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_loop                        # label120:
-	i32.const	$push95=, 1
-	i32.add 	$10=, $9, $pop95
-.LBB18_51:                              # %my_ffsll.exit1823
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_block                       # label118:
-	i32.ne  	$push96=, $2, $10
-	br_if   	10, $pop96      # 10: down to label75
-# BB#52:                                # %if.end100
-                                        #   in Loop: Header=BB18_47 Depth=1
-	i64.const	$7=, 0
-	block
-	i64.const	$push339=, 0
-	i64.eq  	$push97=, $8, $pop339
-	br_if   	0, $pop97       # 0: down to label121
-# BB#53:                                # %land.lhs.true103
-                                        #   in Loop: Header=BB18_47 Depth=1
-	i64.const	$6=, 63
-	i64.clz 	$push98=, $8
-	i32.wrap/i64	$10=, $pop98
-	i32.const	$9=, 0
-.LBB18_54:                              # %for.body.i1902
-                                        #   Parent Loop BB18_47 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label122:
-	i64.const	$push340=, 1
-	i64.const	$push99=, 4294967295
-	i64.and 	$push100=, $6, $pop99
-	i64.shl 	$push101=, $pop340, $pop100
-	i64.and 	$push102=, $pop101, $8
-	i64.const	$push103=, 0
-	i64.ne  	$push104=, $pop102, $pop103
-	br_if   	1, $pop104      # 1: down to label123
-# BB#55:                                # %for.inc.i1906
-                                        #   in Loop: Header=BB18_54 Depth=2
-	i32.const	$push105=, 1
-	i32.add 	$9=, $9, $pop105
-	i64.const	$push341=, 1
-	i64.add 	$7=, $7, $pop341
-	i64.const	$push106=, -1
-	i64.add 	$6=, $6, $pop106
-	i64.const	$push107=, 64
-	i64.lt_u	$push108=, $7, $pop107
-	br_if   	0, $pop108      # 0: up to label122
-.LBB18_56:                              # %my_clzll.exit1909
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_loop                        # label123:
-	i32.ne  	$push109=, $10, $9
-	br_if   	19, $pop109     # 19: down to label67
-# BB#57:                                # %land.lhs.true113
-                                        #   in Loop: Header=BB18_47 Depth=1
-	i64.const	$7=, 0
-	i32.wrap/i64	$10=, $3
-	i32.const	$9=, 0
-.LBB18_58:                              # %for.body.i1948
-                                        #   Parent Loop BB18_47 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label124:
-	i64.const	$push343=, 1
-	i64.shl 	$push110=, $pop343, $7
-	i64.and 	$push111=, $pop110, $8
-	i64.const	$push342=, 0
-	i64.ne  	$push112=, $pop111, $pop342
-	br_if   	1, $pop112      # 1: down to label125
-# BB#59:                                # %for.inc.i1952
-                                        #   in Loop: Header=BB18_58 Depth=2
-	i32.const	$push113=, 1
-	i32.add 	$9=, $9, $pop113
-	i64.const	$push344=, 1
-	i64.add 	$7=, $7, $pop344
-	i64.const	$push114=, 64
-	i64.lt_u	$push115=, $7, $pop114
-	br_if   	0, $pop115      # 0: up to label124
-.LBB18_60:                              # %my_ctzll.exit1955
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_loop                        # label125:
-	i32.ne  	$push116=, $10, $9
-	br_if   	20, $pop116     # 20: down to label66
-.LBB18_61:                              # %if.end120
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_block                       # label121:
-	i32.call	$10=, __builtin_clrsbll@FUNCTION, $8
-	i32.const	$push85=, longlongs
-	i32.add 	$push2=, $0, $pop85
-	i64.load	$push346=, 0($pop2)
-	tee_local	$push345=, $8=, $pop346
-	i64.const	$push117=, 63
-	i64.shr_u	$3=, $pop345, $pop117
-	i64.const	$7=, 62
-	i64.const	$6=, 1
-	i32.const	$9=, 1
-.LBB18_62:                              # %for.body.i2018
-                                        #   Parent Loop BB18_47 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label126:
-	i64.shr_u	$push118=, $8, $7
-	i64.const	$push347=, 1
-	i64.and 	$push119=, $pop118, $pop347
-	i64.ne  	$push120=, $pop119, $3
-	br_if   	1, $pop120      # 1: down to label127
-# BB#63:                                # %for.inc.i2022
-                                        #   in Loop: Header=BB18_62 Depth=2
-	i32.const	$push122=, 1
-	i32.add 	$9=, $9, $pop122
-	i64.const	$push121=, 1
-	i64.add 	$6=, $6, $pop121
-	i64.const	$push123=, -1
-	i64.add 	$7=, $7, $pop123
-	i64.const	$push124=, 64
-	i64.lt_u	$push125=, $6, $pop124
-	br_if   	0, $pop125      # 0: up to label126
-.LBB18_64:                              # %my_clrsbll.exit2026
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_loop                        # label127:
-	i32.const	$push126=, -1
-	i32.add 	$push127=, $9, $pop126
-	i32.ne  	$push128=, $10, $pop127
-	br_if   	11, $pop128     # 11: down to label74
-# BB#65:                                # %if.end127
-                                        #   in Loop: Header=BB18_47 Depth=1
-	i64.popcnt	$6=, $8
-	i64.const	$7=, 0
-	i32.const	$9=, 0
-.LBB18_66:                              # %for.body.i2110
-                                        #   Parent Loop BB18_47 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label128:
-	i64.const	$push129=, 1
-	i64.shl 	$push130=, $pop129, $7
-	i64.and 	$push131=, $pop130, $8
-	i64.const	$push349=, 0
-	i64.ne  	$push132=, $pop131, $pop349
-	i32.add 	$9=, $pop132, $9
-	i64.const	$push348=, 1
-	i64.add 	$7=, $7, $pop348
-	i64.const	$push133=, 64
-	i64.ne  	$push134=, $7, $pop133
-	br_if   	0, $pop134      # 0: up to label128
-# BB#67:                                # %my_popcountll.exit2112
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_loop                        # label129:
-	i64.const	$7=, 0
-	i32.const	$10=, 0
-	i32.wrap/i64	$push135=, $6
-	i32.ne  	$push136=, $pop135, $9
-	br_if   	12, $pop136     # 12: down to label73
-.LBB18_68:                              # %for.body.i2196
-                                        #   Parent Loop BB18_47 Depth=1
-                                        # =>  This Inner Loop Header: Depth=2
-	loop                            # label130:
-	i64.const	$push137=, 1
-	i64.shl 	$push138=, $pop137, $7
-	i64.and 	$push139=, $pop138, $8
-	i64.const	$push351=, 0
-	i64.ne  	$push140=, $pop139, $pop351
-	i32.add 	$10=, $pop140, $10
-	i64.const	$push350=, 1
-	i64.add 	$7=, $7, $pop350
-	i64.const	$push141=, 64
-	i64.ne  	$push142=, $7, $pop141
-	br_if   	0, $pop142      # 0: up to label130
-# BB#69:                                # %my_parityll.exit2199
-                                        #   in Loop: Header=BB18_47 Depth=1
-	end_loop                        # label131:
-	i32.xor 	$push143=, $10, $9
-	i32.const	$push144=, 1
-	i32.and 	$push145=, $pop143, $pop144
-	br_if   	13, $pop145     # 13: down to label72
-# BB#70:                                # %for.cond90
-                                        #   in Loop: Header=BB18_47 Depth=1
-	i32.const	$push325=, 1
-	i32.add 	$4=, $4, $pop325
-	i32.const	$push146=, 12
-	i32.le_u	$push147=, $4, $pop146
-	br_if   	0, $pop147      # 0: up to label116
-# BB#71:                                # %if.end148
-	end_loop                        # label117:
-	i32.const	$push148=, 0
-	i32.call	$push149=, __builtin_clrsb@FUNCTION, $pop148
-	i32.const	$push150=, 31
-	i32.ne  	$push151=, $pop149, $pop150
-	br_if   	18, $pop151     # 18: down to label65
-# BB#72:                                # %my_clrsb.exit2770
-	i32.const	$push152=, 1
-	i32.call	$push153=, __builtin_clrsb@FUNCTION, $pop152
-	i32.const	$push154=, 30
-	i32.ne  	$push155=, $pop153, $pop154
-	br_if   	19, $pop155     # 19: down to label64
-# BB#73:                                # %if.end198
-	i32.const	$push156=, -2147483648
-	i32.call	$push157=, __builtin_clrsb@FUNCTION, $pop156
-	br_if   	20, $pop157     # 20: down to label63
-# BB#74:                                # %my_clrsb.exit2597
-	i32.const	$push158=, 1073741824
-	i32.call	$push159=, __builtin_clrsb@FUNCTION, $pop158
-	br_if   	21, $pop159     # 21: down to label62
-# BB#75:                                # %my_clrsb.exit2514
-	i32.const	$push160=, 65536
-	i32.call	$push161=, __builtin_clrsb@FUNCTION, $pop160
-	i32.const	$push162=, 14
-	i32.ne  	$push163=, $pop161, $pop162
-	br_if   	22, $pop163     # 22: down to label61
-# BB#76:                                # %my_clrsb.exit2432
-	i32.const	$push164=, 32768
-	i32.call	$push165=, __builtin_clrsb@FUNCTION, $pop164
-	i32.const	$push166=, 15
-	i32.ne  	$push167=, $pop165, $pop166
-	br_if   	23, $pop167     # 23: down to label60
-# BB#77:                                # %my_clrsb.exit2348
-	i32.const	$push168=, -1515870811
-	i32.call	$push169=, __builtin_clrsb@FUNCTION, $pop168
-	br_if   	24, $pop169     # 24: down to label59
-# BB#78:                                # %my_clrsb.exit2273
-	i32.const	$push170=, 1515870810
-	i32.call	$push171=, __builtin_clrsb@FUNCTION, $pop170
-	br_if   	25, $pop171     # 25: down to label58
-# BB#79:                                # %for.body.i2179
-	i32.const	$push172=, -889323520
-	i32.call	$push173=, __builtin_clrsb@FUNCTION, $pop172
-	i32.const	$push174=, 1
-	i32.ne  	$push175=, $pop173, $pop174
-	br_if   	26, $pop175     # 26: down to label57
-# BB#80:                                # %for.body.i2093
-	i32.const	$push176=, 13303296
-	i32.call	$push177=, __builtin_clrsb@FUNCTION, $pop176
-	i32.const	$push178=, 7
-	i32.ne  	$push179=, $pop177, $pop178
-	br_if   	27, $pop179     # 27: down to label56
-# BB#81:                                # %for.body.i2004
-	i32.const	$push180=, 51966
-	i32.call	$push181=, __builtin_clrsb@FUNCTION, $pop180
-	i32.const	$push182=, 15
-	i32.ne  	$push183=, $pop181, $pop182
-	br_if   	28, $pop183     # 28: down to label55
-# BB#82:                                # %if.end423
-	i32.const	$push352=, -1
-	i32.call	$4=, __builtin_clrsb@FUNCTION, $pop352
-	i32.const	$10=, 30
-	i32.const	$9=, 1
-.LBB18_83:                              # %for.body.i1935
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label132:
-	i32.const	$push354=, -1
-	i32.shr_u	$push184=, $pop354, $10
-	i32.const	$push353=, 1
-	i32.and 	$push185=, $pop184, $pop353
-	i32.const	$push390=, 0
-	i32.eq  	$push391=, $pop185, $pop390
-	br_if   	1, $pop391      # 1: down to label133
-# BB#84:                                # %for.inc.i1938
-                                        #   in Loop: Header=BB18_83 Depth=1
-	i32.const	$push357=, 1
-	i32.add 	$9=, $9, $pop357
-	i32.const	$push356=, -1
-	i32.add 	$10=, $10, $pop356
-	i32.const	$push355=, 32
-	i32.lt_u	$push186=, $9, $pop355
-	br_if   	0, $pop186      # 0: up to label132
-.LBB18_85:                              # %my_clrsb.exit1942
-	end_loop                        # label133:
-	i32.const	$push187=, -1
-	i32.add 	$push188=, $9, $pop187
-	i32.ne  	$push189=, $4, $pop188
-	br_if   	29, $pop189     # 29: down to label54
-# BB#86:                                # %if.end440
-	i64.const	$8=, 0
-	i64.const	$7=, 63
-	i32.const	$9=, 0
-	i64.const	$push358=, 0
-	i32.call	$push190=, __builtin_clrsbll@FUNCTION, $pop358
-	i32.const	$push191=, 63
-	i32.ne  	$push192=, $pop190, $pop191
-	br_if   	30, $pop192     # 30: down to label53
-.LBB18_87:                              # %for.body.i1844
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label134:
-	i32.wrap/i64	$push193=, $7
-	i32.const	$push392=, 0
-	i32.eq  	$push393=, $pop193, $pop392
-	br_if   	1, $pop393      # 1: down to label135
-# BB#88:                                # %for.inc.i1848
-                                        #   in Loop: Header=BB18_87 Depth=1
-	i32.const	$push195=, 1
-	i32.add 	$9=, $9, $pop195
-	i64.const	$push194=, 1
-	i64.add 	$8=, $8, $pop194
-	i64.const	$push196=, -1
-	i64.add 	$7=, $7, $pop196
-	i64.const	$push197=, 64
-	i64.lt_u	$push198=, $8, $pop197
-	br_if   	0, $pop198      # 0: up to label134
-.LBB18_89:                              # %my_clzll.exit1851
-	end_loop                        # label135:
-	i32.const	$push199=, 63
-	i32.ne  	$push200=, $9, $pop199
-	br_if   	31, $pop200     # 31: down to label52
-# BB#90:                                # %if.end465
-	i64.const	$push359=, 1
-	i32.call	$10=, __builtin_clrsbll@FUNCTION, $pop359
-	i64.const	$7=, 1
-.LBB18_91:                              # %for.body.i1799
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label136:
-	i32.const	$9=, 62
-	i64.const	$push360=, 63
-	i64.eq  	$push201=, $7, $pop360
-	br_if   	1, $pop201      # 1: down to label137
-# BB#92:                                # %for.inc.i1803
-                                        #   in Loop: Header=BB18_91 Depth=1
-	i64.const	$push362=, 1
-	i64.add 	$7=, $7, $pop362
-	i32.const	$9=, 63
-	i64.const	$push361=, 64
-	i64.lt_u	$push202=, $7, $pop361
-	br_if   	0, $pop202      # 0: up to label136
-.LBB18_93:                              # %my_clrsbll.exit1807
-	end_loop                        # label137:
-	i64.const	$8=, 0
-	i64.const	$7=, 0
-	i32.ne  	$push203=, $10, $9
-	br_if   	32, $pop203     # 32: down to label51
-.LBB18_94:                              # %for.body.i1759
-                                        # =>This Inner Loop Header: Depth=1
-	block
-	loop                            # label139:
-	i64.const	$push363=, 63
-	i64.eq  	$push204=, $7, $pop363
-	br_if   	2, $pop204      # 2: down to label138
-# BB#95:                                # %for.inc.i1763
-                                        #   in Loop: Header=BB18_94 Depth=1
-	i64.const	$push205=, 1
-	i64.add 	$7=, $7, $pop205
-	i64.const	$push206=, 64
-	i64.lt_u	$push207=, $7, $pop206
-	br_if   	0, $pop207      # 0: up to label139
-# BB#96:                                # %if.then481
-	end_loop                        # label140:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_97:                              # %for.body.i1731
-                                        # =>This Inner Loop Header: Depth=1
-	end_block                       # label138:
-	block
-	loop                            # label142:
-	i64.const	$push364=, 63
-	i64.eq  	$push208=, $8, $pop364
-	br_if   	2, $pop208      # 2: down to label141
-# BB#98:                                # %for.inc.i1735
-                                        #   in Loop: Header=BB18_97 Depth=1
-	i64.const	$push209=, 1
-	i64.add 	$8=, $8, $pop209
-	i64.const	$push210=, 64
-	i64.lt_u	$push211=, $8, $pop210
-	br_if   	0, $pop211      # 0: up to label142
-# BB#99:                                # %if.then489
-	end_loop                        # label143:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_100:                             # %if.end490
-	end_block                       # label141:
-	i64.const	$push212=, -9223372036854775808
-	i32.call	$push213=, __builtin_clrsbll@FUNCTION, $pop212
-	br_if   	33, $pop213     # 33: down to label50
-# BB#101:                               # %for.body.i1665
-	i64.const	$7=, 63
-	i64.const	$8=, -1
-.LBB18_102:                             # %for.body.i1652
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label144:
-	i64.const	$push367=, 1
-	i64.add 	$8=, $8, $pop367
-	i64.const	$push366=, -1
-	i64.add 	$6=, $7, $pop366
-	i32.wrap/i64	$9=, $7
-	copy_local	$7=, $6
-	i32.const	$push365=, 1
-	i32.ne  	$push214=, $9, $pop365
-	br_if   	0, $pop214      # 0: up to label144
-# BB#103:                               # %my_clzll.exit1659
-	end_loop                        # label145:
-	i32.wrap/i64	$push215=, $8
-	i32.const	$push216=, 62
-	i32.ne  	$push217=, $pop215, $pop216
-	br_if   	34, $pop217     # 34: down to label49
-# BB#104:                               # %for.body.i1612
-	i64.const	$push218=, 2
-	i32.call	$push219=, __builtin_clrsbll@FUNCTION, $pop218
-	i32.const	$push220=, 61
-	i32.ne  	$push221=, $pop219, $pop220
-	br_if   	35, $pop221     # 35: down to label48
-# BB#105:                               # %my_clrsbll.exit1525
-	i64.const	$push222=, 4611686018427387904
-	i32.call	$push223=, __builtin_clrsbll@FUNCTION, $pop222
-	br_if   	36, $pop223     # 36: down to label47
-# BB#106:                               # %for.body.i1425
-	i64.const	$push224=, 4294967296
-	i32.call	$push225=, __builtin_clrsbll@FUNCTION, $pop224
-	i32.const	$push226=, 30
-	i32.ne  	$push227=, $pop225, $pop226
-	br_if   	37, $pop227     # 37: down to label46
-# BB#107:                               # %for.body.i1332
-	i64.const	$push228=, 2147483648
-	i32.call	$push229=, __builtin_clrsbll@FUNCTION, $pop228
-	i32.const	$push230=, 31
-	i32.ne  	$push231=, $pop229, $pop230
-	br_if   	38, $pop231     # 38: down to label45
-# BB#108:                               # %my_clrsbll.exit1245
-	i64.const	$push232=, -6510615555426900571
-	i32.call	$push233=, __builtin_clrsbll@FUNCTION, $pop232
-	br_if   	39, $pop233     # 39: down to label44
-# BB#109:                               # %my_clrsbll.exit1152
-	i64.const	$push234=, 6510615555426900570
-	i32.call	$push235=, __builtin_clrsbll@FUNCTION, $pop234
-	br_if   	40, $pop235     # 40: down to label43
-# BB#110:                               # %for.body.i1053
-	i64.const	$push236=, -3819392241693097984
-	i32.call	$push237=, __builtin_clrsbll@FUNCTION, $pop236
-	i32.const	$push238=, 1
-	i32.ne  	$push239=, $pop237, $pop238
-	br_if   	41, $pop239     # 41: down to label42
-# BB#111:                               # %for.body.i964
-	i64.const	$push240=, 223195676147712
-	i32.call	$push241=, __builtin_clrsbll@FUNCTION, $pop240
-	i32.const	$push242=, 15
-	i32.ne  	$push243=, $pop241, $pop242
-	br_if   	42, $pop243     # 42: down to label41
-# BB#112:                               # %for.body.i925
-	i64.const	$7=, 63
-	i64.const	$8=, -1
-.LBB18_113:                             # %for.body.i913
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label146:
-	i64.const	$push373=, 4294967295
-	i64.and 	$6=, $7, $pop373
-	i64.const	$push372=, 1
-	i64.add 	$8=, $8, $pop372
-	i64.const	$push371=, -1
-	i64.add 	$7=, $7, $pop371
-	i64.const	$push370=, 1
-	i64.shl 	$push244=, $pop370, $6
-	i64.const	$push369=, 3405695742
-	i64.and 	$push245=, $pop244, $pop369
-	i64.const	$push368=, 0
-	i64.eq  	$push246=, $pop245, $pop368
-	br_if   	0, $pop246      # 0: up to label146
-# BB#114:                               # %my_clzll.exit
-	end_loop                        # label147:
-	i32.wrap/i64	$push247=, $8
-	i32.const	$push248=, 32
-	i32.ne  	$push249=, $pop247, $pop248
-	br_if   	43, $pop249     # 43: down to label40
-# BB#115:                               # %for.body.i877
-	i64.const	$push250=, 3405695742
-	i32.call	$push251=, __builtin_clrsbll@FUNCTION, $pop250
-	i32.const	$push252=, 31
-	i32.ne  	$push253=, $pop251, $pop252
-	br_if   	44, $pop253     # 44: down to label39
-# BB#116:                               # %if.end740
-	i64.const	$push374=, -1
-	i32.call	$10=, __builtin_clrsbll@FUNCTION, $pop374
-	i64.const	$7=, 62
-	i64.const	$8=, 1
-	i32.const	$9=, 1
-.LBB18_117:                             # %for.body.i812
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label148:
-	i64.const	$push377=, -1
-	i64.shr_u	$push254=, $pop377, $7
-	i64.const	$push376=, 1
-	i64.and 	$push255=, $pop254, $pop376
-	i64.const	$push375=, 0
-	i64.eq  	$push256=, $pop255, $pop375
-	br_if   	1, $pop256      # 1: down to label149
-# BB#118:                               # %for.inc.i816
-                                        #   in Loop: Header=BB18_117 Depth=1
-	i64.const	$push381=, 1
-	i64.add 	$8=, $8, $pop381
-	i32.const	$push380=, 1
-	i32.add 	$9=, $9, $pop380
-	i64.const	$push379=, -1
-	i64.add 	$7=, $7, $pop379
-	i64.const	$push378=, 64
-	i64.lt_u	$push257=, $8, $pop378
-	br_if   	0, $pop257      # 0: up to label148
-.LBB18_119:                             # %my_clrsbll.exit
-	end_loop                        # label149:
-	block
-	i32.const	$push258=, -1
-	i32.add 	$push259=, $9, $pop258
-	i32.ne  	$push260=, $10, $pop259
-	br_if   	0, $pop260      # 0: down to label150
-# BB#120:                               # %if.end753
-	i32.const	$push261=, 0
-	call    	exit@FUNCTION, $pop261
-	unreachable
-.LBB18_121:                             # %if.then744
-	end_block                       # label150:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_122:                             # %if.then
-	end_block                       # label83:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_123:                             # %if.then25
-	end_block                       # label82:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_124:                             # %if.then31
-	end_block                       # label81:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_125:                             # %if.then37
-	end_block                       # label80:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_126:                             # %if.then48
-	end_block                       # label79:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_127:                             # %if.then73
-	end_block                       # label78:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_128:                             # %if.then79
-	end_block                       # label77:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_129:                             # %if.then85
-	end_block                       # label76:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_130:                             # %if.then99
-	end_block                       # label75:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_131:                             # %if.then126
-	end_block                       # label74:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_132:                             # %if.then133
-	end_block                       # label73:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_133:                             # %if.then140
-	end_block                       # label72:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_134:                             # %if.then9
-	end_block                       # label71:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_135:                             # %if.then18
-	end_block                       # label70:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_136:                             # %if.then57
-	end_block                       # label69:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_137:                             # %if.then66
-	end_block                       # label68:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_138:                             # %if.then109
-	end_block                       # label67:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_139:                             # %if.then119
-	end_block                       # label66:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_140:                             # %if.then152
-	end_block                       # label65:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_141:                             # %if.then177
-	end_block                       # label64:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_142:                             # %if.then202
-	end_block                       # label63:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_143:                             # %if.then227
+	loop                            # label65:
+	i32.const	$push270=, 1
+	i32.shl 	$push44=, $pop270, $8
+	i32.and 	$push45=, $pop44, $10
+	br_if   	1, $pop45       # 1: down to label66
+# BB#37:                                # %for.inc.i1441
+                                        #   in Loop: Header=BB18_36 Depth=2
+	i32.const	$push272=, 1
+	i32.add 	$8=, $8, $pop272
+	i32.const	$push271=, 32
+	i32.lt_u	$push46=, $8, $pop271
+	br_if   	0, $pop46       # 0: up to label65
+.LBB18_38:                              # %my_ctzl.exit
+                                        #   in Loop: Header=BB18_25 Depth=1
+	end_loop                        # label66:
+	i32.ne  	$push47=, $1, $8
+	br_if   	3, $pop47       # 3: down to label40
+.LBB18_39:                              # %if.end67
+                                        #   in Loop: Header=BB18_25 Depth=1
 	end_block                       # label62:
+	i32.call	$1=, __builtin_clrsbl@FUNCTION, $10
+	i32.const	$push276=, longs
+	i32.add 	$push1=, $9, $pop276
+	i32.load	$push275=, 0($pop1)
+	tee_local	$push274=, $10=, $pop275
+	i32.const	$push273=, 31
+	i32.shr_u	$3=, $pop274, $pop273
+	i32.const	$4=, 1
+	i32.const	$8=, 30
+.LBB18_40:                              # %for.body.i1532
+                                        #   Parent Loop BB18_25 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label67:
+	i32.shr_u	$push48=, $10, $8
+	i32.const	$push277=, 1
+	i32.and 	$push49=, $pop48, $pop277
+	i32.ne  	$push50=, $pop49, $3
+	br_if   	1, $pop50       # 1: down to label68
+# BB#41:                                # %for.inc.i1535
+                                        #   in Loop: Header=BB18_40 Depth=2
+	i32.const	$push280=, 1
+	i32.add 	$4=, $4, $pop280
+	i32.const	$push279=, -1
+	i32.add 	$8=, $8, $pop279
+	i32.const	$push278=, 32
+	i32.lt_u	$push51=, $4, $pop278
+	br_if   	0, $pop51       # 0: up to label67
+.LBB18_42:                              # %my_clrsbl.exit
+                                        #   in Loop: Header=BB18_25 Depth=1
+	end_loop                        # label68:
+	i32.const	$3=, 0
+	i32.const	$8=, 0
+	i32.const	$push281=, -1
+	i32.add 	$push52=, $4, $pop281
+	i32.ne  	$push53=, $1, $pop52
+	br_if   	2, $pop53       # 2: down to label40
+.LBB18_43:                              # %for.body.i1630
+                                        #   Parent Loop BB18_25 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label69:
+	i32.const	$push285=, 1
+	i32.shl 	$push54=, $pop285, $8
+	i32.and 	$push55=, $pop54, $10
+	i32.const	$push284=, 0
+	i32.ne  	$push56=, $pop55, $pop284
+	i32.add 	$3=, $pop56, $3
+	i32.const	$push283=, 1
+	i32.add 	$8=, $8, $pop283
+	i32.const	$push282=, 32
+	i32.ne  	$push57=, $8, $pop282
+	br_if   	0, $pop57       # 0: up to label69
+# BB#44:                                # %my_popcountl.exit
+                                        #   in Loop: Header=BB18_25 Depth=1
+	end_loop                        # label70:
+	i32.const	$4=, 0
+	i32.const	$8=, 0
+	i32.popcnt	$push58=, $10
+	i32.ne  	$push59=, $pop58, $3
+	br_if   	2, $pop59       # 2: down to label40
+.LBB18_45:                              # %for.body.i1723
+                                        #   Parent Loop BB18_25 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label71:
+	i32.const	$push289=, 1
+	i32.shl 	$push60=, $pop289, $8
+	i32.and 	$push61=, $pop60, $10
+	i32.const	$push288=, 0
+	i32.ne  	$push62=, $pop61, $pop288
+	i32.add 	$4=, $pop62, $4
+	i32.const	$push287=, 1
+	i32.add 	$8=, $8, $pop287
+	i32.const	$push286=, 32
+	i32.ne  	$push63=, $8, $pop286
+	br_if   	0, $pop63       # 0: up to label71
+# BB#46:                                # %my_parityl.exit
+                                        #   in Loop: Header=BB18_25 Depth=1
+	end_loop                        # label72:
+	i32.xor 	$push64=, $4, $3
+	i32.const	$push290=, 1
+	i32.and 	$push65=, $pop64, $pop290
+	br_if   	2, $pop65       # 2: down to label40
+# BB#47:                                # %for.cond39
+                                        #   in Loop: Header=BB18_25 Depth=1
+	i32.const	$push252=, 1
+	i32.add 	$0=, $0, $pop252
+	i32.const	$push251=, 12
+	i32.le_u	$push66=, $0, $pop251
+	br_if   	0, $pop66       # 0: up to label57
+# BB#48:
+	end_loop                        # label58:
+	i32.const	$3=, 0
+.LBB18_49:                              # %for.body92
+                                        # =>This Loop Header: Depth=1
+                                        #     Child Loop BB18_50 Depth 2
+                                        #     Child Loop BB18_56 Depth 2
+                                        #     Child Loop BB18_60 Depth 2
+                                        #     Child Loop BB18_64 Depth 2
+                                        #     Child Loop BB18_68 Depth 2
+                                        #     Child Loop BB18_71 Depth 2
+	loop                            # label73:
+	i32.const	$8=, 0
+	i32.const	$push304=, 0
+	i32.const	$push303=, 3
+	i32.shl 	$push302=, $3, $pop303
+	tee_local	$push301=, $0=, $pop302
+	i64.load	$push300=, longlongs($pop301)
+	tee_local	$push299=, $7=, $pop300
+	i64.ctz 	$push298=, $pop299
+	tee_local	$push297=, $2=, $pop298
+	i64.const	$push296=, 1
+	i64.add 	$push67=, $pop297, $pop296
+	i32.wrap/i64	$push68=, $pop67
+	i64.const	$push295=, 0
+	i64.eq  	$push294=, $7, $pop295
+	tee_local	$push293=, $10=, $pop294
+	i32.select	$4=, $pop304, $pop68, $pop293
+	i64.const	$6=, 0
+	block
+	br_if   	0, $10          # 0: down to label75
+.LBB18_50:                              # %for.body.i1814
+                                        #   Parent Loop BB18_49 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label76:
+	i64.const	$push306=, 1
+	i64.shl 	$push69=, $pop306, $6
+	i64.and 	$push70=, $pop69, $7
+	i64.const	$push305=, 0
+	i64.ne  	$push71=, $pop70, $pop305
+	br_if   	1, $pop71       # 1: down to label77
+# BB#51:                                # %for.inc.i1818
+                                        #   in Loop: Header=BB18_50 Depth=2
+	i64.const	$push309=, 1
+	i64.add 	$6=, $6, $pop309
+	i32.const	$push308=, 1
+	i32.add 	$8=, $8, $pop308
+	i64.const	$push307=, 64
+	i64.lt_u	$push72=, $6, $pop307
+	br_if   	0, $pop72       # 0: up to label76
+.LBB18_52:                              # %for.end.i1821
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_loop                        # label77:
+	i32.const	$push310=, 1
+	i32.add 	$8=, $8, $pop310
+.LBB18_53:                              # %my_ffsll.exit1823
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_block                       # label75:
+	i32.ne  	$push73=, $4, $8
+	br_if   	2, $pop73       # 2: down to label40
+# BB#54:                                # %if.end100
+                                        #   in Loop: Header=BB18_49 Depth=1
+	block
+	br_if   	0, $10          # 0: down to label78
+# BB#55:                                # %land.lhs.true103
+                                        #   in Loop: Header=BB18_49 Depth=1
+	i64.const	$5=, 0
+	i64.const	$6=, 63
+	i64.clz 	$push74=, $7
+	i32.wrap/i64	$10=, $pop74
+	i32.const	$8=, 0
+.LBB18_56:                              # %for.body.i1902
+                                        #   Parent Loop BB18_49 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label79:
+	i64.const	$push313=, 1
+	i64.const	$push312=, 4294967295
+	i64.and 	$push75=, $6, $pop312
+	i64.shl 	$push76=, $pop313, $pop75
+	i64.and 	$push77=, $pop76, $7
+	i64.const	$push311=, 0
+	i64.ne  	$push78=, $pop77, $pop311
+	br_if   	1, $pop78       # 1: down to label80
+# BB#57:                                # %for.inc.i1906
+                                        #   in Loop: Header=BB18_56 Depth=2
+	i64.const	$push317=, 1
+	i64.add 	$5=, $5, $pop317
+	i32.const	$push316=, 1
+	i32.add 	$8=, $8, $pop316
+	i64.const	$push315=, -1
+	i64.add 	$6=, $6, $pop315
+	i64.const	$push314=, 64
+	i64.lt_u	$push79=, $5, $pop314
+	br_if   	0, $pop79       # 0: up to label79
+.LBB18_58:                              # %my_clzll.exit1909
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_loop                        # label80:
+	i32.ne  	$push80=, $10, $8
+	br_if   	3, $pop80       # 3: down to label40
+# BB#59:                                # %land.lhs.true113
+                                        #   in Loop: Header=BB18_49 Depth=1
+	i64.const	$6=, 0
+	i32.wrap/i64	$10=, $2
+	i32.const	$8=, 0
+.LBB18_60:                              # %for.body.i1948
+                                        #   Parent Loop BB18_49 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label81:
+	i64.const	$push319=, 1
+	i64.shl 	$push81=, $pop319, $6
+	i64.and 	$push82=, $pop81, $7
+	i64.const	$push318=, 0
+	i64.ne  	$push83=, $pop82, $pop318
+	br_if   	1, $pop83       # 1: down to label82
+# BB#61:                                # %for.inc.i1952
+                                        #   in Loop: Header=BB18_60 Depth=2
+	i64.const	$push322=, 1
+	i64.add 	$6=, $6, $pop322
+	i32.const	$push321=, 1
+	i32.add 	$8=, $8, $pop321
+	i64.const	$push320=, 64
+	i64.lt_u	$push84=, $6, $pop320
+	br_if   	0, $pop84       # 0: up to label81
+.LBB18_62:                              # %my_ctzll.exit1955
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_loop                        # label82:
+	i32.ne  	$push85=, $10, $8
+	br_if   	3, $pop85       # 3: down to label40
+.LBB18_63:                              # %if.end120
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_block                       # label78:
+	i32.call	$10=, __builtin_clrsbll@FUNCTION, $7
+	i32.const	$push326=, longlongs
+	i32.add 	$push2=, $0, $pop326
+	i64.load	$push325=, 0($pop2)
+	tee_local	$push324=, $7=, $pop325
+	i64.const	$push323=, 63
+	i64.shr_u	$2=, $pop324, $pop323
+	i64.const	$5=, 1
+	i64.const	$6=, 62
+	i32.const	$8=, 1
+.LBB18_64:                              # %for.body.i2018
+                                        #   Parent Loop BB18_49 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label83:
+	i64.shr_u	$push86=, $7, $6
+	i64.const	$push327=, 1
+	i64.and 	$push87=, $pop86, $pop327
+	i64.ne  	$push88=, $pop87, $2
+	br_if   	1, $pop88       # 1: down to label84
+# BB#65:                                # %for.inc.i2022
+                                        #   in Loop: Header=BB18_64 Depth=2
+	i64.const	$push331=, 1
+	i64.add 	$5=, $5, $pop331
+	i32.const	$push330=, 1
+	i32.add 	$8=, $8, $pop330
+	i64.const	$push329=, -1
+	i64.add 	$6=, $6, $pop329
+	i64.const	$push328=, 64
+	i64.lt_u	$push89=, $5, $pop328
+	br_if   	0, $pop89       # 0: up to label83
+.LBB18_66:                              # %my_clrsbll.exit2026
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_loop                        # label84:
+	i32.const	$push332=, -1
+	i32.add 	$push90=, $8, $pop332
+	i32.ne  	$push91=, $10, $pop90
+	br_if   	2, $pop91       # 2: down to label40
+# BB#67:                                # %if.end127
+                                        #   in Loop: Header=BB18_49 Depth=1
+	i64.popcnt	$5=, $7
+	i64.const	$6=, 0
+	i32.const	$8=, 0
+.LBB18_68:                              # %for.body.i2110
+                                        #   Parent Loop BB18_49 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label85:
+	i64.const	$push336=, 1
+	i64.shl 	$push92=, $pop336, $6
+	i64.and 	$push93=, $pop92, $7
+	i64.const	$push335=, 0
+	i64.ne  	$push94=, $pop93, $pop335
+	i32.add 	$8=, $pop94, $8
+	i64.const	$push334=, 1
+	i64.add 	$6=, $6, $pop334
+	i64.const	$push333=, 64
+	i64.ne  	$push95=, $6, $pop333
+	br_if   	0, $pop95       # 0: up to label85
+# BB#69:                                # %my_popcountll.exit2112
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_loop                        # label86:
+	i32.wrap/i64	$push96=, $5
+	i32.ne  	$push97=, $pop96, $8
+	br_if   	2, $pop97       # 2: down to label40
+# BB#70:                                #   in Loop: Header=BB18_49 Depth=1
+	i64.const	$6=, 0
+	i32.const	$10=, 0
+.LBB18_71:                              # %for.body.i2196
+                                        #   Parent Loop BB18_49 Depth=1
+                                        # =>  This Inner Loop Header: Depth=2
+	loop                            # label87:
+	i64.const	$push340=, 1
+	i64.shl 	$push98=, $pop340, $6
+	i64.and 	$push99=, $pop98, $7
+	i64.const	$push339=, 0
+	i64.ne  	$push100=, $pop99, $pop339
+	i32.add 	$10=, $pop100, $10
+	i64.const	$push338=, 1
+	i64.add 	$6=, $6, $pop338
+	i64.const	$push337=, 64
+	i64.ne  	$push101=, $6, $pop337
+	br_if   	0, $pop101      # 0: up to label87
+# BB#72:                                # %my_parityll.exit2199
+                                        #   in Loop: Header=BB18_49 Depth=1
+	end_loop                        # label88:
+	i32.xor 	$push102=, $10, $8
+	i32.const	$push341=, 1
+	i32.and 	$push103=, $pop102, $pop341
+	br_if   	3, $pop103      # 3: down to label39
+# BB#73:                                # %for.cond90
+                                        #   in Loop: Header=BB18_49 Depth=1
+	i32.const	$push292=, 1
+	i32.add 	$3=, $3, $pop292
+	i32.const	$push291=, 12
+	i32.le_u	$push104=, $3, $pop291
+	br_if   	0, $pop104      # 0: up to label73
+# BB#74:                                # %if.end148
+	end_loop                        # label74:
+	i32.const	$push105=, 0
+	i32.call	$push106=, __builtin_clrsb@FUNCTION, $pop105
+	i32.const	$push107=, 31
+	i32.ne  	$push108=, $pop106, $pop107
+	br_if   	0, $pop108      # 0: down to label40
+# BB#75:                                # %my_clrsb.exit2770
+	i32.const	$push109=, 1
+	i32.call	$push110=, __builtin_clrsb@FUNCTION, $pop109
+	i32.const	$push111=, 30
+	i32.ne  	$push112=, $pop110, $pop111
+	br_if   	0, $pop112      # 0: down to label40
+# BB#76:                                # %if.end198
+	i32.const	$push113=, -2147483648
+	i32.call	$push114=, __builtin_clrsb@FUNCTION, $pop113
+	br_if   	0, $pop114      # 0: down to label40
+# BB#77:                                # %my_clrsb.exit2597
+	i32.const	$push115=, 1073741824
+	i32.call	$push116=, __builtin_clrsb@FUNCTION, $pop115
+	br_if   	0, $pop116      # 0: down to label40
+# BB#78:                                # %my_clrsb.exit2514
+	i32.const	$push117=, 65536
+	i32.call	$push118=, __builtin_clrsb@FUNCTION, $pop117
+	i32.const	$push119=, 14
+	i32.ne  	$push120=, $pop118, $pop119
+	br_if   	0, $pop120      # 0: down to label40
+# BB#79:                                # %my_clrsb.exit2432
+	i32.const	$push121=, 32768
+	i32.call	$push122=, __builtin_clrsb@FUNCTION, $pop121
+	i32.const	$push123=, 15
+	i32.ne  	$push124=, $pop122, $pop123
+	br_if   	0, $pop124      # 0: down to label40
+# BB#80:                                # %my_clrsb.exit2348
+	i32.const	$push125=, -1515870811
+	i32.call	$push126=, __builtin_clrsb@FUNCTION, $pop125
+	br_if   	0, $pop126      # 0: down to label40
+# BB#81:                                # %my_clrsb.exit2273
+	i32.const	$push127=, 1515870810
+	i32.call	$push128=, __builtin_clrsb@FUNCTION, $pop127
+	br_if   	0, $pop128      # 0: down to label40
+# BB#82:                                # %for.body.i2179
+	i32.const	$push129=, -889323520
+	i32.call	$push130=, __builtin_clrsb@FUNCTION, $pop129
+	i32.const	$push131=, 1
+	i32.ne  	$push132=, $pop130, $pop131
+	br_if   	0, $pop132      # 0: down to label40
+# BB#83:                                # %for.body.i2093
+	i32.const	$push133=, 13303296
+	i32.call	$push134=, __builtin_clrsb@FUNCTION, $pop133
+	i32.const	$push135=, 7
+	i32.ne  	$push136=, $pop134, $pop135
+	br_if   	0, $pop136      # 0: down to label40
+# BB#84:                                # %for.body.i2004
+	i32.const	$push137=, 51966
+	i32.call	$push138=, __builtin_clrsb@FUNCTION, $pop137
+	i32.const	$push139=, 15
+	i32.ne  	$push140=, $pop138, $pop139
+	br_if   	0, $pop140      # 0: down to label40
+# BB#85:                                # %if.end423
+	i32.const	$push342=, -1
+	i32.call	$3=, __builtin_clrsb@FUNCTION, $pop342
+	i32.const	$10=, 30
+	i32.const	$8=, 1
+.LBB18_86:                              # %for.body.i1935
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label89:
+	i32.const	$push344=, -1
+	i32.shr_u	$push141=, $pop344, $10
+	i32.const	$push343=, 1
+	i32.and 	$push142=, $pop141, $pop343
+	i32.const	$push388=, 0
+	i32.eq  	$push389=, $pop142, $pop388
+	br_if   	1, $pop389      # 1: down to label90
+# BB#87:                                # %for.inc.i1938
+                                        #   in Loop: Header=BB18_86 Depth=1
+	i32.const	$push347=, 1
+	i32.add 	$8=, $8, $pop347
+	i32.const	$push346=, -1
+	i32.add 	$10=, $10, $pop346
+	i32.const	$push345=, 32
+	i32.lt_u	$push143=, $8, $pop345
+	br_if   	0, $pop143      # 0: up to label89
+.LBB18_88:                              # %my_clrsb.exit1942
+	end_loop                        # label90:
+	i32.const	$push144=, -1
+	i32.add 	$push145=, $8, $pop144
+	i32.ne  	$push146=, $3, $pop145
+	br_if   	0, $pop146      # 0: down to label40
+# BB#89:                                # %if.end440
+	i64.const	$7=, 0
+	i64.const	$push348=, 0
+	i32.call	$push147=, __builtin_clrsbll@FUNCTION, $pop348
+	i32.const	$push148=, 63
+	i32.ne  	$push149=, $pop147, $pop148
+	br_if   	0, $pop149      # 0: down to label40
+# BB#90:
+	i64.const	$6=, 63
+	i32.const	$8=, 0
+.LBB18_91:                              # %for.body.i1844
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label91:
+	i32.wrap/i64	$push150=, $6
+	i32.const	$push390=, 0
+	i32.eq  	$push391=, $pop150, $pop390
+	br_if   	1, $pop391      # 1: down to label92
+# BB#92:                                # %for.inc.i1848
+                                        #   in Loop: Header=BB18_91 Depth=1
+	i64.const	$push352=, 1
+	i64.add 	$7=, $7, $pop352
+	i32.const	$push351=, 1
+	i32.add 	$8=, $8, $pop351
+	i64.const	$push350=, -1
+	i64.add 	$6=, $6, $pop350
+	i64.const	$push349=, 64
+	i64.lt_u	$push151=, $7, $pop349
+	br_if   	0, $pop151      # 0: up to label91
+.LBB18_93:                              # %my_clzll.exit1851
+	end_loop                        # label92:
+	i32.const	$push152=, 63
+	i32.ne  	$push153=, $8, $pop152
+	br_if   	0, $pop153      # 0: down to label40
+# BB#94:                                # %if.end465
+	i64.const	$push353=, 1
+	i32.call	$10=, __builtin_clrsbll@FUNCTION, $pop353
+	i64.const	$6=, 1
+.LBB18_95:                              # %for.body.i1799
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label93:
+	i32.const	$8=, 62
+	i64.const	$push354=, 63
+	i64.eq  	$push154=, $6, $pop354
+	br_if   	1, $pop154      # 1: down to label94
+# BB#96:                                # %for.inc.i1803
+                                        #   in Loop: Header=BB18_95 Depth=1
+	i64.const	$push356=, 1
+	i64.add 	$6=, $6, $pop356
+	i32.const	$8=, 63
+	i64.const	$push355=, 64
+	i64.lt_u	$push155=, $6, $pop355
+	br_if   	0, $pop155      # 0: up to label93
+.LBB18_97:                              # %my_clrsbll.exit1807
+	end_loop                        # label94:
+	i32.ne  	$push156=, $10, $8
+	br_if   	0, $pop156      # 0: down to label40
+# BB#98:
+	i64.const	$6=, 0
+.LBB18_99:                              # %for.body.i1759
+                                        # =>This Inner Loop Header: Depth=1
+	block
+	loop                            # label96:
+	i64.const	$push357=, 63
+	i64.eq  	$push157=, $6, $pop357
+	br_if   	2, $pop157      # 2: down to label95
+# BB#100:                               # %for.inc.i1763
+                                        #   in Loop: Header=BB18_99 Depth=1
+	i64.const	$push359=, 1
+	i64.add 	$6=, $6, $pop359
+	i64.const	$push358=, 64
+	i64.lt_u	$push158=, $6, $pop358
+	br_if   	0, $pop158      # 0: up to label96
+# BB#101:                               # %if.then481
+	end_loop                        # label97:
 	call    	abort@FUNCTION
 	unreachable
-.LBB18_144:                             # %if.then252
-	end_block                       # label61:
+.LBB18_102:
+	end_block                       # label95:
+	i64.const	$6=, 0
+.LBB18_103:                             # %for.body.i1731
+                                        # =>This Inner Loop Header: Depth=1
+	block
+	loop                            # label99:
+	i64.const	$push360=, 63
+	i64.eq  	$push159=, $6, $pop360
+	br_if   	2, $pop159      # 2: down to label98
+# BB#104:                               # %for.inc.i1735
+                                        #   in Loop: Header=BB18_103 Depth=1
+	i64.const	$push362=, 1
+	i64.add 	$6=, $6, $pop362
+	i64.const	$push361=, 64
+	i64.lt_u	$push160=, $6, $pop361
+	br_if   	0, $pop160      # 0: up to label99
+# BB#105:                               # %if.then489
+	end_loop                        # label100:
 	call    	abort@FUNCTION
 	unreachable
-.LBB18_145:                             # %if.then277
-	end_block                       # label60:
-	call    	abort@FUNCTION
+.LBB18_106:                             # %if.end490
+	end_block                       # label98:
+	i64.const	$push161=, -9223372036854775808
+	i32.call	$push162=, __builtin_clrsbll@FUNCTION, $pop161
+	br_if   	0, $pop162      # 0: down to label40
+# BB#107:                               # %for.body.i1665
+	i64.const	$6=, 63
+	i64.const	$7=, -1
+.LBB18_108:                             # %for.body.i1652
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label101:
+	i64.const	$push365=, 1
+	i64.add 	$7=, $7, $pop365
+	i64.const	$push364=, -1
+	i64.add 	$5=, $6, $pop364
+	i32.wrap/i64	$8=, $6
+	copy_local	$6=, $5
+	i32.const	$push363=, 1
+	i32.ne  	$push163=, $8, $pop363
+	br_if   	0, $pop163      # 0: up to label101
+# BB#109:                               # %my_clzll.exit1659
+	end_loop                        # label102:
+	i32.wrap/i64	$push164=, $7
+	i32.const	$push165=, 62
+	i32.ne  	$push166=, $pop164, $pop165
+	br_if   	0, $pop166      # 0: down to label40
+# BB#110:                               # %for.body.i1612
+	i64.const	$push167=, 2
+	i32.call	$push168=, __builtin_clrsbll@FUNCTION, $pop167
+	i32.const	$push169=, 61
+	i32.ne  	$push170=, $pop168, $pop169
+	br_if   	0, $pop170      # 0: down to label40
+# BB#111:                               # %my_clrsbll.exit1525
+	i64.const	$push171=, 4611686018427387904
+	i32.call	$push172=, __builtin_clrsbll@FUNCTION, $pop171
+	br_if   	0, $pop172      # 0: down to label40
+# BB#112:                               # %for.body.i1425
+	i64.const	$push173=, 4294967296
+	i32.call	$push174=, __builtin_clrsbll@FUNCTION, $pop173
+	i32.const	$push175=, 30
+	i32.ne  	$push176=, $pop174, $pop175
+	br_if   	0, $pop176      # 0: down to label40
+# BB#113:                               # %for.body.i1332
+	i64.const	$push177=, 2147483648
+	i32.call	$push178=, __builtin_clrsbll@FUNCTION, $pop177
+	i32.const	$push179=, 31
+	i32.ne  	$push180=, $pop178, $pop179
+	br_if   	0, $pop180      # 0: down to label40
+# BB#114:                               # %my_clrsbll.exit1245
+	i64.const	$push181=, -6510615555426900571
+	i32.call	$push182=, __builtin_clrsbll@FUNCTION, $pop181
+	br_if   	0, $pop182      # 0: down to label40
+# BB#115:                               # %my_clrsbll.exit1152
+	i64.const	$push183=, 6510615555426900570
+	i32.call	$push184=, __builtin_clrsbll@FUNCTION, $pop183
+	br_if   	0, $pop184      # 0: down to label40
+# BB#116:                               # %for.body.i1053
+	i64.const	$push185=, -3819392241693097984
+	i32.call	$push186=, __builtin_clrsbll@FUNCTION, $pop185
+	i32.const	$push187=, 1
+	i32.ne  	$push188=, $pop186, $pop187
+	br_if   	0, $pop188      # 0: down to label40
+# BB#117:                               # %for.body.i964
+	i64.const	$push189=, 223195676147712
+	i32.call	$push190=, __builtin_clrsbll@FUNCTION, $pop189
+	i32.const	$push191=, 15
+	i32.ne  	$push192=, $pop190, $pop191
+	br_if   	0, $pop192      # 0: down to label40
+# BB#118:                               # %for.body.i925
+	i64.const	$6=, 63
+	i64.const	$7=, -1
+.LBB18_119:                             # %for.body.i913
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label103:
+	i64.const	$push371=, 4294967295
+	i64.and 	$5=, $6, $pop371
+	i64.const	$push370=, 1
+	i64.add 	$7=, $7, $pop370
+	i64.const	$push369=, -1
+	i64.add 	$6=, $6, $pop369
+	i64.const	$push368=, 1
+	i64.shl 	$push193=, $pop368, $5
+	i64.const	$push367=, 3405695742
+	i64.and 	$push194=, $pop193, $pop367
+	i64.const	$push366=, 0
+	i64.eq  	$push195=, $pop194, $pop366
+	br_if   	0, $pop195      # 0: up to label103
+# BB#120:                               # %my_clzll.exit
+	end_loop                        # label104:
+	i32.wrap/i64	$push196=, $7
+	i32.const	$push197=, 32
+	i32.ne  	$push198=, $pop196, $pop197
+	br_if   	0, $pop198      # 0: down to label40
+# BB#121:                               # %for.body.i877
+	i64.const	$push199=, 3405695742
+	i32.call	$push200=, __builtin_clrsbll@FUNCTION, $pop199
+	i32.const	$push201=, 31
+	i32.ne  	$push202=, $pop200, $pop201
+	br_if   	0, $pop202      # 0: down to label40
+# BB#122:                               # %if.end740
+	i64.const	$push372=, -1
+	i32.call	$10=, __builtin_clrsbll@FUNCTION, $pop372
+	i64.const	$6=, 62
+	i64.const	$7=, 1
+	i32.const	$8=, 1
+.LBB18_123:                             # %for.body.i812
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label105:
+	i64.const	$push375=, -1
+	i64.shr_u	$push203=, $pop375, $6
+	i64.const	$push374=, 1
+	i64.and 	$push204=, $pop203, $pop374
+	i64.const	$push373=, 0
+	i64.eq  	$push205=, $pop204, $pop373
+	br_if   	1, $pop205      # 1: down to label106
+# BB#124:                               # %for.inc.i816
+                                        #   in Loop: Header=BB18_123 Depth=1
+	i64.const	$push379=, 1
+	i64.add 	$7=, $7, $pop379
+	i32.const	$push378=, 1
+	i32.add 	$8=, $8, $pop378
+	i64.const	$push377=, -1
+	i64.add 	$6=, $6, $pop377
+	i64.const	$push376=, 64
+	i64.lt_u	$push206=, $7, $pop376
+	br_if   	0, $pop206      # 0: up to label105
+.LBB18_125:                             # %my_clrsbll.exit
+	end_loop                        # label106:
+	i32.const	$push207=, -1
+	i32.add 	$push208=, $8, $pop207
+	i32.ne  	$push209=, $10, $pop208
+	br_if   	0, $pop209      # 0: down to label40
+# BB#126:                               # %if.end753
+	i32.const	$push210=, 0
+	call    	exit@FUNCTION, $pop210
 	unreachable
-.LBB18_146:                             # %if.then302
-	end_block                       # label59:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_147:                             # %if.then327
-	end_block                       # label58:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_148:                             # %if.then352
-	end_block                       # label57:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_149:                             # %if.then377
-	end_block                       # label56:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_150:                             # %if.then402
-	end_block                       # label55:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_151:                             # %if.then427
-	end_block                       # label54:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_152:                             # %if.then444
-	end_block                       # label53:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_153:                             # %if.then460
-	end_block                       # label52:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_154:                             # %if.then469
-	end_block                       # label51:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_155:                             # %if.then494
-	end_block                       # label50:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_156:                             # %if.then510
-	end_block                       # label49:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_157:                             # %if.then519
-	end_block                       # label48:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_158:                             # %if.then544
-	end_block                       # label47:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_159:                             # %if.then569
-	end_block                       # label46:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_160:                             # %if.then594
-	end_block                       # label45:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_161:                             # %if.then619
-	end_block                       # label44:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_162:                             # %if.then644
-	end_block                       # label43:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_163:                             # %if.then669
-	end_block                       # label42:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_164:                             # %if.then694
-	end_block                       # label41:
-	call    	abort@FUNCTION
-	unreachable
-.LBB18_165:                             # %if.then710
+.LBB18_127:                             # %if.then37
 	end_block                       # label40:
 	call    	abort@FUNCTION
 	unreachable
-.LBB18_166:                             # %if.then719
+.LBB18_128:                             # %if.then140
 	end_block                       # label39:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/builtin-prefetch-4.c.s
+++ b/test/torture-s/builtin-prefetch-4.c.s
@@ -427,28 +427,17 @@ main:                                   # @main
 	.local  	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push41=, 0
 	i32.load	$push40=, ptr($pop41)
 	tee_local	$push39=, $0=, $pop40
 	i32.ne  	$push4=, $pop39, $0
-	br_if   	0, $pop4        # 0: down to label11
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %if.end4
 	i32.const	$push44=, 0
 	i32.load	$push43=, arrindex($pop44)
 	tee_local	$push42=, $0=, $pop43
 	i32.ne  	$push5=, $pop42, $0
-	br_if   	1, $pop5        # 1: down to label10
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end12
 	i32.const	$push48=, 0
 	i32.const	$push47=, 0
@@ -459,7 +448,7 @@ main:                                   # @main
 	i32.const	$push45=, 1
 	i32.const	$push85=, 0
 	i32.eq  	$push86=, $pop45, $pop85
-	br_if   	2, $pop86       # 2: down to label9
+	br_if   	0, $pop86       # 0: down to label0
 # BB#3:                                 # %if.end20
 	i32.const	$push52=, 0
 	i32.const	$push51=, 0
@@ -470,7 +459,7 @@ main:                                   # @main
 	i32.const	$push49=, 1
 	i32.const	$push87=, 0
 	i32.eq  	$push88=, $pop49, $pop87
-	br_if   	3, $pop88       # 3: down to label8
+	br_if   	0, $pop88       # 0: down to label0
 # BB#4:                                 # %if.end28
 	i32.const	$push56=, 0
 	i32.const	$push55=, 0
@@ -481,7 +470,7 @@ main:                                   # @main
 	i32.const	$push53=, 1
 	i32.const	$push89=, 0
 	i32.eq  	$push90=, $pop53, $pop89
-	br_if   	4, $pop90       # 4: down to label7
+	br_if   	0, $pop90       # 0: down to label0
 # BB#5:                                 # %if.end36
 	i32.const	$push60=, 0
 	i32.const	$push59=, 0
@@ -492,7 +481,7 @@ main:                                   # @main
 	i32.const	$push57=, 1
 	i32.const	$push91=, 0
 	i32.eq  	$push92=, $pop57, $pop91
-	br_if   	5, $pop92       # 5: down to label6
+	br_if   	0, $pop92       # 0: down to label0
 # BB#6:                                 # %if.end44
 	i32.const	$push64=, 0
 	i32.const	$push63=, 0
@@ -503,7 +492,7 @@ main:                                   # @main
 	i32.const	$push61=, 0
 	i32.load	$push13=, arrindex($pop61)
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	6, $pop14       # 6: down to label5
+	br_if   	0, $pop14       # 0: down to label0
 # BB#7:                                 # %if.end52
 	i32.const	$push68=, 0
 	i32.const	$push67=, 0
@@ -514,7 +503,7 @@ main:                                   # @main
 	i32.const	$push65=, 0
 	i32.load	$push18=, arrindex($pop65)
 	i32.ne  	$push19=, $pop17, $pop18
-	br_if   	7, $pop19       # 7: down to label4
+	br_if   	0, $pop19       # 0: down to label0
 # BB#8:                                 # %if.end64
 	i32.const	$push72=, 0
 	i32.const	$push71=, 0
@@ -525,7 +514,7 @@ main:                                   # @main
 	i32.const	$push69=, 0
 	i32.load	$push23=, arrindex($pop69)
 	i32.ne  	$push24=, $pop22, $pop23
-	br_if   	8, $pop24       # 8: down to label3
+	br_if   	0, $pop24       # 0: down to label0
 # BB#9:                                 # %if.end72
 	i32.const	$push76=, 0
 	i32.const	$push75=, 0
@@ -536,7 +525,7 @@ main:                                   # @main
 	i32.const	$push73=, 0
 	i32.load	$push28=, arrindex($pop73)
 	i32.ne  	$push29=, $pop27, $pop28
-	br_if   	9, $pop29       # 9: down to label2
+	br_if   	0, $pop29       # 0: down to label0
 # BB#10:                                # %if.end76
 	i32.const	$push80=, 0
 	i32.const	$push79=, 0
@@ -546,7 +535,7 @@ main:                                   # @main
 	i32.store	$push32=, getptrcnt($pop80), $pop31
 	i32.const	$push77=, 1
 	i32.ne  	$push33=, $pop32, $pop77
-	br_if   	10, $pop33      # 10: down to label1
+	br_if   	0, $pop33       # 0: down to label0
 # BB#11:                                # %if.end80
 	i32.const	$push84=, 0
 	i32.const	$push83=, 0
@@ -556,56 +545,12 @@ main:                                   # @main
 	i32.store	$push36=, getintcnt($pop84), $pop35
 	i32.const	$push81=, 1
 	i32.ne  	$push37=, $pop36, $pop81
-	br_if   	11, $pop37      # 11: down to label0
+	br_if   	0, $pop37       # 0: down to label0
 # BB#12:                                # %if.end84
 	i32.const	$push38=, 0
 	call    	exit@FUNCTION, $pop38
 	unreachable
-.LBB24_13:                              # %if.then3
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_14:                              # %if.then11
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_15:                              # %if.then19
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_16:                              # %if.then27
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_17:                              # %if.then35
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_18:                              # %if.then43
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_19:                              # %if.then51
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_20:                              # %if.then59
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_21:                              # %if.then67
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_22:                              # %if.then75
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_23:                              # %if.then79
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB24_24:                              # %if.then83
+.LBB24_13:                              # %if.then83
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/cmpdi-1.c.s
+++ b/test/torture-s/cmpdi-1.c.s
@@ -184,16 +184,7 @@ main:                                   # @main
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB10_2 Depth 2
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label10:
+	loop                            # label1:
 	i32.const	$push43=, 3
 	i32.shl 	$push0=, $0, $pop43
 	i64.load	$1=, args($pop0)
@@ -202,7 +193,7 @@ main:                                   # @main
 .LBB10_2:                               # %for.body3
                                         #   Parent Loop BB10_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label12:
+	loop                            # label3:
 	i32.const	$push49=, 13
 	i32.const	$push48=, 140
 	i64.load	$push47=, 0($2)
@@ -212,7 +203,7 @@ main:                                   # @main
 	i32.select	$push1=, $pop49, $pop48, $pop44
 	i32.load	$push2=, 0($4)
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	4, $pop3        # 4: down to label9
+	br_if   	4, $pop3        # 4: down to label0
 # BB#3:                                 # %if.end
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push52=, 140
@@ -222,7 +213,7 @@ main:                                   # @main
 	i32.add 	$push5=, $4, $pop50
 	i32.load	$push6=, 0($pop5)
 	i32.ne  	$push7=, $pop4, $pop6
-	br_if   	5, $pop7        # 5: down to label8
+	br_if   	4, $pop7        # 4: down to label0
 # BB#4:                                 # %if.end10
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push57=, 13
@@ -234,7 +225,7 @@ main:                                   # @main
 	i32.add 	$push9=, $4, $pop53
 	i32.load	$push10=, 0($pop9)
 	i32.ne  	$push11=, $pop8, $pop10
-	br_if   	6, $pop11       # 6: down to label7
+	br_if   	4, $pop11       # 4: down to label0
 # BB#5:                                 # %if.end15
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push60=, 140
@@ -244,7 +235,7 @@ main:                                   # @main
 	i32.add 	$push13=, $4, $pop58
 	i32.load	$push14=, 0($pop13)
 	i32.ne  	$push15=, $pop12, $pop14
-	br_if   	7, $pop15       # 7: down to label6
+	br_if   	4, $pop15       # 4: down to label0
 # BB#6:                                 # %if.end20
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push65=, 13
@@ -256,7 +247,7 @@ main:                                   # @main
 	i32.add 	$push17=, $4, $pop61
 	i32.load	$push18=, 0($pop17)
 	i32.ne  	$push19=, $pop16, $pop18
-	br_if   	8, $pop19       # 8: down to label5
+	br_if   	4, $pop19       # 4: down to label0
 # BB#7:                                 # %if.end25
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push68=, 140
@@ -266,7 +257,7 @@ main:                                   # @main
 	i32.add 	$push21=, $4, $pop66
 	i32.load	$push22=, 0($pop21)
 	i32.ne  	$push23=, $pop20, $pop22
-	br_if   	9, $pop23       # 9: down to label4
+	br_if   	4, $pop23       # 4: down to label0
 # BB#8:                                 # %if.end30
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push73=, 13
@@ -278,7 +269,7 @@ main:                                   # @main
 	i32.add 	$push25=, $4, $pop69
 	i32.load	$push26=, 0($pop25)
 	i32.ne  	$push27=, $pop24, $pop26
-	br_if   	10, $pop27      # 10: down to label3
+	br_if   	4, $pop27       # 4: down to label0
 # BB#9:                                 # %if.end35
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push76=, 140
@@ -288,7 +279,7 @@ main:                                   # @main
 	i32.add 	$push29=, $4, $pop74
 	i32.load	$push30=, 0($pop29)
 	i32.ne  	$push31=, $pop28, $pop30
-	br_if   	11, $pop31      # 11: down to label2
+	br_if   	4, $pop31       # 4: down to label0
 # BB#10:                                # %if.end40
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push81=, 13
@@ -300,7 +291,7 @@ main:                                   # @main
 	i32.add 	$push33=, $4, $pop77
 	i32.load	$push34=, 0($pop33)
 	i32.ne  	$push35=, $pop32, $pop34
-	br_if   	12, $pop35      # 12: down to label1
+	br_if   	4, $pop35       # 4: down to label0
 # BB#11:                                # %if.end45
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push84=, 140
@@ -310,7 +301,7 @@ main:                                   # @main
 	i32.add 	$push37=, $4, $pop82
 	i32.load	$push38=, 0($pop37)
 	i32.ne  	$push39=, $pop36, $pop38
-	br_if   	13, $pop39      # 13: down to label0
+	br_if   	4, $pop39       # 4: down to label0
 # BB#12:                                # %if.end50
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push88=, 40
@@ -321,57 +312,21 @@ main:                                   # @main
 	i32.add 	$2=, $2, $pop86
 	i32.const	$push85=, 8
 	i32.lt_s	$push40=, $3, $pop85
-	br_if   	0, $pop40       # 0: up to label12
+	br_if   	0, $pop40       # 0: up to label3
 # BB#13:                                # %for.end
                                         #   in Loop: Header=BB10_1 Depth=1
-	end_loop                        # label13:
+	end_loop                        # label4:
 	i32.const	$push90=, 1
 	i32.add 	$0=, $0, $pop90
 	i32.const	$push89=, 8
 	i32.lt_s	$push41=, $0, $pop89
-	br_if   	0, $pop41       # 0: up to label10
+	br_if   	0, $pop41       # 0: up to label1
 # BB#14:                                # %for.end53
-	end_loop                        # label11:
+	end_loop                        # label2:
 	i32.const	$push42=, 0
 	call    	exit@FUNCTION, $pop42
 	unreachable
-.LBB10_15:                              # %if.then
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_16:                              # %if.then9
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_17:                              # %if.then14
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_18:                              # %if.then19
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_19:                              # %if.then24
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_20:                              # %if.then29
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_21:                              # %if.then34
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_22:                              # %if.then39
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_23:                              # %if.then44
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_24:                              # %if.then49
+.LBB10_15:                              # %if.then49
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/cmpsf-1.c.s
+++ b/test/torture-s/cmpsf-1.c.s
@@ -124,12 +124,7 @@ main:                                   # @main
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB6_2 Depth 2
 	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label6:
+	loop                            # label1:
 	i32.const	$push33=, 2
 	i32.shl 	$push0=, $0, $pop33
 	f32.load	$1=, args($pop0)
@@ -138,7 +133,7 @@ main:                                   # @main
 .LBB6_2:                                # %for.body3
                                         #   Parent Loop BB6_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label8:
+	loop                            # label3:
 	i32.const	$push37=, 13
 	i32.const	$push36=, 140
 	f32.load	$push35=, 0($2)
@@ -147,7 +142,7 @@ main:                                   # @main
 	i32.select	$push2=, $pop37, $pop36, $pop1
 	i32.load	$push3=, 0($4)
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	9, $pop4        # 9: down to label0
+	br_if   	4, $pop4        # 4: down to label0
 # BB#3:                                 # %if.end
                                         #   in Loop: Header=BB6_2 Depth=2
 	i32.const	$push40=, 13
@@ -158,7 +153,7 @@ main:                                   # @main
 	i32.add 	$push7=, $4, $pop38
 	i32.load	$push8=, 0($pop7)
 	i32.ne  	$push9=, $pop6, $pop8
-	br_if   	4, $pop9        # 4: down to label5
+	br_if   	4, $pop9        # 4: down to label0
 # BB#4:                                 # %if.end10
                                         #   in Loop: Header=BB6_2 Depth=2
 	i32.const	$push45=, 13
@@ -170,7 +165,7 @@ main:                                   # @main
 	i32.add 	$push11=, $4, $pop41
 	i32.load	$push12=, 0($pop11)
 	i32.ne  	$push13=, $pop10, $pop12
-	br_if   	5, $pop13       # 5: down to label4
+	br_if   	4, $pop13       # 4: down to label0
 # BB#5:                                 # %if.end15
                                         #   in Loop: Header=BB6_2 Depth=2
 	i32.const	$push50=, 140
@@ -185,7 +180,7 @@ main:                                   # @main
 	i32.add 	$push18=, $4, $pop46
 	i32.load	$push19=, 0($pop18)
 	i32.ne  	$push20=, $pop17, $pop19
-	br_if   	6, $pop20       # 6: down to label3
+	br_if   	4, $pop20       # 4: down to label0
 # BB#6:                                 # %if.end20
                                         #   in Loop: Header=BB6_2 Depth=2
 	i32.const	$push55=, 13
@@ -197,7 +192,7 @@ main:                                   # @main
 	i32.add 	$push22=, $4, $pop51
 	i32.load	$push23=, 0($pop22)
 	i32.ne  	$push24=, $pop21, $pop23
-	br_if   	7, $pop24       # 7: down to label2
+	br_if   	4, $pop24       # 4: down to label0
 # BB#7:                                 # %if.end25
                                         #   in Loop: Header=BB6_2 Depth=2
 	i32.const	$push58=, 140
@@ -208,7 +203,7 @@ main:                                   # @main
 	i32.add 	$push27=, $4, $pop56
 	i32.load	$push28=, 0($pop27)
 	i32.ne  	$push29=, $pop26, $pop28
-	br_if   	8, $pop29       # 8: down to label1
+	br_if   	4, $pop29       # 4: down to label0
 # BB#8:                                 # %if.end30
                                         #   in Loop: Header=BB6_2 Depth=2
 	i32.const	$push62=, 24
@@ -219,41 +214,21 @@ main:                                   # @main
 	i32.add 	$2=, $2, $pop60
 	i32.const	$push59=, 8
 	i32.lt_s	$push30=, $3, $pop59
-	br_if   	0, $pop30       # 0: up to label8
+	br_if   	0, $pop30       # 0: up to label3
 # BB#9:                                 # %for.end
                                         #   in Loop: Header=BB6_1 Depth=1
-	end_loop                        # label9:
+	end_loop                        # label4:
 	i32.const	$push64=, 1
 	i32.add 	$0=, $0, $pop64
 	i32.const	$push63=, 8
 	i32.lt_s	$push31=, $0, $pop63
-	br_if   	0, $pop31       # 0: up to label6
+	br_if   	0, $pop31       # 0: up to label1
 # BB#10:                                # %for.end33
-	end_loop                        # label7:
+	end_loop                        # label2:
 	i32.const	$push32=, 0
 	call    	exit@FUNCTION, $pop32
 	unreachable
-.LBB6_11:                               # %if.then9
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_12:                               # %if.then14
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_13:                               # %if.then19
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_14:                               # %if.then24
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_15:                               # %if.then29
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_16:                               # %if.then
+.LBB6_11:                               # %if.then29
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/cmpsi-2.c.s
+++ b/test/torture-s/cmpsi-2.c.s
@@ -184,16 +184,7 @@ main:                                   # @main
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB10_2 Depth 2
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label10:
+	loop                            # label1:
 	i32.const	$push43=, 2
 	i32.shl 	$push0=, $0, $pop43
 	i32.load	$1=, args($pop0)
@@ -202,7 +193,7 @@ main:                                   # @main
 .LBB10_2:                               # %for.body3
                                         #   Parent Loop BB10_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label12:
+	loop                            # label3:
 	i32.const	$push49=, 13
 	i32.const	$push48=, 140
 	i32.load	$push47=, 0($2)
@@ -212,7 +203,7 @@ main:                                   # @main
 	i32.select	$push1=, $pop49, $pop48, $pop44
 	i32.load	$push2=, 0($4)
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	4, $pop3        # 4: down to label9
+	br_if   	4, $pop3        # 4: down to label0
 # BB#3:                                 # %if.end
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push52=, 140
@@ -222,7 +213,7 @@ main:                                   # @main
 	i32.add 	$push5=, $4, $pop50
 	i32.load	$push6=, 0($pop5)
 	i32.ne  	$push7=, $pop4, $pop6
-	br_if   	5, $pop7        # 5: down to label8
+	br_if   	4, $pop7        # 4: down to label0
 # BB#4:                                 # %if.end10
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push57=, 13
@@ -234,7 +225,7 @@ main:                                   # @main
 	i32.add 	$push9=, $4, $pop53
 	i32.load	$push10=, 0($pop9)
 	i32.ne  	$push11=, $pop8, $pop10
-	br_if   	6, $pop11       # 6: down to label7
+	br_if   	4, $pop11       # 4: down to label0
 # BB#5:                                 # %if.end15
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push60=, 140
@@ -244,7 +235,7 @@ main:                                   # @main
 	i32.add 	$push13=, $4, $pop58
 	i32.load	$push14=, 0($pop13)
 	i32.ne  	$push15=, $pop12, $pop14
-	br_if   	7, $pop15       # 7: down to label6
+	br_if   	4, $pop15       # 4: down to label0
 # BB#6:                                 # %if.end20
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push65=, 13
@@ -256,7 +247,7 @@ main:                                   # @main
 	i32.add 	$push17=, $4, $pop61
 	i32.load	$push18=, 0($pop17)
 	i32.ne  	$push19=, $pop16, $pop18
-	br_if   	8, $pop19       # 8: down to label5
+	br_if   	4, $pop19       # 4: down to label0
 # BB#7:                                 # %if.end25
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push68=, 140
@@ -266,7 +257,7 @@ main:                                   # @main
 	i32.add 	$push21=, $4, $pop66
 	i32.load	$push22=, 0($pop21)
 	i32.ne  	$push23=, $pop20, $pop22
-	br_if   	9, $pop23       # 9: down to label4
+	br_if   	4, $pop23       # 4: down to label0
 # BB#8:                                 # %if.end30
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push73=, 13
@@ -278,7 +269,7 @@ main:                                   # @main
 	i32.add 	$push25=, $4, $pop69
 	i32.load	$push26=, 0($pop25)
 	i32.ne  	$push27=, $pop24, $pop26
-	br_if   	10, $pop27      # 10: down to label3
+	br_if   	4, $pop27       # 4: down to label0
 # BB#9:                                 # %if.end35
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push76=, 140
@@ -288,7 +279,7 @@ main:                                   # @main
 	i32.add 	$push29=, $4, $pop74
 	i32.load	$push30=, 0($pop29)
 	i32.ne  	$push31=, $pop28, $pop30
-	br_if   	11, $pop31      # 11: down to label2
+	br_if   	4, $pop31       # 4: down to label0
 # BB#10:                                # %if.end40
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push81=, 13
@@ -300,7 +291,7 @@ main:                                   # @main
 	i32.add 	$push33=, $4, $pop77
 	i32.load	$push34=, 0($pop33)
 	i32.ne  	$push35=, $pop32, $pop34
-	br_if   	12, $pop35      # 12: down to label1
+	br_if   	4, $pop35       # 4: down to label0
 # BB#11:                                # %if.end45
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push84=, 140
@@ -310,7 +301,7 @@ main:                                   # @main
 	i32.add 	$push37=, $4, $pop82
 	i32.load	$push38=, 0($pop37)
 	i32.ne  	$push39=, $pop36, $pop38
-	br_if   	13, $pop39      # 13: down to label0
+	br_if   	4, $pop39       # 4: down to label0
 # BB#12:                                # %if.end50
                                         #   in Loop: Header=BB10_2 Depth=2
 	i32.const	$push88=, 40
@@ -321,57 +312,21 @@ main:                                   # @main
 	i32.add 	$2=, $2, $pop86
 	i32.const	$push85=, 8
 	i32.lt_s	$push40=, $3, $pop85
-	br_if   	0, $pop40       # 0: up to label12
+	br_if   	0, $pop40       # 0: up to label3
 # BB#13:                                # %for.end
                                         #   in Loop: Header=BB10_1 Depth=1
-	end_loop                        # label13:
+	end_loop                        # label4:
 	i32.const	$push90=, 1
 	i32.add 	$0=, $0, $pop90
 	i32.const	$push89=, 8
 	i32.lt_s	$push41=, $0, $pop89
-	br_if   	0, $pop41       # 0: up to label10
+	br_if   	0, $pop41       # 0: up to label1
 # BB#14:                                # %for.end53
-	end_loop                        # label11:
+	end_loop                        # label2:
 	i32.const	$push42=, 0
 	call    	exit@FUNCTION, $pop42
 	unreachable
-.LBB10_15:                              # %if.then
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_16:                              # %if.then9
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_17:                              # %if.then14
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_18:                              # %if.then19
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_19:                              # %if.then24
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_20:                              # %if.then29
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_21:                              # %if.then34
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_22:                              # %if.then39
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_23:                              # %if.then44
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_24:                              # %if.then49
+.LBB10_15:                              # %if.then49
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/compare-1.c.s
+++ b/test/torture-s/compare-1.c.s
@@ -13,85 +13,76 @@ ieq:                                    # @ieq
 	block
 	block
 	block
-	block
 	i32.ne  	$push1=, $0, $1
 	tee_local	$push0=, $1=, $pop1
 	i32.const	$push2=, 0
 	i32.eq  	$push3=, $pop0, $pop2
-	br_if   	0, $pop3        # 0: down to label5
+	br_if   	0, $pop3        # 0: down to label4
 # BB#1:                                 # %if.else
 	i32.const	$push4=, 0
 	i32.eq  	$push5=, $2, $pop4
-	br_if   	1, $pop5        # 1: down to label4
-# BB#2:                                 # %if.then4
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_3:                                # %if.then
-	end_block                       # label5:
+	br_if   	1, $pop5        # 1: down to label3
+	br      	2               # 2: down to label2
+.LBB0_2:                                # %if.then
+	end_block                       # label4:
 	i32.const	$push6=, 0
 	i32.eq  	$push7=, $2, $pop6
-	br_if   	1, $pop7        # 1: down to label3
-.LBB0_4:                                # %if.end6
-	end_block                       # label4:
+	br_if   	2, $pop7        # 2: down to label1
+.LBB0_3:                                # %if.end6
+	end_block                       # label3:
 	block
 	block
-	br_if   	0, $1           # 0: down to label7
-# BB#5:                                 # %if.then10
-	br_if   	1, $2           # 1: down to label6
-# BB#6:                                 # %if.then12
+	br_if   	0, $1           # 0: down to label6
+# BB#4:                                 # %if.then10
+	br_if   	1, $2           # 1: down to label5
+# BB#5:                                 # %if.then12
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_7:                                # %if.else14
-	end_block                       # label7:
-	br_if   	2, $2           # 2: down to label2
-.LBB0_8:                                # %if.end18
+.LBB0_6:                                # %if.else14
 	end_block                       # label6:
+	br_if   	1, $2           # 1: down to label2
+.LBB0_7:                                # %if.end18
+	end_block                       # label5:
 	block
 	block
 	i32.const	$push8=, 0
 	i32.eq  	$push9=, $1, $pop8
-	br_if   	0, $pop9        # 0: down to label9
-# BB#9:                                 # %if.else26
+	br_if   	0, $pop9        # 0: down to label8
+# BB#8:                                 # %if.else26
 	i32.const	$push10=, 0
 	i32.eq  	$push11=, $2, $pop10
-	br_if   	1, $pop11       # 1: down to label8
-# BB#10:                                # %if.then28
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then22
-	end_block                       # label9:
+	br_if   	1, $pop11       # 1: down to label7
+	br      	2               # 2: down to label2
+.LBB0_9:                                # %if.then22
+	end_block                       # label8:
 	i32.const	$push12=, 0
 	i32.eq  	$push13=, $2, $pop12
-	br_if   	3, $pop13       # 3: down to label1
-.LBB0_12:                               # %if.end30
-	end_block                       # label8:
+	br_if   	3, $pop13       # 3: down to label0
+.LBB0_10:                               # %if.end30
+	end_block                       # label7:
 	block
 	block
-	br_if   	0, $1           # 0: down to label11
-# BB#13:                                # %if.then34
-	br_if   	1, $2           # 1: down to label10
-# BB#14:                                # %if.then36
+	br_if   	0, $1           # 0: down to label10
+# BB#11:                                # %if.then34
+	br_if   	1, $2           # 1: down to label9
+# BB#12:                                # %if.then36
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_15:                               # %if.else38
-	end_block                       # label11:
-	br_if   	4, $2           # 4: down to label0
-.LBB0_16:                               # %if.end42
+.LBB0_13:                               # %if.else38
 	end_block                       # label10:
+	br_if   	1, $2           # 1: down to label2
+.LBB0_14:                               # %if.end42
+	end_block                       # label9:
 	return  	$2
-.LBB0_17:                               # %if.then2
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then16
+.LBB0_15:                               # %if.then40
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_19:                               # %if.then24
+.LBB0_16:                               # %if.then2
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_20:                               # %if.then40
+.LBB0_17:                               # %if.then24
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -111,24 +102,24 @@ ine:                                    # @ine
 	block
 	block
 	i32.ne  	$push0=, $0, $1
-	br_if   	0, $pop0        # 0: down to label14
+	br_if   	0, $pop0        # 0: down to label13
 # BB#1:                                 # %if.else
 	i32.const	$push1=, 0
 	i32.eq  	$push2=, $2, $pop1
-	br_if   	1, $pop2        # 1: down to label13
+	br_if   	1, $pop2        # 1: down to label12
 # BB#2:                                 # %if.then4
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_3:                                # %if.then
-	end_block                       # label14:
+	end_block                       # label13:
 	i32.const	$push3=, 0
 	i32.eq  	$push4=, $2, $pop3
-	br_if   	1, $pop4        # 1: down to label12
+	br_if   	1, $pop4        # 1: down to label11
 .LBB1_4:                                # %if.end6
-	end_block                       # label13:
+	end_block                       # label12:
 	return  	$2
 .LBB1_5:                                # %if.then2
-	end_block                       # label12:
+	end_block                       # label11:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -147,20 +138,20 @@ ilt:                                    # @ilt
 	block
 	block
 	i32.ge_s	$push0=, $0, $1
-	br_if   	0, $pop0        # 0: down to label17
+	br_if   	0, $pop0        # 0: down to label16
 # BB#1:                                 # %if.then
-	br_if   	1, $2           # 1: down to label16
+	br_if   	1, $2           # 1: down to label15
 # BB#2:                                 # %if.then2
 	call    	abort@FUNCTION
 	unreachable
 .LBB2_3:                                # %if.else
-	end_block                       # label17:
-	br_if   	1, $2           # 1: down to label15
-.LBB2_4:                                # %if.end6
 	end_block                       # label16:
+	br_if   	1, $2           # 1: down to label14
+.LBB2_4:                                # %if.end6
+	end_block                       # label15:
 	return  	$2
 .LBB2_5:                                # %if.then4
-	end_block                       # label15:
+	end_block                       # label14:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -179,24 +170,24 @@ ile:                                    # @ile
 	block
 	block
 	i32.le_s	$push0=, $0, $1
-	br_if   	0, $pop0        # 0: down to label20
+	br_if   	0, $pop0        # 0: down to label19
 # BB#1:                                 # %if.else
 	i32.const	$push1=, 0
 	i32.eq  	$push2=, $2, $pop1
-	br_if   	1, $pop2        # 1: down to label19
+	br_if   	1, $pop2        # 1: down to label18
 # BB#2:                                 # %if.then4
 	call    	abort@FUNCTION
 	unreachable
 .LBB3_3:                                # %if.then
-	end_block                       # label20:
+	end_block                       # label19:
 	i32.const	$push3=, 0
 	i32.eq  	$push4=, $2, $pop3
-	br_if   	1, $pop4        # 1: down to label18
+	br_if   	1, $pop4        # 1: down to label17
 .LBB3_4:                                # %if.end6
-	end_block                       # label19:
+	end_block                       # label18:
 	return  	$2
 .LBB3_5:                                # %if.then2
-	end_block                       # label18:
+	end_block                       # label17:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -215,20 +206,20 @@ igt:                                    # @igt
 	block
 	block
 	i32.le_s	$push0=, $0, $1
-	br_if   	0, $pop0        # 0: down to label23
+	br_if   	0, $pop0        # 0: down to label22
 # BB#1:                                 # %if.then
-	br_if   	1, $2           # 1: down to label22
+	br_if   	1, $2           # 1: down to label21
 # BB#2:                                 # %if.then2
 	call    	abort@FUNCTION
 	unreachable
 .LBB4_3:                                # %if.else
-	end_block                       # label23:
-	br_if   	1, $2           # 1: down to label21
-.LBB4_4:                                # %if.end6
 	end_block                       # label22:
+	br_if   	1, $2           # 1: down to label20
+.LBB4_4:                                # %if.end6
+	end_block                       # label21:
 	return  	$2
 .LBB4_5:                                # %if.then4
-	end_block                       # label21:
+	end_block                       # label20:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -247,24 +238,24 @@ ige:                                    # @ige
 	block
 	block
 	i32.ge_s	$push0=, $0, $1
-	br_if   	0, $pop0        # 0: down to label26
+	br_if   	0, $pop0        # 0: down to label25
 # BB#1:                                 # %if.else
 	i32.const	$push1=, 0
 	i32.eq  	$push2=, $2, $pop1
-	br_if   	1, $pop2        # 1: down to label25
+	br_if   	1, $pop2        # 1: down to label24
 # BB#2:                                 # %if.then4
 	call    	abort@FUNCTION
 	unreachable
 .LBB5_3:                                # %if.then
-	end_block                       # label26:
+	end_block                       # label25:
 	i32.const	$push3=, 0
 	i32.eq  	$push4=, $2, $pop3
-	br_if   	1, $pop4        # 1: down to label24
+	br_if   	1, $pop4        # 1: down to label23
 .LBB5_4:                                # %if.end6
-	end_block                       # label25:
+	end_block                       # label24:
 	return  	$2
 .LBB5_5:                                # %if.then2
-	end_block                       # label24:
+	end_block                       # label23:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/const-addr-expr-1.c.s
+++ b/test/torture-s/const-addr-expr-1.c.s
@@ -9,28 +9,23 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push9=, 0
 	i32.load	$push0=, Upgd_minor_ID($pop9)
 	i32.load	$push1=, 0($pop0)
 	i32.const	$push2=, 2
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label1
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push10=, 0
 	i32.load	$push4=, Upgd_minor_ID1($pop10)
 	i32.load	$push5=, 0($pop4)
 	i32.const	$push6=, 1
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label0
+	br_if   	0, $pop7        # 0: down to label0
 # BB#2:                                 # %if.end3
 	i32.const	$push8=, 0
 	return  	$pop8
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.then2
+.LBB0_3:                                # %if.then2
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/eeprof-1.c.s
+++ b/test/torture-s/eeprof-1.c.s
@@ -29,82 +29,57 @@ foo:                                    # @foo
 nfoo:                                   # @nfoo
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push19=, 0
 	i32.load	$push1=, entry_calls($pop19)
 	i32.const	$push18=, 2
 	i32.ne  	$push2=, $pop1, $pop18
-	br_if   	0, $pop2        # 0: down to label6
+	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push21=, 0
 	i32.load	$push0=, exit_calls($pop21)
 	i32.const	$push20=, 2
 	i32.ne  	$push3=, $pop0, $pop20
-	br_if   	0, $pop3        # 0: down to label6
+	br_if   	0, $pop3        # 0: down to label1
 # BB#2:                                 # %if.end
 	i32.const	$push22=, 0
 	i32.load	$push4=, last_fn_entered($pop22)
 	i32.const	$push5=, foo@FUNCTION
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	1, $pop6        # 1: down to label5
+	br_if   	0, $pop6        # 0: down to label1
 # BB#3:                                 # %if.end4
 	i32.const	$push23=, 0
 	i32.load	$push7=, last_fn_exited($pop23)
 	i32.const	$push8=, foo2@FUNCTION
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	2, $pop9        # 2: down to label4
+	br_if   	0, $pop9        # 0: down to label1
 # BB#4:                                 # %if.end7
 	call    	foo@FUNCTION
 	i32.const	$push25=, 0
 	i32.load	$push11=, entry_calls($pop25)
 	i32.const	$push24=, 3
 	i32.ne  	$push12=, $pop11, $pop24
-	br_if   	3, $pop12       # 3: down to label3
+	br_if   	0, $pop12       # 0: down to label1
 # BB#5:                                 # %if.end7
 	i32.const	$push27=, 0
 	i32.load	$push10=, exit_calls($pop27)
 	i32.const	$push26=, 3
 	i32.ne  	$push13=, $pop10, $pop26
-	br_if   	3, $pop13       # 3: down to label3
+	br_if   	0, $pop13       # 0: down to label1
 # BB#6:                                 # %if.end12
 	i32.const	$push29=, 0
 	i32.load	$push14=, last_fn_entered($pop29)
 	i32.const	$push28=, foo@FUNCTION
 	i32.ne  	$push15=, $pop14, $pop28
-	br_if   	4, $pop15       # 4: down to label2
+	br_if   	0, $pop15       # 0: down to label1
 # BB#7:                                 # %if.end15
 	i32.const	$push31=, 0
 	i32.load	$push16=, last_fn_exited($pop31)
 	i32.const	$push30=, foo@FUNCTION
 	i32.ne  	$push17=, $pop16, $pop30
-	br_if   	5, $pop17       # 5: down to label1
+	br_if   	0, $pop17       # 0: down to label1
 # BB#8:                                 # %if.end18
 	return
-.LBB1_9:                                # %if.then
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_10:                               # %if.then3
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_11:                               # %if.then6
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_12:                               # %if.then11
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_13:                               # %if.then14
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_14:                               # %if.then17
+.LBB1_9:                                # %if.then17
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
@@ -120,86 +95,61 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push21=, 0
 	i32.load	$push1=, exit_calls($pop21)
 	i32.const	$push20=, 0
 	i32.load	$push0=, entry_calls($pop20)
 	i32.or  	$push2=, $pop1, $pop0
-	br_if   	0, $pop2        # 0: down to label12
+	br_if   	0, $pop2        # 0: down to label2
 # BB#1:                                 # %if.end
 	call    	foo2@FUNCTION
 	i32.const	$push23=, 0
 	i32.load	$push4=, entry_calls($pop23)
 	i32.const	$push22=, 2
 	i32.ne  	$push5=, $pop4, $pop22
-	br_if   	1, $pop5        # 1: down to label11
+	br_if   	0, $pop5        # 0: down to label2
 # BB#2:                                 # %if.end
 	i32.const	$push25=, 0
 	i32.load	$push3=, exit_calls($pop25)
 	i32.const	$push24=, 2
 	i32.ne  	$push6=, $pop3, $pop24
-	br_if   	1, $pop6        # 1: down to label11
+	br_if   	0, $pop6        # 0: down to label2
 # BB#3:                                 # %if.end6
 	i32.const	$push26=, 0
 	i32.load	$push7=, last_fn_entered($pop26)
 	i32.const	$push8=, foo@FUNCTION
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	2, $pop9        # 2: down to label10
+	br_if   	0, $pop9        # 0: down to label2
 # BB#4:                                 # %if.end9
 	i32.const	$push27=, 0
 	i32.load	$push10=, last_fn_exited($pop27)
 	i32.const	$push11=, foo2@FUNCTION
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	3, $pop12       # 3: down to label9
+	br_if   	0, $pop12       # 0: down to label2
 # BB#5:                                 # %if.end12
 	call    	nfoo@FUNCTION
 	i32.const	$push29=, 0
 	i32.load	$push14=, entry_calls($pop29)
 	i32.const	$push28=, 3
 	i32.ne  	$push15=, $pop14, $pop28
-	br_if   	4, $pop15       # 4: down to label8
+	br_if   	0, $pop15       # 0: down to label2
 # BB#6:                                 # %if.end12
 	i32.const	$push31=, 0
 	i32.load	$push13=, exit_calls($pop31)
 	i32.const	$push30=, 3
 	i32.ne  	$push16=, $pop13, $pop30
-	br_if   	4, $pop16       # 4: down to label8
+	br_if   	0, $pop16       # 0: down to label2
 # BB#7:                                 # %if.end17
 	i32.const	$push32=, 0
 	i32.load	$push17=, last_fn_entered($pop32)
 	i32.const	$push18=, foo@FUNCTION
 	i32.ne  	$push19=, $pop17, $pop18
-	br_if   	5, $pop19       # 5: down to label7
+	br_if   	0, $pop19       # 0: down to label2
 # BB#8:                                 # %if.end20
 	i32.const	$push33=, 0
 	return  	$pop33
-.LBB2_9:                                # %if.then
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_10:                               # %if.then5
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_11:                               # %if.then8
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_12:                               # %if.then11
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_13:                               # %if.then16
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_14:                               # %if.then19
-	end_block                       # label7:
+.LBB2_9:                                # %if.then19
+	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -251,70 +201,50 @@ __cyg_profile_func_exit:                # @__cyg_profile_func_exit
 foo2:                                   # @foo2
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
 	i32.const	$push17=, 0
 	i32.load	$push1=, entry_calls($pop17)
 	i32.const	$push2=, 1
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label17
+	br_if   	0, $pop3        # 0: down to label3
 # BB#1:                                 # %entry
 	i32.const	$push18=, 0
 	i32.load	$push0=, exit_calls($pop18)
-	br_if   	0, $pop0        # 0: down to label17
+	br_if   	0, $pop0        # 0: down to label3
 # BB#2:                                 # %if.end
 	i32.const	$push19=, 0
 	i32.load	$push4=, last_fn_entered($pop19)
 	i32.const	$push5=, foo2@FUNCTION
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	1, $pop6        # 1: down to label16
+	br_if   	0, $pop6        # 0: down to label3
 # BB#3:                                 # %if.end4
 	call    	foo@FUNCTION
 	i32.const	$push20=, 0
 	i32.load	$push8=, entry_calls($pop20)
 	i32.const	$push9=, 2
 	i32.ne  	$push10=, $pop8, $pop9
-	br_if   	2, $pop10       # 2: down to label15
+	br_if   	0, $pop10       # 0: down to label3
 # BB#4:                                 # %if.end4
 	i32.const	$push21=, 0
 	i32.load	$push7=, exit_calls($pop21)
 	i32.const	$push11=, 1
 	i32.ne  	$push12=, $pop7, $pop11
-	br_if   	2, $pop12       # 2: down to label15
+	br_if   	0, $pop12       # 0: down to label3
 # BB#5:                                 # %if.end9
 	i32.const	$push23=, 0
 	i32.load	$push13=, last_fn_entered($pop23)
 	i32.const	$push22=, foo@FUNCTION
 	i32.ne  	$push14=, $pop13, $pop22
-	br_if   	3, $pop14       # 3: down to label14
+	br_if   	0, $pop14       # 0: down to label3
 # BB#6:                                 # %if.end12
 	i32.const	$push25=, 0
 	i32.load	$push15=, last_fn_exited($pop25)
 	i32.const	$push24=, foo@FUNCTION
 	i32.ne  	$push16=, $pop15, $pop24
-	br_if   	4, $pop16       # 4: down to label13
+	br_if   	0, $pop16       # 0: down to label3
 # BB#7:                                 # %if.end15
 	return
-.LBB5_8:                                # %if.then
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB5_9:                                # %if.then3
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB5_10:                               # %if.then8
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB5_11:                               # %if.then11
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB5_12:                               # %if.then14
-	end_block                       # label13:
+.LBB5_8:                                # %if.then14
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/fprintf-1.c.s
+++ b/test/torture-s/fprintf-1.c.s
@@ -21,16 +21,6 @@ main:                                   # @main
 	i32.load	$push0=, stdout($pop60)
 	i32.call	$discard=, fwrite@FUNCTION, $pop1, $pop2, $pop61, $pop0
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push59=, 0
 	i32.load	$push3=, stdout($pop59)
 	i32.const	$push58=, .L.str
@@ -38,7 +28,7 @@ main:                                   # @main
 	i32.call	$push4=, fprintf@FUNCTION, $pop3, $pop58, $pop57
 	i32.const	$push56=, 5
 	i32.ne  	$push5=, $pop4, $pop56
-	br_if   	0, $pop5        # 0: down to label10
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push7=, .L.str.1
 	i32.const	$push8=, 6
@@ -53,7 +43,7 @@ main:                                   # @main
 	i32.call	$push10=, fprintf@FUNCTION, $pop9, $pop64, $pop63
 	i32.const	$push62=, 6
 	i32.ne  	$push11=, $pop10, $pop62
-	br_if   	1, $pop11       # 1: down to label9
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.const	$push13=, 97
 	i32.const	$push70=, 0
@@ -66,14 +56,14 @@ main:                                   # @main
 	i32.call	$push16=, fprintf@FUNCTION, $pop14, $pop15, $pop68
 	i32.const	$push17=, 1
 	i32.ne  	$push18=, $pop16, $pop17
-	br_if   	2, $pop18       # 2: down to label8
+	br_if   	0, $pop18       # 0: down to label0
 # BB#3:                                 # %if.end11
 	i32.const	$push72=, 0
 	i32.load	$push19=, stdout($pop72)
 	i32.const	$push20=, .L.str.3
 	i32.const	$push71=, 0
 	i32.call	$push21=, fprintf@FUNCTION, $pop19, $pop20, $pop71
-	br_if   	3, $pop21       # 3: down to label7
+	br_if   	0, $pop21       # 0: down to label0
 # BB#4:                                 # %if.end16
 	i32.const	$push23=, .L.str
 	i32.const	$push24=, 5
@@ -91,7 +81,7 @@ main:                                   # @main
 	i32.call	$push25=, fprintf@FUNCTION, $1, $pop74, $5
 	i32.const	$push73=, 5
 	i32.ne  	$push26=, $pop25, $pop73
-	br_if   	4, $pop26       # 4: down to label6
+	br_if   	0, $pop26       # 0: down to label0
 # BB#5:                                 # %if.end21
 	i32.const	$push28=, .L.str.1
 	i32.const	$push29=, 6
@@ -109,7 +99,7 @@ main:                                   # @main
 	i32.call	$push30=, fprintf@FUNCTION, $1, $pop80, $6
 	i32.const	$push79=, 6
 	i32.ne  	$push31=, $pop30, $pop79
-	br_if   	5, $pop31       # 5: down to label5
+	br_if   	0, $pop31       # 0: down to label0
 # BB#6:                                 # %if.end26
 	i32.const	$push33=, 97
 	i32.const	$push87=, 0
@@ -125,7 +115,7 @@ main:                                   # @main
 	i32.call	$push35=, fprintf@FUNCTION, $1, $pop85, $7
 	i32.const	$push36=, 1
 	i32.ne  	$push37=, $pop35, $pop36
-	br_if   	6, $pop37       # 6: down to label4
+	br_if   	0, $pop37       # 0: down to label0
 # BB#7:                                 # %if.end31
 	i32.const	$push89=, 0
 	i32.load	$1=, stdout($pop89)
@@ -135,7 +125,7 @@ main:                                   # @main
 	i32.const	$8=, 80
 	i32.add 	$8=, $13, $8
 	i32.call	$push39=, fprintf@FUNCTION, $1, $pop88, $8
-	br_if   	7, $pop39       # 7: down to label3
+	br_if   	0, $pop39       # 0: down to label0
 # BB#8:                                 # %if.end36
 	i32.const	$push41=, 120
 	i32.const	$push92=, 0
@@ -151,7 +141,7 @@ main:                                   # @main
 	i32.call	$push43=, fprintf@FUNCTION, $1, $pop42, $9
 	i32.const	$push44=, 1
 	i32.ne  	$push45=, $pop43, $pop44
-	br_if   	8, $pop45       # 8: down to label2
+	br_if   	0, $pop45       # 0: down to label0
 # BB#9:                                 # %if.end41
 	i32.const	$push95=, 0
 	i32.load	$1=, stdout($pop95)
@@ -170,7 +160,7 @@ main:                                   # @main
 	i32.call	$push48=, fprintf@FUNCTION, $1, $pop93, $11
 	i32.const	$push49=, 7
 	i32.ne  	$push50=, $pop48, $pop49
-	br_if   	9, $pop50       # 9: down to label1
+	br_if   	0, $pop50       # 0: down to label0
 # BB#10:                                # %if.end46
 	i32.const	$push51=, 0
 	i32.load	$0=, stdout($pop51)
@@ -186,54 +176,14 @@ main:                                   # @main
 	i32.call	$push53=, fprintf@FUNCTION, $0, $pop96, $13
 	i32.const	$push54=, 2
 	i32.ne  	$push55=, $pop53, $pop54
-	br_if   	10, $pop55      # 10: down to label0
+	br_if   	0, $pop55       # 0: down to label0
 # BB#11:                                # %if.end51
 	i32.const	$4=, 144
 	i32.add 	$13=, $13, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$13=, 0($4), $13
 	return  	$1
-.LBB0_12:                               # %if.then
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then5
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then10
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then15
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then20
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then25
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then30
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then35
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_20:                               # %if.then40
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_21:                               # %if.then45
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_22:                               # %if.then50
+.LBB0_12:                               # %if.then50
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/fprintf-chk-1.c.s
+++ b/test/torture-s/fprintf-chk-1.c.s
@@ -61,43 +61,11 @@ main:                                   # @main
 	i32.const	$push81=, 0
 	i32.call	$discard=, __fprintf_chk@FUNCTION, $pop1, $0, $pop82, $pop81
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push80=, 0
 	i32.load	$push2=, should_optimize($pop80)
 	i32.const	$push178=, 0
 	i32.eq  	$push179=, $pop2, $pop178
-	br_if   	0, $pop179      # 0: down to label33
+	br_if   	0, $pop179      # 0: down to label1
 # BB#1:                                 # %if.end
 	i32.const	$push89=, 0
 	i32.const	$push88=, 0
@@ -108,13 +76,13 @@ main:                                   # @main
 	i32.call	$push4=, __fprintf_chk@FUNCTION, $pop3, $0, $pop85, $0
 	i32.const	$push5=, 5
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	1, $pop6        # 1: down to label32
+	br_if   	0, $pop6        # 0: down to label1
 # BB#2:                                 # %if.end3
 	i32.const	$push90=, 0
 	i32.load	$push7=, should_optimize($pop90)
 	i32.const	$push180=, 0
 	i32.eq  	$push181=, $pop7, $pop180
-	br_if   	2, $pop181      # 2: down to label31
+	br_if   	0, $pop181      # 0: down to label1
 # BB#3:                                 # %if.end6
 	i32.const	$push95=, 0
 	i32.const	$push8=, 1
@@ -128,7 +96,7 @@ main:                                   # @main
 	i32.load	$push10=, should_optimize($pop91)
 	i32.const	$push182=, 0
 	i32.eq  	$push183=, $pop10, $pop182
-	br_if   	3, $pop183      # 3: down to label30
+	br_if   	0, $pop183      # 0: down to label1
 # BB#4:                                 # %if.end10
 	i32.const	$push11=, 0
 	i32.const	$push99=, 0
@@ -139,12 +107,12 @@ main:                                   # @main
 	i32.call	$push13=, __fprintf_chk@FUNCTION, $pop12, $0, $pop96, $0
 	i32.const	$push14=, 6
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	4, $pop15       # 4: down to label29
+	br_if   	0, $pop15       # 0: down to label1
 # BB#5:                                 # %if.end14
 	i32.load	$push16=, should_optimize($0)
 	i32.const	$push184=, 0
 	i32.eq  	$push185=, $pop16, $pop184
-	br_if   	5, $pop185      # 5: down to label28
+	br_if   	0, $pop185      # 0: down to label1
 # BB#6:                                 # %if.end17
 	i32.const	$push104=, 0
 	i32.const	$push17=, 1
@@ -158,7 +126,7 @@ main:                                   # @main
 	i32.load	$push19=, should_optimize($pop100)
 	i32.const	$push186=, 0
 	i32.eq  	$push187=, $pop19, $pop186
-	br_if   	6, $pop187      # 6: down to label27
+	br_if   	0, $pop187      # 0: down to label1
 # BB#7:                                 # %if.end21
 	i32.const	$push109=, 0
 	i32.const	$push108=, 0
@@ -168,13 +136,13 @@ main:                                   # @main
 	i32.const	$push105=, .L.str.2
 	i32.call	$push21=, __fprintf_chk@FUNCTION, $pop20, $0, $pop105, $1
 	i32.ne  	$push22=, $pop21, $0
-	br_if   	7, $pop22       # 7: down to label26
+	br_if   	0, $pop22       # 0: down to label1
 # BB#8:                                 # %if.end25
 	i32.const	$push110=, 0
 	i32.load	$push23=, should_optimize($pop110)
 	i32.const	$push188=, 0
 	i32.eq  	$push189=, $pop23, $pop188
-	br_if   	8, $pop189      # 8: down to label25
+	br_if   	0, $pop189      # 0: down to label1
 # BB#9:                                 # %if.end28
 	i32.const	$push115=, 0
 	i32.const	$push24=, 1
@@ -188,7 +156,7 @@ main:                                   # @main
 	i32.load	$push26=, should_optimize($pop111)
 	i32.const	$push190=, 0
 	i32.eq  	$push191=, $pop26, $pop190
-	br_if   	9, $pop191      # 9: down to label24
+	br_if   	0, $pop191      # 0: down to label1
 # BB#10:                                # %if.end32
 	i32.const	$push27=, 0
 	i32.const	$push119=, 0
@@ -197,12 +165,12 @@ main:                                   # @main
 	i32.load	$push28=, stdout($pop117)
 	i32.const	$push116=, .L.str.3
 	i32.call	$push29=, __fprintf_chk@FUNCTION, $pop28, $0, $pop116, $0
-	br_if   	10, $pop29      # 10: down to label23
+	br_if   	0, $pop29       # 0: down to label1
 # BB#11:                                # %if.end36
 	i32.load	$push30=, should_optimize($0)
 	i32.const	$push192=, 0
 	i32.eq  	$push193=, $pop30, $pop192
-	br_if   	11, $pop193     # 11: down to label22
+	br_if   	0, $pop193      # 0: down to label1
 # BB#12:                                # %if.end39
 	i32.const	$push123=, 0
 	i32.const	$push31=, 1
@@ -219,7 +187,7 @@ main:                                   # @main
 	i32.load	$push33=, should_optimize($pop120)
 	i32.const	$push194=, 0
 	i32.eq  	$push195=, $pop33, $pop194
-	br_if   	12, $pop195     # 12: down to label21
+	br_if   	0, $pop195      # 0: down to label1
 # BB#13:                                # %if.end43
 	i32.const	$push126=, 0
 	i32.const	$push125=, 0
@@ -232,13 +200,13 @@ main:                                   # @main
 	i32.call	$push35=, __fprintf_chk@FUNCTION, $0, $0, $pop124, $7
 	i32.const	$push36=, 5
 	i32.ne  	$push37=, $pop35, $pop36
-	br_if   	13, $pop37      # 13: down to label20
+	br_if   	0, $pop37       # 0: down to label1
 # BB#14:                                # %if.end47
 	i32.const	$push127=, 0
 	i32.load	$push38=, should_optimize($pop127)
 	i32.const	$push196=, 0
 	i32.eq  	$push197=, $pop38, $pop196
-	br_if   	14, $pop197     # 14: down to label19
+	br_if   	0, $pop197      # 0: down to label1
 # BB#15:                                # %if.end50
 	i32.const	$push131=, 0
 	i32.const	$push39=, 1
@@ -255,7 +223,7 @@ main:                                   # @main
 	i32.load	$push41=, should_optimize($pop128)
 	i32.const	$push198=, 0
 	i32.eq  	$push199=, $pop41, $pop198
-	br_if   	15, $pop199     # 15: down to label18
+	br_if   	0, $pop199      # 0: down to label1
 # BB#16:                                # %if.end54
 	i32.const	$push42=, 0
 	i32.const	$push135=, 0
@@ -269,12 +237,12 @@ main:                                   # @main
 	i32.call	$push43=, __fprintf_chk@FUNCTION, $0, $0, $pop132, $9
 	i32.const	$push44=, 6
 	i32.ne  	$push45=, $pop43, $pop44
-	br_if   	16, $pop45      # 16: down to label17
+	br_if   	0, $pop45       # 0: down to label1
 # BB#17:                                # %if.end58
 	i32.load	$push46=, should_optimize($2)
 	i32.const	$push200=, 0
 	i32.eq  	$push201=, $pop46, $pop200
-	br_if   	17, $pop201     # 17: down to label16
+	br_if   	0, $pop201      # 0: down to label1
 # BB#18:                                # %if.end61
 	i32.const	$push139=, 0
 	i32.const	$push47=, 1
@@ -291,7 +259,7 @@ main:                                   # @main
 	i32.load	$push49=, should_optimize($pop136)
 	i32.const	$push202=, 0
 	i32.eq  	$push203=, $pop49, $pop202
-	br_if   	18, $pop203     # 18: down to label15
+	br_if   	0, $pop203      # 0: down to label1
 # BB#19:                                # %if.end65
 	i32.const	$push142=, 0
 	i32.const	$push141=, 0
@@ -303,13 +271,13 @@ main:                                   # @main
 	i32.add 	$11=, $19, $11
 	i32.call	$push51=, __fprintf_chk@FUNCTION, $0, $0, $pop140, $11
 	i32.ne  	$push52=, $pop51, $1
-	br_if   	19, $pop52      # 19: down to label14
+	br_if   	0, $pop52       # 0: down to label1
 # BB#20:                                # %if.end69
 	i32.const	$push143=, 0
 	i32.load	$push53=, should_optimize($pop143)
 	i32.const	$push204=, 0
 	i32.eq  	$push205=, $pop53, $pop204
-	br_if   	20, $pop205     # 20: down to label13
+	br_if   	0, $pop205      # 0: down to label1
 # BB#21:                                # %if.end72
 	i32.const	$push147=, 0
 	i32.const	$push54=, 1
@@ -326,7 +294,7 @@ main:                                   # @main
 	i32.load	$push56=, should_optimize($pop144)
 	i32.const	$push206=, 0
 	i32.eq  	$push207=, $pop56, $pop206
-	br_if   	21, $pop207     # 21: down to label12
+	br_if   	0, $pop207      # 0: down to label1
 # BB#22:                                # %if.end76
 	i32.const	$push57=, 0
 	i32.const	$push151=, 0
@@ -338,12 +306,12 @@ main:                                   # @main
 	i32.const	$13=, 96
 	i32.add 	$13=, $19, $13
 	i32.call	$push58=, __fprintf_chk@FUNCTION, $0, $0, $pop148, $13
-	br_if   	22, $pop58      # 22: down to label11
+	br_if   	0, $pop58       # 0: down to label1
 # BB#23:                                # %if.end80
 	i32.load	$push59=, should_optimize($2)
 	i32.const	$push208=, 0
 	i32.eq  	$push209=, $pop59, $pop208
-	br_if   	23, $pop209     # 23: down to label10
+	br_if   	0, $pop209      # 0: down to label1
 # BB#24:                                # %if.end83
 	i32.const	$push155=, 0
 	i32.const	$push60=, 1
@@ -360,7 +328,7 @@ main:                                   # @main
 	i32.load	$push62=, should_optimize($pop152)
 	i32.const	$push210=, 0
 	i32.eq  	$push211=, $pop62, $pop210
-	br_if   	24, $pop211     # 24: down to label9
+	br_if   	0, $pop211      # 0: down to label1
 # BB#25:                                # %if.end87
 	i32.const	$push158=, 0
 	i32.const	$push157=, 0
@@ -372,13 +340,13 @@ main:                                   # @main
 	i32.add 	$15=, $19, $15
 	i32.call	$push64=, __fprintf_chk@FUNCTION, $0, $0, $pop156, $15
 	i32.ne  	$push65=, $pop64, $1
-	br_if   	25, $pop65      # 25: down to label8
+	br_if   	0, $pop65       # 0: down to label1
 # BB#26:                                # %if.end91
 	i32.const	$push159=, 0
 	i32.load	$push66=, should_optimize($pop159)
 	i32.const	$push212=, 0
 	i32.eq  	$push213=, $pop66, $pop212
-	br_if   	26, $pop213     # 26: down to label7
+	br_if   	0, $pop213      # 0: down to label1
 # BB#27:                                # %if.end94
 	i32.const	$push164=, 0
 	i32.const	$push163=, 0
@@ -394,7 +362,7 @@ main:                                   # @main
 	i32.load	$push68=, should_optimize($0)
 	i32.const	$push214=, 0
 	i32.eq  	$push215=, $pop68, $pop214
-	br_if   	27, $pop215     # 27: down to label6
+	br_if   	0, $pop215      # 0: down to label1
 # BB#28:                                # %if.end98
 	i32.const	$push69=, 0
 	i32.const	$push168=, 0
@@ -408,12 +376,12 @@ main:                                   # @main
 	i32.call	$push70=, __fprintf_chk@FUNCTION, $0, $0, $pop165, $17
 	i32.const	$push71=, 7
 	i32.ne  	$push72=, $pop70, $pop71
-	br_if   	28, $pop72      # 28: down to label5
+	br_if   	0, $pop72       # 0: down to label1
 # BB#29:                                # %if.end102
 	i32.load	$push73=, should_optimize($1)
 	i32.const	$push216=, 0
 	i32.eq  	$push217=, $pop73, $pop216
-	br_if   	29, $pop217     # 29: down to label4
+	br_if   	0, $pop217      # 0: down to label1
 # BB#30:                                # %if.end105
 	i32.const	$push74=, 0
 	i32.const	$push172=, 0
@@ -428,7 +396,7 @@ main:                                   # @main
 	i32.load	$push75=, should_optimize($0)
 	i32.const	$push218=, 0
 	i32.eq  	$push219=, $pop75, $pop218
-	br_if   	30, $pop219     # 30: down to label3
+	br_if   	0, $pop219      # 0: down to label1
 # BB#31:                                # %if.end109
 	i32.store	$push175=, should_optimize($0), $0
 	tee_local	$push174=, $0=, $pop175
@@ -438,13 +406,13 @@ main:                                   # @main
 	i32.call	$push76=, __fprintf_chk@FUNCTION, $1, $0, $pop173, $19
 	i32.const	$push77=, 2
 	i32.ne  	$push78=, $pop76, $pop77
-	br_if   	31, $pop78      # 31: down to label2
+	br_if   	0, $pop78       # 0: down to label1
 # BB#32:                                # %if.end113
 	i32.const	$push176=, 0
 	i32.load	$push79=, should_optimize($pop176)
 	i32.const	$push220=, 0
 	i32.eq  	$push221=, $pop79, $pop220
-	br_if   	32, $pop221     # 32: down to label1
+	br_if   	0, $pop221      # 0: down to label1
 # BB#33:                                # %if.end116
 	i32.const	$push177=, 0
 	i32.const	$5=, 224
@@ -452,135 +420,7 @@ main:                                   # @main
 	i32.const	$5=, __stack_pointer
 	i32.store	$19=, 0($5), $19
 	return  	$pop177
-.LBB1_34:                               # %if.then
-	end_block                       # label33:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_35:                               # %if.then2
-	end_block                       # label32:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_36:                               # %if.then5
-	end_block                       # label31:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_37:                               # %if.then9
-	end_block                       # label30:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_38:                               # %if.then13
-	end_block                       # label29:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_39:                               # %if.then16
-	end_block                       # label28:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_40:                               # %if.then20
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_41:                               # %if.then24
-	end_block                       # label26:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_42:                               # %if.then27
-	end_block                       # label25:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_43:                               # %if.then31
-	end_block                       # label24:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_44:                               # %if.then35
-	end_block                       # label23:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_45:                               # %if.then38
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_46:                               # %if.then42
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_47:                               # %if.then46
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_48:                               # %if.then49
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_49:                               # %if.then53
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_50:                               # %if.then57
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_51:                               # %if.then60
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_52:                               # %if.then64
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_53:                               # %if.then68
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_54:                               # %if.then71
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_55:                               # %if.then75
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_56:                               # %if.then79
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_57:                               # %if.then82
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_58:                               # %if.then86
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_59:                               # %if.then90
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_60:                               # %if.then93
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_61:                               # %if.then97
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_62:                               # %if.then101
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_63:                               # %if.then104
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_64:                               # %if.then108
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_65:                               # %if.then112
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_66:                               # %if.then115
+.LBB1_34:                               # %if.then115
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/frame-address.c.s
+++ b/test/torture-s/frame-address.c.s
@@ -1,0 +1,140 @@
+	.text
+	.file	"/b/build/slave/linux/build/src/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/frame-address.c"
+	.section	.text.check_fa_work,"ax",@progbits
+	.hidden	check_fa_work
+	.globl	check_fa_work
+	.type	check_fa_work,@function
+check_fa_work:                          # @check_fa_work
+	.param  	i32, i32
+	.result 	i32
+	.local  	i32, i32, i32, i32, i32, i32, i32
+# BB#0:                                 # %entry
+	i32.const	$2=, __stack_pointer
+	i32.load	$2=, 0($2)
+	i32.const	$3=, 16
+	i32.sub 	$8=, $2, $3
+	i32.const	$3=, __stack_pointer
+	i32.store	$8=, 0($3), $8
+	i32.const	$push0=, 0
+	i32.store8	$discard=, 15($8), $pop0
+	i32.const	$5=, 15
+	i32.add 	$5=, $8, $5
+	block
+	block
+	i32.le_u	$push1=, $5, $0
+	br_if   	0, $pop1        # 0: down to label1
+# BB#1:                                 # %if.else
+	i32.le_u	$push4=, $0, $1
+	i32.const	$6=, 15
+	i32.add 	$6=, $8, $6
+	i32.ge_u	$push5=, $6, $1
+	i32.and 	$1=, $pop4, $pop5
+	br      	1               # 1: down to label0
+.LBB0_2:                                # %if.then
+	end_block                       # label1:
+	i32.ge_u	$push2=, $0, $1
+	i32.const	$7=, 15
+	i32.add 	$7=, $8, $7
+	i32.le_u	$push3=, $7, $1
+	i32.and 	$1=, $pop2, $pop3
+.LBB0_3:                                # %cleanup
+	end_block                       # label0:
+	i32.const	$4=, 16
+	i32.add 	$8=, $8, $4
+	i32.const	$4=, __stack_pointer
+	i32.store	$8=, 0($4), $8
+	return  	$1
+	.endfunc
+.Lfunc_end0:
+	.size	check_fa_work, .Lfunc_end0-check_fa_work
+
+	.section	.text.check_fa_mid,"ax",@progbits
+	.hidden	check_fa_mid
+	.globl	check_fa_mid
+	.type	check_fa_mid,@function
+check_fa_mid:                           # @check_fa_mid
+	.param  	i32
+	.result 	i32
+	.local  	i32, i32, i32, i32
+# BB#0:                                 # %entry
+	i32.const	$1=, __stack_pointer
+	i32.load	$3=, 0($1)
+	copy_local	$4=, $3
+	i32.call	$push0=, check_fa_work@FUNCTION, $0, $4
+	i32.const	$push1=, 0
+	i32.ne  	$push2=, $pop0, $pop1
+	i32.const	$2=, __stack_pointer
+	i32.store	$3=, 0($2), $4
+	return  	$pop2
+	.endfunc
+.Lfunc_end1:
+	.size	check_fa_mid, .Lfunc_end1-check_fa_mid
+
+	.section	.text.check_fa,"ax",@progbits
+	.hidden	check_fa
+	.globl	check_fa
+	.type	check_fa,@function
+check_fa:                               # @check_fa
+	.param  	i32
+	.result 	i32
+	.local  	i32, i32, i32, i32, i32
+# BB#0:                                 # %entry
+	i32.const	$1=, __stack_pointer
+	i32.load	$1=, 0($1)
+	i32.const	$2=, 16
+	i32.sub 	$5=, $1, $2
+	i32.const	$2=, __stack_pointer
+	i32.store	$5=, 0($2), $5
+	i32.const	$4=, 15
+	i32.add 	$4=, $5, $4
+	i32.call	$push0=, check_fa_mid@FUNCTION, $4
+	i32.const	$push1=, 0
+	i32.ne  	$push2=, $pop0, $pop1
+	i32.const	$3=, 16
+	i32.add 	$5=, $5, $3
+	i32.const	$3=, __stack_pointer
+	i32.store	$5=, 0($3), $5
+	return  	$pop2
+	.endfunc
+.Lfunc_end2:
+	.size	check_fa, .Lfunc_end2-check_fa
+
+	.section	.text.how_much,"ax",@progbits
+	.hidden	how_much
+	.globl	how_much
+	.type	how_much,@function
+how_much:                               # @how_much
+	.result 	i32
+# BB#0:                                 # %entry
+	i32.const	$push0=, 8
+	return  	$pop0
+	.endfunc
+.Lfunc_end3:
+	.size	how_much, .Lfunc_end3-how_much
+
+	.section	.text.main,"ax",@progbits
+	.hidden	main
+	.globl	main
+	.type	main,@function
+main:                                   # @main
+	.result 	i32
+	.local  	i32
+# BB#0:                                 # %entry
+	block
+	i32.call	$push0=, check_fa@FUNCTION, $0
+	i32.const	$push2=, 0
+	i32.eq  	$push3=, $pop0, $pop2
+	br_if   	0, $pop3        # 0: down to label2
+# BB#1:                                 # %if.end
+	i32.const	$push1=, 0
+	return  	$pop1
+.LBB4_2:                                # %if.then
+	end_block                       # label2:
+	call    	abort@FUNCTION
+	unreachable
+	.endfunc
+.Lfunc_end4:
+	.size	main, .Lfunc_end4-main
+
+
+	.ident	"clang version 3.9.0 "

--- a/test/torture-s/loop-11.c.s
+++ b/test/torture-s/loop-11.c.s
@@ -6,45 +6,46 @@
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32
+	.local  	i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$1=, 199
 	i32.const	$0=, a+792
 .LBB0_1:                                # %for.body.i
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label0:
-	i32.const	$push11=, -1
-	i32.add 	$push0=, $1, $pop11
+	i32.const	$push8=, -1
+	i32.add 	$push0=, $1, $pop8
 	i32.store	$1=, 0($0), $pop0
-	i32.const	$push10=, -4
-	i32.add 	$0=, $0, $pop10
-	i32.const	$3=, 0
-	i32.const	$2=, a
-	i32.const	$push9=, 0
-	i32.gt_s	$push1=, $1, $pop9
+	i32.const	$push7=, -4
+	i32.add 	$0=, $0, $pop7
+	i32.const	$2=, 0
+	i32.const	$push6=, 0
+	i32.gt_s	$push1=, $1, $pop6
 	br_if   	0, $pop1        # 0: up to label0
-.LBB0_2:                                # %for.body
-                                        # =>This Inner Loop Header: Depth=1
+# BB#2:
 	end_loop                        # label1:
+	i32.const	$1=, a
+.LBB0_3:                                # %for.body
+                                        # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label3:
-	i32.load	$push2=, 0($2)
-	i32.ne  	$push3=, $3, $pop2
+	i32.load	$push2=, 0($1)
+	i32.ne  	$push3=, $2, $pop2
 	br_if   	2, $pop3        # 2: down to label2
-# BB#3:                                 # %for.cond
-                                        #   in Loop: Header=BB0_2 Depth=1
-	i32.const	$push4=, 1
-	i32.add 	$3=, $3, $pop4
-	i32.const	$push5=, 4
-	i32.add 	$2=, $2, $pop5
-	i32.const	$push6=, 198
-	i32.le_s	$push7=, $3, $pop6
-	br_if   	0, $pop7        # 0: up to label3
-# BB#4:                                 # %for.end
+# BB#4:                                 # %for.cond
+                                        #   in Loop: Header=BB0_3 Depth=1
+	i32.const	$push11=, 1
+	i32.add 	$2=, $2, $pop11
+	i32.const	$push10=, 4
+	i32.add 	$1=, $1, $pop10
+	i32.const	$push9=, 198
+	i32.le_s	$push4=, $2, $pop9
+	br_if   	0, $pop4        # 0: up to label3
+# BB#5:                                 # %for.end
 	end_loop                        # label4:
-	i32.const	$push8=, 0
-	return  	$pop8
-.LBB0_5:                                # %if.then
+	i32.const	$push5=, 0
+	return  	$pop5
+.LBB0_6:                                # %if.then
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/loop-15.c.s
+++ b/test/torture-s/loop-15.c.s
@@ -14,14 +14,14 @@ foo:                                    # @foo
 .LBB0_1:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push1=, -4
-	i32.add 	$push5=, $1, $pop1
-	tee_local	$push4=, $2=, $pop5
-	i32.load	$push2=, 0($pop4)
-	i32.store	$discard=, 0($1), $pop2
+	i32.const	$push5=, -4
+	i32.add 	$push4=, $1, $pop5
+	tee_local	$push3=, $2=, $pop4
+	i32.load	$push1=, 0($pop3)
+	i32.store	$discard=, 0($1), $pop1
 	copy_local	$1=, $2
-	i32.gt_u	$push3=, $2, $0
-	br_if   	0, $pop3        # 0: up to label1
+	i32.gt_u	$push2=, $2, $0
+	br_if   	0, $pop2        # 0: up to label1
 .LBB0_2:                                # %while.end
 	end_loop                        # label2:
 	end_block                       # label0:
@@ -58,8 +58,8 @@ main:                                   # @main
                                         #     Child Loop BB1_2 Depth 2
                                         #       Child Loop BB1_4 Depth 3
                                         #       Child Loop BB1_5 Depth 3
-                                        #       Child Loop BB1_7 Depth 3
-                                        #       Child Loop BB1_10 Depth 3
+                                        #       Child Loop BB1_8 Depth 3
+                                        #       Child Loop BB1_11 Depth 3
 	block
 	block
 	block
@@ -74,8 +74,8 @@ main:                                   # @main
                                         # =>  This Loop Header: Depth=2
                                         #       Child Loop BB1_4 Depth 3
                                         #       Child Loop BB1_5 Depth 3
-                                        #       Child Loop BB1_7 Depth 3
-                                        #       Child Loop BB1_10 Depth 3
+                                        #       Child Loop BB1_8 Depth 3
+                                        #       Child Loop BB1_11 Depth 3
 	loop                            # label8:
 	i64.const	$push23=, 4294967296
 	i64.store	$discard=, 0($17):p2align=4, $pop23
@@ -83,8 +83,8 @@ main:                                   # @main
 	i64.store	$discard=, 0($7), $pop22
 	i32.const	$push21=, 4
 	i32.store	$9=, 0($8):p2align=4, $pop21
-	i32.const	$11=, -1
-	copy_local	$10=, $17
+	i32.const	$12=, -1
+	copy_local	$11=, $17
 	block
 	i32.le_s	$push3=, $6, $3
 	br_if   	0, $pop3        # 0: down to label10
@@ -92,20 +92,20 @@ main:                                   # @main
                                         #   in Loop: Header=BB1_2 Depth=2
 	i32.const	$push24=, 2
 	i32.shl 	$push4=, $6, $pop24
-	i32.add 	$13=, $17, $pop4
+	i32.add 	$10=, $17, $pop4
 .LBB1_4:                                # %while.body.i
                                         #   Parent Loop BB1_1 Depth=1
                                         #     Parent Loop BB1_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	loop                            # label11:
 	i32.const	$push27=, -4
-	i32.add 	$push26=, $13, $pop27
-	tee_local	$push25=, $12=, $pop26
+	i32.add 	$push26=, $10, $pop27
+	tee_local	$push25=, $13=, $pop26
 	i32.load	$push5=, 0($pop25)
-	i32.store	$discard=, 0($13), $pop5
-	copy_local	$13=, $12
-	copy_local	$10=, $17
-	i32.gt_u	$push6=, $12, $4
+	i32.store	$discard=, 0($10), $pop5
+	copy_local	$10=, $13
+	copy_local	$11=, $17
+	i32.gt_u	$push6=, $13, $4
 	br_if   	0, $pop6        # 0: up to label11
 .LBB1_5:                                # %for.body11
                                         #   Parent Loop BB1_1 Depth=1
@@ -115,66 +115,67 @@ main:                                   # @main
 	end_block                       # label10:
 	loop                            # label13:
 	i32.const	$push28=, 1
-	i32.add 	$11=, $11, $pop28
-	i32.load	$push7=, 0($10)
-	i32.ne  	$push8=, $11, $pop7
+	i32.add 	$12=, $12, $pop28
+	i32.load	$push7=, 0($11)
+	i32.ne  	$push8=, $12, $pop7
 	br_if   	6, $pop8        # 6: down to label5
 # BB#6:                                 # %for.cond9
                                         #   in Loop: Header=BB1_5 Depth=3
-	i32.add 	$10=, $10, $9
-	copy_local	$12=, $1
-	copy_local	$13=, $2
-	i32.lt_s	$push9=, $11, $3
+	i32.add 	$11=, $11, $9
+	i32.lt_s	$push9=, $12, $3
 	br_if   	0, $pop9        # 0: up to label13
-.LBB1_7:                                # %for.cond17
+# BB#7:                                 #   in Loop: Header=BB1_2 Depth=2
+	end_loop                        # label14:
+	copy_local	$11=, $1
+	copy_local	$12=, $2
+.LBB1_8:                                # %for.cond17
                                         #   Parent Loop BB1_1 Depth=1
                                         #     Parent Loop BB1_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	end_loop                        # label14:
 	loop                            # label15:
 	i32.const	$push29=, 1
-	i32.add 	$13=, $13, $pop29
-	i32.ge_s	$push10=, $13, $6
+	i32.add 	$12=, $12, $pop29
+	i32.ge_s	$push10=, $12, $6
 	br_if   	1, $pop10       # 1: down to label16
-# BB#8:                                 # %for.body19
-                                        #   in Loop: Header=BB1_7 Depth=3
-	i32.load	$11=, 0($12)
-	i32.add 	$12=, $12, $9
-	i32.eq  	$push18=, $13, $11
+# BB#9:                                 # %for.body19
+                                        #   in Loop: Header=BB1_8 Depth=3
+	i32.load	$10=, 0($11)
+	i32.add 	$11=, $11, $9
+	i32.eq  	$push18=, $12, $10
 	br_if   	0, $pop18       # 0: up to label15
 	br      	7               # 7: down to label4
-.LBB1_9:                                # %for.end26
+.LBB1_10:                               # %for.end26
                                         #   in Loop: Header=BB1_2 Depth=2
 	end_loop                        # label16:
 	i32.const	$push31=, 1
 	i32.add 	$6=, $6, $pop31
 	copy_local	$11=, $5
-	copy_local	$13=, $6
+	copy_local	$12=, $6
 	i32.const	$push30=, 5
 	i32.ge_s	$push11=, $6, $pop30
 	br_if   	1, $pop11       # 1: down to label9
-.LBB1_10:                               # %for.body30
+.LBB1_11:                               # %for.body30
                                         #   Parent Loop BB1_1 Depth=1
                                         #     Parent Loop BB1_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	loop                            # label17:
 	i32.load	$push12=, 0($11)
-	i32.ne  	$push13=, $13, $pop12
+	i32.ne  	$push13=, $12, $pop12
 	br_if   	8, $pop13       # 8: down to label3
-# BB#11:                                # %for.cond28
-                                        #   in Loop: Header=BB1_10 Depth=3
+# BB#12:                                # %for.cond28
+                                        #   in Loop: Header=BB1_11 Depth=3
 	i32.const	$push32=, 1
-	i32.add 	$13=, $13, $pop32
+	i32.add 	$12=, $12, $pop32
 	i32.add 	$11=, $11, $9
-	i32.le_s	$push14=, $13, $9
+	i32.le_s	$push14=, $12, $9
 	br_if   	0, $pop14       # 0: up to label17
-# BB#12:                                # %for.cond1.loopexit
+# BB#13:                                # %for.cond1.loopexit
                                         #   in Loop: Header=BB1_2 Depth=2
 	end_loop                        # label18:
 	i32.add 	$5=, $5, $9
 	i32.le_s	$push15=, $6, $9
 	br_if   	0, $pop15       # 0: up to label8
-.LBB1_13:                               # %for.inc41
+.LBB1_14:                               # %for.inc41
                                         #   in Loop: Header=BB1_1 Depth=1
 	end_loop                        # label9:
 	i32.add 	$1=, $1, $9
@@ -185,7 +186,7 @@ main:                                   # @main
 	i32.const	$push33=, 5
 	i32.lt_s	$push16=, $3, $pop33
 	br_if   	0, $pop16       # 0: up to label6
-# BB#14:                                # %for.end43
+# BB#15:                                # %for.end43
 	end_loop                        # label7:
 	i32.const	$push17=, 0
 	i32.const	$16=, 32
@@ -193,15 +194,15 @@ main:                                   # @main
 	i32.const	$16=, __stack_pointer
 	i32.store	$17=, 0($16), $17
 	return  	$pop17
-.LBB1_15:                               # %if.then
+.LBB1_16:                               # %if.then
 	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_16:                               # %if.then22
+.LBB1_17:                               # %if.then22
 	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_17:                               # %if.then33
+.LBB1_18:                               # %if.then33
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/loop-2.c.s
+++ b/test/torture-s/loop-2.c.s
@@ -9,25 +9,26 @@ f:                                      # @f
 	.result 	i32
 	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$2=, 0
-	i32.const	$1=, a
 	block
 	i32.const	$push5=, 0
 	i32.eq  	$push6=, $0, $pop5
 	br_if   	0, $pop6        # 0: down to label0
-.LBB0_1:                                # %for.body
+# BB#1:
+	i32.const	$2=, 0
+	i32.const	$1=, a
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push0=, -2
-	i32.add 	$push1=, $2, $pop0
-	i32.store	$discard=, 0($1), $pop1
-	i32.const	$push2=, 1
-	i32.add 	$2=, $2, $pop2
-	i32.const	$push3=, 4
-	i32.add 	$1=, $1, $pop3
-	i32.ne  	$push4=, $0, $2
-	br_if   	0, $pop4        # 0: up to label1
-.LBB0_2:                                # %for.end
+	i32.const	$push4=, -2
+	i32.add 	$push0=, $2, $pop4
+	i32.store	$discard=, 0($1), $pop0
+	i32.const	$push3=, 1
+	i32.add 	$2=, $2, $pop3
+	i32.const	$push2=, 4
+	i32.add 	$1=, $1, $pop2
+	i32.ne  	$push1=, $0, $2
+	br_if   	0, $pop1        # 0: up to label1
+.LBB0_3:                                # %for.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	return  	$2

--- a/test/torture-s/loop-5.c.s
+++ b/test/torture-s/loop-5.c.s
@@ -9,13 +9,12 @@ main:                                   # @main
 	.local  	i64, i32, i32, i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push35=, 0
 	i32.load	$push34=, t($pop35)
 	tee_local	$push33=, $2=, $pop34
 	i32.const	$push3=, 4
 	i32.ge_s	$push4=, $pop33, $pop3
-	br_if   	0, $pop4        # 0: down to label1
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %ap.exit.i
 	i32.const	$push39=, 2
 	i32.shl 	$push6=, $2, $pop39
@@ -27,7 +26,7 @@ main:                                   # @main
 	i32.store	$1=, t($pop37), $pop0
 	i32.const	$push36=, 2
 	i32.gt_s	$push7=, $2, $pop36
-	br_if   	0, $pop7        # 0: down to label1
+	br_if   	0, $pop7        # 0: down to label0
 # BB#2:                                 # %ap.exit.1.i
 	i32.const	$push44=, 2
 	i32.shl 	$push8=, $1, $pop44
@@ -39,7 +38,7 @@ main:                                   # @main
 	i32.store	$push41=, t($pop43), $pop1
 	tee_local	$push40=, $3=, $pop41
 	i32.gt_s	$push10=, $pop40, $1
-	br_if   	0, $pop10       # 0: down to label1
+	br_if   	0, $pop10       # 0: down to label0
 # BB#3:                                 # %ap.exit.2.i
 	i32.const	$push11=, 2
 	i32.shl 	$push12=, $3, $pop11
@@ -49,14 +48,9 @@ main:                                   # @main
 	i32.add 	$push2=, $2, $1
 	i32.store	$1=, t($pop46), $pop2
 	i32.const	$push45=, 0
-	i32.le_s	$push13=, $2, $pop45
-	br_if   	1, $pop13       # 1: down to label0
-.LBB0_4:                                # %if.then.i.i
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %testit.exit
-	end_block                       # label0:
+	i32.gt_s	$push13=, $2, $pop45
+	br_if   	0, $pop13       # 0: down to label0
+# BB#4:                                 # %testit.exit
 	i32.shl 	$push17=, $1, $3
 	i32.const	$push18=, 1
 	i32.store	$discard=, a($pop17), $pop18
@@ -66,50 +60,34 @@ main:                                   # @main
 	i32.const	$push14=, 4
 	i32.add 	$push15=, $2, $pop14
 	i32.store	$discard=, t($pop48), $pop15
-	block
-	block
-	block
-	block
 	i32.wrap/i64	$push19=, $0
-	br_if   	0, $pop19       # 0: down to label5
-# BB#6:                                 # %if.end
+	br_if   	0, $pop19       # 0: down to label0
+# BB#5:                                 # %if.end
 	i64.const	$push20=, -4294967296
 	i64.and 	$push21=, $0, $pop20
 	i64.const	$push22=, 12884901888
 	i64.ne  	$push23=, $pop21, $pop22
-	br_if   	1, $pop23       # 1: down to label4
-# BB#7:                                 # %if.end3
+	br_if   	0, $pop23       # 0: down to label0
+# BB#6:                                 # %if.end3
 	i32.const	$push24=, 0
 	i64.load	$push50=, a+8($pop24)
 	tee_local	$push49=, $0=, $pop50
 	i32.wrap/i64	$push25=, $pop49
 	i32.const	$push26=, 2
 	i32.ne  	$push27=, $pop25, $pop26
-	br_if   	2, $pop27       # 2: down to label3
-# BB#8:                                 # %if.end6
+	br_if   	0, $pop27       # 0: down to label0
+# BB#7:                                 # %if.end6
 	i64.const	$push28=, -4294967296
 	i64.and 	$push29=, $0, $pop28
 	i64.const	$push30=, 4294967296
 	i64.ne  	$push31=, $pop29, $pop30
-	br_if   	3, $pop31       # 3: down to label2
-# BB#9:                                 # %if.end9
+	br_if   	0, $pop31       # 0: down to label0
+# BB#8:                                 # %if.end9
 	i32.const	$push32=, 0
 	call    	exit@FUNCTION, $pop32
 	unreachable
-.LBB0_10:                               # %if.then
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then2
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then5
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then8
-	end_block                       # label2:
+.LBB0_9:                                # %if.then8
+	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/loop-ivopts-2.c.s
+++ b/test/torture-s/loop-ivopts-2.c.s
@@ -90,7 +90,7 @@ main:                                   # @main
 	i32.const	$push45=, 448
 	i32.ne  	$push4=, $3, $pop45
 	br_if   	0, $pop4        # 0: up to label5
-# BB#4:                                 # %for.body.i.preheader
+# BB#4:                                 # %for.body17
 	end_loop                        # label6:
 	i64.const	$push5=, 30064771079
 	i64.store	$push6=, 1024($7):p2align=4, $pop5

--- a/test/torture-s/lshrdi-1.c.s
+++ b/test/torture-s/lshrdi-1.c.s
@@ -6,58 +6,59 @@
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i64, i32, i32
+	.local  	i64, i32, i32
 # BB#0:                                 # %entry
-	i64.const	$1=, 0
-	i32.const	$0=, .Lswitch.table
+	i64.const	$0=, 0
+	i32.const	$2=, .Lswitch.table
 .LBB0_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label1:
-	i64.const	$push12=, -8690466092652643696
-	i64.shr_u	$push0=, $pop12, $1
-	i64.load	$push1=, 0($0)
+	i64.const	$push9=, -8690466092652643696
+	i64.shr_u	$push0=, $pop9, $0
+	i64.load	$push1=, 0($2)
 	i64.ne  	$push2=, $pop0, $pop1
 	br_if   	2, $pop2        # 2: down to label0
 # BB#2:                                 # %for.cond
                                         #   in Loop: Header=BB0_1 Depth=1
-	i64.const	$push11=, 1
-	i64.add 	$1=, $1, $pop11
-	i32.const	$push10=, 8
-	i32.add 	$0=, $0, $pop10
-	i32.const	$3=, 0
-	i32.const	$2=, .Lswitch.table
-	i64.const	$push9=, 63
-	i64.le_s	$push3=, $1, $pop9
+	i64.const	$push8=, 1
+	i64.add 	$0=, $0, $pop8
+	i32.const	$push7=, 8
+	i32.add 	$2=, $2, $pop7
+	i64.const	$push6=, 63
+	i64.le_s	$push3=, $0, $pop6
 	br_if   	0, $pop3        # 0: up to label1
-.LBB0_3:                                # %constant_shift.exit
-                                        # =>This Inner Loop Header: Depth=1
+# BB#3:
 	end_loop                        # label2:
+	i32.const	$2=, 0
+	i32.const	$1=, .Lswitch.table
+.LBB0_4:                                # %constant_shift.exit
+                                        # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label4:
-	i32.const	$push4=, 1
-	i32.const	$push14=, 0
-	i32.eq  	$push15=, $pop4, $pop14
-	br_if   	2, $pop15       # 2: down to label3
-# BB#4:                                 # %for.cond2
-                                        #   in Loop: Header=BB0_3 Depth=1
 	i32.const	$push13=, 1
-	i32.add 	$3=, $3, $pop13
-	i32.const	$push5=, 8
-	i32.add 	$2=, $2, $pop5
-	i32.const	$push6=, 63
-	i32.le_s	$push7=, $3, $pop6
-	br_if   	0, $pop7        # 0: up to label4
-# BB#5:                                 # %for.end13
+	i32.const	$push14=, 0
+	i32.eq  	$push15=, $pop13, $pop14
+	br_if   	2, $pop15       # 2: down to label3
+# BB#5:                                 # %for.cond2
+                                        #   in Loop: Header=BB0_4 Depth=1
+	i32.const	$push12=, 1
+	i32.add 	$2=, $2, $pop12
+	i32.const	$push11=, 8
+	i32.add 	$1=, $1, $pop11
+	i32.const	$push10=, 63
+	i32.le_s	$push4=, $2, $pop10
+	br_if   	0, $pop4        # 0: up to label4
+# BB#6:                                 # %for.end13
 	end_loop                        # label5:
-	i32.const	$push8=, 0
-	call    	exit@FUNCTION, $pop8
+	i32.const	$push5=, 0
+	call    	exit@FUNCTION, $pop5
 	unreachable
-.LBB0_6:                                # %if.then9
+.LBB0_7:                                # %if.then9
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_7:                                # %if.then
+.LBB0_8:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/memcpy-1.c.s
+++ b/test/torture-s/memcpy-1.c.s
@@ -24,30 +24,30 @@ main:                                   # @main
 # BB#0:                                 # %entry
 	i32.const	$2=, __stack_pointer
 	i32.load	$2=, 0($2)
-	i32.const	$3=, 262144
+	i32.const	$3=, 696320
 	i32.sub 	$9=, $2, $3
 	i32.const	$3=, __stack_pointer
 	i32.store	$9=, 0($3), $9
 	i32.const	$1=, 0
 	i32.const	$push37=, 0
-	i32.const	$push36=, 131072
+	i32.const	$push36=, 348160
 	i32.call	$discard=, memset@FUNCTION, $9, $pop37, $pop36
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label0:
-	i32.const	$4=, 131072
+	i32.const	$4=, 348160
 	i32.add 	$4=, $9, $4
 	i32.add 	$push0=, $4, $1
 	i32.store8	$push1=, 0($pop0), $1
 	i32.const	$push39=, 1
 	i32.add 	$1=, $pop1, $pop39
-	i32.const	$push38=, 131072
+	i32.const	$push38=, 348160
 	i32.ne  	$push2=, $1, $pop38
 	br_if   	0, $pop2        # 0: up to label0
 # BB#2:                                 # %for.end
 	end_loop                        # label1:
-	i32.const	$push3=, 1024
-	i32.const	$5=, 131072
+	i32.const	$push3=, 2720
+	i32.const	$5=, 348160
 	i32.add 	$5=, $9, $5
 	i32.call	$discard=, memcpy@FUNCTION, $9, $5, $pop3
 	i32.const	$1=, 0
@@ -67,20 +67,20 @@ main:                                   # @main
                                         #   in Loop: Header=BB1_3 Depth=1
 	i32.const	$push41=, 1
 	i32.add 	$1=, $1, $pop41
-	i32.const	$push40=, 1023
+	i32.const	$push40=, 2719
 	i32.le_u	$push8=, $1, $pop40
 	br_if   	0, $pop8        # 0: up to label5
 # BB#5:                                 # %for.end15
 	end_loop                        # label6:
 	i32.const	$push43=, 1
-	i32.const	$push9=, 1024
+	i32.const	$push9=, 2720
 	i32.call	$discard=, memset@FUNCTION, $9, $pop43, $pop9
 	i32.const	$1=, 1
 .LBB1_6:                                # %for.cond17
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label8:
-	i32.const	$push44=, 1023
+	i32.const	$push44=, 2719
 	i32.gt_u	$push10=, $1, $pop44
 	br_if   	2, $pop10       # 2: down to label7
 # BB#7:                                 # %for.cond17.for.body20_crit_edge
@@ -98,8 +98,8 @@ main:                                   # @main
 	unreachable
 .LBB1_9:                                # %for.end29
 	end_block                       # label7:
-	i32.const	$push11=, 131072
-	i32.const	$6=, 131072
+	i32.const	$push11=, 348160
+	i32.const	$6=, 348160
 	i32.add 	$6=, $9, $6
 	i32.call	$discard=, memcpy@FUNCTION, $9, $6, $pop11
 	i32.const	$1=, 0
@@ -116,20 +116,20 @@ main:                                   # @main
                                         #   in Loop: Header=BB1_10 Depth=1
 	i32.const	$push48=, 1
 	i32.add 	$1=, $1, $pop48
-	i32.const	$push47=, 131071
+	i32.const	$push47=, 348159
 	i32.le_u	$push16=, $1, $pop47
 	br_if   	0, $pop16       # 0: up to label10
 # BB#12:                                # %for.end46
 	end_loop                        # label11:
 	i32.const	$push18=, 0
-	i32.const	$push17=, 131072
+	i32.const	$push17=, 348160
 	i32.call	$discard=, memset@FUNCTION, $9, $pop18, $pop17
 	i32.const	$1=, 1
 .LBB1_13:                               # %for.cond48
                                         # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label13:
-	i32.const	$push50=, 131071
+	i32.const	$push50=, 348159
 	i32.gt_u	$push19=, $1, $pop50
 	br_if   	2, $pop19       # 2: down to label12
 # BB#14:                                # %for.cond48.for.body51_crit_edge
@@ -147,8 +147,8 @@ main:                                   # @main
 	unreachable
 .LBB1_16:                               # %for.end60
 	end_block                       # label12:
-	i32.const	$push20=, 1024
-	i32.const	$7=, 131072
+	i32.const	$push20=, 2720
+	i32.const	$7=, 348160
 	i32.add 	$7=, $9, $7
 	i32.call	$discard=, memcpy@FUNCTION, $9, $7, $pop20
 	i32.const	$1=, 0
@@ -165,13 +165,13 @@ main:                                   # @main
                                         #   in Loop: Header=BB1_17 Depth=1
 	i32.const	$push53=, 1
 	i32.add 	$1=, $1, $pop53
-	i32.const	$push52=, 1023
+	i32.const	$push52=, 2719
 	i32.le_u	$push25=, $1, $pop52
 	br_if   	0, $pop25       # 0: up to label15
 # BB#19:                                # %for.end77
 	end_loop                        # label16:
-	i32.const	$push26=, 131072
-	i32.const	$8=, 131072
+	i32.const	$push26=, 348160
+	i32.const	$8=, 348160
 	i32.add 	$8=, $9, $8
 	i32.call	$discard=, memcpy@FUNCTION, $9, $8, $pop26
 	i32.const	$1=, 0
@@ -189,7 +189,7 @@ main:                                   # @main
                                         #   in Loop: Header=BB1_20 Depth=1
 	i32.const	$push56=, 1
 	i32.add 	$1=, $1, $pop56
-	i32.const	$push55=, 131071
+	i32.const	$push55=, 348159
 	i32.le_u	$push31=, $1, $pop55
 	br_if   	0, $pop31       # 0: up to label18
 # BB#22:                                # %for.end96

--- a/test/torture-s/memcpy-2.c.s
+++ b/test/torture-s/memcpy-2.c.s
@@ -15,11 +15,9 @@ main:                                   # @main
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_6 Depth 4
-                                        #         Child Loop BB0_9 Depth 4
+                                        #         Child Loop BB0_10 Depth 4
 	block
-	block
-	block
-	loop                            # label3:
+	loop                            # label1:
 	i32.const	$push44=, u1
 	i32.add 	$1=, $0, $pop44
 	i32.const	$2=, 0
@@ -29,8 +27,8 @@ main:                                   # @main
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_6 Depth 4
-                                        #         Child Loop BB0_9 Depth 4
-	loop                            # label5:
+                                        #         Child Loop BB0_10 Depth 4
+	loop                            # label3:
 	i32.const	$push46=, u2
 	i32.add 	$3=, $2, $pop46
 	i32.const	$push45=, 65
@@ -42,8 +40,8 @@ main:                                   # @main
                                         # =>    This Loop Header: Depth=3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_6 Depth 4
-                                        #         Child Loop BB0_9 Depth 4
-	loop                            # label7:
+                                        #         Child Loop BB0_10 Depth 4
+	loop                            # label5:
 	i32.const	$push49=, u1
 	i32.const	$push48=, 97
 	i32.const	$push47=, 96
@@ -55,7 +53,7 @@ main:                                   # @main
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop                            # label9:
+	loop                            # label7:
 	i32.const	$push55=, 65
 	i32.const	$push54=, 24
 	i32.shl 	$push0=, $6, $pop54
@@ -69,173 +67,167 @@ main:                                   # @main
 	i32.add 	$6=, $pop4, $pop51
 	i32.const	$push50=, 1
 	i32.add 	$8=, $8, $pop50
-	br_if   	0, $8           # 0: up to label9
+	br_if   	0, $8           # 0: up to label7
 # BB#5:                                 # %for.end
                                         #   in Loop: Header=BB0_3 Depth=3
-	end_loop                        # label10:
+	end_loop                        # label8:
 	i32.call	$discard=, memcpy@FUNCTION, $1, $3, $5
 	i32.const	$7=, u1
 	i32.const	$8=, 0
 	block
 	i32.const	$push56=, 1
 	i32.lt_s	$push5=, $0, $pop56
-	br_if   	0, $pop5        # 0: down to label11
+	br_if   	0, $pop5        # 0: down to label9
 .LBB0_6:                                # %for.body23
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop                            # label12:
-	i32.load8_u	$push6=, u1($8)
+	loop                            # label10:
+	copy_local	$push59=, $8
+	tee_local	$push58=, $6=, $pop59
+	i32.load8_u	$push6=, u1($pop58)
 	i32.const	$push57=, 97
 	i32.ne  	$push7=, $pop6, $pop57
-	br_if   	10, $pop7       # 10: down to label1
+	br_if   	9, $pop7        # 9: down to label0
 # BB#7:                                 # %for.inc29
                                         #   in Loop: Header=BB0_6 Depth=4
-	i32.const	$push59=, u1+1
-	i32.add 	$7=, $8, $pop59
-	i32.const	$push58=, 1
-	i32.add 	$6=, $8, $pop58
-	copy_local	$8=, $6
-	i32.lt_s	$push8=, $6, $0
-	br_if   	0, $pop8        # 0: up to label12
-.LBB0_8:                                # %for.body36.preheader
+	i32.const	$push60=, 1
+	i32.add 	$8=, $6, $pop60
+	i32.lt_s	$push8=, $8, $0
+	br_if   	0, $pop8        # 0: up to label10
+# BB#8:                                 #   in Loop: Header=BB0_3 Depth=3
+	end_loop                        # label11:
+	i32.const	$push61=, u1+1
+	i32.add 	$7=, $6, $pop61
+.LBB0_9:                                # %for.body36.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
-	end_loop                        # label13:
-	end_block                       # label11:
+	end_block                       # label9:
 	i32.const	$8=, 0
 	copy_local	$6=, $4
-.LBB0_9:                                # %for.body36
+.LBB0_10:                               # %for.body36
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop                            # label14:
+	loop                            # label12:
 	i32.add 	$push13=, $7, $8
 	i32.load8_u	$push14=, 0($pop13)
-	i32.const	$push66=, 65
-	i32.const	$push65=, 24
-	i32.shl 	$push9=, $6, $pop65
-	i32.const	$push64=, 24
-	i32.shr_s	$push10=, $pop9, $pop64
-	i32.const	$push63=, 95
-	i32.gt_s	$push11=, $pop10, $pop63
-	i32.select	$push62=, $pop66, $6, $pop11
-	tee_local	$push61=, $6=, $pop62
-	i32.const	$push60=, 255
-	i32.and 	$push12=, $pop61, $pop60
+	i32.const	$push68=, 65
+	i32.const	$push67=, 24
+	i32.shl 	$push9=, $6, $pop67
+	i32.const	$push66=, 24
+	i32.shr_s	$push10=, $pop9, $pop66
+	i32.const	$push65=, 95
+	i32.gt_s	$push11=, $pop10, $pop65
+	i32.select	$push64=, $pop68, $6, $pop11
+	tee_local	$push63=, $6=, $pop64
+	i32.const	$push62=, 255
+	i32.and 	$push12=, $pop63, $pop62
 	i32.ne  	$push15=, $pop14, $pop12
-	br_if   	8, $pop15       # 8: down to label2
-# BB#10:                                # %for.inc48
-                                        #   in Loop: Header=BB0_9 Depth=4
-	i32.const	$push68=, 1
-	i32.add 	$8=, $8, $pop68
-	i32.const	$push67=, 1
-	i32.add 	$6=, $6, $pop67
+	br_if   	8, $pop15       # 8: down to label0
+# BB#11:                                # %for.inc48
+                                        #   in Loop: Header=BB0_10 Depth=4
+	i32.const	$push70=, 1
+	i32.add 	$8=, $8, $pop70
+	i32.const	$push69=, 1
+	i32.add 	$6=, $6, $pop69
 	i32.lt_s	$push16=, $8, $5
-	br_if   	0, $pop16       # 0: up to label14
-# BB#11:                                # %for.body56.preheader
+	br_if   	0, $pop16       # 0: up to label12
+# BB#12:                                # %for.body56.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
-	end_loop                        # label15:
-	i32.add 	$push71=, $7, $8
-	tee_local	$push70=, $8=, $pop71
-	i32.load8_u	$push17=, 0($pop70)
-	i32.const	$push69=, 97
-	i32.ne  	$push18=, $pop17, $pop69
-	br_if   	8, $pop18       # 8: down to label0
-# BB#12:                                # %for.inc62
+	end_loop                        # label13:
+	i32.add 	$push73=, $7, $8
+	tee_local	$push72=, $8=, $pop73
+	i32.load8_u	$push17=, 0($pop72)
+	i32.const	$push71=, 97
+	i32.ne  	$push18=, $pop17, $pop71
+	br_if   	6, $pop18       # 6: down to label0
+# BB#13:                                # %for.inc62
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push73=, 1
-	i32.add 	$push19=, $8, $pop73
-	i32.load8_u	$push20=, 0($pop19)
-	i32.const	$push72=, 97
-	i32.ne  	$push21=, $pop20, $pop72
-	br_if   	8, $pop21       # 8: down to label0
-# BB#13:                                # %for.inc62.1
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push79=, 2
-	i32.add 	$push22=, $8, $pop79
-	i32.load8_u	$push23=, 0($pop22)
-	i32.const	$push78=, 97
-	i32.ne  	$push24=, $pop23, $pop78
-	br_if   	8, $pop24       # 8: down to label0
-# BB#14:                                # %for.inc62.2
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push81=, 3
-	i32.add 	$push25=, $8, $pop81
-	i32.load8_u	$push26=, 0($pop25)
-	i32.const	$push80=, 97
-	i32.ne  	$push27=, $pop26, $pop80
-	br_if   	8, $pop27       # 8: down to label0
-# BB#15:                                # %for.inc62.3
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push83=, 4
-	i32.add 	$push28=, $8, $pop83
-	i32.load8_u	$push29=, 0($pop28)
-	i32.const	$push82=, 97
-	i32.ne  	$push30=, $pop29, $pop82
-	br_if   	8, $pop30       # 8: down to label0
-# BB#16:                                # %for.inc62.4
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push85=, 5
-	i32.add 	$push31=, $8, $pop85
-	i32.load8_u	$push32=, 0($pop31)
-	i32.const	$push84=, 97
-	i32.ne  	$push33=, $pop32, $pop84
-	br_if   	8, $pop33       # 8: down to label0
-# BB#17:                                # %for.inc62.5
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push87=, 6
-	i32.add 	$push34=, $8, $pop87
-	i32.load8_u	$push35=, 0($pop34)
-	i32.const	$push86=, 97
-	i32.ne  	$push36=, $pop35, $pop86
-	br_if   	8, $pop36       # 8: down to label0
-# BB#18:                                # %for.inc62.6
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push89=, 7
-	i32.add 	$push37=, $8, $pop89
-	i32.load8_u	$push38=, 0($pop37)
-	i32.const	$push88=, 97
-	i32.ne  	$push39=, $pop38, $pop88
-	br_if   	8, $pop39       # 8: down to label0
-# BB#19:                                # %for.inc62.7
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push91=, 1
-	i32.add 	$5=, $5, $pop91
-	i32.const	$push90=, 80
-	i32.lt_u	$push40=, $5, $pop90
-	br_if   	0, $pop40       # 0: up to label7
-# BB#20:                                # %for.inc69
-                                        #   in Loop: Header=BB0_2 Depth=2
-	end_loop                        # label8:
 	i32.const	$push75=, 1
-	i32.add 	$2=, $2, $pop75
-	i32.const	$push74=, 8
-	i32.lt_u	$push41=, $2, $pop74
-	br_if   	0, $pop41       # 0: up to label5
-# BB#21:                                # %for.inc72
-                                        #   in Loop: Header=BB0_1 Depth=1
+	i32.add 	$push19=, $8, $pop75
+	i32.load8_u	$push20=, 0($pop19)
+	i32.const	$push74=, 97
+	i32.ne  	$push21=, $pop20, $pop74
+	br_if   	6, $pop21       # 6: down to label0
+# BB#14:                                # %for.inc62.1
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push81=, 2
+	i32.add 	$push22=, $8, $pop81
+	i32.load8_u	$push23=, 0($pop22)
+	i32.const	$push80=, 97
+	i32.ne  	$push24=, $pop23, $pop80
+	br_if   	6, $pop24       # 6: down to label0
+# BB#15:                                # %for.inc62.2
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push83=, 3
+	i32.add 	$push25=, $8, $pop83
+	i32.load8_u	$push26=, 0($pop25)
+	i32.const	$push82=, 97
+	i32.ne  	$push27=, $pop26, $pop82
+	br_if   	6, $pop27       # 6: down to label0
+# BB#16:                                # %for.inc62.3
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push85=, 4
+	i32.add 	$push28=, $8, $pop85
+	i32.load8_u	$push29=, 0($pop28)
+	i32.const	$push84=, 97
+	i32.ne  	$push30=, $pop29, $pop84
+	br_if   	6, $pop30       # 6: down to label0
+# BB#17:                                # %for.inc62.4
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push87=, 5
+	i32.add 	$push31=, $8, $pop87
+	i32.load8_u	$push32=, 0($pop31)
+	i32.const	$push86=, 97
+	i32.ne  	$push33=, $pop32, $pop86
+	br_if   	6, $pop33       # 6: down to label0
+# BB#18:                                # %for.inc62.5
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push89=, 6
+	i32.add 	$push34=, $8, $pop89
+	i32.load8_u	$push35=, 0($pop34)
+	i32.const	$push88=, 97
+	i32.ne  	$push36=, $pop35, $pop88
+	br_if   	6, $pop36       # 6: down to label0
+# BB#19:                                # %for.inc62.6
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push91=, 7
+	i32.add 	$push37=, $8, $pop91
+	i32.load8_u	$push38=, 0($pop37)
+	i32.const	$push90=, 97
+	i32.ne  	$push39=, $pop38, $pop90
+	br_if   	6, $pop39       # 6: down to label0
+# BB#20:                                # %for.inc62.7
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push93=, 1
+	i32.add 	$5=, $5, $pop93
+	i32.const	$push92=, 80
+	i32.lt_u	$push40=, $5, $pop92
+	br_if   	0, $pop40       # 0: up to label5
+# BB#21:                                # %for.inc69
+                                        #   in Loop: Header=BB0_2 Depth=2
 	end_loop                        # label6:
 	i32.const	$push77=, 1
-	i32.add 	$0=, $0, $pop77
+	i32.add 	$2=, $2, $pop77
 	i32.const	$push76=, 8
-	i32.lt_u	$push42=, $0, $pop76
-	br_if   	0, $pop42       # 0: up to label3
-# BB#22:                                # %for.end74
+	i32.lt_u	$push41=, $2, $pop76
+	br_if   	0, $pop41       # 0: up to label3
+# BB#22:                                # %for.inc72
+                                        #   in Loop: Header=BB0_1 Depth=1
 	end_loop                        # label4:
+	i32.const	$push79=, 1
+	i32.add 	$0=, $0, $pop79
+	i32.const	$push78=, 8
+	i32.lt_u	$push42=, $0, $pop78
+	br_if   	0, $pop42       # 0: up to label1
+# BB#23:                                # %for.end74
+	end_loop                        # label2:
 	i32.const	$push43=, 0
 	call    	exit@FUNCTION, $pop43
 	unreachable
-.LBB0_23:                               # %if.then46
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then27
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then60
+.LBB0_24:                               # %if.then60
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/memcpy-bi.c.s
+++ b/test/torture-s/memcpy-bi.c.s
@@ -49,85 +49,10 @@ main:                                   # @main
 	i32.load16_u	$push3=, src($pop252):p2align=4
 	i32.store16	$discard=, dst($pop253):p2align=4, $pop3
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push4=, 1
 	i32.const	$push676=, 0
 	i32.eq  	$push677=, $pop4, $pop676
-	br_if   	0, $pop677      # 0: down to label78
+	br_if   	0, $pop677      # 0: down to label3
 # BB#3:                                 # %check.exit13
 	i32.const	$push259=, 0
 	i32.const	$push258=, 0
@@ -141,7 +66,7 @@ main:                                   # @main
 	i32.const	$push254=, src
 	i32.const	$push7=, 3
 	i32.call	$push8=, memcmp@FUNCTION, $pop255, $pop254, $pop7
-	br_if   	1, $pop8        # 1: down to label77
+	br_if   	0, $pop8        # 0: down to label3
 # BB#4:                                 # %check.exit17
 	i32.const	$push265=, 0
 	i32.load	$4=, src($pop265):p2align=4
@@ -155,7 +80,7 @@ main:                                   # @main
 	i32.const	$push260=, src
 	i32.const	$push10=, 5
 	i32.call	$push11=, memcmp@FUNCTION, $pop261, $pop260, $pop10
-	br_if   	2, $pop11       # 2: down to label76
+	br_if   	0, $pop11       # 0: down to label3
 # BB#5:                                 # %check.exit25
 	i32.const	$push271=, 0
 	i32.const	$push270=, 0
@@ -169,7 +94,7 @@ main:                                   # @main
 	i32.const	$push266=, src
 	i32.const	$push14=, 6
 	i32.call	$push15=, memcmp@FUNCTION, $pop267, $pop266, $pop14
-	br_if   	3, $pop15       # 3: down to label75
+	br_if   	0, $pop15       # 0: down to label3
 # BB#6:                                 # %check.exit29
 	i32.const	$push279=, 0
 	i32.load16_u	$4=, src+4($pop279):p2align=2
@@ -187,7 +112,7 @@ main:                                   # @main
 	i32.const	$push272=, src
 	i32.const	$push17=, 7
 	i32.call	$push18=, memcmp@FUNCTION, $pop273, $pop272, $pop17
-	br_if   	4, $pop18       # 4: down to label74
+	br_if   	0, $pop18       # 0: down to label3
 # BB#7:                                 # %check.exit33
 	i32.const	$push285=, 0
 	i32.const	$push284=, 0
@@ -201,7 +126,7 @@ main:                                   # @main
 	i32.const	$push280=, src
 	i32.const	$push21=, 9
 	i32.call	$push22=, memcmp@FUNCTION, $pop281, $pop280, $pop21
-	br_if   	5, $pop22       # 5: down to label73
+	br_if   	0, $pop22       # 0: down to label3
 # BB#8:                                 # %check.exit41
 	i32.const	$push291=, 0
 	i64.load	$1=, src($pop291):p2align=4
@@ -215,7 +140,7 @@ main:                                   # @main
 	i32.const	$push286=, src
 	i32.const	$push24=, 10
 	i32.call	$push25=, memcmp@FUNCTION, $pop287, $pop286, $pop24
-	br_if   	6, $pop25       # 6: down to label72
+	br_if   	0, $pop25       # 0: down to label3
 # BB#9:                                 # %check.exit45
 	i32.const	$push299=, 0
 	i32.load16_u	$4=, src+8($pop299):p2align=3
@@ -233,7 +158,7 @@ main:                                   # @main
 	i32.const	$push292=, src
 	i32.const	$push28=, 11
 	i32.call	$push29=, memcmp@FUNCTION, $pop293, $pop292, $pop28
-	br_if   	7, $pop29       # 7: down to label71
+	br_if   	0, $pop29       # 0: down to label3
 # BB#10:                                # %check.exit49
 	i32.const	$push305=, 0
 	i64.load	$1=, src($pop305):p2align=4
@@ -247,7 +172,7 @@ main:                                   # @main
 	i32.const	$push300=, src
 	i32.const	$push31=, 12
 	i32.call	$push32=, memcmp@FUNCTION, $pop301, $pop300, $pop31
-	br_if   	8, $pop32       # 8: down to label70
+	br_if   	0, $pop32       # 0: down to label3
 # BB#11:                                # %check.exit53
 	i32.const	$push313=, 0
 	i32.load	$4=, src+8($pop313):p2align=3
@@ -265,7 +190,7 @@ main:                                   # @main
 	i32.const	$push306=, src
 	i32.const	$push35=, 13
 	i32.call	$push36=, memcmp@FUNCTION, $pop307, $pop306, $pop35
-	br_if   	9, $pop36       # 9: down to label69
+	br_if   	0, $pop36       # 0: down to label3
 # BB#12:                                # %check.exit57
 	i32.const	$push321=, 0
 	i32.load	$4=, src+8($pop321):p2align=3
@@ -283,7 +208,7 @@ main:                                   # @main
 	i32.const	$push314=, src
 	i32.const	$push38=, 14
 	i32.call	$push39=, memcmp@FUNCTION, $pop315, $pop314, $pop38
-	br_if   	10, $pop39      # 10: down to label68
+	br_if   	0, $pop39       # 0: down to label3
 # BB#13:                                # %check.exit61
 	i32.const	$push331=, 0
 	i32.load16_u	$4=, src+12($pop331):p2align=2
@@ -305,7 +230,7 @@ main:                                   # @main
 	i32.const	$push322=, src
 	i32.const	$push42=, 15
 	i32.call	$push43=, memcmp@FUNCTION, $pop323, $pop322, $pop42
-	br_if   	11, $pop43      # 11: down to label67
+	br_if   	0, $pop43       # 0: down to label3
 # BB#14:                                # %check.exit65
 	i32.const	$push337=, 0
 	i64.load	$1=, src($pop337):p2align=4
@@ -319,7 +244,7 @@ main:                                   # @main
 	i32.const	$push332=, src
 	i32.const	$push45=, 16
 	i32.call	$push46=, memcmp@FUNCTION, $pop333, $pop332, $pop45
-	br_if   	12, $pop46      # 12: down to label66
+	br_if   	0, $pop46       # 0: down to label3
 # BB#15:                                # %check.exit69
 	i32.const	$push345=, 0
 	i64.load	$1=, src+8($pop345)
@@ -337,7 +262,7 @@ main:                                   # @main
 	i32.const	$push338=, src
 	i32.const	$push49=, 17
 	i32.call	$push50=, memcmp@FUNCTION, $pop339, $pop338, $pop49
-	br_if   	13, $pop50      # 13: down to label65
+	br_if   	0, $pop50       # 0: down to label3
 # BB#16:                                # %check.exit73
 	i32.const	$push353=, 0
 	i64.load	$1=, src+8($pop353)
@@ -355,7 +280,7 @@ main:                                   # @main
 	i32.const	$push346=, src
 	i32.const	$push52=, 18
 	i32.call	$push53=, memcmp@FUNCTION, $pop347, $pop346, $pop52
-	br_if   	14, $pop53      # 14: down to label64
+	br_if   	0, $pop53       # 0: down to label3
 # BB#17:                                # %check.exit77
 	i32.const	$push363=, 0
 	i32.load16_u	$4=, src+16($pop363):p2align=4
@@ -377,7 +302,7 @@ main:                                   # @main
 	i32.const	$push354=, src
 	i32.const	$push56=, 19
 	i32.call	$push57=, memcmp@FUNCTION, $pop355, $pop354, $pop56
-	br_if   	15, $pop57      # 15: down to label63
+	br_if   	0, $pop57       # 0: down to label3
 # BB#18:                                # %check.exit81
 	i32.const	$push371=, 0
 	i64.load	$1=, src+8($pop371)
@@ -395,7 +320,7 @@ main:                                   # @main
 	i32.const	$push364=, src
 	i32.const	$push59=, 20
 	i32.call	$push60=, memcmp@FUNCTION, $pop365, $pop364, $pop59
-	br_if   	16, $pop60      # 16: down to label62
+	br_if   	0, $pop60       # 0: down to label3
 # BB#19:                                # %check.exit85
 	i32.const	$push381=, 0
 	i32.load	$4=, src+16($pop381):p2align=4
@@ -417,7 +342,7 @@ main:                                   # @main
 	i32.const	$push372=, src
 	i32.const	$push63=, 21
 	i32.call	$push64=, memcmp@FUNCTION, $pop373, $pop372, $pop63
-	br_if   	17, $pop64      # 17: down to label61
+	br_if   	0, $pop64       # 0: down to label3
 # BB#20:                                # %check.exit89
 	i32.const	$push391=, 0
 	i32.load	$4=, src+16($pop391):p2align=4
@@ -439,7 +364,7 @@ main:                                   # @main
 	i32.const	$push382=, src
 	i32.const	$push66=, 22
 	i32.call	$push67=, memcmp@FUNCTION, $pop383, $pop382, $pop66
-	br_if   	18, $pop67      # 18: down to label60
+	br_if   	0, $pop67       # 0: down to label3
 # BB#21:                                # %check.exit93
 	i32.const	$push403=, 0
 	i32.load16_u	$4=, src+20($pop403):p2align=2
@@ -465,7 +390,7 @@ main:                                   # @main
 	i32.const	$push392=, src
 	i32.const	$push70=, 23
 	i32.call	$push71=, memcmp@FUNCTION, $pop393, $pop392, $pop70
-	br_if   	19, $pop71      # 19: down to label59
+	br_if   	0, $pop71       # 0: down to label3
 # BB#22:                                # %check.exit97
 	i32.const	$push411=, 0
 	i64.load	$1=, src+8($pop411)
@@ -483,7 +408,7 @@ main:                                   # @main
 	i32.const	$push404=, src
 	i32.const	$push73=, 24
 	i32.call	$push74=, memcmp@FUNCTION, $pop405, $pop404, $pop73
-	br_if   	20, $pop74      # 20: down to label58
+	br_if   	0, $pop74       # 0: down to label3
 # BB#23:                                # %check.exit101
 	i32.const	$push421=, 0
 	i64.load	$1=, src+16($pop421):p2align=4
@@ -505,7 +430,7 @@ main:                                   # @main
 	i32.const	$push412=, src
 	i32.const	$push77=, 25
 	i32.call	$push78=, memcmp@FUNCTION, $pop413, $pop412, $pop77
-	br_if   	21, $pop78      # 21: down to label57
+	br_if   	0, $pop78       # 0: down to label3
 # BB#24:                                # %check.exit105
 	i32.const	$push431=, 0
 	i64.load	$1=, src+16($pop431):p2align=4
@@ -527,7 +452,7 @@ main:                                   # @main
 	i32.const	$push422=, src
 	i32.const	$push80=, 26
 	i32.call	$push81=, memcmp@FUNCTION, $pop423, $pop422, $pop80
-	br_if   	22, $pop81      # 22: down to label56
+	br_if   	0, $pop81       # 0: down to label3
 # BB#25:                                # %check.exit109
 	i32.const	$push443=, 0
 	i32.load16_u	$4=, src+24($pop443):p2align=3
@@ -553,7 +478,7 @@ main:                                   # @main
 	i32.const	$push432=, src
 	i32.const	$push84=, 27
 	i32.call	$push85=, memcmp@FUNCTION, $pop433, $pop432, $pop84
-	br_if   	23, $pop85      # 23: down to label55
+	br_if   	0, $pop85       # 0: down to label3
 # BB#26:                                # %check.exit113
 	i32.const	$push453=, 0
 	i64.load	$1=, src+16($pop453):p2align=4
@@ -575,7 +500,7 @@ main:                                   # @main
 	i32.const	$push444=, src
 	i32.const	$push87=, 28
 	i32.call	$push88=, memcmp@FUNCTION, $pop445, $pop444, $pop87
-	br_if   	24, $pop88      # 24: down to label54
+	br_if   	0, $pop88       # 0: down to label3
 # BB#27:                                # %check.exit117
 	i32.const	$push465=, 0
 	i32.load	$4=, src+24($pop465):p2align=3
@@ -601,7 +526,7 @@ main:                                   # @main
 	i32.const	$push454=, src
 	i32.const	$push91=, 29
 	i32.call	$push92=, memcmp@FUNCTION, $pop455, $pop454, $pop91
-	br_if   	25, $pop92      # 25: down to label53
+	br_if   	0, $pop92       # 0: down to label3
 # BB#28:                                # %check.exit121
 	i32.const	$push93=, 0
 	i32.load	$4=, src+24($pop93):p2align=3
@@ -627,7 +552,7 @@ main:                                   # @main
 	i32.const	$push466=, src
 	i32.const	$push95=, 30
 	i32.call	$push96=, memcmp@FUNCTION, $pop467, $pop466, $pop95
-	br_if   	26, $pop96      # 26: down to label52
+	br_if   	0, $pop96       # 0: down to label3
 # BB#29:                                # %check.exit125
 	i32.const	$push97=, dst
 	i32.const	$push481=, src
@@ -637,7 +562,7 @@ main:                                   # @main
 	i32.const	$push478=, src
 	i32.const	$push477=, 31
 	i32.call	$push99=, memcmp@FUNCTION, $pop479, $pop478, $pop477
-	br_if   	27, $pop99      # 27: down to label51
+	br_if   	0, $pop99       # 0: down to label3
 # BB#30:                                # %check.exit129
 	i32.const	$push100=, 0
 	i64.load	$1=, src+16($pop100):p2align=4
@@ -658,7 +583,7 @@ main:                                   # @main
 	i32.const	$push482=, src
 	i32.const	$push102=, 32
 	i32.call	$push103=, memcmp@FUNCTION, $4, $pop482, $pop102
-	br_if   	28, $pop103     # 28: down to label50
+	br_if   	0, $pop103      # 0: down to label3
 # BB#31:                                # %check.exit133
 	i32.const	$push104=, dst
 	i32.const	$push494=, src
@@ -668,7 +593,7 @@ main:                                   # @main
 	i32.const	$push491=, src
 	i32.const	$push490=, 33
 	i32.call	$push106=, memcmp@FUNCTION, $pop492, $pop491, $pop490
-	br_if   	29, $pop106     # 29: down to label49
+	br_if   	0, $pop106      # 0: down to label3
 # BB#32:                                # %check.exit137
 	i32.const	$push497=, src
 	i32.const	$push107=, 34
@@ -676,7 +601,7 @@ main:                                   # @main
 	i32.const	$push496=, src
 	i32.const	$push495=, 34
 	i32.call	$push109=, memcmp@FUNCTION, $pop108, $pop496, $pop495
-	br_if   	30, $pop109     # 30: down to label48
+	br_if   	0, $pop109      # 0: down to label3
 # BB#33:                                # %check.exit141
 	i32.const	$push110=, dst
 	i32.const	$push502=, src
@@ -686,7 +611,7 @@ main:                                   # @main
 	i32.const	$push499=, src
 	i32.const	$push498=, 35
 	i32.call	$push112=, memcmp@FUNCTION, $pop500, $pop499, $pop498
-	br_if   	31, $pop112     # 31: down to label47
+	br_if   	0, $pop112      # 0: down to label3
 # BB#34:                                # %check.exit145
 	i32.const	$push505=, src
 	i32.const	$push113=, 36
@@ -694,7 +619,7 @@ main:                                   # @main
 	i32.const	$push504=, src
 	i32.const	$push503=, 36
 	i32.call	$push115=, memcmp@FUNCTION, $pop114, $pop504, $pop503
-	br_if   	32, $pop115     # 32: down to label46
+	br_if   	0, $pop115      # 0: down to label3
 # BB#35:                                # %check.exit149
 	i32.const	$push116=, dst
 	i32.const	$push510=, src
@@ -704,7 +629,7 @@ main:                                   # @main
 	i32.const	$push507=, src
 	i32.const	$push506=, 37
 	i32.call	$push118=, memcmp@FUNCTION, $pop508, $pop507, $pop506
-	br_if   	33, $pop118     # 33: down to label45
+	br_if   	0, $pop118      # 0: down to label3
 # BB#36:                                # %check.exit153
 	i32.const	$push513=, src
 	i32.const	$push119=, 38
@@ -712,7 +637,7 @@ main:                                   # @main
 	i32.const	$push512=, src
 	i32.const	$push511=, 38
 	i32.call	$push121=, memcmp@FUNCTION, $pop120, $pop512, $pop511
-	br_if   	34, $pop121     # 34: down to label44
+	br_if   	0, $pop121      # 0: down to label3
 # BB#37:                                # %check.exit157
 	i32.const	$push122=, dst
 	i32.const	$push518=, src
@@ -722,7 +647,7 @@ main:                                   # @main
 	i32.const	$push515=, src
 	i32.const	$push514=, 39
 	i32.call	$push124=, memcmp@FUNCTION, $pop516, $pop515, $pop514
-	br_if   	35, $pop124     # 35: down to label43
+	br_if   	0, $pop124      # 0: down to label3
 # BB#38:                                # %check.exit161
 	i32.const	$push521=, src
 	i32.const	$push125=, 40
@@ -730,7 +655,7 @@ main:                                   # @main
 	i32.const	$push520=, src
 	i32.const	$push519=, 40
 	i32.call	$push127=, memcmp@FUNCTION, $pop126, $pop520, $pop519
-	br_if   	36, $pop127     # 36: down to label42
+	br_if   	0, $pop127      # 0: down to label3
 # BB#39:                                # %check.exit165
 	i32.const	$push128=, dst
 	i32.const	$push526=, src
@@ -740,7 +665,7 @@ main:                                   # @main
 	i32.const	$push523=, src
 	i32.const	$push522=, 41
 	i32.call	$push130=, memcmp@FUNCTION, $pop524, $pop523, $pop522
-	br_if   	37, $pop130     # 37: down to label41
+	br_if   	0, $pop130      # 0: down to label3
 # BB#40:                                # %check.exit169
 	i32.const	$push529=, src
 	i32.const	$push131=, 42
@@ -748,7 +673,7 @@ main:                                   # @main
 	i32.const	$push528=, src
 	i32.const	$push527=, 42
 	i32.call	$push133=, memcmp@FUNCTION, $pop132, $pop528, $pop527
-	br_if   	38, $pop133     # 38: down to label40
+	br_if   	0, $pop133      # 0: down to label3
 # BB#41:                                # %check.exit173
 	i32.const	$push134=, dst
 	i32.const	$push534=, src
@@ -758,7 +683,7 @@ main:                                   # @main
 	i32.const	$push531=, src
 	i32.const	$push530=, 43
 	i32.call	$push136=, memcmp@FUNCTION, $pop532, $pop531, $pop530
-	br_if   	39, $pop136     # 39: down to label39
+	br_if   	0, $pop136      # 0: down to label3
 # BB#42:                                # %check.exit177
 	i32.const	$push537=, src
 	i32.const	$push137=, 44
@@ -766,7 +691,7 @@ main:                                   # @main
 	i32.const	$push536=, src
 	i32.const	$push535=, 44
 	i32.call	$push139=, memcmp@FUNCTION, $pop138, $pop536, $pop535
-	br_if   	40, $pop139     # 40: down to label38
+	br_if   	0, $pop139      # 0: down to label3
 # BB#43:                                # %check.exit181
 	i32.const	$push140=, dst
 	i32.const	$push542=, src
@@ -776,7 +701,7 @@ main:                                   # @main
 	i32.const	$push539=, src
 	i32.const	$push538=, 45
 	i32.call	$push142=, memcmp@FUNCTION, $pop540, $pop539, $pop538
-	br_if   	41, $pop142     # 41: down to label37
+	br_if   	0, $pop142      # 0: down to label3
 # BB#44:                                # %check.exit185
 	i32.const	$push545=, src
 	i32.const	$push143=, 46
@@ -784,7 +709,7 @@ main:                                   # @main
 	i32.const	$push544=, src
 	i32.const	$push543=, 46
 	i32.call	$push145=, memcmp@FUNCTION, $pop144, $pop544, $pop543
-	br_if   	42, $pop145     # 42: down to label36
+	br_if   	0, $pop145      # 0: down to label3
 # BB#45:                                # %check.exit189
 	i32.const	$push146=, dst
 	i32.const	$push550=, src
@@ -794,7 +719,7 @@ main:                                   # @main
 	i32.const	$push547=, src
 	i32.const	$push546=, 47
 	i32.call	$push148=, memcmp@FUNCTION, $pop548, $pop547, $pop546
-	br_if   	43, $pop148     # 43: down to label35
+	br_if   	0, $pop148      # 0: down to label3
 # BB#46:                                # %check.exit193
 	i32.const	$push553=, src
 	i32.const	$push149=, 48
@@ -802,7 +727,7 @@ main:                                   # @main
 	i32.const	$push552=, src
 	i32.const	$push551=, 48
 	i32.call	$push151=, memcmp@FUNCTION, $pop150, $pop552, $pop551
-	br_if   	44, $pop151     # 44: down to label34
+	br_if   	0, $pop151      # 0: down to label3
 # BB#47:                                # %check.exit197
 	i32.const	$push152=, dst
 	i32.const	$push558=, src
@@ -812,7 +737,7 @@ main:                                   # @main
 	i32.const	$push555=, src
 	i32.const	$push554=, 49
 	i32.call	$push154=, memcmp@FUNCTION, $pop556, $pop555, $pop554
-	br_if   	45, $pop154     # 45: down to label33
+	br_if   	0, $pop154      # 0: down to label3
 # BB#48:                                # %check.exit201
 	i32.const	$push561=, src
 	i32.const	$push155=, 50
@@ -820,7 +745,7 @@ main:                                   # @main
 	i32.const	$push560=, src
 	i32.const	$push559=, 50
 	i32.call	$push157=, memcmp@FUNCTION, $pop156, $pop560, $pop559
-	br_if   	46, $pop157     # 46: down to label32
+	br_if   	0, $pop157      # 0: down to label3
 # BB#49:                                # %check.exit205
 	i32.const	$push158=, dst
 	i32.const	$push566=, src
@@ -830,7 +755,7 @@ main:                                   # @main
 	i32.const	$push563=, src
 	i32.const	$push562=, 51
 	i32.call	$push160=, memcmp@FUNCTION, $pop564, $pop563, $pop562
-	br_if   	47, $pop160     # 47: down to label31
+	br_if   	0, $pop160      # 0: down to label3
 # BB#50:                                # %check.exit209
 	i32.const	$push569=, src
 	i32.const	$push161=, 52
@@ -838,7 +763,7 @@ main:                                   # @main
 	i32.const	$push568=, src
 	i32.const	$push567=, 52
 	i32.call	$push163=, memcmp@FUNCTION, $pop162, $pop568, $pop567
-	br_if   	48, $pop163     # 48: down to label30
+	br_if   	0, $pop163      # 0: down to label3
 # BB#51:                                # %check.exit213
 	i32.const	$push164=, dst
 	i32.const	$push574=, src
@@ -848,7 +773,7 @@ main:                                   # @main
 	i32.const	$push571=, src
 	i32.const	$push570=, 53
 	i32.call	$push166=, memcmp@FUNCTION, $pop572, $pop571, $pop570
-	br_if   	49, $pop166     # 49: down to label29
+	br_if   	0, $pop166      # 0: down to label3
 # BB#52:                                # %check.exit217
 	i32.const	$push577=, src
 	i32.const	$push167=, 54
@@ -856,7 +781,7 @@ main:                                   # @main
 	i32.const	$push576=, src
 	i32.const	$push575=, 54
 	i32.call	$push169=, memcmp@FUNCTION, $pop168, $pop576, $pop575
-	br_if   	50, $pop169     # 50: down to label28
+	br_if   	0, $pop169      # 0: down to label3
 # BB#53:                                # %check.exit221
 	i32.const	$push170=, dst
 	i32.const	$push582=, src
@@ -866,7 +791,7 @@ main:                                   # @main
 	i32.const	$push579=, src
 	i32.const	$push578=, 55
 	i32.call	$push172=, memcmp@FUNCTION, $pop580, $pop579, $pop578
-	br_if   	51, $pop172     # 51: down to label27
+	br_if   	0, $pop172      # 0: down to label3
 # BB#54:                                # %check.exit225
 	i32.const	$push585=, src
 	i32.const	$push173=, 56
@@ -874,7 +799,7 @@ main:                                   # @main
 	i32.const	$push584=, src
 	i32.const	$push583=, 56
 	i32.call	$push175=, memcmp@FUNCTION, $pop174, $pop584, $pop583
-	br_if   	52, $pop175     # 52: down to label26
+	br_if   	0, $pop175      # 0: down to label3
 # BB#55:                                # %check.exit229
 	i32.const	$push176=, dst
 	i32.const	$push590=, src
@@ -884,7 +809,7 @@ main:                                   # @main
 	i32.const	$push587=, src
 	i32.const	$push586=, 57
 	i32.call	$push178=, memcmp@FUNCTION, $pop588, $pop587, $pop586
-	br_if   	53, $pop178     # 53: down to label25
+	br_if   	0, $pop178      # 0: down to label3
 # BB#56:                                # %check.exit233
 	i32.const	$push593=, src
 	i32.const	$push179=, 58
@@ -892,7 +817,7 @@ main:                                   # @main
 	i32.const	$push592=, src
 	i32.const	$push591=, 58
 	i32.call	$push181=, memcmp@FUNCTION, $pop180, $pop592, $pop591
-	br_if   	54, $pop181     # 54: down to label24
+	br_if   	0, $pop181      # 0: down to label3
 # BB#57:                                # %check.exit237
 	i32.const	$push182=, dst
 	i32.const	$push598=, src
@@ -902,7 +827,7 @@ main:                                   # @main
 	i32.const	$push595=, src
 	i32.const	$push594=, 59
 	i32.call	$push184=, memcmp@FUNCTION, $pop596, $pop595, $pop594
-	br_if   	55, $pop184     # 55: down to label23
+	br_if   	0, $pop184      # 0: down to label3
 # BB#58:                                # %check.exit241
 	i32.const	$push601=, src
 	i32.const	$push185=, 60
@@ -910,7 +835,7 @@ main:                                   # @main
 	i32.const	$push600=, src
 	i32.const	$push599=, 60
 	i32.call	$push187=, memcmp@FUNCTION, $pop186, $pop600, $pop599
-	br_if   	56, $pop187     # 56: down to label22
+	br_if   	0, $pop187      # 0: down to label3
 # BB#59:                                # %check.exit245
 	i32.const	$push188=, dst
 	i32.const	$push606=, src
@@ -920,7 +845,7 @@ main:                                   # @main
 	i32.const	$push603=, src
 	i32.const	$push602=, 61
 	i32.call	$push190=, memcmp@FUNCTION, $pop604, $pop603, $pop602
-	br_if   	57, $pop190     # 57: down to label21
+	br_if   	0, $pop190      # 0: down to label3
 # BB#60:                                # %check.exit249
 	i32.const	$push609=, src
 	i32.const	$push191=, 62
@@ -928,7 +853,7 @@ main:                                   # @main
 	i32.const	$push608=, src
 	i32.const	$push607=, 62
 	i32.call	$push193=, memcmp@FUNCTION, $pop192, $pop608, $pop607
-	br_if   	58, $pop193     # 58: down to label20
+	br_if   	0, $pop193      # 0: down to label3
 # BB#61:                                # %check.exit253
 	i32.const	$push194=, dst
 	i32.const	$push614=, src
@@ -938,7 +863,7 @@ main:                                   # @main
 	i32.const	$push611=, src
 	i32.const	$push610=, 63
 	i32.call	$push196=, memcmp@FUNCTION, $pop612, $pop611, $pop610
-	br_if   	59, $pop196     # 59: down to label19
+	br_if   	0, $pop196      # 0: down to label3
 # BB#62:                                # %check.exit257
 	i32.const	$push617=, src
 	i32.const	$push197=, 64
@@ -946,7 +871,7 @@ main:                                   # @main
 	i32.const	$push616=, src
 	i32.const	$push615=, 64
 	i32.call	$push199=, memcmp@FUNCTION, $pop198, $pop616, $pop615
-	br_if   	60, $pop199     # 60: down to label18
+	br_if   	0, $pop199      # 0: down to label3
 # BB#63:                                # %check.exit261
 	i32.const	$push200=, dst
 	i32.const	$push622=, src
@@ -956,7 +881,7 @@ main:                                   # @main
 	i32.const	$push619=, src
 	i32.const	$push618=, 65
 	i32.call	$push202=, memcmp@FUNCTION, $pop620, $pop619, $pop618
-	br_if   	61, $pop202     # 61: down to label17
+	br_if   	0, $pop202      # 0: down to label3
 # BB#64:                                # %check.exit265
 	i32.const	$push625=, src
 	i32.const	$push203=, 66
@@ -964,7 +889,7 @@ main:                                   # @main
 	i32.const	$push624=, src
 	i32.const	$push623=, 66
 	i32.call	$push205=, memcmp@FUNCTION, $pop204, $pop624, $pop623
-	br_if   	62, $pop205     # 62: down to label16
+	br_if   	0, $pop205      # 0: down to label3
 # BB#65:                                # %check.exit269
 	i32.const	$push206=, dst
 	i32.const	$push630=, src
@@ -974,7 +899,7 @@ main:                                   # @main
 	i32.const	$push627=, src
 	i32.const	$push626=, 67
 	i32.call	$push208=, memcmp@FUNCTION, $pop628, $pop627, $pop626
-	br_if   	63, $pop208     # 63: down to label15
+	br_if   	0, $pop208      # 0: down to label3
 # BB#66:                                # %check.exit273
 	i32.const	$push633=, src
 	i32.const	$push209=, 68
@@ -982,7 +907,7 @@ main:                                   # @main
 	i32.const	$push632=, src
 	i32.const	$push631=, 68
 	i32.call	$push211=, memcmp@FUNCTION, $pop210, $pop632, $pop631
-	br_if   	64, $pop211     # 64: down to label14
+	br_if   	0, $pop211      # 0: down to label3
 # BB#67:                                # %check.exit277
 	i32.const	$push212=, dst
 	i32.const	$push638=, src
@@ -992,7 +917,7 @@ main:                                   # @main
 	i32.const	$push635=, src
 	i32.const	$push634=, 69
 	i32.call	$push214=, memcmp@FUNCTION, $pop636, $pop635, $pop634
-	br_if   	65, $pop214     # 65: down to label13
+	br_if   	0, $pop214      # 0: down to label3
 # BB#68:                                # %check.exit281
 	i32.const	$push641=, src
 	i32.const	$push215=, 70
@@ -1000,7 +925,7 @@ main:                                   # @main
 	i32.const	$push640=, src
 	i32.const	$push639=, 70
 	i32.call	$push217=, memcmp@FUNCTION, $pop216, $pop640, $pop639
-	br_if   	66, $pop217     # 66: down to label12
+	br_if   	0, $pop217      # 0: down to label3
 # BB#69:                                # %check.exit285
 	i32.const	$push218=, dst
 	i32.const	$push646=, src
@@ -1010,7 +935,7 @@ main:                                   # @main
 	i32.const	$push643=, src
 	i32.const	$push642=, 71
 	i32.call	$push220=, memcmp@FUNCTION, $pop644, $pop643, $pop642
-	br_if   	67, $pop220     # 67: down to label11
+	br_if   	0, $pop220      # 0: down to label3
 # BB#70:                                # %check.exit289
 	i32.const	$push649=, src
 	i32.const	$push221=, 72
@@ -1018,7 +943,7 @@ main:                                   # @main
 	i32.const	$push648=, src
 	i32.const	$push647=, 72
 	i32.call	$push223=, memcmp@FUNCTION, $pop222, $pop648, $pop647
-	br_if   	68, $pop223     # 68: down to label10
+	br_if   	0, $pop223      # 0: down to label3
 # BB#71:                                # %check.exit293
 	i32.const	$push224=, dst
 	i32.const	$push654=, src
@@ -1028,7 +953,7 @@ main:                                   # @main
 	i32.const	$push651=, src
 	i32.const	$push650=, 73
 	i32.call	$push226=, memcmp@FUNCTION, $pop652, $pop651, $pop650
-	br_if   	69, $pop226     # 69: down to label9
+	br_if   	0, $pop226      # 0: down to label3
 # BB#72:                                # %check.exit297
 	i32.const	$push657=, src
 	i32.const	$push227=, 74
@@ -1036,7 +961,7 @@ main:                                   # @main
 	i32.const	$push656=, src
 	i32.const	$push655=, 74
 	i32.call	$push229=, memcmp@FUNCTION, $pop228, $pop656, $pop655
-	br_if   	70, $pop229     # 70: down to label8
+	br_if   	0, $pop229      # 0: down to label3
 # BB#73:                                # %check.exit301
 	i32.const	$push230=, dst
 	i32.const	$push662=, src
@@ -1046,7 +971,7 @@ main:                                   # @main
 	i32.const	$push659=, src
 	i32.const	$push658=, 75
 	i32.call	$push232=, memcmp@FUNCTION, $pop660, $pop659, $pop658
-	br_if   	71, $pop232     # 71: down to label7
+	br_if   	0, $pop232      # 0: down to label3
 # BB#74:                                # %check.exit305
 	i32.const	$push665=, src
 	i32.const	$push233=, 76
@@ -1054,7 +979,7 @@ main:                                   # @main
 	i32.const	$push664=, src
 	i32.const	$push663=, 76
 	i32.call	$push235=, memcmp@FUNCTION, $pop234, $pop664, $pop663
-	br_if   	72, $pop235     # 72: down to label6
+	br_if   	0, $pop235      # 0: down to label3
 # BB#75:                                # %check.exit309
 	i32.const	$push236=, dst
 	i32.const	$push670=, src
@@ -1064,7 +989,7 @@ main:                                   # @main
 	i32.const	$push667=, src
 	i32.const	$push666=, 77
 	i32.call	$push238=, memcmp@FUNCTION, $pop668, $pop667, $pop666
-	br_if   	73, $pop238     # 73: down to label5
+	br_if   	0, $pop238      # 0: down to label3
 # BB#76:                                # %check.exit313
 	i32.const	$push673=, src
 	i32.const	$push239=, 78
@@ -1072,7 +997,7 @@ main:                                   # @main
 	i32.const	$push672=, src
 	i32.const	$push671=, 78
 	i32.call	$push241=, memcmp@FUNCTION, $pop240, $pop672, $pop671
-	br_if   	74, $pop241     # 74: down to label4
+	br_if   	0, $pop241      # 0: down to label3
 # BB#77:                                # %check.exit317
 	i32.const	$push243=, dst
 	i32.const	$push242=, src
@@ -1081,311 +1006,11 @@ main:                                   # @main
 	i32.const	$push675=, src
 	i32.const	$push674=, 79
 	i32.call	$push246=, memcmp@FUNCTION, $pop245, $pop675, $pop674
-	br_if   	75, $pop246     # 75: down to label3
+	br_if   	0, $pop246      # 0: down to label3
 # BB#78:                                # %check.exit321
 	i32.const	$push247=, 0
 	return  	$pop247
-.LBB1_79:                               # %if.then.i12
-	end_block                       # label78:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_80:                               # %if.then.i16
-	end_block                       # label77:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_81:                               # %if.then.i24
-	end_block                       # label76:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_82:                               # %if.then.i28
-	end_block                       # label75:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_83:                               # %if.then.i32
-	end_block                       # label74:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_84:                               # %if.then.i40
-	end_block                       # label73:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_85:                               # %if.then.i44
-	end_block                       # label72:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_86:                               # %if.then.i48
-	end_block                       # label71:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_87:                               # %if.then.i52
-	end_block                       # label70:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_88:                               # %if.then.i56
-	end_block                       # label69:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_89:                               # %if.then.i60
-	end_block                       # label68:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_90:                               # %if.then.i64
-	end_block                       # label67:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_91:                               # %if.then.i68
-	end_block                       # label66:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_92:                               # %if.then.i72
-	end_block                       # label65:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_93:                               # %if.then.i76
-	end_block                       # label64:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_94:                               # %if.then.i80
-	end_block                       # label63:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_95:                               # %if.then.i84
-	end_block                       # label62:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_96:                               # %if.then.i88
-	end_block                       # label61:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_97:                               # %if.then.i92
-	end_block                       # label60:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_98:                               # %if.then.i96
-	end_block                       # label59:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_99:                               # %if.then.i100
-	end_block                       # label58:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_100:                              # %if.then.i104
-	end_block                       # label57:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_101:                              # %if.then.i108
-	end_block                       # label56:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_102:                              # %if.then.i112
-	end_block                       # label55:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_103:                              # %if.then.i116
-	end_block                       # label54:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_104:                              # %if.then.i120
-	end_block                       # label53:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_105:                              # %if.then.i124
-	end_block                       # label52:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_106:                              # %if.then.i128
-	end_block                       # label51:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_107:                              # %if.then.i132
-	end_block                       # label50:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_108:                              # %if.then.i136
-	end_block                       # label49:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_109:                              # %if.then.i140
-	end_block                       # label48:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_110:                              # %if.then.i144
-	end_block                       # label47:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_111:                              # %if.then.i148
-	end_block                       # label46:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_112:                              # %if.then.i152
-	end_block                       # label45:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_113:                              # %if.then.i156
-	end_block                       # label44:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_114:                              # %if.then.i160
-	end_block                       # label43:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_115:                              # %if.then.i164
-	end_block                       # label42:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_116:                              # %if.then.i168
-	end_block                       # label41:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_117:                              # %if.then.i172
-	end_block                       # label40:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_118:                              # %if.then.i176
-	end_block                       # label39:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_119:                              # %if.then.i180
-	end_block                       # label38:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_120:                              # %if.then.i184
-	end_block                       # label37:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_121:                              # %if.then.i188
-	end_block                       # label36:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_122:                              # %if.then.i192
-	end_block                       # label35:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_123:                              # %if.then.i196
-	end_block                       # label34:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_124:                              # %if.then.i200
-	end_block                       # label33:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_125:                              # %if.then.i204
-	end_block                       # label32:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_126:                              # %if.then.i208
-	end_block                       # label31:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_127:                              # %if.then.i212
-	end_block                       # label30:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_128:                              # %if.then.i216
-	end_block                       # label29:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_129:                              # %if.then.i220
-	end_block                       # label28:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_130:                              # %if.then.i224
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_131:                              # %if.then.i228
-	end_block                       # label26:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_132:                              # %if.then.i232
-	end_block                       # label25:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_133:                              # %if.then.i236
-	end_block                       # label24:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_134:                              # %if.then.i240
-	end_block                       # label23:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_135:                              # %if.then.i244
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_136:                              # %if.then.i248
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_137:                              # %if.then.i252
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_138:                              # %if.then.i256
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_139:                              # %if.then.i260
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_140:                              # %if.then.i264
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_141:                              # %if.then.i268
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_142:                              # %if.then.i272
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_143:                              # %if.then.i276
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_144:                              # %if.then.i280
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_145:                              # %if.then.i284
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_146:                              # %if.then.i288
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_147:                              # %if.then.i292
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_148:                              # %if.then.i296
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_149:                              # %if.then.i300
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_150:                              # %if.then.i304
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_151:                              # %if.then.i308
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_152:                              # %if.then.i312
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_153:                              # %if.then.i316
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_154:                              # %if.then.i320
+.LBB1_79:                               # %if.then.i320
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/memset-1.c.s
+++ b/test/torture-s/memset-1.c.s
@@ -6,28 +6,20 @@
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$0=, 0
 .LBB0_1:                                # %for.cond1.preheader
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_2 Depth 2
                                         #       Child Loop BB0_3 Depth 3
-                                        #       Child Loop BB0_6 Depth 3
-                                        #       Child Loop BB0_17 Depth 3
-                                        #       Child Loop BB0_20 Depth 3
-                                        #       Child Loop BB0_31 Depth 3
-                                        #       Child Loop BB0_34 Depth 3
+                                        #       Child Loop BB0_7 Depth 3
+                                        #       Child Loop BB0_18 Depth 3
+                                        #       Child Loop BB0_22 Depth 3
+                                        #       Child Loop BB0_33 Depth 3
+                                        #       Child Loop BB0_37 Depth 3
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label9:
+	loop                            # label1:
 	i32.const	$push97=, u
 	i32.add 	$1=, $0, $pop97
 	i32.const	$2=, 1
@@ -35,407 +27,381 @@ main:                                   # @main
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Loop Header: Depth=2
                                         #       Child Loop BB0_3 Depth 3
-                                        #       Child Loop BB0_6 Depth 3
-                                        #       Child Loop BB0_17 Depth 3
-                                        #       Child Loop BB0_20 Depth 3
-                                        #       Child Loop BB0_31 Depth 3
-                                        #       Child Loop BB0_34 Depth 3
-	loop                            # label11:
+                                        #       Child Loop BB0_7 Depth 3
+                                        #       Child Loop BB0_18 Depth 3
+                                        #       Child Loop BB0_22 Depth 3
+                                        #       Child Loop BB0_33 Depth 3
+                                        #       Child Loop BB0_37 Depth 3
+	loop                            # label3:
 	i32.const	$push0=, u
 	i32.const	$push101=, 97
 	i32.const	$push100=, 96
 	i32.call	$5=, memset@FUNCTION, $pop0, $pop101, $pop100
-	i32.const	$6=, 0
+	i32.const	$4=, 0
 	i32.const	$push99=, 0
-	i32.call	$4=, memset@FUNCTION, $1, $pop99, $2
+	i32.call	$3=, memset@FUNCTION, $1, $pop99, $2
 	block
 	i32.const	$push98=, 1
 	i32.lt_s	$push1=, $0, $pop98
-	br_if   	0, $pop1        # 0: down to label13
+	br_if   	0, $pop1        # 0: down to label5
 .LBB0_3:                                # %for.body11
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop                            # label14:
-	i32.load8_u	$push2=, u($6)
+	loop                            # label6:
+	copy_local	$push104=, $4
+	tee_local	$push103=, $5=, $pop104
+	i32.load8_u	$push2=, u($pop103)
 	i32.const	$push102=, 97
 	i32.ne  	$push3=, $pop2, $pop102
-	br_if   	10, $pop3       # 10: down to label5
+	br_if   	7, $pop3        # 7: down to label0
 # BB#4:                                 # %for.inc16
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push104=, u+1
-	i32.add 	$5=, $6, $pop104
-	i32.const	$push103=, 1
-	i32.add 	$3=, $6, $pop103
-	copy_local	$6=, $3
-	i32.lt_s	$push4=, $3, $0
-	br_if   	0, $pop4        # 0: up to label14
-.LBB0_5:                                # %for.body22.preheader
+	i32.const	$push105=, 1
+	i32.add 	$4=, $5, $pop105
+	i32.lt_s	$push4=, $4, $0
+	br_if   	0, $pop4        # 0: up to label6
+# BB#5:                                 #   in Loop: Header=BB0_2 Depth=2
+	end_loop                        # label7:
+	i32.const	$push106=, u+1
+	i32.add 	$5=, $5, $pop106
+.LBB0_6:                                # %for.body22.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
-	end_loop                        # label15:
-	end_block                       # label13:
-	i32.const	$6=, 0
-.LBB0_6:                                # %for.body22
+	end_block                       # label5:
+	i32.const	$4=, 0
+.LBB0_7:                                # %for.body22
+                                        #   Parent Loop BB0_1 Depth=1
+                                        #     Parent Loop BB0_2 Depth=2
+                                        # =>    This Inner Loop Header: Depth=3
+	loop                            # label8:
+	i32.add 	$push5=, $5, $4
+	i32.load8_u	$push6=, 0($pop5)
+	br_if   	6, $pop6        # 6: down to label0
+# BB#8:                                 # %for.inc28
+                                        #   in Loop: Header=BB0_7 Depth=3
+	i32.const	$push107=, 1
+	i32.add 	$4=, $4, $pop107
+	i32.lt_s	$push7=, $4, $2
+	br_if   	0, $pop7        # 0: up to label8
+# BB#9:                                 # %for.body35.preheader
+                                        #   in Loop: Header=BB0_2 Depth=2
+	end_loop                        # label9:
+	i32.add 	$push110=, $5, $4
+	tee_local	$push109=, $4=, $pop110
+	i32.load8_u	$push8=, 0($pop109)
+	i32.const	$push108=, 97
+	i32.ne  	$push9=, $pop8, $pop108
+	br_if   	4, $pop9        # 4: down to label0
+# BB#10:                                # %for.inc41
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push112=, 1
+	i32.add 	$push10=, $4, $pop112
+	i32.load8_u	$push11=, 0($pop10)
+	i32.const	$push111=, 97
+	i32.ne  	$push12=, $pop11, $pop111
+	br_if   	4, $pop12       # 4: down to label0
+# BB#11:                                # %for.inc41.1
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push140=, 2
+	i32.add 	$push13=, $4, $pop140
+	i32.load8_u	$push14=, 0($pop13)
+	i32.const	$push139=, 97
+	i32.ne  	$push15=, $pop14, $pop139
+	br_if   	4, $pop15       # 4: down to label0
+# BB#12:                                # %for.inc41.2
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push142=, 3
+	i32.add 	$push16=, $4, $pop142
+	i32.load8_u	$push17=, 0($pop16)
+	i32.const	$push141=, 97
+	i32.ne  	$push18=, $pop17, $pop141
+	br_if   	4, $pop18       # 4: down to label0
+# BB#13:                                # %for.inc41.3
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push144=, 4
+	i32.add 	$push19=, $4, $pop144
+	i32.load8_u	$push20=, 0($pop19)
+	i32.const	$push143=, 97
+	i32.ne  	$push21=, $pop20, $pop143
+	br_if   	4, $pop21       # 4: down to label0
+# BB#14:                                # %for.inc41.4
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push146=, 5
+	i32.add 	$push22=, $4, $pop146
+	i32.load8_u	$push23=, 0($pop22)
+	i32.const	$push145=, 97
+	i32.ne  	$push24=, $pop23, $pop145
+	br_if   	4, $pop24       # 4: down to label0
+# BB#15:                                # %for.inc41.5
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push148=, 6
+	i32.add 	$push25=, $4, $pop148
+	i32.load8_u	$push26=, 0($pop25)
+	i32.const	$push147=, 97
+	i32.ne  	$push27=, $pop26, $pop147
+	br_if   	4, $pop27       # 4: down to label0
+# BB#16:                                # %for.inc41.6
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push150=, 7
+	i32.add 	$push28=, $4, $pop150
+	i32.load8_u	$push29=, 0($pop28)
+	i32.const	$push149=, 97
+	i32.ne  	$push30=, $pop29, $pop149
+	br_if   	4, $pop30       # 4: down to label0
+# BB#17:                                # %for.inc41.7
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$4=, 0
+	i32.const	$push152=, 0
+	i32.load8_u	$push32=, A($pop152)
+	i32.call	$discard=, memset@FUNCTION, $3, $pop32, $2
+	i32.const	$5=, u
+	block
+	i32.const	$push151=, 0
+	i32.le_s	$push31=, $0, $pop151
+	br_if   	0, $pop31       # 0: down to label10
+.LBB0_18:                               # %for.body55
+                                        #   Parent Loop BB0_1 Depth=1
+                                        #     Parent Loop BB0_2 Depth=2
+                                        # =>    This Inner Loop Header: Depth=3
+	loop                            # label11:
+	copy_local	$push115=, $4
+	tee_local	$push114=, $5=, $pop115
+	i32.load8_u	$push33=, u($pop114)
+	i32.const	$push113=, 97
+	i32.ne  	$push34=, $pop33, $pop113
+	br_if   	7, $pop34       # 7: down to label0
+# BB#19:                                # %for.inc61
+                                        #   in Loop: Header=BB0_18 Depth=3
+	i32.const	$push116=, 1
+	i32.add 	$4=, $5, $pop116
+	i32.lt_s	$push35=, $4, $0
+	br_if   	0, $pop35       # 0: up to label11
+# BB#20:                                #   in Loop: Header=BB0_2 Depth=2
+	end_loop                        # label12:
+	i32.const	$push117=, u+1
+	i32.add 	$5=, $5, $pop117
+.LBB0_21:                               # %for.body68.preheader
+                                        #   in Loop: Header=BB0_2 Depth=2
+	end_block                       # label10:
+	i32.const	$4=, 0
+.LBB0_22:                               # %for.body68
+                                        #   Parent Loop BB0_1 Depth=1
+                                        #     Parent Loop BB0_2 Depth=2
+                                        # =>    This Inner Loop Header: Depth=3
+	loop                            # label13:
+	i32.add 	$push36=, $5, $4
+	i32.load8_u	$push37=, 0($pop36)
+	i32.const	$push118=, 65
+	i32.ne  	$push38=, $pop37, $pop118
+	br_if   	6, $pop38       # 6: down to label0
+# BB#23:                                # %for.inc74
+                                        #   in Loop: Header=BB0_22 Depth=3
+	i32.const	$push119=, 1
+	i32.add 	$4=, $4, $pop119
+	i32.lt_s	$push39=, $4, $2
+	br_if   	0, $pop39       # 0: up to label13
+# BB#24:                                # %for.body81.preheader
+                                        #   in Loop: Header=BB0_2 Depth=2
+	end_loop                        # label14:
+	i32.add 	$push122=, $5, $4
+	tee_local	$push121=, $4=, $pop122
+	i32.load8_u	$push40=, 0($pop121)
+	i32.const	$push120=, 97
+	i32.ne  	$push41=, $pop40, $pop120
+	br_if   	4, $pop41       # 4: down to label0
+# BB#25:                                # %for.inc87
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push124=, 1
+	i32.add 	$push42=, $4, $pop124
+	i32.load8_u	$push43=, 0($pop42)
+	i32.const	$push123=, 97
+	i32.ne  	$push44=, $pop43, $pop123
+	br_if   	4, $pop44       # 4: down to label0
+# BB#26:                                # %for.inc87.1
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push154=, 2
+	i32.add 	$push45=, $4, $pop154
+	i32.load8_u	$push46=, 0($pop45)
+	i32.const	$push153=, 97
+	i32.ne  	$push47=, $pop46, $pop153
+	br_if   	4, $pop47       # 4: down to label0
+# BB#27:                                # %for.inc87.2
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push156=, 3
+	i32.add 	$push48=, $4, $pop156
+	i32.load8_u	$push49=, 0($pop48)
+	i32.const	$push155=, 97
+	i32.ne  	$push50=, $pop49, $pop155
+	br_if   	4, $pop50       # 4: down to label0
+# BB#28:                                # %for.inc87.3
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push158=, 4
+	i32.add 	$push51=, $4, $pop158
+	i32.load8_u	$push52=, 0($pop51)
+	i32.const	$push157=, 97
+	i32.ne  	$push53=, $pop52, $pop157
+	br_if   	4, $pop53       # 4: down to label0
+# BB#29:                                # %for.inc87.4
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push160=, 5
+	i32.add 	$push54=, $4, $pop160
+	i32.load8_u	$push55=, 0($pop54)
+	i32.const	$push159=, 97
+	i32.ne  	$push56=, $pop55, $pop159
+	br_if   	4, $pop56       # 4: down to label0
+# BB#30:                                # %for.inc87.5
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push162=, 6
+	i32.add 	$push57=, $4, $pop162
+	i32.load8_u	$push58=, 0($pop57)
+	i32.const	$push161=, 97
+	i32.ne  	$push59=, $pop58, $pop161
+	br_if   	4, $pop59       # 4: down to label0
+# BB#31:                                # %for.inc87.6
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push164=, 7
+	i32.add 	$push60=, $4, $pop164
+	i32.load8_u	$push61=, 0($pop60)
+	i32.const	$push163=, 97
+	i32.ne  	$push62=, $pop61, $pop163
+	br_if   	4, $pop62       # 4: down to label0
+# BB#32:                                # %for.inc87.7
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$4=, 0
+	i32.const	$push166=, 66
+	i32.call	$discard=, memset@FUNCTION, $3, $pop166, $2
+	i32.const	$5=, u
+	block
+	i32.const	$push165=, 0
+	i32.le_s	$push63=, $0, $pop165
+	br_if   	0, $pop63       # 0: down to label15
+.LBB0_33:                               # %for.body100
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	loop                            # label16:
-	i32.add 	$push5=, $5, $6
-	i32.load8_u	$push6=, 0($pop5)
-	br_if   	6, $pop6        # 6: down to label8
-# BB#7:                                 # %for.inc28
-                                        #   in Loop: Header=BB0_6 Depth=3
-	i32.const	$push105=, 1
-	i32.add 	$6=, $6, $pop105
-	i32.lt_s	$push7=, $6, $2
-	br_if   	0, $pop7        # 0: up to label16
-# BB#8:                                 # %for.body35.preheader
-                                        #   in Loop: Header=BB0_2 Depth=2
+	copy_local	$push127=, $4
+	tee_local	$push126=, $5=, $pop127
+	i32.load8_u	$push64=, u($pop126)
+	i32.const	$push125=, 97
+	i32.ne  	$push65=, $pop64, $pop125
+	br_if   	7, $pop65       # 7: down to label0
+# BB#34:                                # %for.inc106
+                                        #   in Loop: Header=BB0_33 Depth=3
+	i32.const	$push128=, 1
+	i32.add 	$4=, $5, $pop128
+	i32.lt_s	$push66=, $4, $0
+	br_if   	0, $pop66       # 0: up to label16
+# BB#35:                                #   in Loop: Header=BB0_2 Depth=2
 	end_loop                        # label17:
-	i32.add 	$push108=, $5, $6
-	tee_local	$push107=, $6=, $pop108
-	i32.load8_u	$push8=, 0($pop107)
-	i32.const	$push106=, 97
-	i32.ne  	$push9=, $pop8, $pop106
-	br_if   	10, $pop9       # 10: down to label2
-# BB#9:                                 # %for.inc41
+	i32.const	$push129=, u+1
+	i32.add 	$5=, $5, $pop129
+.LBB0_36:                               # %for.body113.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push110=, 1
-	i32.add 	$push10=, $6, $pop110
-	i32.load8_u	$push11=, 0($pop10)
-	i32.const	$push109=, 97
-	i32.ne  	$push12=, $pop11, $pop109
-	br_if   	10, $pop12      # 10: down to label2
-# BB#10:                                # %for.inc41.1
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push134=, 2
-	i32.add 	$push13=, $6, $pop134
-	i32.load8_u	$push14=, 0($pop13)
-	i32.const	$push133=, 97
-	i32.ne  	$push15=, $pop14, $pop133
-	br_if   	10, $pop15      # 10: down to label2
-# BB#11:                                # %for.inc41.2
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push136=, 3
-	i32.add 	$push16=, $6, $pop136
-	i32.load8_u	$push17=, 0($pop16)
-	i32.const	$push135=, 97
-	i32.ne  	$push18=, $pop17, $pop135
-	br_if   	10, $pop18      # 10: down to label2
-# BB#12:                                # %for.inc41.3
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push138=, 4
-	i32.add 	$push19=, $6, $pop138
-	i32.load8_u	$push20=, 0($pop19)
-	i32.const	$push137=, 97
-	i32.ne  	$push21=, $pop20, $pop137
-	br_if   	10, $pop21      # 10: down to label2
-# BB#13:                                # %for.inc41.4
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push140=, 5
-	i32.add 	$push22=, $6, $pop140
-	i32.load8_u	$push23=, 0($pop22)
-	i32.const	$push139=, 97
-	i32.ne  	$push24=, $pop23, $pop139
-	br_if   	10, $pop24      # 10: down to label2
-# BB#14:                                # %for.inc41.5
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push142=, 6
-	i32.add 	$push25=, $6, $pop142
-	i32.load8_u	$push26=, 0($pop25)
-	i32.const	$push141=, 97
-	i32.ne  	$push27=, $pop26, $pop141
-	br_if   	10, $pop27      # 10: down to label2
-# BB#15:                                # %for.inc41.6
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push144=, 7
-	i32.add 	$push28=, $6, $pop144
-	i32.load8_u	$push29=, 0($pop28)
-	i32.const	$push143=, 97
-	i32.ne  	$push30=, $pop29, $pop143
-	br_if   	10, $pop30      # 10: down to label2
-# BB#16:                                # %for.inc41.7
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$6=, 0
-	i32.const	$push146=, 0
-	i32.load8_u	$push32=, A($pop146)
-	i32.call	$discard=, memset@FUNCTION, $4, $pop32, $2
-	i32.const	$5=, u
-	block
-	i32.const	$push145=, 0
-	i32.le_s	$push31=, $0, $pop145
-	br_if   	0, $pop31       # 0: down to label18
-.LBB0_17:                               # %for.body55
+	end_block                       # label15:
+	i32.const	$4=, 0
+.LBB0_37:                               # %for.body113
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop                            # label19:
-	i32.load8_u	$push33=, u($6)
-	i32.const	$push111=, 97
-	i32.ne  	$push34=, $pop33, $pop111
-	br_if   	11, $pop34      # 11: down to label4
-# BB#18:                                # %for.inc61
-                                        #   in Loop: Header=BB0_17 Depth=3
-	i32.const	$push113=, u+1
-	i32.add 	$5=, $6, $pop113
-	i32.const	$push112=, 1
-	i32.add 	$3=, $6, $pop112
-	copy_local	$6=, $3
-	i32.lt_s	$push35=, $3, $0
-	br_if   	0, $pop35       # 0: up to label19
-.LBB0_19:                               # %for.body68.preheader
-                                        #   in Loop: Header=BB0_2 Depth=2
-	end_loop                        # label20:
-	end_block                       # label18:
-	i32.const	$6=, 0
-.LBB0_20:                               # %for.body68
-                                        #   Parent Loop BB0_1 Depth=1
-                                        #     Parent Loop BB0_2 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
-	loop                            # label21:
-	i32.add 	$push36=, $5, $6
-	i32.load8_u	$push37=, 0($pop36)
-	i32.const	$push114=, 65
-	i32.ne  	$push38=, $pop37, $pop114
-	br_if   	7, $pop38       # 7: down to label7
-# BB#21:                                # %for.inc74
-                                        #   in Loop: Header=BB0_20 Depth=3
-	i32.const	$push115=, 1
-	i32.add 	$6=, $6, $pop115
-	i32.lt_s	$push39=, $6, $2
-	br_if   	0, $pop39       # 0: up to label21
-# BB#22:                                # %for.body81.preheader
-                                        #   in Loop: Header=BB0_2 Depth=2
-	end_loop                        # label22:
-	i32.add 	$push118=, $5, $6
-	tee_local	$push117=, $6=, $pop118
-	i32.load8_u	$push40=, 0($pop117)
-	i32.const	$push116=, 97
-	i32.ne  	$push41=, $pop40, $pop116
-	br_if   	11, $pop41      # 11: down to label1
-# BB#23:                                # %for.inc87
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push120=, 1
-	i32.add 	$push42=, $6, $pop120
-	i32.load8_u	$push43=, 0($pop42)
-	i32.const	$push119=, 97
-	i32.ne  	$push44=, $pop43, $pop119
-	br_if   	11, $pop44      # 11: down to label1
-# BB#24:                                # %for.inc87.1
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push148=, 2
-	i32.add 	$push45=, $6, $pop148
-	i32.load8_u	$push46=, 0($pop45)
-	i32.const	$push147=, 97
-	i32.ne  	$push47=, $pop46, $pop147
-	br_if   	11, $pop47      # 11: down to label1
-# BB#25:                                # %for.inc87.2
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push150=, 3
-	i32.add 	$push48=, $6, $pop150
-	i32.load8_u	$push49=, 0($pop48)
-	i32.const	$push149=, 97
-	i32.ne  	$push50=, $pop49, $pop149
-	br_if   	11, $pop50      # 11: down to label1
-# BB#26:                                # %for.inc87.3
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push152=, 4
-	i32.add 	$push51=, $6, $pop152
-	i32.load8_u	$push52=, 0($pop51)
-	i32.const	$push151=, 97
-	i32.ne  	$push53=, $pop52, $pop151
-	br_if   	11, $pop53      # 11: down to label1
-# BB#27:                                # %for.inc87.4
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push154=, 5
-	i32.add 	$push54=, $6, $pop154
-	i32.load8_u	$push55=, 0($pop54)
-	i32.const	$push153=, 97
-	i32.ne  	$push56=, $pop55, $pop153
-	br_if   	11, $pop56      # 11: down to label1
-# BB#28:                                # %for.inc87.5
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push156=, 6
-	i32.add 	$push57=, $6, $pop156
-	i32.load8_u	$push58=, 0($pop57)
-	i32.const	$push155=, 97
-	i32.ne  	$push59=, $pop58, $pop155
-	br_if   	11, $pop59      # 11: down to label1
-# BB#29:                                # %for.inc87.6
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push158=, 7
-	i32.add 	$push60=, $6, $pop158
-	i32.load8_u	$push61=, 0($pop60)
-	i32.const	$push157=, 97
-	i32.ne  	$push62=, $pop61, $pop157
-	br_if   	11, $pop62      # 11: down to label1
-# BB#30:                                # %for.inc87.7
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$6=, 0
-	i32.const	$push160=, 66
-	i32.call	$discard=, memset@FUNCTION, $4, $pop160, $2
-	i32.const	$5=, u
-	block
-	i32.const	$push159=, 0
-	i32.le_s	$push63=, $0, $pop159
-	br_if   	0, $pop63       # 0: down to label23
-.LBB0_31:                               # %for.body100
-                                        #   Parent Loop BB0_1 Depth=1
-                                        #     Parent Loop BB0_2 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
-	loop                            # label24:
-	i32.load8_u	$push64=, u($6)
-	i32.const	$push121=, 97
-	i32.ne  	$push65=, $pop64, $pop121
-	br_if   	12, $pop65      # 12: down to label3
-# BB#32:                                # %for.inc106
-                                        #   in Loop: Header=BB0_31 Depth=3
-	i32.const	$push123=, u+1
-	i32.add 	$5=, $6, $pop123
-	i32.const	$push122=, 1
-	i32.add 	$3=, $6, $pop122
-	copy_local	$6=, $3
-	i32.lt_s	$push66=, $3, $0
-	br_if   	0, $pop66       # 0: up to label24
-.LBB0_33:                               # %for.body113.preheader
-                                        #   in Loop: Header=BB0_2 Depth=2
-	end_loop                        # label25:
-	end_block                       # label23:
-	i32.const	$6=, 0
-.LBB0_34:                               # %for.body113
-                                        #   Parent Loop BB0_1 Depth=1
-                                        #     Parent Loop BB0_2 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
-	loop                            # label26:
-	i32.add 	$push67=, $5, $6
+	loop                            # label18:
+	i32.add 	$push67=, $5, $4
 	i32.load8_u	$push68=, 0($pop67)
-	i32.const	$push124=, 66
-	i32.ne  	$push69=, $pop68, $pop124
-	br_if   	8, $pop69       # 8: down to label6
-# BB#35:                                # %for.inc119
-                                        #   in Loop: Header=BB0_34 Depth=3
-	i32.const	$push125=, 1
-	i32.add 	$6=, $6, $pop125
-	i32.lt_s	$push70=, $6, $2
-	br_if   	0, $pop70       # 0: up to label26
-# BB#36:                                # %for.body126.preheader
+	i32.const	$push130=, 66
+	i32.ne  	$push69=, $pop68, $pop130
+	br_if   	6, $pop69       # 6: down to label0
+# BB#38:                                # %for.inc119
+                                        #   in Loop: Header=BB0_37 Depth=3
+	i32.const	$push131=, 1
+	i32.add 	$4=, $4, $pop131
+	i32.lt_s	$push70=, $4, $2
+	br_if   	0, $pop70       # 0: up to label18
+# BB#39:                                # %for.body126.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
-	end_loop                        # label27:
-	i32.add 	$push128=, $5, $6
-	tee_local	$push127=, $6=, $pop128
-	i32.load8_u	$push71=, 0($pop127)
-	i32.const	$push126=, 97
-	i32.ne  	$push72=, $pop71, $pop126
-	br_if   	12, $pop72      # 12: down to label0
-# BB#37:                                # %for.inc132
+	end_loop                        # label19:
+	i32.add 	$push134=, $5, $4
+	tee_local	$push133=, $4=, $pop134
+	i32.load8_u	$push71=, 0($pop133)
+	i32.const	$push132=, 97
+	i32.ne  	$push72=, $pop71, $pop132
+	br_if   	4, $pop72       # 4: down to label0
+# BB#40:                                # %for.inc132
                                         #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push130=, 1
-	i32.add 	$push73=, $6, $pop130
+	i32.const	$push136=, 1
+	i32.add 	$push73=, $4, $pop136
 	i32.load8_u	$push74=, 0($pop73)
-	i32.const	$push129=, 97
-	i32.ne  	$push75=, $pop74, $pop129
-	br_if   	12, $pop75      # 12: down to label0
-# BB#38:                                # %for.inc132.1
+	i32.const	$push135=, 97
+	i32.ne  	$push75=, $pop74, $pop135
+	br_if   	4, $pop75       # 4: down to label0
+# BB#41:                                # %for.inc132.1
                                         #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push162=, 2
-	i32.add 	$push76=, $6, $pop162
+	i32.const	$push168=, 2
+	i32.add 	$push76=, $4, $pop168
 	i32.load8_u	$push77=, 0($pop76)
-	i32.const	$push161=, 97
-	i32.ne  	$push78=, $pop77, $pop161
-	br_if   	12, $pop78      # 12: down to label0
-# BB#39:                                # %for.inc132.2
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push164=, 3
-	i32.add 	$push79=, $6, $pop164
-	i32.load8_u	$push80=, 0($pop79)
-	i32.const	$push163=, 97
-	i32.ne  	$push81=, $pop80, $pop163
-	br_if   	12, $pop81      # 12: down to label0
-# BB#40:                                # %for.inc132.3
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push166=, 4
-	i32.add 	$push82=, $6, $pop166
-	i32.load8_u	$push83=, 0($pop82)
-	i32.const	$push165=, 97
-	i32.ne  	$push84=, $pop83, $pop165
-	br_if   	12, $pop84      # 12: down to label0
-# BB#41:                                # %for.inc132.4
-                                        #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push168=, 5
-	i32.add 	$push85=, $6, $pop168
-	i32.load8_u	$push86=, 0($pop85)
 	i32.const	$push167=, 97
-	i32.ne  	$push87=, $pop86, $pop167
-	br_if   	12, $pop87      # 12: down to label0
-# BB#42:                                # %for.inc132.5
+	i32.ne  	$push78=, $pop77, $pop167
+	br_if   	4, $pop78       # 4: down to label0
+# BB#42:                                # %for.inc132.2
                                         #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push170=, 6
-	i32.add 	$push88=, $6, $pop170
-	i32.load8_u	$push89=, 0($pop88)
+	i32.const	$push170=, 3
+	i32.add 	$push79=, $4, $pop170
+	i32.load8_u	$push80=, 0($pop79)
 	i32.const	$push169=, 97
-	i32.ne  	$push90=, $pop89, $pop169
-	br_if   	12, $pop90      # 12: down to label0
-# BB#43:                                # %for.inc132.6
+	i32.ne  	$push81=, $pop80, $pop169
+	br_if   	4, $pop81       # 4: down to label0
+# BB#43:                                # %for.inc132.3
                                         #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push172=, 7
-	i32.add 	$push91=, $6, $pop172
-	i32.load8_u	$push92=, 0($pop91)
+	i32.const	$push172=, 4
+	i32.add 	$push82=, $4, $pop172
+	i32.load8_u	$push83=, 0($pop82)
 	i32.const	$push171=, 97
-	i32.ne  	$push93=, $pop92, $pop171
-	br_if   	12, $pop93      # 12: down to label0
-# BB#44:                                # %for.inc132.7
+	i32.ne  	$push84=, $pop83, $pop171
+	br_if   	4, $pop84       # 4: down to label0
+# BB#44:                                # %for.inc132.4
                                         #   in Loop: Header=BB0_2 Depth=2
-	i32.const	$push174=, 1
-	i32.add 	$2=, $2, $pop174
-	i32.const	$push173=, 80
-	i32.lt_u	$push94=, $2, $pop173
-	br_if   	0, $pop94       # 0: up to label11
-# BB#45:                                # %for.inc139
+	i32.const	$push174=, 5
+	i32.add 	$push85=, $4, $pop174
+	i32.load8_u	$push86=, 0($pop85)
+	i32.const	$push173=, 97
+	i32.ne  	$push87=, $pop86, $pop173
+	br_if   	4, $pop87       # 4: down to label0
+# BB#45:                                # %for.inc132.5
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push176=, 6
+	i32.add 	$push88=, $4, $pop176
+	i32.load8_u	$push89=, 0($pop88)
+	i32.const	$push175=, 97
+	i32.ne  	$push90=, $pop89, $pop175
+	br_if   	4, $pop90       # 4: down to label0
+# BB#46:                                # %for.inc132.6
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push178=, 7
+	i32.add 	$push91=, $4, $pop178
+	i32.load8_u	$push92=, 0($pop91)
+	i32.const	$push177=, 97
+	i32.ne  	$push93=, $pop92, $pop177
+	br_if   	4, $pop93       # 4: down to label0
+# BB#47:                                # %for.inc132.7
+                                        #   in Loop: Header=BB0_2 Depth=2
+	i32.const	$push180=, 1
+	i32.add 	$2=, $2, $pop180
+	i32.const	$push179=, 80
+	i32.lt_u	$push94=, $2, $pop179
+	br_if   	0, $pop94       # 0: up to label3
+# BB#48:                                # %for.inc139
                                         #   in Loop: Header=BB0_1 Depth=1
-	end_loop                        # label12:
-	i32.const	$push132=, 1
-	i32.add 	$0=, $0, $pop132
-	i32.const	$push131=, 8
-	i32.lt_u	$push95=, $0, $pop131
-	br_if   	0, $pop95       # 0: up to label9
-# BB#46:                                # %for.end141
-	end_loop                        # label10:
+	end_loop                        # label4:
+	i32.const	$push138=, 1
+	i32.add 	$0=, $0, $pop138
+	i32.const	$push137=, 8
+	i32.lt_u	$push95=, $0, $pop137
+	br_if   	0, $pop95       # 0: up to label1
+# BB#49:                                # %for.end141
+	end_loop                        # label2:
 	i32.const	$push96=, 0
 	call    	exit@FUNCTION, $pop96
 	unreachable
-.LBB0_47:                               # %if.then26
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_48:                               # %if.then72
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_49:                               # %if.then117
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_50:                               # %if.then14
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_51:                               # %if.then59
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_52:                               # %if.then104
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_53:                               # %if.then39
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_54:                               # %if.then85
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_55:                               # %if.then130
+.LBB0_50:                               # %if.then130
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/memset-2.c.s
+++ b/test/torture-s/memset-2.c.s
@@ -21,108 +21,100 @@ reset:                                  # @reset
 	.type	check,@function
 check:                                  # @check
 	.param  	i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$5=, 0
-	i32.const	$3=, u
+	i32.const	$3=, 0
+	i32.const	$4=, u
 	block
 	block
-	block
-	block
-	i32.const	$push29=, 0
-	i32.le_s	$push0=, $0, $pop29
-	br_if   	0, $pop0        # 0: down to label3
+	i32.const	$push25=, 0
+	i32.le_s	$push0=, $0, $pop25
+	br_if   	0, $pop0        # 0: down to label1
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label4:
-	i32.load8_u	$push1=, u($5)
-	i32.const	$push2=, 97
-	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	3, $pop3        # 3: down to label2
+	loop                            # label2:
+	copy_local	$push29=, $3
+	tee_local	$push28=, $4=, $pop29
+	i32.load8_u	$push1=, u($pop28)
+	i32.const	$push27=, 97
+	i32.ne  	$push2=, $pop1, $pop27
+	br_if   	3, $pop2        # 3: down to label0
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push6=, u+1
-	i32.add 	$3=, $5, $pop6
-	i32.const	$push4=, 1
-	i32.add 	$4=, $5, $pop4
-	copy_local	$5=, $4
-	i32.lt_s	$push5=, $4, $0
-	br_if   	0, $pop5        # 0: up to label4
-.LBB1_3:                                # %for.cond3.preheader
-	end_loop                        # label5:
-	end_block                       # label3:
-	i32.const	$5=, 0
-	copy_local	$4=, $3
-	block
-	i32.const	$push30=, 0
-	i32.le_s	$push7=, $1, $pop30
-	br_if   	0, $pop7        # 0: down to label6
-.LBB1_4:                                # %for.body6
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label7:
-	i32.add 	$push8=, $3, $5
-	i32.load8_s	$push9=, 0($pop8)
-	i32.ne  	$push10=, $pop9, $2
-	br_if   	4, $pop10       # 4: down to label1
-# BB#5:                                 # %for.inc12
-                                        #   in Loop: Header=BB1_4 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$5=, $5, $pop11
-	i32.add 	$4=, $3, $5
-	i32.lt_s	$push12=, $5, $1
-	br_if   	0, $pop12       # 0: up to label7
-.LBB1_6:                                # %for.body19.preheader
-	end_loop                        # label8:
-	end_block                       # label6:
-	i32.load8_u	$push13=, 0($4)
-	i32.const	$push31=, 97
-	i32.ne  	$push14=, $pop13, $pop31
-	br_if   	2, $pop14       # 2: down to label0
-# BB#7:                                 # %for.inc25
-	i32.load8_u	$push15=, 1($4)
-	i32.const	$push32=, 97
-	i32.ne  	$push16=, $pop15, $pop32
-	br_if   	2, $pop16       # 2: down to label0
-# BB#8:                                 # %for.inc25.1
-	i32.load8_u	$push17=, 2($4)
-	i32.const	$push33=, 97
-	i32.ne  	$push18=, $pop17, $pop33
-	br_if   	2, $pop18       # 2: down to label0
-# BB#9:                                 # %for.inc25.2
-	i32.load8_u	$push19=, 3($4)
-	i32.const	$push34=, 97
-	i32.ne  	$push20=, $pop19, $pop34
-	br_if   	2, $pop20       # 2: down to label0
-# BB#10:                                # %for.inc25.3
-	i32.load8_u	$push21=, 4($4)
-	i32.const	$push35=, 97
-	i32.ne  	$push22=, $pop21, $pop35
-	br_if   	2, $pop22       # 2: down to label0
-# BB#11:                                # %for.inc25.4
-	i32.load8_u	$push23=, 5($4)
-	i32.const	$push36=, 97
-	i32.ne  	$push24=, $pop23, $pop36
-	br_if   	2, $pop24       # 2: down to label0
-# BB#12:                                # %for.inc25.5
-	i32.load8_u	$push25=, 6($4)
-	i32.const	$push37=, 97
-	i32.ne  	$push26=, $pop25, $pop37
-	br_if   	2, $pop26       # 2: down to label0
-# BB#13:                                # %for.inc25.6
-	i32.load8_u	$push27=, 7($4)
-	i32.const	$push38=, 97
-	i32.ne  	$push28=, $pop27, $pop38
-	br_if   	2, $pop28       # 2: down to label0
-# BB#14:                                # %for.inc25.7
-	return
-.LBB1_15:                               # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_16:                               # %if.then10
+	i32.const	$push30=, 1
+	i32.add 	$3=, $4, $pop30
+	i32.lt_s	$push3=, $3, $0
+	br_if   	0, $pop3        # 0: up to label2
+# BB#3:
+	end_loop                        # label3:
+	i32.const	$push31=, u+1
+	i32.add 	$4=, $4, $pop31
+.LBB1_4:                                # %for.cond3.preheader
 	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
+	i32.const	$3=, 0
+	block
+	i32.const	$push26=, 0
+	i32.le_s	$push4=, $1, $pop26
+	br_if   	0, $pop4        # 0: down to label4
+.LBB1_5:                                # %for.body6
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label5:
+	i32.add 	$push5=, $4, $3
+	i32.load8_s	$push6=, 0($pop5)
+	i32.ne  	$push7=, $pop6, $2
+	br_if   	3, $pop7        # 3: down to label0
+# BB#6:                                 # %for.inc12
+                                        #   in Loop: Header=BB1_5 Depth=1
+	i32.const	$push32=, 1
+	i32.add 	$3=, $3, $pop32
+	i32.lt_s	$push8=, $3, $1
+	br_if   	0, $pop8        # 0: up to label5
+# BB#7:
+	end_loop                        # label6:
+	i32.add 	$4=, $4, $3
+.LBB1_8:                                # %for.body19.preheader
+	end_block                       # label4:
+	i32.load8_u	$push9=, 0($4)
+	i32.const	$push33=, 97
+	i32.ne  	$push10=, $pop9, $pop33
+	br_if   	0, $pop10       # 0: down to label0
+# BB#9:                                 # %for.inc25
+	i32.load8_u	$push11=, 1($4)
+	i32.const	$push34=, 97
+	i32.ne  	$push12=, $pop11, $pop34
+	br_if   	0, $pop12       # 0: down to label0
+# BB#10:                                # %for.inc25.1
+	i32.load8_u	$push13=, 2($4)
+	i32.const	$push35=, 97
+	i32.ne  	$push14=, $pop13, $pop35
+	br_if   	0, $pop14       # 0: down to label0
+# BB#11:                                # %for.inc25.2
+	i32.load8_u	$push15=, 3($4)
+	i32.const	$push36=, 97
+	i32.ne  	$push16=, $pop15, $pop36
+	br_if   	0, $pop16       # 0: down to label0
+# BB#12:                                # %for.inc25.3
+	i32.load8_u	$push17=, 4($4)
+	i32.const	$push37=, 97
+	i32.ne  	$push18=, $pop17, $pop37
+	br_if   	0, $pop18       # 0: down to label0
+# BB#13:                                # %for.inc25.4
+	i32.load8_u	$push19=, 5($4)
+	i32.const	$push38=, 97
+	i32.ne  	$push20=, $pop19, $pop38
+	br_if   	0, $pop20       # 0: down to label0
+# BB#14:                                # %for.inc25.5
+	i32.load8_u	$push21=, 6($4)
+	i32.const	$push39=, 97
+	i32.ne  	$push22=, $pop21, $pop39
+	br_if   	0, $pop22       # 0: down to label0
+# BB#15:                                # %for.inc25.6
+	i32.load8_u	$push23=, 7($4)
+	i32.const	$push40=, 97
+	i32.ne  	$push24=, $pop23, $pop40
+	br_if   	0, $pop24       # 0: down to label0
+# BB#16:                                # %for.inc25.7
+	return
 .LBB1_17:                               # %if.then23
 	end_block                       # label0:
 	call    	abort@FUNCTION
@@ -137,538 +129,558 @@ check:                                  # @check
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i64, i32, i64, i32, i32, i32, i32
+	.local  	i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$6=, 0
+	i32.const	$2=, 0
 .LBB2_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label9:
-	i32.const	$push135=, u
-	i32.const	$push134=, 97
-	i32.const	$push133=, 31
-	i32.call	$discard=, memset@FUNCTION, $pop135, $pop134, $pop133
-	i32.const	$push132=, 1
-	i32.const	$push131=, 0
-	i32.store8	$push130=, u($6), $pop131
-	tee_local	$push129=, $5=, $pop130
-	call    	check@FUNCTION, $6, $pop132, $pop129
-	i32.load8_u	$push0=, A($5)
-	i32.store8	$discard=, u($6), $pop0
-	i32.const	$push128=, 1
-	i32.const	$push127=, 65
-	call    	check@FUNCTION, $6, $pop128, $pop127
-	i32.const	$push126=, 1
-	i32.const	$push125=, 66
-	i32.store8	$push1=, u($6), $pop125
-	call    	check@FUNCTION, $6, $pop126, $pop1
-	i32.const	$push124=, 1
-	i32.add 	$6=, $6, $pop124
-	i32.const	$push123=, 8
-	i32.ne  	$push2=, $6, $pop123
-	br_if   	0, $pop2        # 0: up to label9
+	loop                            # label7:
+	i32.const	$push105=, u
+	i32.const	$push104=, 97
+	i32.const	$push103=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop105, $pop104, $pop103
+	i32.const	$push102=, 1
+	i32.const	$push101=, 0
+	i32.store8	$push100=, u($2), $pop101
+	tee_local	$push99=, $1=, $pop100
+	call    	check@FUNCTION, $2, $pop102, $pop99
+	i32.load8_u	$push0=, A($1)
+	i32.store8	$discard=, u($2), $pop0
+	i32.const	$push98=, 1
+	i32.const	$push97=, 65
+	call    	check@FUNCTION, $2, $pop98, $pop97
+	i32.const	$push96=, 1
+	i32.const	$push95=, 66
+	i32.store8	$push1=, u($2), $pop95
+	call    	check@FUNCTION, $2, $pop96, $pop1
+	i32.const	$push94=, 1
+	i32.add 	$2=, $2, $pop94
+	i32.const	$push93=, 8
+	i32.ne  	$push2=, $2, $pop93
+	br_if   	0, $pop2        # 0: up to label7
 .LBB2_2:                                # %for.body18
+                                        # =>This Inner Loop Header: Depth=1
+	end_loop                        # label8:
+	loop                            # label9:
+	i32.const	$push119=, u
+	i32.const	$push118=, 97
+	i32.const	$push117=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop119, $pop118, $pop117
+	i32.const	$push116=, 2
+	i32.const	$push3=, 0
+	i32.store16	$push115=, u($1):p2align=0, $pop3
+	tee_local	$push114=, $2=, $pop115
+	call    	check@FUNCTION, $1, $pop116, $pop114
+	i32.load8_u	$push4=, A($2)
+	i32.const	$push113=, 257
+	i32.mul 	$push5=, $pop4, $pop113
+	i32.store16	$discard=, u($1):p2align=0, $pop5
+	i32.const	$push112=, 2
+	i32.const	$push111=, 65
+	call    	check@FUNCTION, $1, $pop112, $pop111
+	i32.const	$push110=, 16962
+	i32.store16	$discard=, u($1):p2align=0, $pop110
+	i32.const	$push109=, 2
+	i32.const	$push108=, 66
+	call    	check@FUNCTION, $1, $pop109, $pop108
+	i32.const	$push107=, 1
+	i32.add 	$1=, $1, $pop107
+	i32.const	$push106=, 8
+	i32.ne  	$push6=, $1, $pop106
+	br_if   	0, $pop6        # 0: up to label9
+.LBB2_3:                                # %for.body44
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label10:
 	loop                            # label11:
-	i32.const	$push4=, u
-	i32.const	$push146=, 97
-	i32.const	$push145=, 31
-	i32.call	$1=, memset@FUNCTION, $pop4, $pop146, $pop145
-	i32.const	$push5=, 2
-	i32.const	$push3=, 0
-	i32.store16	$push144=, u($5):p2align=0, $pop3
-	tee_local	$push143=, $8=, $pop144
-	call    	check@FUNCTION, $5, $pop5, $pop143
-	i32.load8_u	$push6=, A($8)
-	i32.const	$push142=, 257
-	i32.mul 	$push7=, $pop6, $pop142
-	i32.store16	$discard=, u($5):p2align=0, $pop7
-	i32.const	$push141=, 2
-	i32.const	$push140=, 65
-	call    	check@FUNCTION, $5, $pop141, $pop140
-	i32.const	$push8=, 16962
-	i32.store16	$3=, u($5):p2align=0, $pop8
-	i32.const	$push139=, 2
-	i32.const	$push138=, 66
-	call    	check@FUNCTION, $5, $pop139, $pop138
-	i32.const	$push137=, 1
-	i32.add 	$5=, $5, $pop137
-	copy_local	$6=, $8
-	i32.const	$push136=, 8
-	i32.ne  	$push9=, $5, $pop136
-	br_if   	0, $pop9        # 0: up to label11
-.LBB2_3:                                # %for.body44
+	i32.const	$push133=, u
+	i32.const	$push132=, 97
+	i32.const	$push131=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop133, $pop132, $pop131
+	i32.const	$push130=, 3
+	i32.const	$push7=, 0
+	i32.store8	$push8=, u+2($2), $pop7
+	i32.store16	$push129=, u($2):p2align=0, $pop8
+	tee_local	$push128=, $1=, $pop129
+	call    	check@FUNCTION, $2, $pop130, $pop128
+	i32.load8_u	$push9=, A($1)
+	i32.store8	$push10=, u+2($2), $pop9
+	i32.const	$push127=, 257
+	i32.mul 	$push11=, $pop10, $pop127
+	i32.store16	$discard=, u($2):p2align=0, $pop11
+	i32.const	$push126=, 3
+	i32.const	$push125=, 65
+	call    	check@FUNCTION, $2, $pop126, $pop125
+	i32.const	$push124=, 66
+	i32.store8	$0=, u+2($2), $pop124
+	i32.const	$push123=, 16962
+	i32.store16	$discard=, u($2):p2align=0, $pop123
+	i32.const	$push122=, 3
+	call    	check@FUNCTION, $2, $pop122, $0
+	i32.const	$push121=, 1
+	i32.add 	$2=, $2, $pop121
+	i32.const	$push120=, 8
+	i32.ne  	$push12=, $2, $pop120
+	br_if   	0, $pop12       # 0: up to label11
+.LBB2_4:                                # %for.body70
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label12:
 	loop                            # label13:
-	i32.const	$push157=, 97
-	i32.const	$push156=, 31
-	i32.call	$discard=, memset@FUNCTION, $1, $pop157, $pop156
-	i32.const	$push11=, 3
-	i32.store8	$push10=, u+2($6), $8
-	i32.store16	$push155=, u($6):p2align=0, $pop10
-	tee_local	$push154=, $5=, $pop155
-	call    	check@FUNCTION, $6, $pop11, $pop154
-	i32.load8_u	$push12=, A($5)
-	i32.store8	$push13=, u+2($6), $pop12
-	i32.const	$push153=, 257
-	i32.mul 	$push14=, $pop13, $pop153
-	i32.store16	$discard=, u($6):p2align=0, $pop14
-	i32.const	$push152=, 3
-	i32.const	$push151=, 65
-	call    	check@FUNCTION, $6, $pop152, $pop151
-	i32.const	$push150=, 66
-	i32.store8	$0=, u+2($6), $pop150
-	i32.store16	$discard=, u($6):p2align=0, $3
-	i32.const	$push149=, 3
-	call    	check@FUNCTION, $6, $pop149, $0
-	i32.const	$push148=, 1
-	i32.add 	$6=, $6, $pop148
-	i32.const	$push147=, 8
-	i32.ne  	$push15=, $6, $pop147
-	br_if   	0, $pop15       # 0: up to label13
-.LBB2_4:                                # %for.body70
+	i32.const	$push147=, u
+	i32.const	$push146=, 97
+	i32.const	$push145=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop147, $pop146, $pop145
+	i32.const	$push144=, 4
+	i32.const	$push13=, 0
+	i32.store	$push143=, u($1):p2align=0, $pop13
+	tee_local	$push142=, $2=, $pop143
+	call    	check@FUNCTION, $1, $pop144, $pop142
+	i32.load8_u	$push14=, A($2)
+	i32.const	$push141=, 16843009
+	i32.mul 	$push15=, $pop14, $pop141
+	i32.store	$discard=, u($1):p2align=0, $pop15
+	i32.const	$push140=, 4
+	i32.const	$push139=, 65
+	call    	check@FUNCTION, $1, $pop140, $pop139
+	i32.const	$push138=, 1111638594
+	i32.store	$discard=, u($1):p2align=0, $pop138
+	i32.const	$push137=, 4
+	i32.const	$push136=, 66
+	call    	check@FUNCTION, $1, $pop137, $pop136
+	i32.const	$push135=, 1
+	i32.add 	$1=, $1, $pop135
+	i32.const	$push134=, 8
+	i32.ne  	$push16=, $1, $pop134
+	br_if   	0, $pop16       # 0: up to label13
+.LBB2_5:                                # %for.body96
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label14:
 	loop                            # label15:
-	i32.const	$push17=, u
-	i32.const	$push168=, 97
-	i32.const	$push167=, 31
-	i32.call	$1=, memset@FUNCTION, $pop17, $pop168, $pop167
-	i32.const	$push18=, 4
-	i32.const	$push16=, 0
-	i32.store	$push166=, u($5):p2align=0, $pop16
-	tee_local	$push165=, $8=, $pop166
-	call    	check@FUNCTION, $5, $pop18, $pop165
-	i32.load8_u	$push19=, A($8)
-	i32.const	$push164=, 16843009
-	i32.mul 	$push20=, $pop19, $pop164
-	i32.store	$discard=, u($5):p2align=0, $pop20
-	i32.const	$push163=, 4
-	i32.const	$push162=, 65
-	call    	check@FUNCTION, $5, $pop163, $pop162
-	i32.const	$push21=, 1111638594
-	i32.store	$3=, u($5):p2align=0, $pop21
-	i32.const	$push161=, 4
-	i32.const	$push160=, 66
-	call    	check@FUNCTION, $5, $pop161, $pop160
-	i32.const	$push159=, 1
-	i32.add 	$5=, $5, $pop159
-	copy_local	$6=, $8
-	i32.const	$push158=, 8
-	i32.ne  	$push22=, $5, $pop158
+	i32.const	$push161=, u
+	i32.const	$push160=, 97
+	i32.const	$push159=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop161, $pop160, $pop159
+	i32.const	$push158=, 5
+	i32.const	$push17=, 0
+	i32.store8	$push18=, u+4($2), $pop17
+	i32.store	$push157=, u($2):p2align=0, $pop18
+	tee_local	$push156=, $1=, $pop157
+	call    	check@FUNCTION, $2, $pop158, $pop156
+	i32.load8_u	$push19=, A($1)
+	i32.store8	$push20=, u+4($2), $pop19
+	i32.const	$push155=, 16843009
+	i32.mul 	$push21=, $pop20, $pop155
+	i32.store	$discard=, u($2):p2align=0, $pop21
+	i32.const	$push154=, 5
+	i32.const	$push153=, 65
+	call    	check@FUNCTION, $2, $pop154, $pop153
+	i32.const	$push152=, 66
+	i32.store8	$0=, u+4($2), $pop152
+	i32.const	$push151=, 1111638594
+	i32.store	$discard=, u($2):p2align=0, $pop151
+	i32.const	$push150=, 5
+	call    	check@FUNCTION, $2, $pop150, $0
+	i32.const	$push149=, 1
+	i32.add 	$2=, $2, $pop149
+	i32.const	$push148=, 8
+	i32.ne  	$push22=, $2, $pop148
 	br_if   	0, $pop22       # 0: up to label15
-.LBB2_5:                                # %for.body96
+.LBB2_6:                                # %for.body122
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label16:
 	loop                            # label17:
-	i32.const	$push179=, 97
-	i32.const	$push178=, 31
-	i32.call	$discard=, memset@FUNCTION, $1, $pop179, $pop178
-	i32.const	$push24=, 5
-	i32.store8	$push23=, u+4($6), $8
-	i32.store	$push177=, u($6):p2align=0, $pop23
-	tee_local	$push176=, $5=, $pop177
-	call    	check@FUNCTION, $6, $pop24, $pop176
-	i32.load8_u	$push25=, A($5)
-	i32.store8	$push26=, u+4($6), $pop25
-	i32.const	$push175=, 16843009
-	i32.mul 	$push27=, $pop26, $pop175
-	i32.store	$discard=, u($6):p2align=0, $pop27
-	i32.const	$push174=, 5
-	i32.const	$push173=, 65
-	call    	check@FUNCTION, $6, $pop174, $pop173
-	i32.const	$push172=, 66
-	i32.store8	$0=, u+4($6), $pop172
-	i32.store	$discard=, u($6):p2align=0, $3
-	i32.const	$push171=, 5
-	call    	check@FUNCTION, $6, $pop171, $0
-	i32.const	$push170=, 1
-	i32.add 	$6=, $6, $pop170
-	i32.const	$push169=, 8
-	i32.ne  	$push28=, $6, $pop169
-	br_if   	0, $pop28       # 0: up to label17
-.LBB2_6:                                # %for.body122
+	i32.const	$push179=, u
+	i32.const	$push178=, 97
+	i32.const	$push177=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop179, $pop178, $pop177
+	i32.const	$push176=, 6
+	i32.const	$push23=, 0
+	i32.store16	$push24=, u+4($1):p2align=0, $pop23
+	i32.store	$push175=, u($1):p2align=0, $pop24
+	tee_local	$push174=, $2=, $pop175
+	call    	check@FUNCTION, $1, $pop176, $pop174
+	i32.load8_u	$push173=, A($2)
+	tee_local	$push172=, $0=, $pop173
+	i32.const	$push171=, 257
+	i32.mul 	$push25=, $pop172, $pop171
+	i32.store16	$discard=, u+4($1):p2align=0, $pop25
+	i32.const	$push170=, 16843009
+	i32.mul 	$push26=, $0, $pop170
+	i32.store	$discard=, u($1):p2align=0, $pop26
+	i32.const	$push169=, 6
+	i32.const	$push168=, 65
+	call    	check@FUNCTION, $1, $pop169, $pop168
+	i32.const	$push167=, 16962
+	i32.store16	$discard=, u+4($1):p2align=0, $pop167
+	i32.const	$push166=, 1111638594
+	i32.store	$discard=, u($1):p2align=0, $pop166
+	i32.const	$push165=, 6
+	i32.const	$push164=, 66
+	call    	check@FUNCTION, $1, $pop165, $pop164
+	i32.const	$push163=, 1
+	i32.add 	$1=, $1, $pop163
+	i32.const	$push162=, 8
+	i32.ne  	$push27=, $1, $pop162
+	br_if   	0, $pop27       # 0: up to label17
+.LBB2_7:                                # %for.body148
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label18:
 	loop                            # label19:
-	i32.const	$push30=, u
-	i32.const	$push193=, 97
-	i32.const	$push192=, 31
-	i32.call	$1=, memset@FUNCTION, $pop30, $pop193, $pop192
-	i32.const	$push32=, 6
-	i32.const	$push29=, 0
-	i32.store16	$push31=, u+4($5):p2align=0, $pop29
-	i32.store	$push191=, u($5):p2align=0, $pop31
-	tee_local	$push190=, $8=, $pop191
-	call    	check@FUNCTION, $5, $pop32, $pop190
-	i32.load8_u	$push189=, A($8)
-	tee_local	$push188=, $6=, $pop189
-	i32.const	$push187=, 257
-	i32.mul 	$push33=, $pop188, $pop187
-	i32.store16	$discard=, u+4($5):p2align=0, $pop33
-	i32.const	$push186=, 16843009
-	i32.mul 	$push34=, $6, $pop186
-	i32.store	$discard=, u($5):p2align=0, $pop34
-	i32.const	$push185=, 6
-	i32.const	$push184=, 65
-	call    	check@FUNCTION, $5, $pop185, $pop184
-	i32.const	$push35=, 16962
-	i32.store16	$3=, u+4($5):p2align=0, $pop35
-	i32.const	$push36=, 1111638594
-	i32.store	$0=, u($5):p2align=0, $pop36
-	i32.const	$push183=, 6
-	i32.const	$push182=, 66
-	call    	check@FUNCTION, $5, $pop183, $pop182
+	i32.const	$push197=, u
+	i32.const	$push196=, 97
+	i32.const	$push195=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop197, $pop196, $pop195
+	i32.const	$push194=, 7
+	i32.const	$push28=, 0
+	i32.store8	$push29=, u+6($2), $pop28
+	i32.store16	$push30=, u+4($2):p2align=0, $pop29
+	i32.store	$push193=, u($2):p2align=0, $pop30
+	tee_local	$push192=, $1=, $pop193
+	call    	check@FUNCTION, $2, $pop194, $pop192
+	i32.load8_u	$push31=, A($1)
+	i32.store8	$push191=, u+6($2), $pop31
+	tee_local	$push190=, $0=, $pop191
+	i32.const	$push189=, 257
+	i32.mul 	$push32=, $pop190, $pop189
+	i32.store16	$discard=, u+4($2):p2align=0, $pop32
+	i32.const	$push188=, 16843009
+	i32.mul 	$push33=, $0, $pop188
+	i32.store	$discard=, u($2):p2align=0, $pop33
+	i32.const	$push187=, 7
+	i32.const	$push186=, 65
+	call    	check@FUNCTION, $2, $pop187, $pop186
+	i32.const	$push185=, 66
+	i32.store8	$0=, u+6($2), $pop185
+	i32.const	$push184=, 16962
+	i32.store16	$discard=, u+4($2):p2align=0, $pop184
+	i32.const	$push183=, 1111638594
+	i32.store	$discard=, u($2):p2align=0, $pop183
+	i32.const	$push182=, 7
+	call    	check@FUNCTION, $2, $pop182, $0
 	i32.const	$push181=, 1
-	i32.add 	$5=, $5, $pop181
-	copy_local	$6=, $8
+	i32.add 	$2=, $2, $pop181
 	i32.const	$push180=, 8
-	i32.ne  	$push37=, $5, $pop180
-	br_if   	0, $pop37       # 0: up to label19
-.LBB2_7:                                # %for.body148
+	i32.ne  	$push34=, $2, $pop180
+	br_if   	0, $pop34       # 0: up to label19
+.LBB2_8:                                # %for.body174
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label20:
 	loop                            # label21:
-	i32.const	$push207=, 97
-	i32.const	$push206=, 31
-	i32.call	$discard=, memset@FUNCTION, $1, $pop207, $pop206
-	i32.const	$push40=, 7
-	i32.store8	$push38=, u+6($6), $8
-	i32.store16	$push39=, u+4($6):p2align=0, $pop38
-	i32.store	$push205=, u($6):p2align=0, $pop39
-	tee_local	$push204=, $5=, $pop205
-	call    	check@FUNCTION, $6, $pop40, $pop204
-	i32.load8_u	$push41=, A($5)
-	i32.store8	$push203=, u+6($6), $pop41
-	tee_local	$push202=, $7=, $pop203
-	i32.const	$push201=, 257
-	i32.mul 	$push42=, $pop202, $pop201
-	i32.store16	$discard=, u+4($6):p2align=0, $pop42
-	i32.const	$push200=, 16843009
-	i32.mul 	$push43=, $7, $pop200
-	i32.store	$discard=, u($6):p2align=0, $pop43
-	i32.const	$push199=, 7
-	i32.const	$push198=, 65
-	call    	check@FUNCTION, $6, $pop199, $pop198
-	i32.const	$push197=, 66
-	i32.store8	$7=, u+6($6), $pop197
-	i32.store16	$discard=, u+4($6):p2align=0, $3
-	i32.store	$discard=, u($6):p2align=0, $0
-	i32.const	$push196=, 7
-	call    	check@FUNCTION, $6, $pop196, $7
-	i32.const	$push195=, 1
-	i32.add 	$6=, $6, $pop195
-	i32.const	$push194=, 8
-	i32.ne  	$push44=, $6, $pop194
-	br_if   	0, $pop44       # 0: up to label21
-.LBB2_8:                                # %for.body174
+	i32.const	$push212=, u
+	i32.const	$push211=, 97
+	i32.const	$push210=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop212, $pop211, $pop210
+	i32.const	$2=, 0
+	i64.const	$push209=, 0
+	i64.store	$discard=, u($1):p2align=0, $pop209
+	i32.const	$push208=, 8
+	i32.const	$push207=, 0
+	call    	check@FUNCTION, $1, $pop208, $pop207
+	i32.const	$push206=, 0
+	i32.load8_u	$push35=, A($pop206)
+	i32.const	$push205=, 16843009
+	i32.mul 	$push36=, $pop35, $pop205
+	i32.store	$push37=, u+4($1):p2align=0, $pop36
+	i32.store	$discard=, u($1):p2align=0, $pop37
+	i32.const	$push204=, 8
+	i32.const	$push203=, 65
+	call    	check@FUNCTION, $1, $pop204, $pop203
+	i64.const	$push202=, 4774451407313060418
+	i64.store	$discard=, u($1):p2align=0, $pop202
+	i32.const	$push201=, 8
+	i32.const	$push200=, 66
+	call    	check@FUNCTION, $1, $pop201, $pop200
+	i32.const	$push199=, 1
+	i32.add 	$1=, $1, $pop199
+	i32.const	$push198=, 8
+	i32.ne  	$push38=, $1, $pop198
+	br_if   	0, $pop38       # 0: up to label21
+.LBB2_9:                                # %for.body200
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label22:
 	loop                            # label23:
-	i32.const	$push45=, u
-	i32.const	$push219=, 97
-	i32.const	$push218=, 31
-	i32.call	$8=, memset@FUNCTION, $pop45, $pop219, $pop218
-	i64.const	$push46=, 0
-	i64.store	$discard=, u($5):p2align=0, $pop46
-	i32.const	$push217=, 8
-	i32.const	$push216=, 0
-	call    	check@FUNCTION, $5, $pop217, $pop216
-	i32.const	$push215=, 0
-	i32.load8_u	$push47=, A($pop215)
-	i32.const	$push214=, 16843009
-	i32.mul 	$push48=, $pop47, $pop214
-	i32.store	$push49=, u+4($5):p2align=0, $pop48
-	i32.store	$discard=, u($5):p2align=0, $pop49
+	i32.const	$push226=, u
+	i32.const	$push225=, 97
+	i32.const	$push224=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop226, $pop225, $pop224
+	i32.const	$push223=, 9
+	i32.const	$push39=, 0
+	i32.store8	$push40=, u+8($2), $pop39
+	i32.store	$push41=, u+4($2):p2align=0, $pop40
+	i32.store	$push222=, u($2):p2align=0, $pop41
+	tee_local	$push221=, $1=, $pop222
+	call    	check@FUNCTION, $2, $pop223, $pop221
+	i32.load8_u	$push42=, A($1)
+	i32.store8	$push43=, u+8($2), $pop42
+	i32.const	$push220=, 16843009
+	i32.mul 	$push44=, $pop43, $pop220
+	i32.store	$push45=, u+4($2):p2align=0, $pop44
+	i32.store	$discard=, u($2):p2align=0, $pop45
+	i32.const	$push219=, 9
+	i32.const	$push218=, 65
+	call    	check@FUNCTION, $2, $pop219, $pop218
+	i32.const	$push217=, 66
+	i32.store8	$0=, u+8($2), $pop217
+	i32.const	$push216=, 1111638594
+	i32.store	$push46=, u+4($2):p2align=0, $pop216
+	i32.store	$discard=, u($2):p2align=0, $pop46
+	i32.const	$push215=, 9
+	call    	check@FUNCTION, $2, $pop215, $0
+	i32.const	$push214=, 1
+	i32.add 	$2=, $2, $pop214
 	i32.const	$push213=, 8
-	i32.const	$push212=, 65
-	call    	check@FUNCTION, $5, $pop213, $pop212
-	i64.const	$push50=, 4774451407313060418
-	i64.store	$discard=, u($5):p2align=0, $pop50
-	i32.const	$push211=, 8
-	i32.const	$push210=, 66
-	call    	check@FUNCTION, $5, $pop211, $pop210
-	i32.const	$push209=, 1
-	i32.add 	$5=, $5, $pop209
-	i32.const	$6=, 0
-	i32.const	$push208=, 8
-	i32.ne  	$push51=, $5, $pop208
-	br_if   	0, $pop51       # 0: up to label23
-.LBB2_9:                                # %for.body200
+	i32.ne  	$push47=, $2, $pop213
+	br_if   	0, $pop47       # 0: up to label23
+.LBB2_10:                               # %for.body226
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label24:
 	loop                            # label25:
-	i32.const	$push231=, 97
-	i32.const	$push230=, 31
-	i32.call	$discard=, memset@FUNCTION, $8, $pop231, $pop230
-	i32.const	$push54=, 9
-	i32.const	$push229=, 0
-	i32.store8	$push52=, u+8($6), $pop229
-	i32.store	$push53=, u+4($6):p2align=0, $pop52
-	i32.store	$push228=, u($6):p2align=0, $pop53
-	tee_local	$push227=, $5=, $pop228
-	call    	check@FUNCTION, $6, $pop54, $pop227
-	i32.load8_u	$push55=, A($5)
-	i32.store8	$push56=, u+8($6), $pop55
-	i32.const	$push226=, 16843009
-	i32.mul 	$push57=, $pop56, $pop226
-	i32.store	$push58=, u+4($6):p2align=0, $pop57
-	i32.store	$discard=, u($6):p2align=0, $pop58
-	i32.const	$push225=, 9
-	i32.const	$push224=, 65
-	call    	check@FUNCTION, $6, $pop225, $pop224
-	i32.const	$push223=, 66
-	i32.store8	$1=, u+8($6), $pop223
-	i32.const	$push59=, 1111638594
-	i32.store	$push60=, u+4($6):p2align=0, $pop59
-	i32.store	$3=, u($6):p2align=0, $pop60
-	i32.const	$push222=, 9
-	call    	check@FUNCTION, $6, $pop222, $1
-	i32.const	$push221=, 1
-	i32.add 	$6=, $6, $pop221
-	i32.const	$push220=, 8
-	i32.ne  	$push61=, $6, $pop220
-	br_if   	0, $pop61       # 0: up to label25
-.LBB2_10:                               # %for.body226
+	i32.const	$push244=, u
+	i32.const	$push243=, 97
+	i32.const	$push242=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop244, $pop243, $pop242
+	i32.const	$push241=, 10
+	i32.const	$push48=, 0
+	i32.store16	$push49=, u+8($1):p2align=0, $pop48
+	i32.store	$push50=, u+4($1):p2align=0, $pop49
+	i32.store	$push240=, u($1):p2align=0, $pop50
+	tee_local	$push239=, $2=, $pop240
+	call    	check@FUNCTION, $1, $pop241, $pop239
+	i32.load8_u	$push238=, A($2)
+	tee_local	$push237=, $0=, $pop238
+	i32.const	$push236=, 257
+	i32.mul 	$push51=, $pop237, $pop236
+	i32.store16	$discard=, u+8($1):p2align=0, $pop51
+	i32.const	$push235=, 16843009
+	i32.mul 	$push52=, $0, $pop235
+	i32.store	$push53=, u+4($1):p2align=0, $pop52
+	i32.store	$discard=, u($1):p2align=0, $pop53
+	i32.const	$push234=, 10
+	i32.const	$push233=, 65
+	call    	check@FUNCTION, $1, $pop234, $pop233
+	i32.const	$push232=, 16962
+	i32.store16	$discard=, u+8($1):p2align=0, $pop232
+	i32.const	$push231=, 1111638594
+	i32.store	$push54=, u+4($1):p2align=0, $pop231
+	i32.store	$discard=, u($1):p2align=0, $pop54
+	i32.const	$push230=, 10
+	i32.const	$push229=, 66
+	call    	check@FUNCTION, $1, $pop230, $pop229
+	i32.const	$push228=, 1
+	i32.add 	$1=, $1, $pop228
+	i32.const	$push227=, 8
+	i32.ne  	$push55=, $1, $pop227
+	br_if   	0, $pop55       # 0: up to label25
+.LBB2_11:                               # %for.body252
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label26:
 	loop                            # label27:
-	i32.const	$push63=, u
-	i32.const	$push245=, 97
-	i32.const	$push244=, 31
-	i32.call	$1=, memset@FUNCTION, $pop63, $pop245, $pop244
-	i32.const	$push66=, 10
-	i32.const	$push62=, 0
-	i32.store16	$push64=, u+8($5):p2align=0, $pop62
-	i32.store	$push65=, u+4($5):p2align=0, $pop64
-	i32.store	$push243=, u($5):p2align=0, $pop65
-	tee_local	$push242=, $8=, $pop243
-	call    	check@FUNCTION, $5, $pop66, $pop242
-	i32.load8_u	$push241=, A($8)
-	tee_local	$push240=, $6=, $pop241
-	i32.const	$push239=, 257
-	i32.mul 	$push67=, $pop240, $pop239
-	i32.store16	$discard=, u+8($5):p2align=0, $pop67
-	i32.const	$push238=, 16843009
-	i32.mul 	$push68=, $6, $pop238
-	i32.store	$push69=, u+4($5):p2align=0, $pop68
-	i32.store	$discard=, u($5):p2align=0, $pop69
-	i32.const	$push237=, 10
-	i32.const	$push236=, 65
-	call    	check@FUNCTION, $5, $pop237, $pop236
-	i32.const	$push70=, 16962
-	i32.store16	$0=, u+8($5):p2align=0, $pop70
-	i32.store	$push71=, u+4($5):p2align=0, $3
-	i32.store	$discard=, u($5):p2align=0, $pop71
-	i32.const	$push235=, 10
-	i32.const	$push234=, 66
-	call    	check@FUNCTION, $5, $pop235, $pop234
-	i32.const	$push233=, 1
-	i32.add 	$5=, $5, $pop233
-	copy_local	$6=, $8
-	i32.const	$push232=, 8
-	i32.ne  	$push72=, $5, $pop232
-	br_if   	0, $pop72       # 0: up to label27
-.LBB2_11:                               # %for.body252
+	i32.const	$push262=, u
+	i32.const	$push261=, 97
+	i32.const	$push260=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop262, $pop261, $pop260
+	i32.const	$push259=, 11
+	i32.const	$push56=, 0
+	i32.store8	$push57=, u+10($2), $pop56
+	i32.store16	$push58=, u+8($2):p2align=0, $pop57
+	i32.store	$push59=, u+4($2):p2align=0, $pop58
+	i32.store	$push258=, u($2):p2align=0, $pop59
+	tee_local	$push257=, $1=, $pop258
+	call    	check@FUNCTION, $2, $pop259, $pop257
+	i32.load8_u	$push60=, A($1)
+	i32.store8	$push256=, u+10($2), $pop60
+	tee_local	$push255=, $0=, $pop256
+	i32.const	$push254=, 257
+	i32.mul 	$push61=, $pop255, $pop254
+	i32.store16	$discard=, u+8($2):p2align=0, $pop61
+	i32.const	$push253=, 16843009
+	i32.mul 	$push62=, $0, $pop253
+	i32.store	$push63=, u+4($2):p2align=0, $pop62
+	i32.store	$discard=, u($2):p2align=0, $pop63
+	i32.const	$push252=, 11
+	i32.const	$push251=, 65
+	call    	check@FUNCTION, $2, $pop252, $pop251
+	i32.const	$push250=, 66
+	i32.store8	$0=, u+10($2), $pop250
+	i32.const	$push249=, 16962
+	i32.store16	$discard=, u+8($2):p2align=0, $pop249
+	i32.const	$push248=, 1111638594
+	i32.store	$push64=, u+4($2):p2align=0, $pop248
+	i32.store	$discard=, u($2):p2align=0, $pop64
+	i32.const	$push247=, 11
+	call    	check@FUNCTION, $2, $pop247, $0
+	i32.const	$push246=, 1
+	i32.add 	$2=, $2, $pop246
+	i32.const	$push245=, 8
+	i32.ne  	$push65=, $2, $pop245
+	br_if   	0, $pop65       # 0: up to label27
+.LBB2_12:                               # %for.body278
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label28:
 	loop                            # label29:
-	i32.const	$push259=, 97
-	i32.const	$push258=, 31
-	i32.call	$discard=, memset@FUNCTION, $1, $pop259, $pop258
-	i32.const	$push76=, 11
-	i32.store8	$push73=, u+10($6), $8
-	i32.store16	$push74=, u+8($6):p2align=0, $pop73
-	i32.store	$push75=, u+4($6):p2align=0, $pop74
-	i32.store	$push257=, u($6):p2align=0, $pop75
-	tee_local	$push256=, $5=, $pop257
-	call    	check@FUNCTION, $6, $pop76, $pop256
-	i32.load8_u	$push77=, A($5)
-	i32.store8	$push255=, u+10($6), $pop77
-	tee_local	$push254=, $3=, $pop255
-	i32.const	$push253=, 257
-	i32.mul 	$push78=, $pop254, $pop253
-	i32.store16	$discard=, u+8($6):p2align=0, $pop78
-	i32.const	$push252=, 16843009
-	i32.mul 	$push79=, $3, $pop252
-	i32.store	$push80=, u+4($6):p2align=0, $pop79
-	i32.store	$discard=, u($6):p2align=0, $pop80
-	i32.const	$push251=, 11
-	i32.const	$push250=, 65
-	call    	check@FUNCTION, $6, $pop251, $pop250
-	i32.const	$push249=, 66
-	i32.store8	$3=, u+10($6), $pop249
-	i32.store16	$discard=, u+8($6):p2align=0, $0
-	i32.const	$push81=, 1111638594
-	i32.store	$push82=, u+4($6):p2align=0, $pop81
-	i32.store	$7=, u($6):p2align=0, $pop82
-	i32.const	$push248=, 11
-	call    	check@FUNCTION, $6, $pop248, $3
-	i32.const	$push247=, 1
-	i32.add 	$6=, $6, $pop247
-	i32.const	$push246=, 8
-	i32.ne  	$push83=, $6, $pop246
-	br_if   	0, $pop83       # 0: up to label29
-.LBB2_12:                               # %for.body278
+	i32.const	$push278=, u
+	i32.const	$push277=, 97
+	i32.const	$push276=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop278, $pop277, $pop276
+	i64.const	$push275=, 0
+	i64.store	$discard=, u+4($1):p2align=0, $pop275
+	i32.const	$push274=, 12
+	i32.const	$push66=, 0
+	i32.store	$push273=, u($1):p2align=0, $pop66
+	tee_local	$push272=, $2=, $pop273
+	call    	check@FUNCTION, $1, $pop274, $pop272
+	i32.load8_u	$push67=, A($2)
+	i32.const	$push271=, 16843009
+	i32.mul 	$push68=, $pop67, $pop271
+	i32.store	$push69=, u+8($1):p2align=0, $pop68
+	i32.store	$push70=, u+4($1):p2align=0, $pop69
+	i32.store	$discard=, u($1):p2align=0, $pop70
+	i32.const	$push270=, 12
+	i32.const	$push269=, 65
+	call    	check@FUNCTION, $1, $pop270, $pop269
+	i64.const	$push268=, 4774451407313060418
+	i64.store	$discard=, u+4($1):p2align=0, $pop268
+	i32.const	$push267=, 1111638594
+	i32.store	$discard=, u($1):p2align=0, $pop267
+	i32.const	$push266=, 12
+	i32.const	$push265=, 66
+	call    	check@FUNCTION, $1, $pop266, $pop265
+	i32.const	$push264=, 1
+	i32.add 	$1=, $1, $pop264
+	i32.const	$push263=, 8
+	i32.ne  	$push71=, $1, $pop263
+	br_if   	0, $pop71       # 0: up to label29
+.LBB2_13:                               # %for.body304
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label30:
 	loop                            # label31:
-	i32.const	$push85=, u
-	i32.const	$push270=, 97
-	i32.const	$push269=, 31
-	i32.call	$1=, memset@FUNCTION, $pop85, $pop270, $pop269
-	i64.const	$push86=, 0
-	i64.store	$2=, u+4($5):p2align=0, $pop86
-	i32.const	$push87=, 12
-	i32.const	$push84=, 0
-	i32.store	$push268=, u($5):p2align=0, $pop84
-	tee_local	$push267=, $8=, $pop268
-	call    	check@FUNCTION, $5, $pop87, $pop267
-	i32.load8_u	$push88=, A($8)
-	i32.const	$push266=, 16843009
-	i32.mul 	$push89=, $pop88, $pop266
-	i32.store	$push90=, u+8($5):p2align=0, $pop89
-	i32.store	$push91=, u+4($5):p2align=0, $pop90
-	i32.store	$discard=, u($5):p2align=0, $pop91
-	i32.const	$push265=, 12
-	i32.const	$push264=, 65
-	call    	check@FUNCTION, $5, $pop265, $pop264
-	i64.const	$push92=, 4774451407313060418
-	i64.store	$4=, u+4($5):p2align=0, $pop92
-	i32.store	$discard=, u($5):p2align=0, $7
-	i32.const	$push263=, 12
-	i32.const	$push262=, 66
-	call    	check@FUNCTION, $5, $pop263, $pop262
-	i32.const	$push261=, 1
-	i32.add 	$5=, $5, $pop261
-	copy_local	$6=, $8
-	i32.const	$push260=, 8
-	i32.ne  	$push93=, $5, $pop260
-	br_if   	0, $pop93       # 0: up to label31
-.LBB2_13:                               # %for.body304
+	i32.const	$push294=, u
+	i32.const	$push293=, 97
+	i32.const	$push292=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop294, $pop293, $pop292
+	i32.const	$push72=, 0
+	i32.store8	$1=, u+12($2), $pop72
+	i64.const	$push291=, 0
+	i64.store	$discard=, u+4($2):p2align=0, $pop291
+	i32.const	$push290=, 13
+	i32.store	$push289=, u($2):p2align=0, $1
+	tee_local	$push288=, $1=, $pop289
+	call    	check@FUNCTION, $2, $pop290, $pop288
+	i32.load8_u	$push73=, A($1)
+	i32.store8	$push74=, u+12($2), $pop73
+	i32.const	$push287=, 16843009
+	i32.mul 	$push75=, $pop74, $pop287
+	i32.store	$push76=, u+8($2):p2align=0, $pop75
+	i32.store	$push77=, u+4($2):p2align=0, $pop76
+	i32.store	$discard=, u($2):p2align=0, $pop77
+	i32.const	$push286=, 13
+	i32.const	$push285=, 65
+	call    	check@FUNCTION, $2, $pop286, $pop285
+	i32.const	$push284=, 66
+	i32.store8	$0=, u+12($2), $pop284
+	i64.const	$push283=, 4774451407313060418
+	i64.store	$discard=, u+4($2):p2align=0, $pop283
+	i32.const	$push282=, 1111638594
+	i32.store	$discard=, u($2):p2align=0, $pop282
+	i32.const	$push281=, 13
+	call    	check@FUNCTION, $2, $pop281, $0
+	i32.const	$push280=, 1
+	i32.add 	$2=, $2, $pop280
+	i32.const	$push279=, 8
+	i32.ne  	$push78=, $2, $pop279
+	br_if   	0, $pop78       # 0: up to label31
+.LBB2_14:                               # %for.body330
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label32:
 	loop                            # label33:
-	i32.const	$push281=, 97
-	i32.const	$push280=, 31
-	i32.call	$discard=, memset@FUNCTION, $1, $pop281, $pop280
-	i32.store8	$5=, u+12($6), $8
-	i64.store	$discard=, u+4($6):p2align=0, $2
-	i32.const	$push94=, 13
-	i32.store	$push279=, u($6):p2align=0, $5
-	tee_local	$push278=, $5=, $pop279
-	call    	check@FUNCTION, $6, $pop94, $pop278
-	i32.load8_u	$push95=, A($5)
-	i32.store8	$push96=, u+12($6), $pop95
-	i32.const	$push277=, 16843009
-	i32.mul 	$push97=, $pop96, $pop277
-	i32.store	$push98=, u+8($6):p2align=0, $pop97
-	i32.store	$push99=, u+4($6):p2align=0, $pop98
-	i32.store	$discard=, u($6):p2align=0, $pop99
-	i32.const	$push276=, 13
-	i32.const	$push275=, 65
-	call    	check@FUNCTION, $6, $pop276, $pop275
-	i32.const	$push274=, 66
-	i32.store8	$3=, u+12($6), $pop274
-	i64.store	$discard=, u+4($6):p2align=0, $4
-	i32.const	$push100=, 1111638594
-	i32.store	$0=, u($6):p2align=0, $pop100
-	i32.const	$push273=, 13
-	call    	check@FUNCTION, $6, $pop273, $3
-	i32.const	$push272=, 1
-	i32.add 	$6=, $6, $pop272
-	i32.const	$push271=, 8
-	i32.ne  	$push101=, $6, $pop271
-	br_if   	0, $pop101      # 0: up to label33
-.LBB2_14:                               # %for.body330
+	i32.const	$push314=, u
+	i32.const	$push313=, 97
+	i32.const	$push312=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop314, $pop313, $pop312
+	i32.const	$push79=, 0
+	i32.store16	$2=, u+12($1):p2align=0, $pop79
+	i64.const	$push311=, 0
+	i64.store	$discard=, u+4($1):p2align=0, $pop311
+	i32.const	$push310=, 14
+	i32.store	$push309=, u($1):p2align=0, $2
+	tee_local	$push308=, $2=, $pop309
+	call    	check@FUNCTION, $1, $pop310, $pop308
+	i32.load8_u	$push307=, A($2)
+	tee_local	$push306=, $0=, $pop307
+	i32.const	$push305=, 257
+	i32.mul 	$push80=, $pop306, $pop305
+	i32.store16	$discard=, u+12($1):p2align=0, $pop80
+	i32.const	$push304=, 16843009
+	i32.mul 	$push81=, $0, $pop304
+	i32.store	$push82=, u+8($1):p2align=0, $pop81
+	i32.store	$push83=, u+4($1):p2align=0, $pop82
+	i32.store	$discard=, u($1):p2align=0, $pop83
+	i32.const	$push303=, 14
+	i32.const	$push302=, 65
+	call    	check@FUNCTION, $1, $pop303, $pop302
+	i32.const	$push301=, 16962
+	i32.store16	$discard=, u+12($1):p2align=0, $pop301
+	i64.const	$push300=, 4774451407313060418
+	i64.store	$discard=, u+4($1):p2align=0, $pop300
+	i32.const	$push299=, 1111638594
+	i32.store	$discard=, u($1):p2align=0, $pop299
+	i32.const	$push298=, 14
+	i32.const	$push297=, 66
+	call    	check@FUNCTION, $1, $pop298, $pop297
+	i32.const	$push296=, 1
+	i32.add 	$1=, $1, $pop296
+	i32.const	$push295=, 8
+	i32.ne  	$push84=, $1, $pop295
+	br_if   	0, $pop84       # 0: up to label33
+.LBB2_15:                               # %for.body356
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label34:
 	loop                            # label35:
-	i32.const	$push103=, u
-	i32.const	$push295=, 97
-	i32.const	$push294=, 31
-	i32.call	$1=, memset@FUNCTION, $pop103, $pop295, $pop294
-	i32.const	$push102=, 0
-	i32.store16	$6=, u+12($5):p2align=0, $pop102
-	i64.const	$push104=, 0
-	i64.store	$2=, u+4($5):p2align=0, $pop104
-	i32.const	$push105=, 14
-	i32.store	$push293=, u($5):p2align=0, $6
-	tee_local	$push292=, $8=, $pop293
-	call    	check@FUNCTION, $5, $pop105, $pop292
-	i32.load8_u	$push291=, A($8)
-	tee_local	$push290=, $6=, $pop291
-	i32.const	$push289=, 257
-	i32.mul 	$push106=, $pop290, $pop289
-	i32.store16	$discard=, u+12($5):p2align=0, $pop106
-	i32.const	$push288=, 16843009
-	i32.mul 	$push107=, $6, $pop288
-	i32.store	$push108=, u+8($5):p2align=0, $pop107
-	i32.store	$push109=, u+4($5):p2align=0, $pop108
-	i32.store	$discard=, u($5):p2align=0, $pop109
-	i32.const	$push287=, 14
-	i32.const	$push286=, 65
-	call    	check@FUNCTION, $5, $pop287, $pop286
-	i32.const	$push110=, 16962
-	i32.store16	$3=, u+12($5):p2align=0, $pop110
-	i64.const	$push111=, 4774451407313060418
-	i64.store	$4=, u+4($5):p2align=0, $pop111
-	i32.store	$discard=, u($5):p2align=0, $0
-	i32.const	$push285=, 14
-	i32.const	$push284=, 66
-	call    	check@FUNCTION, $5, $pop285, $pop284
-	i32.const	$push283=, 1
-	i32.add 	$5=, $5, $pop283
-	copy_local	$6=, $8
-	i32.const	$push282=, 8
-	i32.ne  	$push112=, $5, $pop282
-	br_if   	0, $pop112      # 0: up to label35
-.LBB2_15:                               # %for.body356
-                                        # =>This Inner Loop Header: Depth=1
-	end_loop                        # label36:
-	loop                            # label37:
-	i32.const	$push309=, 97
-	i32.const	$push308=, 31
-	i32.call	$discard=, memset@FUNCTION, $1, $pop309, $pop308
-	i32.store8	$push113=, u+14($6), $8
-	i32.store16	$5=, u+12($6):p2align=0, $pop113
-	i64.store	$discard=, u+4($6):p2align=0, $2
-	i32.const	$push114=, 15
-	i32.store	$push307=, u($6):p2align=0, $5
-	tee_local	$push306=, $5=, $pop307
-	call    	check@FUNCTION, $6, $pop114, $pop306
-	i32.load8_u	$push115=, A($5)
-	i32.store8	$push305=, u+14($6), $pop115
-	tee_local	$push304=, $5=, $pop305
-	i32.const	$push303=, 257
-	i32.mul 	$push116=, $pop304, $pop303
-	i32.store16	$discard=, u+12($6):p2align=0, $pop116
-	i32.const	$push302=, 16843009
-	i32.mul 	$push117=, $5, $pop302
-	i32.store	$push118=, u+8($6):p2align=0, $pop117
-	i32.store	$push119=, u+4($6):p2align=0, $pop118
-	i32.store	$discard=, u($6):p2align=0, $pop119
-	i32.const	$push301=, 15
-	i32.const	$push300=, 65
-	call    	check@FUNCTION, $6, $pop301, $pop300
-	i32.const	$push299=, 66
-	i32.store8	$5=, u+14($6), $pop299
-	i32.store16	$discard=, u+12($6):p2align=0, $3
-	i64.store	$discard=, u+4($6):p2align=0, $4
-	i32.const	$push120=, 1111638594
-	i32.store	$discard=, u($6):p2align=0, $pop120
-	i32.const	$push298=, 15
-	call    	check@FUNCTION, $6, $pop298, $5
-	i32.const	$push297=, 1
-	i32.add 	$6=, $6, $pop297
-	i32.const	$push296=, 8
-	i32.ne  	$push121=, $6, $pop296
-	br_if   	0, $pop121      # 0: up to label37
+	i32.const	$push335=, u
+	i32.const	$push334=, 97
+	i32.const	$push333=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop335, $pop334, $pop333
+	i32.const	$push332=, 0
+	i32.store8	$push85=, u+14($2), $pop332
+	i32.store16	$1=, u+12($2):p2align=0, $pop85
+	i64.const	$push331=, 0
+	i64.store	$discard=, u+4($2):p2align=0, $pop331
+	i32.const	$push330=, 15
+	i32.store	$push329=, u($2):p2align=0, $1
+	tee_local	$push328=, $1=, $pop329
+	call    	check@FUNCTION, $2, $pop330, $pop328
+	i32.load8_u	$push86=, A($1)
+	i32.store8	$push327=, u+14($2), $pop86
+	tee_local	$push326=, $1=, $pop327
+	i32.const	$push325=, 257
+	i32.mul 	$push87=, $pop326, $pop325
+	i32.store16	$discard=, u+12($2):p2align=0, $pop87
+	i32.const	$push324=, 16843009
+	i32.mul 	$push88=, $1, $pop324
+	i32.store	$push89=, u+8($2):p2align=0, $pop88
+	i32.store	$push90=, u+4($2):p2align=0, $pop89
+	i32.store	$discard=, u($2):p2align=0, $pop90
+	i32.const	$push323=, 15
+	i32.const	$push322=, 65
+	call    	check@FUNCTION, $2, $pop323, $pop322
+	i32.const	$push321=, 66
+	i32.store8	$1=, u+14($2), $pop321
+	i32.const	$push320=, 16962
+	i32.store16	$discard=, u+12($2):p2align=0, $pop320
+	i64.const	$push319=, 4774451407313060418
+	i64.store	$discard=, u+4($2):p2align=0, $pop319
+	i32.const	$push318=, 1111638594
+	i32.store	$discard=, u($2):p2align=0, $pop318
+	i32.const	$push317=, 15
+	call    	check@FUNCTION, $2, $pop317, $1
+	i32.const	$push316=, 1
+	i32.add 	$2=, $2, $pop316
+	i32.const	$push315=, 8
+	i32.ne  	$push91=, $2, $pop315
+	br_if   	0, $pop91       # 0: up to label35
 # BB#16:                                # %for.end378
-	end_loop                        # label38:
-	i32.const	$push122=, 0
-	call    	exit@FUNCTION, $pop122
+	end_loop                        # label36:
+	i32.const	$push92=, 0
+	call    	exit@FUNCTION, $pop92
 	unreachable
 	.endfunc
 .Lfunc_end2:

--- a/test/torture-s/memset-3.c.s
+++ b/test/torture-s/memset-3.c.s
@@ -21,108 +21,100 @@ reset:                                  # @reset
 	.type	check,@function
 check:                                  # @check
 	.param  	i32, i32, i32
-	.local  	i32, i32, i32
+	.local  	i32, i32
 # BB#0:                                 # %entry
-	i32.const	$5=, 0
-	i32.const	$3=, u
+	i32.const	$3=, 0
+	i32.const	$4=, u
 	block
 	block
-	block
-	block
-	i32.const	$push29=, 0
-	i32.le_s	$push0=, $0, $pop29
-	br_if   	0, $pop0        # 0: down to label3
+	i32.const	$push25=, 0
+	i32.le_s	$push0=, $0, $pop25
+	br_if   	0, $pop0        # 0: down to label1
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label4:
-	i32.load8_u	$push1=, u($5)
-	i32.const	$push2=, 97
-	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	3, $pop3        # 3: down to label2
+	loop                            # label2:
+	copy_local	$push29=, $3
+	tee_local	$push28=, $4=, $pop29
+	i32.load8_u	$push1=, u($pop28)
+	i32.const	$push27=, 97
+	i32.ne  	$push2=, $pop1, $pop27
+	br_if   	3, $pop2        # 3: down to label0
 # BB#2:                                 # %for.inc
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push6=, u+1
-	i32.add 	$3=, $5, $pop6
-	i32.const	$push4=, 1
-	i32.add 	$4=, $5, $pop4
-	copy_local	$5=, $4
-	i32.lt_s	$push5=, $4, $0
-	br_if   	0, $pop5        # 0: up to label4
-.LBB1_3:                                # %for.cond3.preheader
-	end_loop                        # label5:
-	end_block                       # label3:
-	i32.const	$5=, 0
-	copy_local	$4=, $3
-	block
-	i32.const	$push30=, 0
-	i32.le_s	$push7=, $1, $pop30
-	br_if   	0, $pop7        # 0: down to label6
-.LBB1_4:                                # %for.body6
-                                        # =>This Inner Loop Header: Depth=1
-	loop                            # label7:
-	i32.add 	$push8=, $3, $5
-	i32.load8_s	$push9=, 0($pop8)
-	i32.ne  	$push10=, $pop9, $2
-	br_if   	4, $pop10       # 4: down to label1
-# BB#5:                                 # %for.inc12
-                                        #   in Loop: Header=BB1_4 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$5=, $5, $pop11
-	i32.add 	$4=, $3, $5
-	i32.lt_s	$push12=, $5, $1
-	br_if   	0, $pop12       # 0: up to label7
-.LBB1_6:                                # %for.body19.preheader
-	end_loop                        # label8:
-	end_block                       # label6:
-	i32.load8_u	$push13=, 0($4)
-	i32.const	$push31=, 97
-	i32.ne  	$push14=, $pop13, $pop31
-	br_if   	2, $pop14       # 2: down to label0
-# BB#7:                                 # %for.inc25
-	i32.load8_u	$push15=, 1($4)
-	i32.const	$push32=, 97
-	i32.ne  	$push16=, $pop15, $pop32
-	br_if   	2, $pop16       # 2: down to label0
-# BB#8:                                 # %for.inc25.1
-	i32.load8_u	$push17=, 2($4)
-	i32.const	$push33=, 97
-	i32.ne  	$push18=, $pop17, $pop33
-	br_if   	2, $pop18       # 2: down to label0
-# BB#9:                                 # %for.inc25.2
-	i32.load8_u	$push19=, 3($4)
-	i32.const	$push34=, 97
-	i32.ne  	$push20=, $pop19, $pop34
-	br_if   	2, $pop20       # 2: down to label0
-# BB#10:                                # %for.inc25.3
-	i32.load8_u	$push21=, 4($4)
-	i32.const	$push35=, 97
-	i32.ne  	$push22=, $pop21, $pop35
-	br_if   	2, $pop22       # 2: down to label0
-# BB#11:                                # %for.inc25.4
-	i32.load8_u	$push23=, 5($4)
-	i32.const	$push36=, 97
-	i32.ne  	$push24=, $pop23, $pop36
-	br_if   	2, $pop24       # 2: down to label0
-# BB#12:                                # %for.inc25.5
-	i32.load8_u	$push25=, 6($4)
-	i32.const	$push37=, 97
-	i32.ne  	$push26=, $pop25, $pop37
-	br_if   	2, $pop26       # 2: down to label0
-# BB#13:                                # %for.inc25.6
-	i32.load8_u	$push27=, 7($4)
-	i32.const	$push38=, 97
-	i32.ne  	$push28=, $pop27, $pop38
-	br_if   	2, $pop28       # 2: down to label0
-# BB#14:                                # %for.inc25.7
-	return
-.LBB1_15:                               # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_16:                               # %if.then10
+	i32.const	$push30=, 1
+	i32.add 	$3=, $4, $pop30
+	i32.lt_s	$push3=, $3, $0
+	br_if   	0, $pop3        # 0: up to label2
+# BB#3:
+	end_loop                        # label3:
+	i32.const	$push31=, u+1
+	i32.add 	$4=, $4, $pop31
+.LBB1_4:                                # %for.cond3.preheader
 	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
+	i32.const	$3=, 0
+	block
+	i32.const	$push26=, 0
+	i32.le_s	$push4=, $1, $pop26
+	br_if   	0, $pop4        # 0: down to label4
+.LBB1_5:                                # %for.body6
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label5:
+	i32.add 	$push5=, $4, $3
+	i32.load8_s	$push6=, 0($pop5)
+	i32.ne  	$push7=, $pop6, $2
+	br_if   	3, $pop7        # 3: down to label0
+# BB#6:                                 # %for.inc12
+                                        #   in Loop: Header=BB1_5 Depth=1
+	i32.const	$push32=, 1
+	i32.add 	$3=, $3, $pop32
+	i32.lt_s	$push8=, $3, $1
+	br_if   	0, $pop8        # 0: up to label5
+# BB#7:
+	end_loop                        # label6:
+	i32.add 	$4=, $4, $3
+.LBB1_8:                                # %for.body19.preheader
+	end_block                       # label4:
+	i32.load8_u	$push9=, 0($4)
+	i32.const	$push33=, 97
+	i32.ne  	$push10=, $pop9, $pop33
+	br_if   	0, $pop10       # 0: down to label0
+# BB#9:                                 # %for.inc25
+	i32.load8_u	$push11=, 1($4)
+	i32.const	$push34=, 97
+	i32.ne  	$push12=, $pop11, $pop34
+	br_if   	0, $pop12       # 0: down to label0
+# BB#10:                                # %for.inc25.1
+	i32.load8_u	$push13=, 2($4)
+	i32.const	$push35=, 97
+	i32.ne  	$push14=, $pop13, $pop35
+	br_if   	0, $pop14       # 0: down to label0
+# BB#11:                                # %for.inc25.2
+	i32.load8_u	$push15=, 3($4)
+	i32.const	$push36=, 97
+	i32.ne  	$push16=, $pop15, $pop36
+	br_if   	0, $pop16       # 0: down to label0
+# BB#12:                                # %for.inc25.3
+	i32.load8_u	$push17=, 4($4)
+	i32.const	$push37=, 97
+	i32.ne  	$push18=, $pop17, $pop37
+	br_if   	0, $pop18       # 0: down to label0
+# BB#13:                                # %for.inc25.4
+	i32.load8_u	$push19=, 5($4)
+	i32.const	$push38=, 97
+	i32.ne  	$push20=, $pop19, $pop38
+	br_if   	0, $pop20       # 0: down to label0
+# BB#14:                                # %for.inc25.5
+	i32.load8_u	$push21=, 6($4)
+	i32.const	$push39=, 97
+	i32.ne  	$push22=, $pop21, $pop39
+	br_if   	0, $pop22       # 0: down to label0
+# BB#15:                                # %for.inc25.6
+	i32.load8_u	$push23=, 7($4)
+	i32.const	$push40=, 97
+	i32.ne  	$push24=, $pop23, $pop40
+	br_if   	0, $pop24       # 0: down to label0
+# BB#16:                                # %for.inc25.7
+	return
 .LBB1_17:                               # %if.then23
 	end_block                       # label0:
 	call    	abort@FUNCTION
@@ -137,497 +129,482 @@ check:                                  # @check
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$1=, 0
 .LBB2_1:                                # %for.body
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB2_2 Depth 2
-                                        #     Child Loop BB2_13 Depth 2
-                                        #     Child Loop BB2_24 Depth 2
+                                        #     Child Loop BB2_14 Depth 2
+                                        #     Child Loop BB2_26 Depth 2
 	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label15:
+	loop                            # label8:
 	i32.const	$push0=, u
-	i32.const	$push107=, 97
-	i32.const	$push106=, 31
-	i32.call	$push1=, memset@FUNCTION, $pop0, $pop107, $pop106
-	i32.const	$push105=, 0
-	i32.call	$2=, memset@FUNCTION, $pop1, $pop105, $1
-	i32.const	$3=, 0
+	i32.const	$push84=, 97
+	i32.const	$push83=, 31
+	i32.call	$push1=, memset@FUNCTION, $pop0, $pop84, $pop83
+	i32.const	$push82=, 0
+	i32.call	$3=, memset@FUNCTION, $pop1, $pop82, $1
+	i32.const	$0=, 0
 	block
-	i32.const	$push104=, 1
-	i32.lt_s	$push103=, $1, $pop104
-	tee_local	$push102=, $4=, $pop103
-	br_if   	0, $pop102      # 0: down to label17
+	i32.const	$push81=, 1
+	i32.lt_s	$push80=, $1, $pop81
+	tee_local	$push79=, $2=, $pop80
+	br_if   	0, $pop79       # 0: down to label10
 .LBB2_2:                                # %for.body6.i
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label18:
-	i32.load8_u	$push2=, u($3)
-	br_if   	5, $pop2        # 5: down to label14
+	loop                            # label11:
+	copy_local	$push86=, $0
+	tee_local	$push85=, $3=, $pop86
+	i32.load8_u	$push2=, u($pop85)
+	br_if   	5, $pop2        # 5: down to label7
 # BB#3:                                 # %for.inc12.i
                                         #   in Loop: Header=BB2_2 Depth=2
-	i32.const	$push109=, u+1
-	i32.add 	$2=, $3, $pop109
-	i32.const	$push108=, 1
-	i32.add 	$0=, $3, $pop108
-	copy_local	$3=, $0
+	i32.const	$push87=, 1
+	i32.add 	$0=, $3, $pop87
 	i32.lt_s	$push3=, $0, $1
-	br_if   	0, $pop3        # 0: up to label18
-.LBB2_4:                                # %for.body19.preheader.i
+	br_if   	0, $pop3        # 0: up to label11
+# BB#4:                                 #   in Loop: Header=BB2_1 Depth=1
+	end_loop                        # label12:
+	i32.const	$push88=, u+1
+	i32.add 	$3=, $3, $pop88
+.LBB2_5:                                # %for.body19.preheader.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label19:
-	end_block                       # label17:
-	i32.load8_u	$push4=, 0($2)
-	i32.const	$push110=, 97
-	i32.ne  	$push5=, $pop4, $pop110
-	br_if   	5, $pop5        # 5: down to label11
-# BB#5:                                 # %for.inc25.i
+	end_block                       # label10:
+	i32.load8_u	$push4=, 0($3)
+	i32.const	$push89=, 97
+	i32.ne  	$push5=, $pop4, $pop89
+	br_if   	2, $pop5        # 2: down to label7
+# BB#6:                                 # %for.inc25.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push6=, 1($2)
-	i32.const	$push111=, 97
-	i32.ne  	$push7=, $pop6, $pop111
-	br_if   	5, $pop7        # 5: down to label11
-# BB#6:                                 # %for.inc25.1.i
+	i32.load8_u	$push6=, 1($3)
+	i32.const	$push90=, 97
+	i32.ne  	$push7=, $pop6, $pop90
+	br_if   	2, $pop7        # 2: down to label7
+# BB#7:                                 # %for.inc25.1.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push8=, 2($2)
-	i32.const	$push112=, 97
-	i32.ne  	$push9=, $pop8, $pop112
-	br_if   	5, $pop9        # 5: down to label11
-# BB#7:                                 # %for.inc25.2.i
+	i32.load8_u	$push8=, 2($3)
+	i32.const	$push91=, 97
+	i32.ne  	$push9=, $pop8, $pop91
+	br_if   	2, $pop9        # 2: down to label7
+# BB#8:                                 # %for.inc25.2.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push10=, 3($2)
-	i32.const	$push113=, 97
-	i32.ne  	$push11=, $pop10, $pop113
-	br_if   	5, $pop11       # 5: down to label11
-# BB#8:                                 # %for.inc25.3.i
+	i32.load8_u	$push10=, 3($3)
+	i32.const	$push92=, 97
+	i32.ne  	$push11=, $pop10, $pop92
+	br_if   	2, $pop11       # 2: down to label7
+# BB#9:                                 # %for.inc25.3.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push12=, 4($2)
-	i32.const	$push114=, 97
-	i32.ne  	$push13=, $pop12, $pop114
-	br_if   	5, $pop13       # 5: down to label11
-# BB#9:                                 # %for.inc25.4.i
+	i32.load8_u	$push12=, 4($3)
+	i32.const	$push93=, 97
+	i32.ne  	$push13=, $pop12, $pop93
+	br_if   	2, $pop13       # 2: down to label7
+# BB#10:                                # %for.inc25.4.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push14=, 5($2)
-	i32.const	$push115=, 97
-	i32.ne  	$push15=, $pop14, $pop115
-	br_if   	5, $pop15       # 5: down to label11
-# BB#10:                                # %for.inc25.5.i
+	i32.load8_u	$push14=, 5($3)
+	i32.const	$push94=, 97
+	i32.ne  	$push15=, $pop14, $pop94
+	br_if   	2, $pop15       # 2: down to label7
+# BB#11:                                # %for.inc25.5.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push16=, 6($2)
-	i32.const	$push116=, 97
-	i32.ne  	$push17=, $pop16, $pop116
-	br_if   	5, $pop17       # 5: down to label11
-# BB#11:                                # %for.inc25.6.i
+	i32.load8_u	$push16=, 6($3)
+	i32.const	$push95=, 97
+	i32.ne  	$push17=, $pop16, $pop95
+	br_if   	2, $pop17       # 2: down to label7
+# BB#12:                                # %for.inc25.6.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push18=, 7($2)
-	i32.const	$push117=, 97
-	i32.ne  	$push19=, $pop18, $pop117
-	br_if   	5, $pop19       # 5: down to label11
-# BB#12:                                # %check.exit
+	i32.load8_u	$push18=, 7($3)
+	i32.const	$push96=, 97
+	i32.ne  	$push19=, $pop18, $pop96
+	br_if   	2, $pop19       # 2: down to label7
+# BB#13:                                # %check.exit
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$3=, 0
+	i32.const	$0=, 0
 	i32.const	$push20=, u
-	i32.const	$push118=, 0
-	i32.load8_u	$push21=, A($pop118)
-	i32.call	$2=, memset@FUNCTION, $pop20, $pop21, $1
+	i32.const	$push97=, 0
+	i32.load8_u	$push21=, A($pop97)
+	i32.call	$3=, memset@FUNCTION, $pop20, $pop21, $1
 	block
-	br_if   	0, $4           # 0: down to label20
-.LBB2_13:                               # %for.body6.i241
+	br_if   	0, $2           # 0: down to label13
+.LBB2_14:                               # %for.body6.i241
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label21:
-	i32.load8_u	$push22=, u($3)
-	i32.const	$push119=, 65
-	i32.ne  	$push23=, $pop22, $pop119
-	br_if   	6, $pop23       # 6: down to label13
-# BB#14:                                # %for.inc12.i246
-                                        #   in Loop: Header=BB2_13 Depth=2
-	i32.const	$push121=, u+1
-	i32.add 	$2=, $3, $pop121
-	i32.const	$push120=, 1
-	i32.add 	$0=, $3, $pop120
-	copy_local	$3=, $0
+	loop                            # label14:
+	copy_local	$push100=, $0
+	tee_local	$push99=, $3=, $pop100
+	i32.load8_u	$push22=, u($pop99)
+	i32.const	$push98=, 65
+	i32.ne  	$push23=, $pop22, $pop98
+	br_if   	5, $pop23       # 5: down to label7
+# BB#15:                                # %for.inc12.i246
+                                        #   in Loop: Header=BB2_14 Depth=2
+	i32.const	$push101=, 1
+	i32.add 	$0=, $3, $pop101
 	i32.lt_s	$push24=, $0, $1
-	br_if   	0, $pop24       # 0: up to label21
-.LBB2_15:                               # %for.body19.preheader.i249
+	br_if   	0, $pop24       # 0: up to label14
+# BB#16:                                #   in Loop: Header=BB2_1 Depth=1
+	end_loop                        # label15:
+	i32.const	$push102=, u+1
+	i32.add 	$3=, $3, $pop102
+.LBB2_17:                               # %for.body19.preheader.i249
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label22:
-	end_block                       # label20:
-	i32.load8_u	$push25=, 0($2)
-	i32.const	$push122=, 97
-	i32.ne  	$push26=, $pop25, $pop122
-	br_if   	6, $pop26       # 6: down to label10
-# BB#16:                                # %for.inc25.i253
+	end_block                       # label13:
+	i32.load8_u	$push25=, 0($3)
+	i32.const	$push103=, 97
+	i32.ne  	$push26=, $pop25, $pop103
+	br_if   	2, $pop26       # 2: down to label7
+# BB#18:                                # %for.inc25.i253
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push27=, 1($2)
-	i32.const	$push123=, 97
-	i32.ne  	$push28=, $pop27, $pop123
-	br_if   	6, $pop28       # 6: down to label10
-# BB#17:                                # %for.inc25.1.i256
+	i32.load8_u	$push27=, 1($3)
+	i32.const	$push104=, 97
+	i32.ne  	$push28=, $pop27, $pop104
+	br_if   	2, $pop28       # 2: down to label7
+# BB#19:                                # %for.inc25.1.i256
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push29=, 2($2)
-	i32.const	$push124=, 97
-	i32.ne  	$push30=, $pop29, $pop124
-	br_if   	6, $pop30       # 6: down to label10
-# BB#18:                                # %for.inc25.2.i259
+	i32.load8_u	$push29=, 2($3)
+	i32.const	$push105=, 97
+	i32.ne  	$push30=, $pop29, $pop105
+	br_if   	2, $pop30       # 2: down to label7
+# BB#20:                                # %for.inc25.2.i259
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push31=, 3($2)
-	i32.const	$push125=, 97
-	i32.ne  	$push32=, $pop31, $pop125
-	br_if   	6, $pop32       # 6: down to label10
-# BB#19:                                # %for.inc25.3.i262
+	i32.load8_u	$push31=, 3($3)
+	i32.const	$push106=, 97
+	i32.ne  	$push32=, $pop31, $pop106
+	br_if   	2, $pop32       # 2: down to label7
+# BB#21:                                # %for.inc25.3.i262
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push33=, 4($2)
-	i32.const	$push126=, 97
-	i32.ne  	$push34=, $pop33, $pop126
-	br_if   	6, $pop34       # 6: down to label10
-# BB#20:                                # %for.inc25.4.i265
+	i32.load8_u	$push33=, 4($3)
+	i32.const	$push107=, 97
+	i32.ne  	$push34=, $pop33, $pop107
+	br_if   	2, $pop34       # 2: down to label7
+# BB#22:                                # %for.inc25.4.i265
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push35=, 5($2)
-	i32.const	$push127=, 97
-	i32.ne  	$push36=, $pop35, $pop127
-	br_if   	6, $pop36       # 6: down to label10
-# BB#21:                                # %for.inc25.5.i268
+	i32.load8_u	$push35=, 5($3)
+	i32.const	$push108=, 97
+	i32.ne  	$push36=, $pop35, $pop108
+	br_if   	2, $pop36       # 2: down to label7
+# BB#23:                                # %for.inc25.5.i268
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push37=, 6($2)
-	i32.const	$push128=, 97
-	i32.ne  	$push38=, $pop37, $pop128
-	br_if   	6, $pop38       # 6: down to label10
-# BB#22:                                # %for.inc25.6.i271
+	i32.load8_u	$push37=, 6($3)
+	i32.const	$push109=, 97
+	i32.ne  	$push38=, $pop37, $pop109
+	br_if   	2, $pop38       # 2: down to label7
+# BB#24:                                # %for.inc25.6.i271
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push39=, 7($2)
-	i32.const	$push129=, 97
-	i32.ne  	$push40=, $pop39, $pop129
-	br_if   	6, $pop40       # 6: down to label10
-# BB#23:                                # %check.exit272
+	i32.load8_u	$push39=, 7($3)
+	i32.const	$push110=, 97
+	i32.ne  	$push40=, $pop39, $pop110
+	br_if   	2, $pop40       # 2: down to label7
+# BB#25:                                # %check.exit272
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push41=, u
-	i32.const	$push130=, 66
-	i32.call	$2=, memset@FUNCTION, $pop41, $pop130, $1
-	i32.const	$3=, 0
+	i32.const	$push111=, 66
+	i32.call	$3=, memset@FUNCTION, $pop41, $pop111, $1
+	i32.const	$0=, 0
 	block
-	br_if   	0, $4           # 0: down to label23
-.LBB2_24:                               # %for.body6.i278
+	br_if   	0, $2           # 0: down to label16
+.LBB2_26:                               # %for.body6.i278
                                         #   Parent Loop BB2_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label24:
-	i32.load8_u	$push42=, u($3)
-	i32.const	$push131=, 66
-	i32.ne  	$push43=, $pop42, $pop131
-	br_if   	7, $pop43       # 7: down to label12
-# BB#25:                                # %for.inc12.i283
-                                        #   in Loop: Header=BB2_24 Depth=2
-	i32.const	$push133=, u+1
-	i32.add 	$2=, $3, $pop133
-	i32.const	$push132=, 1
-	i32.add 	$0=, $3, $pop132
-	copy_local	$3=, $0
+	loop                            # label17:
+	copy_local	$push114=, $0
+	tee_local	$push113=, $3=, $pop114
+	i32.load8_u	$push42=, u($pop113)
+	i32.const	$push112=, 66
+	i32.ne  	$push43=, $pop42, $pop112
+	br_if   	5, $pop43       # 5: down to label7
+# BB#27:                                # %for.inc12.i283
+                                        #   in Loop: Header=BB2_26 Depth=2
+	i32.const	$push115=, 1
+	i32.add 	$0=, $3, $pop115
 	i32.lt_s	$push44=, $0, $1
-	br_if   	0, $pop44       # 0: up to label24
-.LBB2_26:                               # %for.body19.preheader.i286
+	br_if   	0, $pop44       # 0: up to label17
+# BB#28:                                #   in Loop: Header=BB2_1 Depth=1
+	end_loop                        # label18:
+	i32.const	$push116=, u+1
+	i32.add 	$3=, $3, $pop116
+.LBB2_29:                               # %for.body19.preheader.i286
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_loop                        # label25:
-	end_block                       # label23:
-	i32.load8_u	$push45=, 0($2)
-	i32.const	$push134=, 97
-	i32.ne  	$push46=, $pop45, $pop134
-	br_if   	7, $pop46       # 7: down to label9
-# BB#27:                                # %for.inc25.i290
+	end_block                       # label16:
+	i32.load8_u	$push45=, 0($3)
+	i32.const	$push117=, 97
+	i32.ne  	$push46=, $pop45, $pop117
+	br_if   	2, $pop46       # 2: down to label7
+# BB#30:                                # %for.inc25.i290
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push47=, 1($2)
-	i32.const	$push135=, 97
-	i32.ne  	$push48=, $pop47, $pop135
-	br_if   	7, $pop48       # 7: down to label9
-# BB#28:                                # %for.inc25.1.i293
+	i32.load8_u	$push47=, 1($3)
+	i32.const	$push118=, 97
+	i32.ne  	$push48=, $pop47, $pop118
+	br_if   	2, $pop48       # 2: down to label7
+# BB#31:                                # %for.inc25.1.i293
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push49=, 2($2)
-	i32.const	$push136=, 97
-	i32.ne  	$push50=, $pop49, $pop136
-	br_if   	7, $pop50       # 7: down to label9
-# BB#29:                                # %for.inc25.2.i296
+	i32.load8_u	$push49=, 2($3)
+	i32.const	$push119=, 97
+	i32.ne  	$push50=, $pop49, $pop119
+	br_if   	2, $pop50       # 2: down to label7
+# BB#32:                                # %for.inc25.2.i296
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push51=, 3($2)
-	i32.const	$push137=, 97
-	i32.ne  	$push52=, $pop51, $pop137
-	br_if   	7, $pop52       # 7: down to label9
-# BB#30:                                # %for.inc25.3.i299
+	i32.load8_u	$push51=, 3($3)
+	i32.const	$push120=, 97
+	i32.ne  	$push52=, $pop51, $pop120
+	br_if   	2, $pop52       # 2: down to label7
+# BB#33:                                # %for.inc25.3.i299
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push53=, 4($2)
+	i32.load8_u	$push53=, 4($3)
+	i32.const	$push121=, 97
+	i32.ne  	$push54=, $pop53, $pop121
+	br_if   	2, $pop54       # 2: down to label7
+# BB#34:                                # %for.inc25.4.i302
+                                        #   in Loop: Header=BB2_1 Depth=1
+	i32.load8_u	$push55=, 5($3)
+	i32.const	$push122=, 97
+	i32.ne  	$push56=, $pop55, $pop122
+	br_if   	2, $pop56       # 2: down to label7
+# BB#35:                                # %for.inc25.5.i305
+                                        #   in Loop: Header=BB2_1 Depth=1
+	i32.load8_u	$push57=, 6($3)
+	i32.const	$push123=, 97
+	i32.ne  	$push58=, $pop57, $pop123
+	br_if   	2, $pop58       # 2: down to label7
+# BB#36:                                # %for.inc25.6.i308
+                                        #   in Loop: Header=BB2_1 Depth=1
+	i32.load8_u	$push59=, 7($3)
+	i32.const	$push124=, 97
+	i32.ne  	$push60=, $pop59, $pop124
+	br_if   	2, $pop60       # 2: down to label7
+# BB#37:                                # %for.cond
+                                        #   in Loop: Header=BB2_1 Depth=1
+	i32.const	$push78=, 1
+	i32.add 	$1=, $1, $pop78
+	i32.const	$push77=, 14
+	i32.le_s	$push61=, $1, $pop77
+	br_if   	0, $pop61       # 0: up to label8
+# BB#38:
+	end_loop                        # label9:
+	i32.const	$0=, 0
+.LBB2_39:                               # %for.body13
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label19:
+	i32.const	$push139=, u
 	i32.const	$push138=, 97
-	i32.ne  	$push54=, $pop53, $pop138
-	br_if   	7, $pop54       # 7: down to label9
-# BB#31:                                # %for.inc25.4.i302
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push55=, 5($2)
-	i32.const	$push139=, 97
-	i32.ne  	$push56=, $pop55, $pop139
-	br_if   	7, $pop56       # 7: down to label9
-# BB#32:                                # %for.inc25.5.i305
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push57=, 6($2)
-	i32.const	$push140=, 97
-	i32.ne  	$push58=, $pop57, $pop140
-	br_if   	7, $pop58       # 7: down to label9
-# BB#33:                                # %for.inc25.6.i308
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.load8_u	$push59=, 7($2)
-	i32.const	$push141=, 97
-	i32.ne  	$push60=, $pop59, $pop141
-	br_if   	7, $pop60       # 7: down to label9
-# BB#34:                                # %for.cond
-                                        #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push101=, 1
-	i32.add 	$1=, $1, $pop101
-	i32.const	$3=, 0
-	i32.const	$0=, 0
-	i32.const	$push100=, 14
-	i32.le_s	$push61=, $1, $pop100
-	br_if   	0, $pop61       # 0: up to label15
-.LBB2_35:                               # %for.body13
-                                        # =>This Inner Loop Header: Depth=1
-	end_loop                        # label16:
-	loop                            # label26:
-	i32.const	$push62=, u
-	i32.const	$push154=, 97
-	i32.const	$push153=, 31
-	i32.call	$2=, memset@FUNCTION, $pop62, $pop154, $pop153
-	i32.const	$push63=, u+1
-	i32.const	$push152=, 0
-	i32.call	$1=, memset@FUNCTION, $pop63, $pop152, $0
-	i32.const	$push151=, 1
-	i32.const	$push150=, 0
-	call    	check@FUNCTION, $pop151, $0, $pop150
-	i32.const	$push149=, 0
-	i32.load8_u	$push64=, A($pop149)
-	i32.call	$discard=, memset@FUNCTION, $1, $pop64, $0
-	i32.const	$push148=, 1
-	i32.const	$push147=, 65
-	call    	check@FUNCTION, $pop148, $0, $pop147
-	i32.const	$push146=, 66
-	i32.call	$discard=, memset@FUNCTION, $1, $pop146, $0
-	i32.const	$push145=, 1
-	i32.const	$push144=, 66
-	call    	check@FUNCTION, $pop145, $0, $pop144
-	i32.const	$push143=, 1
-	i32.add 	$0=, $0, $pop143
-	i32.const	$push142=, 15
-	i32.ne  	$push65=, $0, $pop142
-	br_if   	0, $pop65       # 0: up to label26
-.LBB2_36:                               # %for.body33
-                                        # =>This Inner Loop Header: Depth=1
-	end_loop                        # label27:
-	loop                            # label28:
-	i32.const	$push166=, 97
-	i32.const	$push165=, 31
-	i32.call	$discard=, memset@FUNCTION, $2, $pop166, $pop165
+	i32.const	$push137=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop139, $pop138, $pop137
 	i32.const	$1=, 0
-	i32.const	$push66=, u+2
-	i32.const	$push164=, 0
-	i32.call	$0=, memset@FUNCTION, $pop66, $pop164, $3
-	i32.const	$push67=, 2
+	i32.const	$push136=, u+1
+	i32.const	$push135=, 0
+	i32.call	$3=, memset@FUNCTION, $pop136, $pop135, $0
+	i32.const	$push134=, 1
+	i32.const	$push133=, 0
+	call    	check@FUNCTION, $pop134, $0, $pop133
+	i32.const	$push132=, 0
+	i32.load8_u	$push62=, A($pop132)
+	i32.call	$discard=, memset@FUNCTION, $3, $pop62, $0
+	i32.const	$push131=, 1
+	i32.const	$push130=, 65
+	call    	check@FUNCTION, $pop131, $0, $pop130
+	i32.const	$push129=, 66
+	i32.call	$discard=, memset@FUNCTION, $3, $pop129, $0
+	i32.const	$push128=, 1
+	i32.const	$push127=, 66
+	call    	check@FUNCTION, $pop128, $0, $pop127
+	i32.const	$push126=, 1
+	i32.add 	$0=, $0, $pop126
+	i32.const	$push125=, 15
+	i32.ne  	$push63=, $0, $pop125
+	br_if   	0, $pop63       # 0: up to label19
+.LBB2_40:                               # %for.body33
+                                        # =>This Inner Loop Header: Depth=1
+	end_loop                        # label20:
+	loop                            # label21:
+	i32.const	$push154=, u
+	i32.const	$push153=, 97
+	i32.const	$push152=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop154, $pop153, $pop152
+	i32.const	$0=, 0
+	i32.const	$push151=, u+2
+	i32.const	$push150=, 0
+	i32.call	$3=, memset@FUNCTION, $pop151, $pop150, $1
+	i32.const	$push149=, 2
+	i32.const	$push148=, 0
+	call    	check@FUNCTION, $pop149, $1, $pop148
+	i32.const	$push147=, 0
+	i32.load8_u	$push64=, A($pop147)
+	i32.call	$discard=, memset@FUNCTION, $3, $pop64, $1
+	i32.const	$push146=, 2
+	i32.const	$push145=, 65
+	call    	check@FUNCTION, $pop146, $1, $pop145
+	i32.const	$push144=, 66
+	i32.call	$discard=, memset@FUNCTION, $3, $pop144, $1
+	i32.const	$push143=, 2
+	i32.const	$push142=, 66
+	call    	check@FUNCTION, $pop143, $1, $pop142
+	i32.const	$push141=, 1
+	i32.add 	$1=, $1, $pop141
+	i32.const	$push140=, 15
+	i32.ne  	$push65=, $1, $pop140
+	br_if   	0, $pop65       # 0: up to label21
+.LBB2_41:                               # %for.body53
+                                        # =>This Inner Loop Header: Depth=1
+	end_loop                        # label22:
+	loop                            # label23:
+	i32.const	$push169=, u
+	i32.const	$push168=, 97
+	i32.const	$push167=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop169, $pop168, $pop167
+	i32.const	$1=, 0
+	i32.const	$push166=, u+3
+	i32.const	$push165=, 0
+	i32.call	$3=, memset@FUNCTION, $pop166, $pop165, $0
+	i32.const	$push164=, 3
 	i32.const	$push163=, 0
-	call    	check@FUNCTION, $pop67, $3, $pop163
+	call    	check@FUNCTION, $pop164, $0, $pop163
 	i32.const	$push162=, 0
-	i32.load8_u	$push68=, A($pop162)
-	i32.call	$discard=, memset@FUNCTION, $0, $pop68, $3
-	i32.const	$push161=, 2
+	i32.load8_u	$push66=, A($pop162)
+	i32.call	$discard=, memset@FUNCTION, $3, $pop66, $0
+	i32.const	$push161=, 3
 	i32.const	$push160=, 65
-	call    	check@FUNCTION, $pop161, $3, $pop160
+	call    	check@FUNCTION, $pop161, $0, $pop160
 	i32.const	$push159=, 66
-	i32.call	$discard=, memset@FUNCTION, $0, $pop159, $3
-	i32.const	$push158=, 2
+	i32.call	$discard=, memset@FUNCTION, $3, $pop159, $0
+	i32.const	$push158=, 3
 	i32.const	$push157=, 66
-	call    	check@FUNCTION, $pop158, $3, $pop157
+	call    	check@FUNCTION, $pop158, $0, $pop157
 	i32.const	$push156=, 1
-	i32.add 	$3=, $3, $pop156
-	i32.const	$0=, 0
+	i32.add 	$0=, $0, $pop156
 	i32.const	$push155=, 15
-	i32.ne  	$push69=, $3, $pop155
-	br_if   	0, $pop69       # 0: up to label28
-.LBB2_37:                               # %for.body53
+	i32.ne  	$push67=, $0, $pop155
+	br_if   	0, $pop67       # 0: up to label23
+.LBB2_42:                               # %for.body73
                                         # =>This Inner Loop Header: Depth=1
-	end_loop                        # label29:
-	loop                            # label30:
-	i32.const	$push70=, u
-	i32.const	$push178=, 97
-	i32.const	$push177=, 31
-	i32.call	$2=, memset@FUNCTION, $pop70, $pop178, $pop177
-	i32.const	$push71=, u+3
-	i32.const	$push176=, 0
-	i32.call	$3=, memset@FUNCTION, $pop71, $pop176, $0
-	i32.const	$push72=, 3
-	i32.const	$push175=, 0
-	call    	check@FUNCTION, $pop72, $0, $pop175
-	i32.const	$push174=, 0
-	i32.load8_u	$push73=, A($pop174)
-	i32.call	$discard=, memset@FUNCTION, $3, $pop73, $0
-	i32.const	$push173=, 3
-	i32.const	$push172=, 65
-	call    	check@FUNCTION, $pop173, $0, $pop172
-	i32.const	$push171=, 66
-	i32.call	$discard=, memset@FUNCTION, $3, $pop171, $0
-	i32.const	$push170=, 3
-	i32.const	$push169=, 66
-	call    	check@FUNCTION, $pop170, $0, $pop169
-	i32.const	$push168=, 1
-	i32.add 	$0=, $0, $pop168
-	i32.const	$push167=, 15
-	i32.ne  	$push74=, $0, $pop167
-	br_if   	0, $pop74       # 0: up to label30
-.LBB2_38:                               # %for.body73
-                                        # =>This Inner Loop Header: Depth=1
-	end_loop                        # label31:
-	loop                            # label32:
-	i32.const	$push190=, 97
-	i32.const	$push189=, 31
-	i32.call	$discard=, memset@FUNCTION, $2, $pop190, $pop189
+	end_loop                        # label24:
+	loop                            # label25:
+	i32.const	$push184=, u
+	i32.const	$push183=, 97
+	i32.const	$push182=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop184, $pop183, $pop182
 	i32.const	$0=, 0
-	i32.const	$push75=, u+4
-	i32.const	$push188=, 0
-	i32.call	$3=, memset@FUNCTION, $pop75, $pop188, $1
-	i32.const	$push76=, 4
-	i32.const	$push187=, 0
-	call    	check@FUNCTION, $pop76, $1, $pop187
-	i32.const	$push186=, 0
-	i32.load8_u	$push77=, A($pop186)
-	i32.call	$discard=, memset@FUNCTION, $3, $pop77, $1
-	i32.const	$push185=, 4
-	i32.const	$push184=, 65
-	call    	check@FUNCTION, $pop185, $1, $pop184
-	i32.const	$push183=, 66
-	i32.call	$discard=, memset@FUNCTION, $3, $pop183, $1
-	i32.const	$push182=, 4
-	i32.const	$push181=, 66
-	call    	check@FUNCTION, $pop182, $1, $pop181
-	i32.const	$push180=, 1
-	i32.add 	$1=, $1, $pop180
-	i32.const	$3=, 0
-	i32.const	$push179=, 15
-	i32.ne  	$push78=, $1, $pop179
-	br_if   	0, $pop78       # 0: up to label32
-.LBB2_39:                               # %for.body93
+	i32.const	$push181=, u+4
+	i32.const	$push180=, 0
+	i32.call	$3=, memset@FUNCTION, $pop181, $pop180, $1
+	i32.const	$push179=, 4
+	i32.const	$push178=, 0
+	call    	check@FUNCTION, $pop179, $1, $pop178
+	i32.const	$push177=, 0
+	i32.load8_u	$push68=, A($pop177)
+	i32.call	$discard=, memset@FUNCTION, $3, $pop68, $1
+	i32.const	$push176=, 4
+	i32.const	$push175=, 65
+	call    	check@FUNCTION, $pop176, $1, $pop175
+	i32.const	$push174=, 66
+	i32.call	$discard=, memset@FUNCTION, $3, $pop174, $1
+	i32.const	$push173=, 4
+	i32.const	$push172=, 66
+	call    	check@FUNCTION, $pop173, $1, $pop172
+	i32.const	$push171=, 1
+	i32.add 	$1=, $1, $pop171
+	i32.const	$push170=, 15
+	i32.ne  	$push69=, $1, $pop170
+	br_if   	0, $pop69       # 0: up to label25
+.LBB2_43:                               # %for.body93
                                         # =>This Inner Loop Header: Depth=1
-	end_loop                        # label33:
-	loop                            # label34:
-	i32.const	$push79=, u
-	i32.const	$push202=, 97
-	i32.const	$push201=, 31
-	i32.call	$1=, memset@FUNCTION, $pop79, $pop202, $pop201
-	i32.const	$push80=, u+5
-	i32.const	$push200=, 0
-	i32.call	$2=, memset@FUNCTION, $pop80, $pop200, $3
-	i32.const	$push81=, 5
-	i32.const	$push199=, 0
-	call    	check@FUNCTION, $pop81, $3, $pop199
-	i32.const	$push198=, 0
-	i32.load8_u	$push82=, A($pop198)
-	i32.call	$discard=, memset@FUNCTION, $2, $pop82, $3
-	i32.const	$push197=, 5
-	i32.const	$push196=, 65
-	call    	check@FUNCTION, $pop197, $3, $pop196
-	i32.const	$push195=, 66
-	i32.call	$discard=, memset@FUNCTION, $2, $pop195, $3
+	end_loop                        # label26:
+	loop                            # label27:
+	i32.const	$push199=, u
+	i32.const	$push198=, 97
+	i32.const	$push197=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop199, $pop198, $pop197
+	i32.const	$3=, 0
+	i32.const	$push196=, u+5
+	i32.const	$push195=, 0
+	i32.call	$1=, memset@FUNCTION, $pop196, $pop195, $0
 	i32.const	$push194=, 5
-	i32.const	$push193=, 66
-	call    	check@FUNCTION, $pop194, $3, $pop193
-	i32.const	$push192=, 1
-	i32.add 	$3=, $3, $pop192
-	i32.const	$push191=, 15
-	i32.ne  	$push83=, $3, $pop191
-	br_if   	0, $pop83       # 0: up to label34
-.LBB2_40:                               # %for.body113
+	i32.const	$push193=, 0
+	call    	check@FUNCTION, $pop194, $0, $pop193
+	i32.const	$push192=, 0
+	i32.load8_u	$push70=, A($pop192)
+	i32.call	$discard=, memset@FUNCTION, $1, $pop70, $0
+	i32.const	$push191=, 5
+	i32.const	$push190=, 65
+	call    	check@FUNCTION, $pop191, $0, $pop190
+	i32.const	$push189=, 66
+	i32.call	$discard=, memset@FUNCTION, $1, $pop189, $0
+	i32.const	$push188=, 5
+	i32.const	$push187=, 66
+	call    	check@FUNCTION, $pop188, $0, $pop187
+	i32.const	$push186=, 1
+	i32.add 	$0=, $0, $pop186
+	i32.const	$push185=, 15
+	i32.ne  	$push71=, $0, $pop185
+	br_if   	0, $pop71       # 0: up to label27
+.LBB2_44:                               # %for.body113
                                         # =>This Inner Loop Header: Depth=1
-	end_loop                        # label35:
-	loop                            # label36:
-	i32.const	$push214=, 97
-	i32.const	$push213=, 31
-	i32.call	$discard=, memset@FUNCTION, $1, $pop214, $pop213
-	i32.const	$push84=, u+6
-	i32.const	$push212=, 0
-	i32.call	$3=, memset@FUNCTION, $pop84, $pop212, $0
-	i32.const	$push85=, 6
-	i32.const	$push211=, 0
-	call    	check@FUNCTION, $pop85, $0, $pop211
+	end_loop                        # label28:
+	loop                            # label29:
+	i32.const	$push214=, u
+	i32.const	$push213=, 97
+	i32.const	$push212=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop214, $pop213, $pop212
+	i32.const	$1=, 0
+	i32.const	$push211=, u+6
 	i32.const	$push210=, 0
-	i32.load8_u	$push86=, A($pop210)
-	i32.call	$discard=, memset@FUNCTION, $3, $pop86, $0
+	i32.call	$0=, memset@FUNCTION, $pop211, $pop210, $3
 	i32.const	$push209=, 6
-	i32.const	$push208=, 65
-	call    	check@FUNCTION, $pop209, $0, $pop208
-	i32.const	$push207=, 66
-	i32.call	$discard=, memset@FUNCTION, $3, $pop207, $0
+	i32.const	$push208=, 0
+	call    	check@FUNCTION, $pop209, $3, $pop208
+	i32.const	$push207=, 0
+	i32.load8_u	$push72=, A($pop207)
+	i32.call	$discard=, memset@FUNCTION, $0, $pop72, $3
 	i32.const	$push206=, 6
-	i32.const	$push205=, 66
-	call    	check@FUNCTION, $pop206, $0, $pop205
-	i32.const	$push204=, 1
-	i32.add 	$0=, $0, $pop204
-	i32.const	$3=, 0
-	i32.const	$push203=, 15
-	i32.ne  	$push87=, $0, $pop203
-	br_if   	0, $pop87       # 0: up to label36
-.LBB2_41:                               # %for.body133
+	i32.const	$push205=, 65
+	call    	check@FUNCTION, $pop206, $3, $pop205
+	i32.const	$push204=, 66
+	i32.call	$discard=, memset@FUNCTION, $0, $pop204, $3
+	i32.const	$push203=, 6
+	i32.const	$push202=, 66
+	call    	check@FUNCTION, $pop203, $3, $pop202
+	i32.const	$push201=, 1
+	i32.add 	$3=, $3, $pop201
+	i32.const	$push200=, 15
+	i32.ne  	$push73=, $3, $pop200
+	br_if   	0, $pop73       # 0: up to label29
+.LBB2_45:                               # %for.body133
                                         # =>This Inner Loop Header: Depth=1
-	end_loop                        # label37:
-	loop                            # label38:
-	i32.const	$push88=, u
-	i32.const	$push90=, 97
-	i32.const	$push89=, 31
-	i32.call	$discard=, memset@FUNCTION, $pop88, $pop90, $pop89
-	i32.const	$push91=, u+7
-	i32.const	$push220=, 0
-	i32.call	$1=, memset@FUNCTION, $pop91, $pop220, $3
-	i32.const	$push92=, 7
-	i32.const	$push219=, 0
-	call    	check@FUNCTION, $pop92, $3, $pop219
-	i32.const	$push218=, 0
-	i32.load8_u	$push93=, A($pop218)
-	i32.call	$discard=, memset@FUNCTION, $1, $pop93, $3
-	i32.const	$push217=, 7
-	i32.const	$push94=, 65
-	call    	check@FUNCTION, $pop217, $3, $pop94
-	i32.const	$push95=, 66
-	i32.call	$discard=, memset@FUNCTION, $1, $pop95, $3
-	i32.const	$push216=, 7
-	i32.const	$push215=, 66
-	call    	check@FUNCTION, $pop216, $3, $pop215
-	i32.const	$push96=, 1
-	i32.add 	$3=, $3, $pop96
-	i32.const	$push97=, 15
-	i32.ne  	$push98=, $3, $pop97
-	br_if   	0, $pop98       # 0: up to label38
-# BB#42:                                # %for.end149
-	end_loop                        # label39:
-	i32.const	$push99=, 0
-	call    	exit@FUNCTION, $pop99
+	end_loop                        # label30:
+	loop                            # label31:
+	i32.const	$push229=, u
+	i32.const	$push228=, 97
+	i32.const	$push227=, 31
+	i32.call	$discard=, memset@FUNCTION, $pop229, $pop228, $pop227
+	i32.const	$push226=, u+7
+	i32.const	$push225=, 0
+	i32.call	$0=, memset@FUNCTION, $pop226, $pop225, $1
+	i32.const	$push224=, 7
+	i32.const	$push223=, 0
+	call    	check@FUNCTION, $pop224, $1, $pop223
+	i32.const	$push222=, 0
+	i32.load8_u	$push74=, A($pop222)
+	i32.call	$discard=, memset@FUNCTION, $0, $pop74, $1
+	i32.const	$push221=, 7
+	i32.const	$push220=, 65
+	call    	check@FUNCTION, $pop221, $1, $pop220
+	i32.const	$push219=, 66
+	i32.call	$discard=, memset@FUNCTION, $0, $pop219, $1
+	i32.const	$push218=, 7
+	i32.const	$push217=, 66
+	call    	check@FUNCTION, $pop218, $1, $pop217
+	i32.const	$push216=, 1
+	i32.add 	$1=, $1, $pop216
+	i32.const	$push215=, 15
+	i32.ne  	$push75=, $1, $pop215
+	br_if   	0, $pop75       # 0: up to label31
+# BB#46:                                # %for.end149
+	end_loop                        # label32:
+	i32.const	$push76=, 0
+	call    	exit@FUNCTION, $pop76
 	unreachable
-.LBB2_43:                               # %if.then10.i
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_44:                               # %if.then10.i242
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_45:                               # %if.then10.i279
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_46:                               # %if.then23.i
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_47:                               # %if.then23.i250
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_48:                               # %if.then23.i287
-	end_block                       # label9:
+.LBB2_47:                               # %if.then23.i287
+	end_block                       # label7:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/mode-dependent-address.c.s
+++ b/test/torture-s/mode-dependent-address.c.s
@@ -58,99 +58,101 @@ f883b:                                  # @f883b
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i64, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$3=, 0
-	i32.const	$8=, arg1
-	i32.const	$5=, arg2
-	i32.const	$6=, arg3
-	i32.const	$1=, arg3
-	i32.const	$2=, arg2
+	i32.const	$2=, arg1
+	i32.const	$4=, arg2
+	i32.const	$5=, arg3
+	i32.const	$0=, arg3
+	i32.const	$1=, arg2
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.store8	$push37=, arg4($3), $3
-	tee_local	$push36=, $4=, $pop37
-	i32.const	$push35=, 255
-	i32.and 	$push1=, $pop36, $pop35
-	i32.store16	$push2=, 0($8), $pop1
-	i32.store	$discard=, 0($2), $pop2
+	i32.store8	$push30=, arg4($3), $3
+	tee_local	$push29=, $6=, $pop30
+	i32.const	$push28=, 255
+	i32.and 	$push1=, $pop29, $pop28
+	i32.store16	$push2=, 0($2), $pop1
+	i32.store	$discard=, 0($1), $pop2
 	i64.extend_u/i32	$push0=, $3
-	i64.const	$push34=, 255
-	i64.and 	$push3=, $pop0, $pop34
-	i64.store	$discard=, 0($1), $pop3
-	i32.const	$push33=, 1
-	i32.add 	$3=, $4, $pop33
-	i32.const	$push32=, 2
-	i32.add 	$8=, $8, $pop32
-	i32.const	$push31=, 4
-	i32.add 	$2=, $2, $pop31
-	i32.const	$push30=, 8
-	i32.add 	$1=, $1, $pop30
-	i32.const	$7=, result
-	i32.const	$4=, -192
-	i32.const	$push29=, 96
-	i32.ne  	$push4=, $3, $pop29
+	i64.const	$push27=, 255
+	i64.and 	$push3=, $pop0, $pop27
+	i64.store	$discard=, 0($0), $pop3
+	i32.const	$push26=, 1
+	i32.add 	$3=, $6, $pop26
+	i32.const	$push25=, 2
+	i32.add 	$2=, $2, $pop25
+	i32.const	$push24=, 4
+	i32.add 	$1=, $1, $pop24
+	i32.const	$push23=, 8
+	i32.add 	$0=, $0, $pop23
+	i32.const	$push22=, 96
+	i32.ne  	$push4=, $3, $pop22
 	br_if   	0, $pop4        # 0: up to label2
-.LBB1_2:                                # %for.body.i
-                                        # =>This Inner Loop Header: Depth=1
+# BB#2:
 	end_loop                        # label3:
+	i32.const	$2=, result
+	i32.const	$3=, -192
+.LBB1_3:                                # %for.body.i
+                                        # =>This Inner Loop Header: Depth=1
 	loop                            # label4:
-	i32.load16_s	$3=, arg1+192($4)
-	i32.load	$8=, 0($5)
-	i64.load	$0=, 0($6)
-	i32.const	$push19=, 8
-	i32.add 	$6=, $6, $pop19
-	i32.const	$push20=, 4
-	i32.add 	$5=, $5, $pop20
-	i32.const	$push21=, 2
-	i32.add 	$4=, $4, $pop21
+	i32.load16_s	$0=, arg1+192($3)
 	i32.const	$push41=, 1
 	i32.const	$push40=, 1
-	i32.lt_s	$push5=, $3, $pop40
-	i32.select	$push6=, $3, $pop41, $pop5
-	i32.const	$push7=, 31
-	i32.and 	$push8=, $8, $pop7
+	i32.lt_s	$push5=, $0, $pop40
+	i32.select	$push6=, $0, $pop41, $pop5
+	i32.load	$push7=, 0($4)
+	i32.const	$push39=, 31
+	i32.and 	$push8=, $pop7, $pop39
 	i32.shr_s	$push9=, $pop6, $pop8
-	i32.const	$push39=, 1
-	i32.xor 	$push10=, $pop9, $pop39
-	i32.const	$push11=, 32
-	i32.add 	$push12=, $pop10, $pop11
-	i32.const	$push13=, 7
-	i32.shr_u	$push14=, $pop12, $pop13
-	i32.const	$push15=, 251
-	i32.or  	$push16=, $pop14, $pop15
-	i64.extend_u/i32	$push17=, $pop16
-	i64.and 	$push18=, $0, $pop17
-	i64.store8	$discard=, 0($7), $pop18
 	i32.const	$push38=, 1
-	i32.add 	$7=, $7, $pop38
-	i32.const	$3=, 0
-	i32.const	$8=, .Lmain.correct
-	br_if   	0, $4           # 0: up to label4
-.LBB1_3:                                # %for.body10
-                                        # =>This Inner Loop Header: Depth=1
+	i32.xor 	$push10=, $pop9, $pop38
+	i32.const	$push37=, 32
+	i32.add 	$push11=, $pop10, $pop37
+	i32.const	$push36=, 7
+	i32.shr_u	$push12=, $pop11, $pop36
+	i32.const	$push35=, 251
+	i32.or  	$push13=, $pop12, $pop35
+	i64.extend_u/i32	$push14=, $pop13
+	i64.load	$push15=, 0($5)
+	i64.and 	$push16=, $pop14, $pop15
+	i64.store8	$discard=, 0($2), $pop16
+	i32.const	$push34=, 1
+	i32.add 	$2=, $2, $pop34
+	i32.const	$push33=, 8
+	i32.add 	$5=, $5, $pop33
+	i32.const	$push32=, 4
+	i32.add 	$4=, $4, $pop32
+	i32.const	$push31=, 2
+	i32.add 	$3=, $3, $pop31
+	br_if   	0, $3           # 0: up to label4
+# BB#4:
 	end_loop                        # label5:
+	i32.const	$3=, 0
+	i32.const	$2=, .Lmain.correct
+.LBB1_5:                                # %for.body10
+                                        # =>This Inner Loop Header: Depth=1
 	block
 	loop                            # label7:
-	i32.load8_s	$push22=, result($3)
-	i32.load	$push23=, 0($8)
-	i32.ne  	$push24=, $pop22, $pop23
-	br_if   	2, $pop24       # 2: down to label6
-# BB#4:                                 # %for.cond7
-                                        #   in Loop: Header=BB1_3 Depth=1
-	i32.const	$push25=, 4
-	i32.add 	$8=, $8, $pop25
-	i32.const	$push42=, 1
-	i32.add 	$3=, $3, $pop42
-	i32.const	$push26=, 95
-	i32.le_s	$push27=, $3, $pop26
-	br_if   	0, $pop27       # 0: up to label7
-# BB#5:                                 # %for.end18
+	i32.load8_s	$push17=, result($3)
+	i32.load	$push18=, 0($2)
+	i32.ne  	$push19=, $pop17, $pop18
+	br_if   	2, $pop19       # 2: down to label6
+# BB#6:                                 # %for.cond7
+                                        #   in Loop: Header=BB1_5 Depth=1
+	i32.const	$push44=, 1
+	i32.add 	$3=, $3, $pop44
+	i32.const	$push43=, 4
+	i32.add 	$2=, $2, $pop43
+	i32.const	$push42=, 95
+	i32.le_s	$push20=, $3, $pop42
+	br_if   	0, $pop20       # 0: up to label7
+# BB#7:                                 # %for.end18
 	end_loop                        # label8:
-	i32.const	$push28=, 0
-	return  	$pop28
-.LBB1_6:                                # %if.then
+	i32.const	$push21=, 0
+	return  	$pop21
+.LBB1_8:                                # %if.then
 	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/multi-ix.c.s
+++ b/test/torture-s/multi-ix.c.s
@@ -1151,21 +1151,21 @@ z:                                      # @z
 .LBB2_1:                                # %while.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label7:
-	i32.load	$push1=, 12($5)
-	i32.const	$push2=, 3
-	i32.add 	$push3=, $pop1, $pop2
-	i32.const	$push4=, -4
-	i32.and 	$push11=, $pop3, $pop4
-	tee_local	$push10=, $1=, $pop11
-	i32.const	$push5=, 4
-	i32.add 	$push6=, $pop10, $pop5
-	i32.store	$discard=, 12($5), $pop6
-	i32.const	$push0=, -1
-	i32.add 	$0=, $0, $pop0
-	i32.load	$push7=, 0($1)
-	i32.const	$push9=, 0
-	i32.const	$push8=, 2000
-	i32.call	$discard=, memset@FUNCTION, $pop7, $pop9, $pop8
+	i32.load	$push0=, 12($5)
+	i32.const	$push11=, 3
+	i32.add 	$push1=, $pop0, $pop11
+	i32.const	$push10=, -4
+	i32.and 	$push9=, $pop1, $pop10
+	tee_local	$push8=, $1=, $pop9
+	i32.const	$push7=, 4
+	i32.add 	$push2=, $pop8, $pop7
+	i32.store	$discard=, 12($5), $pop2
+	i32.const	$push6=, -1
+	i32.add 	$0=, $0, $pop6
+	i32.load	$push3=, 0($1)
+	i32.const	$push5=, 0
+	i32.const	$push4=, 2000
+	i32.call	$discard=, memset@FUNCTION, $pop3, $pop5, $pop4
 	br_if   	0, $0           # 0: up to label7
 .LBB2_2:                                # %while.end
 	end_loop                        # label8:

--- a/test/torture-s/nestfunc-4.c.s
+++ b/test/torture-s/nestfunc-4.c.s
@@ -11,8 +11,8 @@ main:                                   # @main
 	i32.const	$push0=, 0
 	i32.load	$0=, level($pop0)
 	i32.const	$push8=, 0
-	i32.const	$push1=, 499
-	i32.const	$push7=, 499
+	i32.const	$push1=, 2040
+	i32.const	$push7=, 2040
 	i32.gt_s	$push2=, $0, $pop7
 	i32.select	$push3=, $0, $pop1, $pop2
 	i32.const	$push4=, 1
@@ -36,8 +36,8 @@ foo:                                    # @foo
 	i32.const	$push0=, 0
 	i32.load	$0=, level($pop0)
 	i32.const	$push8=, 0
-	i32.const	$push1=, 499
-	i32.const	$push7=, 499
+	i32.const	$push1=, 2040
+	i32.const	$push7=, 2040
 	i32.gt_s	$push2=, $0, $pop7
 	i32.select	$push3=, $0, $pop1, $pop2
 	i32.const	$push4=, 1
@@ -62,7 +62,7 @@ bar:                                    # @bar
 	i32.const	$push0=, 0
 	i32.load	$push5=, level($pop0)
 	tee_local	$push4=, $1=, $pop5
-	i32.const	$push1=, 499
+	i32.const	$push1=, 2040
 	i32.gt_s	$push2=, $pop4, $pop1
 	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %cond.false

--- a/test/torture-s/pr15296.c.s
+++ b/test/torture-s/pr15296.c.s
@@ -22,56 +22,46 @@ f:                                      # @f
 	block
 	block
 	block
-	block
-	block
 	i32.const	$push12=, 0
 	i32.eq  	$push13=, $3, $pop12
-	br_if   	0, $pop13       # 0: down to label8
+	br_if   	0, $pop13       # 0: down to label6
 # BB#3:                                 # %if.end3
 	copy_local	$4=, $5
 	i32.const	$push14=, 0
 	i32.eq  	$push15=, $5, $pop14
-	br_if   	1, $pop15       # 1: down to label7
+	br_if   	1, $pop15       # 1: down to label5
 .LBB0_4:                                # %l3
-	end_block                       # label8:
+	end_block                       # label6:
 	i32.const	$push10=, 8
 	i32.add 	$push11=, $1, $pop10
 	i32.load	$3=, 0($pop11)
 	i32.const	$push8=, 4
 	i32.add 	$push9=, $1, $pop8
 	i32.store	$1=, 0($pop9), $4
-	br_if   	2, $3           # 2: down to label5
+	br_if   	2, $3           # 2: down to label3
 # BB#5:                                 # %if.end19
 	i32.const	$push16=, 0
 	i32.eq  	$push17=, $1, $pop16
-	br_if   	3, $pop17       # 3: down to label4
+	br_if   	2, $pop17       # 2: down to label3
 # BB#6:                                 # %if.end24
 	i32.store	$discard=, 8($1), $3
-	br      	1               # 1: down to label6
+	br      	1               # 1: down to label4
 .LBB0_7:                                # %if.end6
-	end_block                       # label7:
+	end_block                       # label5:
 	i32.const	$push3=, 4
 	i32.add 	$push4=, $1, $pop3
 	i32.load	$push0=, 0($1)
 	i32.load	$push2=, 0($pop0)
 	i32.store	$push5=, 0($pop4), $pop2
-	br_if   	3, $pop5        # 3: down to label3
+	br_if   	1, $pop5        # 1: down to label3
 # BB#8:                                 # %if.end12
 	i32.const	$push6=, 0
 	i32.const	$push7=, -1
 	i32.store	$discard=, 12($pop6), $pop7
 .LBB0_9:                                # %l4
-	end_block                       # label6:
-	return
-.LBB0_10:                               # %if.then18
-	end_block                       # label5:
-	call    	g@FUNCTION, $3, $3
-	unreachable
-.LBB0_11:                               # %if.then23
 	end_block                       # label4:
-	call    	g@FUNCTION, $3, $3
-	unreachable
-.LBB0_12:                               # %if.then11
+	return
+.LBB0_10:                               # %if.then23
 	end_block                       # label3:
 	call    	g@FUNCTION, $3, $3
 	unreachable
@@ -151,10 +141,10 @@ main:                                   # @main
 	i32.add 	$9=, $13, $9
 	block
 	i32.ne  	$push15=, $pop14, $9
-	br_if   	0, $pop15       # 0: down to label9
+	br_if   	0, $pop15       # 0: down to label7
 # BB#1:                                 # %lor.lhs.false
 	i32.load	$push16=, 0($0):p2align=3
-	br_if   	0, $pop16       # 0: down to label9
+	br_if   	0, $pop16       # 0: down to label7
 # BB#2:                                 # %lor.lhs.false6
 	i32.const	$push17=, 12
 	i32.const	$10=, 8
@@ -163,7 +153,7 @@ main:                                   # @main
 	i32.load	$push19=, 0($pop18)
 	i32.const	$push20=, 999
 	i32.ne  	$push21=, $pop19, $pop20
-	br_if   	0, $pop21       # 0: down to label9
+	br_if   	0, $pop21       # 0: down to label7
 # BB#3:                                 # %lor.lhs.false11
 	i32.const	$push22=, 16
 	i32.const	$11=, 8
@@ -172,12 +162,12 @@ main:                                   # @main
 	i32.load	$push24=, 0($pop23):p2align=3
 	i32.const	$push25=, 777
 	i32.ne  	$push26=, $pop24, $pop25
-	br_if   	0, $pop26       # 0: down to label9
+	br_if   	0, $pop26       # 0: down to label7
 # BB#4:                                 # %lor.lhs.false16
 	i64.load	$push27=, 32($13):p2align=4
 	i64.const	$push28=, 953482739823
 	i64.ne  	$push29=, $pop27, $pop28
-	br_if   	0, $pop29       # 0: down to label9
+	br_if   	0, $pop29       # 0: down to label7
 # BB#5:                                 # %lor.lhs.false24
 	i32.const	$push30=, 8
 	i32.const	$12=, 32
@@ -186,13 +176,13 @@ main:                                   # @main
 	i64.load	$push32=, 0($pop31)
 	i64.const	$push33=, 1906965479424
 	i64.ne  	$push34=, $pop32, $pop33
-	br_if   	0, $pop34       # 0: down to label9
+	br_if   	0, $pop34       # 0: down to label7
 # BB#6:                                 # %if.end
 	i32.const	$push35=, 0
 	call    	exit@FUNCTION, $pop35
 	unreachable
 .LBB2_7:                                # %if.then
-	end_block                       # label9:
+	end_block                       # label7:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/pr17133.c.s
+++ b/test/torture-s/pr17133.c.s
@@ -10,36 +10,39 @@ pure_alloc:                             # @pure_alloc
 # BB#0:                                 # %entry
 	i32.const	$push0=, 0
 	i32.load	$0=, bar($pop0)
-	i32.const	$push14=, 0
-	i32.load	$1=, baz($pop14)
-	block
 	i32.const	$push13=, 0
+	i32.load	$1=, baz($pop13)
+	block
 	i32.const	$push12=, 0
-	i32.load	$push11=, foo($pop12)
-	tee_local	$push10=, $2=, $pop11
-	i32.const	$push9=, 2
-	i32.add 	$push1=, $pop10, $pop9
-	i32.store	$push2=, foo($pop13), $pop1
+	i32.const	$push11=, 0
+	i32.load	$push10=, foo($pop11)
+	tee_local	$push9=, $2=, $pop10
+	i32.const	$push8=, 2
+	i32.add 	$push1=, $pop9, $pop8
+	i32.store	$push2=, foo($pop12), $pop1
 	i32.lt_u	$push3=, $pop2, $1
 	br_if   	0, $pop3        # 0: down to label0
-.LBB0_1:                                # %if.end
+# BB#1:
+	i32.const	$push14=, 2
+	i32.gt_u	$1=, $1, $pop14
+.LBB0_2:                                # %if.end
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push16=, 2
-	i32.le_u	$push4=, $1, $pop16
-	br_if   	0, $pop4        # 0: up to label1
-# BB#2:                                 # %while.body.if.then_crit_edge
+	i32.const	$push16=, 0
+	i32.eq  	$push17=, $1, $pop16
+	br_if   	0, $pop17       # 0: up to label1
+# BB#3:                                 # %while.body.if.then_crit_edge
 	end_loop                        # label2:
 	i32.const	$2=, 0
 	i32.const	$push15=, 0
-	i32.const	$push5=, 2
-	i32.store	$discard=, foo($pop15), $pop5
-.LBB0_3:                                # %if.then
+	i32.const	$push4=, 2
+	i32.store	$discard=, foo($pop15), $pop4
+.LBB0_4:                                # %if.then
 	end_block                       # label0:
-	i32.add 	$push6=, $0, $2
-	i32.const	$push7=, -2
-	i32.and 	$push8=, $pop6, $pop7
-	return  	$pop8
+	i32.add 	$push5=, $0, $2
+	i32.const	$push6=, -2
+	i32.and 	$push7=, $pop5, $pop6
+	return  	$pop7
 	.endfunc
 .Lfunc_end0:
 	.size	pure_alloc, .Lfunc_end0-pure_alloc

--- a/test/torture-s/pr19005.c.s
+++ b/test/torture-s/pr19005.c.s
@@ -88,67 +88,62 @@ foo:                                    # @foo
 	block
 	block
 	block
-	block
 	i32.const	$push19=, 0
 	i32.load	$push18=, s($pop19)
 	tee_local	$push17=, $4=, $pop18
 	i32.const	$push31=, 0
 	i32.eq  	$push32=, $pop17, $pop31
-	br_if   	0, $pop32       # 0: down to label9
+	br_if   	0, $pop32       # 0: down to label8
 # BB#1:                                 # %if.else.i
 	i32.ne  	$push3=, $0, $2
-	br_if   	5, $pop3        # 5: down to label4
+	br_if   	3, $pop3        # 3: down to label5
 # BB#2:                                 # %if.else.i
 	i32.const	$push29=, 1
 	i32.add 	$push2=, $3, $pop29
 	i32.const	$push28=, 255
 	i32.and 	$3=, $pop2, $pop28
 	i32.ne  	$push4=, $3, $1
-	br_if   	5, $pop4        # 5: down to label4
+	br_if   	3, $pop4        # 3: down to label5
 # BB#3:                                 # %bar.exit
 	i32.const	$push7=, 0
 	i32.const	$push5=, 1
 	i32.xor 	$push6=, $4, $pop5
 	i32.store	$push8=, s($pop7), $pop6
-	br_if   	1, $pop8        # 1: down to label8
-	br      	2               # 2: down to label7
+	br_if   	1, $pop8        # 1: down to label7
+	br      	2               # 2: down to label6
 .LBB1_4:                                # %if.then.i
-	end_block                       # label9:
+	end_block                       # label8:
 	i32.ne  	$push9=, $0, $1
-	br_if   	2, $pop9        # 2: down to label6
+	br_if   	3, $pop9        # 3: down to label4
 # BB#5:                                 # %lor.lhs.false.i
 	i32.const	$push26=, 1
 	i32.add 	$push10=, $3, $pop26
 	i32.const	$push11=, 255
 	i32.and 	$3=, $pop10, $pop11
 	i32.ne  	$push12=, $3, $2
-	br_if   	2, $pop12       # 2: down to label6
+	br_if   	3, $pop12       # 3: down to label4
 # BB#6:                                 # %bar.exit.thread
 	i32.const	$push13=, 0
 	i32.const	$push27=, 1
 	i32.store	$discard=, s($pop13), $pop27
 .LBB1_7:                                # %if.else.i40
-	end_block                       # label8:
+	end_block                       # label7:
 	i32.ne  	$push14=, $0, $1
-	br_if   	2, $pop14       # 2: down to label5
+	br_if   	1, $pop14       # 1: down to label5
 # BB#8:                                 # %if.else.i40
 	i32.ne  	$push15=, $3, $2
-	br_if   	2, $pop15       # 2: down to label5
+	br_if   	1, $pop15       # 1: down to label5
 .LBB1_9:                                # %bar.exit43
-	end_block                       # label7:
+	end_block                       # label6:
 	i32.const	$push16=, 0
 	i32.store	$discard=, s($pop16), $4
 	i32.const	$push30=, 0
 	return  	$pop30
-.LBB1_10:                               # %if.then8.i
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_11:                               # %if.then19.i41
+.LBB1_10:                               # %if.then19.i41
 	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_12:                               # %if.then19.i
+.LBB1_11:                               # %if.then8.i
 	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
@@ -169,7 +164,7 @@ main:                                   # @main
 	i32.store	$0=, v($pop5), $pop1
 .LBB2_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label10:
+	loop                            # label9:
 	i32.call	$discard=, foo@FUNCTION, $0
 	i32.const	$push9=, 0
 	i32.const	$push8=, 0
@@ -179,9 +174,9 @@ main:                                   # @main
 	i32.store	$0=, v($pop9), $pop0
 	i32.const	$push6=, 266
 	i32.lt_s	$push3=, $0, $pop6
-	br_if   	0, $pop3        # 0: up to label10
+	br_if   	0, $pop3        # 0: up to label9
 # BB#2:                                 # %for.end
-	end_loop                        # label11:
+	end_loop                        # label10:
 	i32.const	$push4=, 0
 	return  	$pop4
 	.endfunc

--- a/test/torture-s/pr19606.c.s
+++ b/test/torture-s/pr19606.c.s
@@ -41,7 +41,6 @@ main:                                   # @main
 	.local  	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push0=, 0
 	i32.load8_s	$push11=, a($pop0)
 	tee_local	$push10=, $0=, $pop11
@@ -49,22 +48,18 @@ main:                                   # @main
 	i32.shr_u	$push2=, $pop10, $pop1
 	i32.const	$push3=, 2147483646
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label1
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push5=, 5
 	i32.rem_u	$push6=, $0, $pop5
 	i32.const	$push7=, 2
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	1, $pop8        # 1: down to label0
+	br_if   	0, $pop8        # 0: down to label0
 # BB#2:                                 # %if.end7
 	i32.const	$push9=, 0
 	call    	exit@FUNCTION, $pop9
 	unreachable
-.LBB2_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_4:                                # %if.then6
+.LBB2_3:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr20601-1.c.s
+++ b/test/torture-s/pr20601-1.c.s
@@ -57,13 +57,14 @@ main:                                   # @main
 	block
 	block
 	block
-	loop                            # label6:
+	block
+	loop                            # label7:
 	i32.load	$push45=, 0($0)
 	tee_local	$push44=, $5=, $pop45
 	i32.load8_u	$push10=, 0($pop44)
 	i32.const	$push43=, 45
 	i32.ne  	$push11=, $pop10, $pop43
-	br_if   	1, $pop11       # 1: down to label7
+	br_if   	1, $pop11       # 1: down to label8
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	block
@@ -71,44 +72,44 @@ main:                                   # @main
 	tee_local	$push46=, $3=, $pop47
 	i32.const	$push70=, 0
 	i32.eq  	$push71=, $pop46, $pop70
-	br_if   	0, $pop71       # 0: down to label8
+	br_if   	0, $pop71       # 0: down to label9
 # BB#3:                                 # %land.lhs.true.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load8_u	$push12=, 2($5)
-	br_if   	5, $pop12       # 5: down to label3
+	br_if   	6, $pop12       # 6: down to label3
 .LBB2_4:                                # %if.end.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label8:
+	end_block                       # label9:
 	block
 	block
 	block
 	i32.const	$push48=, 80
 	i32.eq  	$push13=, $3, $pop48
-	br_if   	0, $pop13       # 0: down to label11
+	br_if   	0, $pop13       # 0: down to label12
 # BB#5:                                 # %if.end.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push49=, 117
 	i32.eq  	$push14=, $3, $pop49
-	br_if   	1, $pop14       # 1: down to label10
+	br_if   	1, $pop14       # 1: down to label11
 # BB#6:                                 # %if.end.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push50=, 45
 	i32.ne  	$push15=, $3, $pop50
-	br_if   	2, $pop15       # 2: down to label9
-	br      	5               # 5: down to label5
+	br_if   	2, $pop15       # 2: down to label10
+	br      	6               # 6: down to label5
 .LBB2_7:                                # %sw.bb21.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label11:
+	end_block                       # label12:
 	i32.const	$push55=, 4096
 	i32.or  	$1=, $1, $pop55
-	br      	1               # 1: down to label9
+	br      	1               # 1: down to label10
 .LBB2_8:                                # %sw.bb.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label10:
+	end_block                       # label11:
 	i32.load	$push23=, 4($0)
 	i32.const	$push72=, 0
 	i32.eq  	$push73=, $pop23, $pop72
-	br_if   	6, $pop73       # 6: down to label2
+	br_if   	6, $pop73       # 6: down to label3
 # BB#9:                                 # %if.end19.i
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.const	$push54=, 0
@@ -122,29 +123,32 @@ main:                                   # @main
 	i32.store	$0=, e($pop51), $3
 .LBB2_10:                               # %sw.epilog.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	end_block                       # label9:
-	i32.const	$push60=, 1
-	i32.gt_s	$3=, $4, $pop60
-	i32.const	$push59=, 0
-	i32.const	$push58=, -1
-	i32.add 	$push4=, $4, $pop58
-	i32.store	$4=, d($pop59), $pop4
-	i32.const	$push57=, 0
+	end_block                       # label10:
+	i32.const	$push60=, 0
+	i32.const	$push59=, -1
+	i32.add 	$push4=, $4, $pop59
+	i32.store	$3=, d($pop60), $pop4
+	i32.const	$push58=, 0
 	i32.add 	$push5=, $0, $2
-	i32.store	$0=, e($pop57), $pop5
-	br_if   	0, $3           # 0: up to label6
-.LBB2_11:                               # %while.end.i
-	end_loop                        # label7:
+	i32.store	$0=, e($pop58), $pop5
+	i32.const	$push57=, 1
+	i32.gt_s	$5=, $4, $pop57
+	copy_local	$4=, $3
+	br_if   	0, $5           # 0: up to label7
+	br      	2               # 2: down to label6
+.LBB2_11:
+	end_loop                        # label8:
+	copy_local	$3=, $4
+.LBB2_12:                               # %while.end.i
+	end_block                       # label6:
 	i32.const	$push61=, 1
-	i32.lt_s	$push25=, $4, $pop61
+	i32.lt_s	$push25=, $3, $pop61
 	br_if   	1, $pop25       # 1: down to label4
-# BB#12:                                # %while.end.i
+# BB#13:                                # %while.end.i
 	i32.const	$push62=, 1
 	i32.and 	$push24=, $1, $pop62
 	br_if   	1, $pop24       # 1: down to label4
-# BB#13:                                # %if.then36.i
-	call    	abort@FUNCTION
-	unreachable
+	br      	2               # 2: down to label3
 .LBB2_14:                               # %sw.bb22.i
 	end_block                       # label5:
 	i32.const	$push21=, 1536
@@ -155,7 +159,7 @@ main:                                   # @main
 	i32.const	$push17=, 0
 	i32.const	$push16=, -1
 	i32.add 	$push2=, $4, $pop16
-	i32.store	$4=, d($pop17), $pop2
+	i32.store	$3=, d($pop17), $pop2
 	i32.const	$push56=, 0
 	i32.const	$push18=, 4
 	i32.add 	$push3=, $0, $pop18
@@ -164,27 +168,27 @@ main:                                   # @main
 	end_block                       # label4:
 	i32.const	$push63=, 0
 	i32.const	$push26=, .L.str.4
-	i32.store	$3=, t($pop63), $pop26
+	i32.store	$4=, t($pop63), $pop26
 	block
 	i32.const	$push27=, 512
 	i32.and 	$push28=, $1, $pop27
 	i32.const	$push74=, 0
 	i32.eq  	$push75=, $pop28, $pop74
-	br_if   	0, $pop75       # 0: down to label12
+	br_if   	0, $pop75       # 0: down to label13
 # BB#16:                                # %if.then6.i
 	i32.const	$push66=, 0
 	i32.const	$push29=, 1
-	i32.add 	$push30=, $4, $pop29
+	i32.add 	$push30=, $3, $pop29
 	i32.store	$discard=, d($pop66), $pop30
 	i32.const	$push65=, 0
 	i32.const	$push31=, f
 	i32.store	$discard=, e($pop65), $pop31
 	i32.const	$push64=, 0
-	i32.store	$discard=, f($pop64):p2align=4, $3
+	i32.store	$discard=, f($pop64):p2align=4, $4
 	i32.const	$4=, 4
 .LBB2_17:                               # %for.cond.i
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label13:
+	loop                            # label14:
 	i32.add 	$push32=, $0, $4
 	i32.const	$push68=, -4
 	i32.add 	$push33=, $pop32, $pop68
@@ -192,35 +196,27 @@ main:                                   # @main
 	i32.store	$3=, f($4), $pop34
 	i32.const	$push67=, 4
 	i32.add 	$4=, $4, $pop67
-	br_if   	0, $3           # 0: up to label13
+	br_if   	0, $3           # 0: up to label14
 .LBB2_18:                               # %setup1.exit
-	end_loop                        # label14:
-	end_block                       # label12:
-	block
+	end_loop                        # label15:
+	end_block                       # label13:
 	i32.const	$push36=, 1024
 	i32.and 	$push37=, $1, $pop36
 	i32.const	$push76=, 0
 	i32.eq  	$push77=, $pop37, $pop76
-	br_if   	0, $pop77       # 0: down to label15
+	br_if   	1, $pop77       # 1: down to label2
 # BB#19:                                # %setup1.exit
 	i32.const	$push69=, 0
 	i32.load	$push35=, a+16($pop69):p2align=4
-	br_if   	0, $pop35       # 0: down to label15
-# BB#20:                                # %if.then
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_21:                               # %if.end
-	end_block                       # label15:
-	i32.const	$push38=, 0
-	call    	exit@FUNCTION, $pop38
-	unreachable
-.LBB2_22:                               # %if.then.i
+	br_if   	1, $pop35       # 1: down to label2
+.LBB2_20:                               # %if.then
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
-.LBB2_23:                               # %if.then18.i
+.LBB2_21:                               # %if.end
 	end_block                       # label2:
-	call    	abort@FUNCTION
+	i32.const	$push38=, 0
+	call    	exit@FUNCTION, $pop38
 	unreachable
 	.endfunc
 .Lfunc_end2:

--- a/test/torture-s/pr23135.c.s
+++ b/test/torture-s/pr23135.c.s
@@ -45,27 +45,17 @@ main:                                   # @main
 	i32.add 	$push1=, $pop106, $pop103
 	i32.store	$3=, res+4($pop109), $pop1
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push102=, 0
 	i32.add 	$push0=, $1, $0
 	i32.store	$push101=, res($pop102):p2align=3, $pop0
 	tee_local	$push100=, $15=, $pop101
 	i32.const	$push16=, 160
 	i32.ne  	$push17=, $pop100, $pop16
-	br_if   	0, $pop17       # 0: down to label11
+	br_if   	0, $pop17       # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push18=, 113
 	i32.ne  	$push19=, $3, $pop18
-	br_if   	0, $pop19       # 0: down to label11
+	br_if   	0, $pop19       # 0: down to label1
 # BB#2:                                 # %verify.exit
 	i32.const	$push20=, 0
 	i32.mul 	$push2=, $1, $0
@@ -75,11 +65,11 @@ main:                                   # @main
 	i32.store	$5=, res+4($pop111), $pop3
 	i32.const	$push21=, 1500
 	i32.ne  	$push22=, $4, $pop21
-	br_if   	1, $pop22       # 1: down to label10
+	br_if   	0, $pop22       # 0: down to label1
 # BB#3:                                 # %verify.exit
 	i32.const	$push23=, 1300
 	i32.ne  	$push24=, $5, $pop23
-	br_if   	1, $pop24       # 1: down to label10
+	br_if   	0, $pop24       # 0: down to label1
 # BB#4:                                 # %verify.exit48
 	i32.div_s	$2=, $16, $17
 	i32.const	$push25=, 0
@@ -89,11 +79,11 @@ main:                                   # @main
 	i32.store	$discard=, res+4($pop112), $2
 	i32.const	$push26=, 15
 	i32.ne  	$push27=, $6, $pop26
-	br_if   	2, $pop27       # 2: down to label9
+	br_if   	0, $pop27       # 0: down to label1
 # BB#5:                                 # %verify.exit48
 	i32.const	$push28=, 7
 	i32.ne  	$push29=, $2, $pop28
-	br_if   	2, $pop29       # 2: down to label9
+	br_if   	0, $pop29       # 0: down to label1
 # BB#6:                                 # %verify.exit54
 	i32.const	$push30=, 0
 	i32.and 	$push5=, $1, $0
@@ -103,11 +93,11 @@ main:                                   # @main
 	i32.store	$8=, res+4($pop113), $pop6
 	i32.const	$push31=, 2
 	i32.ne  	$push32=, $7, $pop31
-	br_if   	3, $pop32       # 3: down to label8
+	br_if   	0, $pop32       # 0: down to label1
 # BB#7:                                 # %verify.exit54
 	i32.const	$push33=, 4
 	i32.ne  	$push34=, $8, $pop33
-	br_if   	3, $pop34       # 3: down to label8
+	br_if   	0, $pop34       # 0: down to label1
 # BB#8:                                 # %verify.exit60
 	i32.const	$push35=, 0
 	i32.or  	$push7=, $1, $0
@@ -117,11 +107,11 @@ main:                                   # @main
 	i32.store	$10=, res+4($pop114), $pop8
 	i32.const	$push36=, 158
 	i32.ne  	$push37=, $9, $pop36
-	br_if   	4, $pop37       # 4: down to label7
+	br_if   	0, $pop37       # 0: down to label1
 # BB#9:                                 # %verify.exit60
 	i32.const	$push38=, 109
 	i32.ne  	$push39=, $10, $pop38
-	br_if   	4, $pop39       # 4: down to label7
+	br_if   	0, $pop39       # 0: down to label1
 # BB#10:                                # %verify.exit66
 	i32.const	$push40=, 0
 	i32.xor 	$push9=, $0, $1
@@ -131,11 +121,11 @@ main:                                   # @main
 	i32.store	$17=, res+4($pop115), $pop10
 	i32.const	$push41=, 156
 	i32.ne  	$push42=, $1, $pop41
-	br_if   	5, $pop42       # 5: down to label6
+	br_if   	0, $pop42       # 0: down to label1
 # BB#11:                                # %verify.exit66
 	i32.const	$push43=, 105
 	i32.ne  	$push44=, $17, $pop43
-	br_if   	5, $pop44       # 5: down to label6
+	br_if   	0, $pop44       # 0: down to label1
 # BB#12:                                # %verify.exit72
 	i32.const	$push45=, 0
 	i32.const	$push118=, 0
@@ -147,11 +137,11 @@ main:                                   # @main
 	i32.store	$12=, res+4($pop117), $pop12
 	i32.const	$push46=, -150
 	i32.ne  	$push47=, $11, $pop46
-	br_if   	6, $pop47       # 6: down to label5
+	br_if   	0, $pop47       # 0: down to label1
 # BB#13:                                # %verify.exit72
 	i32.const	$push48=, -100
 	i32.ne  	$push49=, $12, $pop48
-	br_if   	6, $pop49       # 6: down to label5
+	br_if   	0, $pop49       # 0: down to label1
 # BB#14:                                # %verify.exit78
 	i32.const	$push51=, 0
 	i32.const	$push50=, -1
@@ -163,11 +153,11 @@ main:                                   # @main
 	i32.store	$14=, res+4($pop120), $pop14
 	i32.const	$push52=, 150
 	i32.ne  	$push53=, $0, $pop52
-	br_if   	7, $pop53       # 7: down to label4
+	br_if   	0, $pop53       # 0: down to label1
 # BB#15:                                # %verify.exit78
 	i32.const	$push54=, -101
 	i32.ne  	$push55=, $14, $pop54
-	br_if   	7, $pop55       # 7: down to label4
+	br_if   	0, $pop55       # 0: down to label1
 # BB#16:                                # %verify.exit84
 	i32.const	$push68=, 0
 	i32.add 	$push57=, $4, $15
@@ -191,11 +181,11 @@ main:                                   # @main
 	i32.store	$discard=, res+4($pop121), $16
 	i32.const	$push69=, 1675
 	i32.ne  	$push70=, $0, $pop69
-	br_if   	8, $pop70       # 8: down to label3
+	br_if   	0, $pop70       # 0: down to label1
 # BB#17:                                # %verify.exit84
 	i32.const	$push71=, 1430
 	i32.ne  	$push72=, $16, $pop71
-	br_if   	8, $pop72       # 8: down to label3
+	br_if   	0, $pop72       # 0: down to label1
 # BB#18:                                # %verify.exit90
 	i32.const	$push85=, 0
 	i32.mul 	$push74=, $4, $15
@@ -219,11 +209,11 @@ main:                                   # @main
 	i32.store	$discard=, res+4($pop124), $16
 	i32.const	$push86=, 1456467968
 	i32.ne  	$push87=, $0, $pop86
-	br_if   	9, $pop87       # 9: down to label2
+	br_if   	0, $pop87       # 0: down to label1
 # BB#19:                                # %verify.exit90
 	i32.const	$push88=, -1579586240
 	i32.ne  	$push89=, $16, $pop88
-	br_if   	9, $pop89       # 9: down to label2
+	br_if   	0, $pop89       # 0: down to label1
 # BB#20:                                # %verify.exit96
 	i32.div_s	$0=, $3, $5
 	i32.div_s	$push90=, $15, $4
@@ -248,52 +238,12 @@ main:                                   # @main
 	i32.const	$push127=, 0
 	i32.store	$push98=, res+4($pop127), $0
 	i32.or  	$push99=, $pop97, $pop98
-	br_if   	10, $pop99      # 10: down to label1
+	br_if   	0, $pop99       # 0: down to label1
 # BB#21:                                # %verify.exit102
 	i32.const	$push131=, 0
 	call    	exit@FUNCTION, $pop131
 	unreachable
-.LBB1_22:                               # %if.then.i
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_23:                               # %if.then.i47
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_24:                               # %if.then.i53
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_25:                               # %if.then.i59
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_26:                               # %if.then.i65
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_27:                               # %if.then.i71
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_28:                               # %if.then.i77
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_29:                               # %if.then.i83
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_30:                               # %if.then.i89
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_31:                               # %if.then.i95
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_32:                               # %if.then.i101
+.LBB1_22:                               # %if.then.i101
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr23324.c.s
+++ b/test/torture-s/pr23324.c.s
@@ -9,59 +9,39 @@ main:                                   # @main
 	.local  	f64, f32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
 	i32.const	$push9=, 0
 	f64.load	$push8=, wv6+32($pop9)
 	tee_local	$push7=, $0=, $pop8
 	f64.ne  	$push0=, $pop7, $0
-	br_if   	0, $pop0        # 0: down to label4
+	br_if   	0, $pop0        # 0: down to label0
 # BB#1:                                 # %caller_bf6.exit
 	i32.const	$push12=, 0
 	f32.load	$push11=, yv7($pop12):p2align=3
 	tee_local	$push10=, $1=, $pop11
 	f32.ne  	$push1=, $pop10, $1
-	br_if   	1, $pop1        # 1: down to label3
+	br_if   	0, $pop1        # 0: down to label0
 # BB#2:                                 # %if.end26.i.i
 	i32.const	$push2=, 0
 	f64.load	$push14=, yv7+16($pop2)
 	tee_local	$push13=, $0=, $pop14
 	f64.ne  	$push3=, $pop13, $0
-	br_if   	2, $pop3        # 2: down to label2
+	br_if   	0, $pop3        # 0: down to label0
 # BB#3:                                 # %if.end30.i.i
 	i32.const	$push17=, 0
 	f32.load	$push16=, yv7+24($pop17):p2align=3
 	tee_local	$push15=, $1=, $pop16
 	f32.ne  	$push4=, $pop15, $1
-	br_if   	3, $pop4        # 3: down to label1
+	br_if   	0, $pop4        # 0: down to label0
 # BB#4:                                 # %if.end34.i.i
 	i32.const	$push20=, 0
 	f32.load	$push19=, zv7($pop20)
 	tee_local	$push18=, $1=, $pop19
 	f32.ne  	$push5=, $pop18, $1
-	br_if   	4, $pop5        # 4: down to label0
+	br_if   	0, $pop5        # 0: down to label0
 # BB#5:                                 # %caller_bf7.exit
 	i32.const	$push6=, 0
 	return  	$pop6
-.LBB0_6:                                # %if.then109.i.i
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_7:                                # %if.then5.i.i
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then29.i.i
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then33.i.i
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.then37.i.i
+.LBB0_6:                                # %if.then37.i.i
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr24716.c.s
+++ b/test/torture-s/pr24716.c.s
@@ -9,26 +9,25 @@ f:                                      # @f
 	.result 	i32
 	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$4=, 0
+	i32.const	$5=, 0
 	i32.const	$2=, 0
 .LBB0_1:                                # %for.cond
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_6 Depth 2
                                         #     Child Loop BB0_8 Depth 2
                                         #       Child Loop BB0_9 Depth 3
-                                        #     Child Loop BB0_13 Depth 2
-                                        #       Child Loop BB0_14 Depth 3
+                                        #     Child Loop BB0_14 Depth 2
+                                        #       Child Loop BB0_15 Depth 3
 	loop                            # label0:
-	copy_local	$5=, $0
 	block
 	block
 	i32.const	$push11=, 3
-	i32.lt_s	$push0=, $4, $pop11
+	i32.lt_s	$push0=, $5, $pop11
 	br_if   	0, $pop0        # 0: down to label3
 # BB#2:                                 # %if.end.thread
                                         #   in Loop: Header=BB0_1 Depth=1
 	i32.const	$push13=, 1
-	i32.add 	$4=, $4, $pop13
+	i32.add 	$5=, $5, $pop13
 	i32.const	$push12=, -1
 	i32.add 	$3=, $2, $pop12
 	br      	1               # 1: down to label2
@@ -43,24 +42,24 @@ f:                                      # @f
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_block                       # label2:
 	block
-	i32.le_s	$push2=, $4, $1
+	i32.le_s	$push2=, $5, $1
 	br_if   	0, $pop2        # 0: down to label4
 # BB#5:                                 # %while.body.lr.ph
                                         #   in Loop: Header=BB0_1 Depth=1
-	i32.eq  	$0=, $3, $1
+	i32.eq  	$4=, $3, $1
 .LBB0_6:                                # %while.body
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop                            # label5:
-	i32.add 	$4=, $4, $0
-	i32.gt_s	$push3=, $4, $1
+	i32.add 	$5=, $5, $4
+	i32.gt_s	$push3=, $5, $1
 	br_if   	0, $pop3        # 0: up to label5
 .LBB0_7:                                # %do.body10.preheader
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_loop                        # label6:
 	end_block                       # label4:
 	i32.const	$push16=, 2
-	i32.shl 	$push4=, $5, $pop16
+	i32.shl 	$push4=, $0, $pop16
 	i32.const	$push15=, W
 	i32.add 	$2=, $pop4, $pop15
 .LBB0_8:                                # %do.body10
@@ -68,7 +67,7 @@ f:                                      # @f
                                         # =>  This Loop Header: Depth=2
                                         #       Child Loop BB0_9 Depth 3
 	loop                            # label7:
-	i32.load	$0=, 0($2)
+	i32.load	$4=, 0($2)
 .LBB0_9:                                # %do.body11
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_8 Depth=2
@@ -76,17 +75,17 @@ f:                                      # @f
 	loop                            # label9:
 	block
 	i32.const	$push25=, 0
-	i32.eq  	$push26=, $0, $pop25
+	i32.eq  	$push26=, $4, $pop25
 	br_if   	0, $pop26       # 0: down to label11
 # BB#10:                                # %if.then13
                                         #   in Loop: Header=BB0_9 Depth=3
 	i32.const	$push17=, 0
 	i32.store	$discard=, 0($2), $pop17
-	i32.const	$4=, 1
+	i32.const	$5=, 1
 .LBB0_11:                               # %do.cond16
                                         #   in Loop: Header=BB0_9 Depth=3
 	end_block                       # label11:
-	i32.const	$0=, 0
+	i32.const	$4=, 0
 	i32.const	$push18=, 1
 	i32.lt_s	$push5=, $1, $pop18
 	br_if   	0, $pop5        # 0: up to label9
@@ -94,50 +93,52 @@ f:                                      # @f
                                         #   in Loop: Header=BB0_8 Depth=2
 	end_loop                        # label10:
 	i32.const	$push19=, 0
-	i32.gt_s	$push6=, $5, $pop19
+	i32.gt_s	$push6=, $0, $pop19
 	br_if   	0, $pop6        # 0: up to label7
-.LBB0_13:                               # %do.body22
+# BB#13:                                #   in Loop: Header=BB0_1 Depth=1
+	end_loop                        # label8:
+	copy_local	$4=, $0
+.LBB0_14:                               # %do.body22
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB0_14 Depth 3
-	end_loop                        # label8:
+                                        #       Child Loop BB0_15 Depth 3
 	loop                            # label12:
 	i32.const	$push20=, 2
-	i32.shl 	$push7=, $5, $pop20
-	i32.load	$5=, Link($pop7)
+	i32.shl 	$push7=, $4, $pop20
+	i32.load	$4=, Link($pop7)
 	i32.const	$1=, 0
-.LBB0_14:                               # %while.cond24
+.LBB0_15:                               # %while.cond24
                                         #   Parent Loop BB0_1 Depth=1
-                                        #     Parent Loop BB0_13 Depth=2
+                                        #     Parent Loop BB0_14 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
 	loop                            # label14:
 	i32.ge_s	$push8=, $1, $3
 	br_if   	1, $pop8        # 1: down to label15
-# BB#15:                                # %while.body26
-                                        #   in Loop: Header=BB0_14 Depth=3
+# BB#16:                                # %while.body26
+                                        #   in Loop: Header=BB0_15 Depth=3
 	i32.const	$push21=, -1
-	i32.eq  	$push10=, $5, $pop21
+	i32.eq  	$push10=, $4, $pop21
 	br_if   	0, $pop10       # 0: up to label14
-# BB#16:                                # %if.then28
-                                        #   in Loop: Header=BB0_14 Depth=3
+# BB#17:                                # %if.then28
+                                        #   in Loop: Header=BB0_15 Depth=3
 	i32.const	$push23=, 1
-	i32.add 	$4=, $4, $pop23
+	i32.add 	$5=, $5, $pop23
 	i32.const	$push22=, 1
 	i32.add 	$1=, $1, $pop22
 	br      	0               # 0: up to label14
-.LBB0_17:                               # %do.cond33
-                                        #   in Loop: Header=BB0_13 Depth=2
+.LBB0_18:                               # %do.cond33
+                                        #   in Loop: Header=BB0_14 Depth=2
 	end_loop                        # label15:
 	i32.const	$0=, -1
 	i32.const	$2=, 1
 	i32.const	$push24=, -1
-	i32.ne  	$push9=, $5, $pop24
+	i32.ne  	$push9=, $4, $pop24
 	br_if   	0, $pop9        # 0: up to label12
 	br      	2               # 2: up to label0
-.LBB0_18:                               # %for.end
+.LBB0_19:                               # %for.end
 	end_loop                        # label13:
 	end_loop                        # label1:
-	return  	$4
+	return  	$5
 	.endfunc
 .Lfunc_end0:
 	.size	f, .Lfunc_end0-f
@@ -150,113 +151,117 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$4=, 0
+	i32.const	$2=, 2
 	i32.const	$0=, 0
-	i32.const	$1=, 2
 	i32.const	$3=, 0
-	i32.const	$2=, 0
 .LBB1_1:                                # %for.cond.i
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB1_6 Depth 2
                                         #     Child Loop BB1_8 Depth 2
-                                        #     Child Loop BB1_12 Depth 2
+                                        #     Child Loop BB1_11 Depth 2
 	loop                            # label16:
 	block
 	block
-	i32.const	$push7=, 3
-	i32.lt_s	$push0=, $3, $pop7
-	br_if   	0, $pop0        # 0: down to label19
+	block
+	block
+	i32.const	$push8=, 3
+	i32.lt_s	$push0=, $0, $pop8
+	br_if   	0, $pop0        # 0: down to label21
 # BB#2:                                 # %if.end.thread.i
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push9=, 1
-	i32.add 	$3=, $3, $pop9
-	i32.const	$push8=, -1
-	i32.add 	$4=, $2, $pop8
-	br      	1               # 1: down to label18
+	i32.const	$push10=, 1
+	i32.add 	$0=, $0, $pop10
+	i32.const	$push9=, -1
+	i32.add 	$1=, $3, $pop9
+	br      	1               # 1: down to label20
 .LBB1_3:                                # %if.end.i
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label19:
-	i32.const	$4=, 0
-	i32.const	$push10=, 1
-	i32.eq  	$push1=, $2, $pop10
-	br_if   	2, $pop1        # 2: down to label17
+	end_block                       # label21:
+	i32.const	$1=, 0
+	i32.const	$push11=, 1
+	i32.eq  	$push1=, $3, $pop11
+	br_if   	1, $pop1        # 1: down to label19
 .LBB1_4:                                # %while.cond.preheader.i
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label18:
+	end_block                       # label20:
 	block
-	i32.le_s	$push3=, $3, $1
-	br_if   	0, $pop3        # 0: down to label20
+	i32.le_s	$push3=, $0, $2
+	br_if   	0, $pop3        # 0: down to label22
 # BB#5:                                 # %while.body.lr.ph.i
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.eq  	$4=, $4, $1
+	i32.eq  	$3=, $1, $2
 .LBB1_6:                                # %while.body.i
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label21:
-	i32.add 	$3=, $3, $4
-	i32.gt_s	$push4=, $3, $1
-	br_if   	0, $pop4        # 0: up to label21
+	loop                            # label23:
+	i32.add 	$0=, $0, $3
+	i32.gt_s	$push4=, $0, $2
+	br_if   	0, $pop4        # 0: up to label23
 .LBB1_7:                                # %do.body10.i
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_loop                        # label22:
-	end_block                       # label20:
-	i32.const	$push14=, 2
-	i32.shl 	$push13=, $0, $pop14
-	tee_local	$push12=, $2=, $pop13
-	i32.load	$4=, W($pop12)
-	i32.const	$push11=, W
-	i32.add 	$2=, $2, $pop11
+	end_loop                        # label24:
+	end_block                       # label22:
+	i32.const	$push15=, 2
+	i32.shl 	$push14=, $4, $pop15
+	tee_local	$push13=, $1=, $pop14
+	i32.load	$3=, W($pop13)
+	i32.const	$push12=, W
+	i32.add 	$1=, $1, $pop12
 .LBB1_8:                                # %do.body11.i
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label23:
+	loop                            # label25:
 	block
 	i32.const	$push18=, 0
-	i32.eq  	$push19=, $4, $pop18
-	br_if   	0, $pop19       # 0: down to label25
+	i32.eq  	$push19=, $3, $pop18
+	br_if   	0, $pop19       # 0: down to label27
 # BB#9:                                 # %if.then13.i
                                         #   in Loop: Header=BB1_8 Depth=2
-	i32.const	$push15=, 0
-	i32.store	$discard=, 0($2), $pop15
-	i32.const	$3=, 1
+	i32.const	$push16=, 0
+	i32.store	$discard=, 0($1), $pop16
+	i32.const	$0=, 1
 .LBB1_10:                               # %do.cond16.i
                                         #   in Loop: Header=BB1_8 Depth=2
-	end_block                       # label25:
-	i32.const	$4=, 0
+	end_block                       # label27:
+	i32.const	$3=, 0
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $1, $pop20
-	br_if   	0, $pop21       # 0: up to label23
-# BB#11:                                # %do.cond33.i.preheader
-                                        #   in Loop: Header=BB1_1 Depth=1
-	end_loop                        # label24:
-	copy_local	$4=, $0
-.LBB1_12:                               # %do.cond33.i
+	i32.eq  	$push21=, $2, $pop20
+	br_if   	0, $pop21       # 0: up to label25
+.LBB1_11:                               # %do.cond33.i
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
-	loop                            # label26:
+	end_loop                        # label26:
+	loop                            # label28:
 	i32.const	$push17=, 2
-	i32.shl 	$push5=, $4, $pop17
-	i32.load	$4=, Link($pop5)
-	i32.const	$0=, -1
-	i32.const	$2=, 1
-	i32.const	$1=, 0
-	i32.const	$push16=, -1
-	i32.ne  	$push6=, $4, $pop16
-	br_if   	0, $pop6        # 0: up to label26
-	br      	2               # 2: up to label16
-.LBB1_13:                               # %f.exit
-	end_loop                        # label27:
-	end_loop                        # label17:
+	i32.shl 	$push6=, $4, $pop17
+	i32.load	$4=, Link($pop6)
+	i32.const	$push5=, -1
+	i32.ne  	$push7=, $4, $pop5
+	br_if   	0, $pop7        # 0: up to label28
+	br      	3               # 3: down to label18
+.LBB1_12:                               # %f.exit
+	end_loop                        # label29:
+	end_block                       # label19:
 	block
 	i32.const	$push22=, 0
-	i32.eq  	$push23=, $3, $pop22
-	br_if   	0, $pop23       # 0: down to label28
-# BB#14:                                # %if.end
+	i32.eq  	$push23=, $0, $pop22
+	br_if   	0, $pop23       # 0: down to label30
+# BB#13:                                # %if.end
 	i32.const	$push2=, 0
 	return  	$pop2
-.LBB1_15:                               # %if.then
-	end_block                       # label28:
+.LBB1_14:                               # %if.then
+	end_block                       # label30:
 	call    	abort@FUNCTION
 	unreachable
+.LBB1_15:                               #   in Loop: Header=BB1_1 Depth=1
+	end_block                       # label18:
+	i32.const	$3=, 1
+	i32.const	$2=, 0
+	i32.const	$4=, -1
+	br      	0               # 0: up to label16
+.LBB1_16:
+	end_loop                        # label17:
 	.endfunc
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main

--- a/test/torture-s/pr28982b.c.s
+++ b/test/torture-s/pr28982b.c.s
@@ -1,0 +1,606 @@
+	.text
+	.file	"/b/build/slave/linux/build/src/src/work/gcc/gcc/testsuite/gcc.c-torture/execute/pr28982b.c"
+	.section	.text.bar,"ax",@progbits
+	.hidden	bar
+	.globl	bar
+	.type	bar,@function
+bar:                                    # @bar
+	.param  	i32
+# BB#0:                                 # %entry
+	i32.const	$push1=, 0
+	i32.const	$push4=, 0
+	i32.load	$push2=, incs($pop4):p2align=4
+	i32.load	$push0=, 0($0)
+	i32.add 	$push3=, $pop2, $pop0
+	i32.store	$discard=, incs($pop1):p2align=4, $pop3
+	return
+	.endfunc
+.Lfunc_end0:
+	.size	bar, .Lfunc_end0-bar
+
+	.section	.text.foo,"ax",@progbits
+	.hidden	foo
+	.globl	foo
+	.type	foo,@function
+foo:                                    # @foo
+	.param  	i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, i64, i32, i32, i32, i32, i32, i32
+# BB#0:                                 # %entry
+	i32.const	$62=, __stack_pointer
+	i32.load	$62=, 0($62)
+	i32.const	$63=, 524288
+	i32.sub 	$67=, $62, $63
+	i32.const	$63=, __stack_pointer
+	i32.store	$67=, 0($63), $67
+	i32.const	$push53=, 0
+	i32.const	$push52=, 262144
+	i32.const	$65=, 262144
+	i32.add 	$65=, $67, $65
+	i32.call	$discard=, memset@FUNCTION, $65, $pop53, $pop52
+	f32.const	$41=, 0x0p0
+	f32.const	$42=, 0x0p0
+	f32.const	$43=, 0x0p0
+	f32.const	$44=, 0x0p0
+	f32.const	$45=, 0x0p0
+	f32.const	$46=, 0x0p0
+	f32.const	$47=, 0x0p0
+	f32.const	$48=, 0x0p0
+	f32.const	$49=, 0x0p0
+	f32.const	$50=, 0x0p0
+	f32.const	$51=, 0x0p0
+	f32.const	$52=, 0x0p0
+	f32.const	$53=, 0x0p0
+	f32.const	$54=, 0x0p0
+	f32.const	$55=, 0x0p0
+	f32.const	$56=, 0x0p0
+	f32.const	$57=, 0x0p0
+	f32.const	$58=, 0x0p0
+	f32.const	$59=, 0x0p0
+	f32.const	$60=, 0x0p0
+	block
+	i32.const	$push154=, 0
+	i32.eq  	$push155=, $0, $pop154
+	br_if   	0, $pop155      # 0: down to label0
+# BB#1:                                 # %while.body.preheader
+	i32.const	$push131=, 0
+	i64.load	$push130=, incs+72($pop131)
+	tee_local	$push129=, $61=, $pop130
+	i64.const	$push20=, 32
+	i64.shr_u	$push30=, $pop129, $pop20
+	i32.wrap/i64	$push19=, $pop30
+	i32.const	$push31=, 2
+	i32.shl 	$1=, $pop19, $pop31
+	i32.wrap/i64	$push18=, $61
+	i32.const	$push128=, 2
+	i32.shl 	$2=, $pop18, $pop128
+	i32.const	$push127=, 0
+	i64.load	$push126=, incs+64($pop127):p2align=4
+	tee_local	$push125=, $61=, $pop126
+	i64.const	$push124=, 32
+	i64.shr_u	$push29=, $pop125, $pop124
+	i32.wrap/i64	$push17=, $pop29
+	i32.const	$push123=, 2
+	i32.shl 	$3=, $pop17, $pop123
+	i32.wrap/i64	$push16=, $61
+	i32.const	$push122=, 2
+	i32.shl 	$4=, $pop16, $pop122
+	i32.const	$push121=, 0
+	i64.load	$push120=, incs+56($pop121)
+	tee_local	$push119=, $61=, $pop120
+	i64.const	$push118=, 32
+	i64.shr_u	$push28=, $pop119, $pop118
+	i32.wrap/i64	$push15=, $pop28
+	i32.const	$push117=, 2
+	i32.shl 	$5=, $pop15, $pop117
+	i32.wrap/i64	$push14=, $61
+	i32.const	$push116=, 2
+	i32.shl 	$6=, $pop14, $pop116
+	i32.const	$push115=, 0
+	i64.load	$push114=, incs+48($pop115):p2align=4
+	tee_local	$push113=, $61=, $pop114
+	i64.const	$push112=, 32
+	i64.shr_u	$push27=, $pop113, $pop112
+	i32.wrap/i64	$push13=, $pop27
+	i32.const	$push111=, 2
+	i32.shl 	$7=, $pop13, $pop111
+	i32.wrap/i64	$push12=, $61
+	i32.const	$push110=, 2
+	i32.shl 	$8=, $pop12, $pop110
+	i32.const	$push109=, 0
+	i64.load	$push108=, incs+40($pop109)
+	tee_local	$push107=, $61=, $pop108
+	i64.const	$push106=, 32
+	i64.shr_u	$push26=, $pop107, $pop106
+	i32.wrap/i64	$push11=, $pop26
+	i32.const	$push105=, 2
+	i32.shl 	$9=, $pop11, $pop105
+	i32.wrap/i64	$push10=, $61
+	i32.const	$push104=, 2
+	i32.shl 	$10=, $pop10, $pop104
+	i32.const	$push103=, 0
+	i64.load	$push102=, incs+32($pop103):p2align=4
+	tee_local	$push101=, $61=, $pop102
+	i64.const	$push100=, 32
+	i64.shr_u	$push25=, $pop101, $pop100
+	i32.wrap/i64	$push9=, $pop25
+	i32.const	$push99=, 2
+	i32.shl 	$11=, $pop9, $pop99
+	i32.wrap/i64	$push8=, $61
+	i32.const	$push98=, 2
+	i32.shl 	$12=, $pop8, $pop98
+	i32.const	$push97=, 0
+	i64.load	$push96=, incs+24($pop97)
+	tee_local	$push95=, $61=, $pop96
+	i64.const	$push94=, 32
+	i64.shr_u	$push24=, $pop95, $pop94
+	i32.wrap/i64	$push7=, $pop24
+	i32.const	$push93=, 2
+	i32.shl 	$13=, $pop7, $pop93
+	i32.wrap/i64	$push6=, $61
+	i32.const	$push92=, 2
+	i32.shl 	$14=, $pop6, $pop92
+	i32.const	$push91=, 0
+	i64.load	$push90=, incs+16($pop91):p2align=4
+	tee_local	$push89=, $61=, $pop90
+	i64.const	$push88=, 32
+	i64.shr_u	$push23=, $pop89, $pop88
+	i32.wrap/i64	$push5=, $pop23
+	i32.const	$push87=, 2
+	i32.shl 	$15=, $pop5, $pop87
+	i32.wrap/i64	$push4=, $61
+	i32.const	$push86=, 2
+	i32.shl 	$16=, $pop4, $pop86
+	i32.const	$push85=, 0
+	i64.load	$push84=, incs+8($pop85)
+	tee_local	$push83=, $61=, $pop84
+	i64.const	$push82=, 32
+	i64.shr_u	$push22=, $pop83, $pop82
+	i32.wrap/i64	$push3=, $pop22
+	i32.const	$push81=, 2
+	i32.shl 	$17=, $pop3, $pop81
+	i32.wrap/i64	$push2=, $61
+	i32.const	$push80=, 2
+	i32.shl 	$18=, $pop2, $pop80
+	i32.const	$push79=, 0
+	i64.load	$push78=, incs($pop79):p2align=4
+	tee_local	$push77=, $61=, $pop78
+	i64.const	$push76=, 32
+	i64.shr_u	$push21=, $pop77, $pop76
+	i32.wrap/i64	$push1=, $pop21
+	i32.const	$push75=, 2
+	i32.shl 	$19=, $pop1, $pop75
+	i32.wrap/i64	$push0=, $61
+	i32.const	$push74=, 2
+	i32.shl 	$20=, $pop0, $pop74
+	f32.const	$41=, 0x0p0
+	i32.const	$push73=, 0
+	i32.load	$40=, ptrs+76($pop73)
+	i32.const	$push72=, 0
+	i32.load	$39=, ptrs+72($pop72):p2align=3
+	i32.const	$push71=, 0
+	i32.load	$38=, ptrs+68($pop71)
+	i32.const	$push70=, 0
+	i32.load	$37=, ptrs+64($pop70):p2align=4
+	i32.const	$push69=, 0
+	i32.load	$36=, ptrs+60($pop69)
+	i32.const	$push68=, 0
+	i32.load	$35=, ptrs+56($pop68):p2align=3
+	i32.const	$push67=, 0
+	i32.load	$34=, ptrs+52($pop67)
+	i32.const	$push66=, 0
+	i32.load	$33=, ptrs+48($pop66):p2align=4
+	i32.const	$push65=, 0
+	i32.load	$32=, ptrs+44($pop65)
+	i32.const	$push64=, 0
+	i32.load	$31=, ptrs+40($pop64):p2align=3
+	i32.const	$push63=, 0
+	i32.load	$30=, ptrs+36($pop63)
+	i32.const	$push62=, 0
+	i32.load	$29=, ptrs+32($pop62):p2align=4
+	i32.const	$push61=, 0
+	i32.load	$28=, ptrs+28($pop61)
+	i32.const	$push60=, 0
+	i32.load	$27=, ptrs+24($pop60):p2align=3
+	i32.const	$push59=, 0
+	i32.load	$26=, ptrs+20($pop59)
+	i32.const	$push58=, 0
+	i32.load	$25=, ptrs+16($pop58):p2align=4
+	i32.const	$push57=, 0
+	i32.load	$24=, ptrs+12($pop57)
+	i32.const	$push56=, 0
+	i32.load	$23=, ptrs+8($pop56):p2align=3
+	i32.const	$push55=, 0
+	i32.load	$22=, ptrs+4($pop55)
+	i32.const	$push54=, 0
+	i32.load	$21=, ptrs($pop54):p2align=4
+	f32.const	$42=, 0x0p0
+	f32.const	$43=, 0x0p0
+	f32.const	$44=, 0x0p0
+	f32.const	$45=, 0x0p0
+	f32.const	$46=, 0x0p0
+	f32.const	$47=, 0x0p0
+	f32.const	$48=, 0x0p0
+	f32.const	$49=, 0x0p0
+	f32.const	$50=, 0x0p0
+	f32.const	$51=, 0x0p0
+	f32.const	$52=, 0x0p0
+	f32.const	$53=, 0x0p0
+	f32.const	$54=, 0x0p0
+	f32.const	$55=, 0x0p0
+	f32.const	$56=, 0x0p0
+	f32.const	$57=, 0x0p0
+	f32.const	$58=, 0x0p0
+	f32.const	$59=, 0x0p0
+	f32.const	$60=, 0x0p0
+.LBB1_2:                                # %while.body
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label1:
+	f32.load	$push32=, 0($21)
+	f32.add 	$60=, $60, $pop32
+	f32.load	$push33=, 0($22)
+	f32.add 	$59=, $59, $pop33
+	f32.load	$push34=, 0($23)
+	f32.add 	$58=, $58, $pop34
+	f32.load	$push35=, 0($24)
+	f32.add 	$57=, $57, $pop35
+	f32.load	$push36=, 0($25)
+	f32.add 	$56=, $56, $pop36
+	f32.load	$push37=, 0($26)
+	f32.add 	$55=, $55, $pop37
+	f32.load	$push38=, 0($27)
+	f32.add 	$54=, $54, $pop38
+	f32.load	$push39=, 0($28)
+	f32.add 	$53=, $53, $pop39
+	f32.load	$push40=, 0($29)
+	f32.add 	$52=, $52, $pop40
+	f32.load	$push41=, 0($30)
+	f32.add 	$51=, $51, $pop41
+	f32.load	$push42=, 0($31)
+	f32.add 	$50=, $50, $pop42
+	f32.load	$push43=, 0($32)
+	f32.add 	$49=, $49, $pop43
+	f32.load	$push44=, 0($33)
+	f32.add 	$48=, $48, $pop44
+	f32.load	$push45=, 0($34)
+	f32.add 	$47=, $47, $pop45
+	f32.load	$push46=, 0($35)
+	f32.add 	$46=, $46, $pop46
+	f32.load	$push47=, 0($36)
+	f32.add 	$45=, $45, $pop47
+	f32.load	$push48=, 0($37)
+	f32.add 	$44=, $44, $pop48
+	f32.load	$push49=, 0($38)
+	f32.add 	$43=, $43, $pop49
+	f32.load	$push50=, 0($39)
+	f32.add 	$42=, $42, $pop50
+	f32.load	$push51=, 0($40)
+	f32.add 	$41=, $41, $pop51
+	i32.const	$push132=, -1
+	i32.add 	$0=, $0, $pop132
+	i32.add 	$40=, $40, $1
+	i32.add 	$39=, $39, $2
+	i32.add 	$38=, $38, $3
+	i32.add 	$37=, $37, $4
+	i32.add 	$36=, $36, $5
+	i32.add 	$35=, $35, $6
+	i32.add 	$34=, $34, $7
+	i32.add 	$33=, $33, $8
+	i32.add 	$32=, $32, $9
+	i32.add 	$31=, $31, $10
+	i32.add 	$30=, $30, $11
+	i32.add 	$29=, $29, $12
+	i32.add 	$28=, $28, $13
+	i32.add 	$27=, $27, $14
+	i32.add 	$26=, $26, $15
+	i32.add 	$25=, $25, $16
+	i32.add 	$24=, $24, $17
+	i32.add 	$23=, $23, $18
+	i32.add 	$22=, $22, $19
+	i32.add 	$21=, $21, $20
+	br_if   	0, $0           # 0: up to label1
+.LBB1_3:                                # %while.end
+	end_loop                        # label2:
+	end_block                       # label0:
+	i32.const	$push153=, 0
+	f32.store	$discard=, results($pop153):p2align=4, $60
+	i32.const	$push152=, 0
+	f32.store	$discard=, results+4($pop152), $59
+	i32.const	$push151=, 0
+	f32.store	$discard=, results+8($pop151):p2align=3, $58
+	i32.const	$push150=, 0
+	f32.store	$discard=, results+12($pop150), $57
+	i32.const	$push149=, 0
+	f32.store	$discard=, results+16($pop149):p2align=4, $56
+	i32.const	$push148=, 0
+	f32.store	$discard=, results+20($pop148), $55
+	i32.const	$push147=, 0
+	f32.store	$discard=, results+24($pop147):p2align=3, $54
+	i32.const	$push146=, 0
+	f32.store	$discard=, results+28($pop146), $53
+	i32.const	$push145=, 0
+	f32.store	$discard=, results+32($pop145):p2align=4, $52
+	i32.const	$push144=, 0
+	f32.store	$discard=, results+36($pop144), $51
+	i32.const	$push143=, 0
+	f32.store	$discard=, results+40($pop143):p2align=3, $50
+	i32.const	$push142=, 0
+	f32.store	$discard=, results+44($pop142), $49
+	i32.const	$push141=, 0
+	f32.store	$discard=, results+48($pop141):p2align=4, $48
+	i32.const	$push140=, 0
+	f32.store	$discard=, results+52($pop140), $47
+	i32.const	$push139=, 0
+	f32.store	$discard=, results+56($pop139):p2align=3, $46
+	i32.const	$push138=, 0
+	f32.store	$discard=, results+60($pop138), $45
+	i32.const	$push137=, 0
+	f32.store	$discard=, results+64($pop137):p2align=4, $44
+	i32.const	$push136=, 0
+	f32.store	$discard=, results+68($pop136), $43
+	i32.const	$push135=, 0
+	f32.store	$discard=, results+72($pop135):p2align=3, $42
+	i32.const	$push134=, 0
+	f32.store	$discard=, results+76($pop134), $41
+	i32.const	$push133=, 262144
+	i32.const	$66=, 262144
+	i32.add 	$66=, $67, $66
+	i32.call	$discard=, memcpy@FUNCTION, $67, $66, $pop133
+	call    	bar@FUNCTION, $67
+	i32.const	$64=, 524288
+	i32.add 	$67=, $67, $64
+	i32.const	$64=, __stack_pointer
+	i32.store	$67=, 0($64), $67
+	return
+	.endfunc
+.Lfunc_end1:
+	.size	foo, .Lfunc_end1-foo
+
+	.section	.text.main,"ax",@progbits
+	.hidden	main
+	.globl	main
+	.type	main,@function
+main:                                   # @main
+	.result 	i32
+	.local  	i32, i32, i32, i32
+# BB#0:                                 # %entry
+	i32.const	$push1=, 0
+	i32.const	$push0=, input
+	i32.store	$2=, ptrs($pop1):p2align=4, $pop0
+	i32.const	$push128=, 0
+	i32.const	$push127=, 0
+	i32.store	$push126=, incs($pop128):p2align=4, $pop127
+	tee_local	$push125=, $3=, $pop126
+	i32.const	$push2=, input+4
+	i32.store	$discard=, ptrs+4($pop125), $pop2
+	i32.const	$push4=, input+8
+	i32.store	$discard=, ptrs+8($3):p2align=3, $pop4
+	i32.const	$push5=, 2
+	i32.store	$discard=, incs+8($3):p2align=3, $pop5
+	i32.const	$push6=, input+12
+	i32.store	$discard=, ptrs+12($3), $pop6
+	i32.const	$push7=, 3
+	i32.store	$discard=, incs+12($3), $pop7
+	i32.const	$push8=, input+16
+	i32.store	$discard=, ptrs+16($3):p2align=4, $pop8
+	i32.const	$push10=, input+20
+	i32.store	$discard=, ptrs+20($3), $pop10
+	i32.const	$push11=, 5
+	i32.store	$discard=, incs+20($3), $pop11
+	i32.const	$push12=, input+24
+	i32.store	$discard=, ptrs+24($3):p2align=3, $pop12
+	i32.const	$push13=, 6
+	i32.store	$discard=, incs+24($3):p2align=3, $pop13
+	i32.const	$push14=, input+28
+	i32.store	$discard=, ptrs+28($3), $pop14
+	i32.const	$push15=, 7
+	i32.store	$discard=, incs+28($3), $pop15
+	i32.const	$push16=, input+32
+	i32.store	$discard=, ptrs+32($3):p2align=4, $pop16
+	i32.const	$push17=, 8
+	i32.store	$discard=, incs+32($3):p2align=4, $pop17
+	i32.const	$push18=, input+36
+	i32.store	$discard=, ptrs+36($3), $pop18
+	i32.const	$push19=, 9
+	i32.store	$discard=, incs+36($3), $pop19
+	i32.const	$push20=, input+40
+	i32.store	$discard=, ptrs+40($3):p2align=3, $pop20
+	i32.const	$push21=, 10
+	i32.store	$discard=, incs+40($3):p2align=3, $pop21
+	i32.const	$push22=, input+44
+	i32.store	$discard=, ptrs+44($3), $pop22
+	i32.const	$push23=, 11
+	i32.store	$discard=, incs+44($3), $pop23
+	i32.const	$push24=, input+48
+	i32.store	$discard=, ptrs+48($3):p2align=4, $pop24
+	i32.const	$push25=, 12
+	i32.store	$discard=, incs+48($3):p2align=4, $pop25
+	i32.const	$push26=, input+52
+	i32.store	$discard=, ptrs+52($3), $pop26
+	i32.const	$push27=, 13
+	i32.store	$discard=, incs+52($3), $pop27
+	i32.const	$push28=, input+56
+	i32.store	$discard=, ptrs+56($3):p2align=3, $pop28
+	i32.const	$push29=, 14
+	i32.store	$discard=, incs+56($3):p2align=3, $pop29
+	i32.const	$push30=, input+60
+	i32.store	$discard=, ptrs+60($3), $pop30
+	i32.const	$push31=, 15
+	i32.store	$discard=, incs+60($3), $pop31
+	i32.const	$push32=, input+64
+	i32.store	$discard=, ptrs+64($3):p2align=4, $pop32
+	i32.const	$push33=, 16
+	i32.store	$discard=, incs+64($3):p2align=4, $pop33
+	i32.const	$push34=, input+68
+	i32.store	$discard=, ptrs+68($3), $pop34
+	i32.const	$push35=, 17
+	i32.store	$discard=, incs+68($3), $pop35
+	i32.const	$push36=, input+72
+	i32.store	$discard=, ptrs+72($3):p2align=3, $pop36
+	i32.const	$push37=, 18
+	i32.store	$discard=, incs+72($3):p2align=3, $pop37
+	i32.const	$push38=, input+76
+	i32.store	$discard=, ptrs+76($3), $pop38
+	i32.const	$push39=, 19
+	i32.store	$discard=, incs+76($3), $pop39
+	i32.const	$push3=, 1
+	i32.store	$0=, incs+4($3), $pop3
+	i32.const	$push9=, 4
+	i32.store	$1=, incs+16($3):p2align=4, $pop9
+.LBB2_1:                                # %for.body4
+                                        # =>This Inner Loop Header: Depth=1
+	loop                            # label3:
+	f32.convert_s/i32	$push40=, $3
+	f32.store	$discard=, 0($2), $pop40
+	i32.add 	$3=, $3, $0
+	i32.add 	$2=, $2, $1
+	i32.const	$push129=, 80
+	i32.ne  	$push41=, $3, $pop129
+	br_if   	0, $pop41       # 0: up to label3
+# BB#2:                                 # %for.end8
+	end_loop                        # label4:
+	i32.const	$push42=, 4
+	call    	foo@FUNCTION, $pop42
+	i32.const	$push43=, 0
+	f32.load	$push44=, results($pop43):p2align=4
+	f32.const	$push45=, 0x0p0
+	f32.ne  	$push46=, $pop44, $pop45
+	i32.const	$push148=, 0
+	f32.load	$push47=, results+4($pop148)
+	f32.const	$push48=, 0x1.4p3
+	f32.ne  	$push49=, $pop47, $pop48
+	i32.or  	$push50=, $pop46, $pop49
+	i32.const	$push147=, 0
+	f32.load	$push51=, results+8($pop147):p2align=3
+	f32.const	$push52=, 0x1.4p4
+	f32.ne  	$push53=, $pop51, $pop52
+	i32.or  	$push54=, $pop50, $pop53
+	i32.const	$push146=, 0
+	f32.load	$push55=, results+12($pop146)
+	f32.const	$push56=, 0x1.ep4
+	f32.ne  	$push57=, $pop55, $pop56
+	i32.or  	$push58=, $pop54, $pop57
+	i32.const	$push145=, 0
+	f32.load	$push59=, results+16($pop145):p2align=4
+	f32.const	$push60=, 0x1.4p5
+	f32.ne  	$push61=, $pop59, $pop60
+	i32.or  	$push62=, $pop58, $pop61
+	i32.const	$push144=, 0
+	f32.load	$push63=, results+20($pop144)
+	f32.const	$push64=, 0x1.9p5
+	f32.ne  	$push65=, $pop63, $pop64
+	i32.or  	$push66=, $pop62, $pop65
+	i32.const	$push143=, 0
+	f32.load	$push67=, results+24($pop143):p2align=3
+	f32.const	$push68=, 0x1.ep5
+	f32.ne  	$push69=, $pop67, $pop68
+	i32.or  	$push70=, $pop66, $pop69
+	i32.const	$push142=, 0
+	f32.load	$push71=, results+28($pop142)
+	f32.const	$push72=, 0x1.18p6
+	f32.ne  	$push73=, $pop71, $pop72
+	i32.or  	$push74=, $pop70, $pop73
+	i32.const	$push141=, 0
+	f32.load	$push75=, results+32($pop141):p2align=4
+	f32.const	$push76=, 0x1.4p6
+	f32.ne  	$push77=, $pop75, $pop76
+	i32.or  	$push78=, $pop74, $pop77
+	i32.const	$push140=, 0
+	f32.load	$push79=, results+36($pop140)
+	f32.const	$push80=, 0x1.68p6
+	f32.ne  	$push81=, $pop79, $pop80
+	i32.or  	$push82=, $pop78, $pop81
+	i32.const	$push139=, 0
+	f32.load	$push83=, results+40($pop139):p2align=3
+	f32.const	$push84=, 0x1.9p6
+	f32.ne  	$push85=, $pop83, $pop84
+	i32.or  	$push86=, $pop82, $pop85
+	i32.const	$push138=, 0
+	f32.load	$push87=, results+44($pop138)
+	f32.const	$push88=, 0x1.b8p6
+	f32.ne  	$push89=, $pop87, $pop88
+	i32.or  	$push90=, $pop86, $pop89
+	i32.const	$push137=, 0
+	f32.load	$push91=, results+48($pop137):p2align=4
+	f32.const	$push92=, 0x1.ep6
+	f32.ne  	$push93=, $pop91, $pop92
+	i32.or  	$push94=, $pop90, $pop93
+	i32.const	$push136=, 0
+	f32.load	$push95=, results+52($pop136)
+	f32.const	$push96=, 0x1.04p7
+	f32.ne  	$push97=, $pop95, $pop96
+	i32.or  	$push98=, $pop94, $pop97
+	i32.const	$push135=, 0
+	f32.load	$push99=, results+56($pop135):p2align=3
+	f32.const	$push100=, 0x1.18p7
+	f32.ne  	$push101=, $pop99, $pop100
+	i32.or  	$push102=, $pop98, $pop101
+	i32.const	$push134=, 0
+	f32.load	$push103=, results+60($pop134)
+	f32.const	$push104=, 0x1.2cp7
+	f32.ne  	$push105=, $pop103, $pop104
+	i32.or  	$push106=, $pop102, $pop105
+	i32.const	$push133=, 0
+	f32.load	$push107=, results+64($pop133):p2align=4
+	f32.const	$push108=, 0x1.4p7
+	f32.ne  	$push109=, $pop107, $pop108
+	i32.or  	$push110=, $pop106, $pop109
+	i32.const	$push132=, 0
+	f32.load	$push111=, results+68($pop132)
+	f32.const	$push112=, 0x1.54p7
+	f32.ne  	$push113=, $pop111, $pop112
+	i32.or  	$push114=, $pop110, $pop113
+	i32.const	$push131=, 0
+	f32.load	$push115=, results+72($pop131):p2align=3
+	f32.const	$push116=, 0x1.68p7
+	f32.ne  	$push117=, $pop115, $pop116
+	i32.or  	$push118=, $pop114, $pop117
+	i32.const	$push130=, 0
+	f32.load	$push119=, results+76($pop130)
+	f32.const	$push120=, 0x1.7cp7
+	f32.ne  	$push121=, $pop119, $pop120
+	i32.or  	$push122=, $pop118, $pop121
+	i32.const	$push123=, 1
+	i32.and 	$push124=, $pop122, $pop123
+	return  	$pop124
+	.endfunc
+.Lfunc_end2:
+	.size	main, .Lfunc_end2-main
+
+	.hidden	incs                    # @incs
+	.type	incs,@object
+	.section	.bss.incs,"aw",@nobits
+	.globl	incs
+	.p2align	4
+incs:
+	.skip	80
+	.size	incs, 80
+
+	.hidden	ptrs                    # @ptrs
+	.type	ptrs,@object
+	.section	.bss.ptrs,"aw",@nobits
+	.globl	ptrs
+	.p2align	4
+ptrs:
+	.skip	80
+	.size	ptrs, 80
+
+	.hidden	results                 # @results
+	.type	results,@object
+	.section	.bss.results,"aw",@nobits
+	.globl	results
+	.p2align	4
+results:
+	.skip	80
+	.size	results, 80
+
+	.hidden	input                   # @input
+	.type	input,@object
+	.section	.bss.input,"aw",@nobits
+	.globl	input
+	.p2align	4
+input:
+	.skip	320
+	.size	input, 320
+
+
+	.ident	"clang version 3.9.0 "

--- a/test/torture-s/pr29695-2.c.s
+++ b/test/torture-s/pr29695-2.c.s
@@ -154,50 +154,35 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
 	i32.const	$push10=, 0
 	i32.load8_u	$push0=, a($pop10):p2align=2
 	i32.const	$push1=, 7
 	i32.shr_u	$push2=, $pop0, $pop1
 	i32.const	$push17=, 0
 	i32.eq  	$push18=, $pop2, $pop17
-	br_if   	0, $pop18       # 0: down to label3
+	br_if   	0, $pop18       # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push12=, 0
 	i32.load8_s	$push3=, b($pop12)
 	i32.const	$push11=, 0
 	i32.ge_s	$push4=, $pop3, $pop11
-	br_if   	1, $pop4        # 1: down to label2
+	br_if   	0, $pop4        # 0: down to label0
 # BB#2:                                 # %if.end12
 	i32.const	$push14=, 0
 	i32.load	$push5=, c($pop14):p2align=3
 	i32.const	$push13=, 0
 	i32.ge_s	$push6=, $pop5, $pop13
-	br_if   	2, $pop6        # 2: down to label1
+	br_if   	0, $pop6        # 0: down to label0
 # BB#3:                                 # %if.end16
 	i32.const	$push16=, 0
 	i32.load	$push7=, d($pop16)
 	i32.const	$push15=, 0
 	i32.ge_s	$push8=, $pop7, $pop15
-	br_if   	3, $pop8        # 3: down to label0
+	br_if   	0, $pop8        # 0: down to label0
 # BB#4:                                 # %if.end28
 	i32.const	$push9=, 0
 	return  	$pop9
-.LBB8_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_6:                                # %if.then3
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_7:                                # %if.then15
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_8:                                # %if.then19
+.LBB8_5:                                # %if.then19
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr33870.c.s
+++ b/test/torture-s/pr33870.c.s
@@ -7,42 +7,42 @@
 sort_pagelist:                          # @sort_pagelist
 	.param  	i32
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$10=, __stack_pointer
+	i32.load	$10=, 0($10)
+	i32.const	$11=, 144
+	i32.sub 	$19=, $10, $11
 	i32.const	$11=, __stack_pointer
-	i32.load	$11=, 0($11)
-	i32.const	$12=, 144
-	i32.sub 	$20=, $11, $12
-	i32.const	$12=, __stack_pointer
-	i32.store	$20=, 0($12), $20
+	i32.store	$19=, 0($11), $19
 	i32.const	$push22=, 0
 	i32.const	$push0=, 100
-	i32.call	$discard=, memset@FUNCTION, $20, $pop22, $pop0
-	i32.const	$9=, 0
+	i32.call	$discard=, memset@FUNCTION, $19, $pop22, $pop0
+	i32.const	$8=, 0
 	block
 	i32.const	$push63=, 0
 	i32.eq  	$push64=, $0, $pop63
 	br_if   	0, $pop64       # 0: down to label0
 # BB#1:                                 # %while.body.lr.ph
 	i32.const	$push8=, 96
-	i32.add 	$4=, $20, $pop8
+	i32.add 	$4=, $19, $pop8
 	i32.const	$push23=, 28
-	i32.const	$16=, 104
-	i32.add 	$16=, $20, $16
-	i32.add 	$1=, $16, $pop23
+	i32.const	$15=, 104
+	i32.add 	$15=, $19, $15
+	i32.add 	$1=, $15, $pop23
 .LBB0_2:                                # %while.body
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_3 Depth 2
                                         #       Child Loop BB0_5 Depth 3
                                         #         Child Loop BB0_6 Depth 4
-                                        #     Child Loop BB0_19 Depth 2
-                                        #       Child Loop BB0_20 Depth 3
+                                        #     Child Loop BB0_20 Depth 2
+                                        #       Child Loop BB0_21 Depth 3
 	loop                            # label1:
 	copy_local	$push26=, $0
-	tee_local	$push25=, $8=, $pop26
+	tee_local	$push25=, $7=, $pop26
 	i32.load	$0=, 28($pop25)
 	i32.const	$push24=, 0
-	i32.store	$3=, 28($8), $pop24
+	i32.store	$3=, 28($7), $pop24
 	copy_local	$5=, $3
 .LBB0_3:                                # %for.body
                                         #   Parent Loop BB0_2 Depth=1
@@ -51,333 +51,336 @@ sort_pagelist:                          # @sort_pagelist
                                         #         Child Loop BB0_6 Depth 4
 	block
 	block
-	loop                            # label5:
+	block
+	block
+	block
+	loop                            # label8:
 	i32.const	$push31=, 2
 	i32.shl 	$push1=, $5, $pop31
-	i32.add 	$push30=, $20, $pop1
-	tee_local	$push29=, $10=, $pop30
+	i32.add 	$push30=, $19, $pop1
+	tee_local	$push29=, $9=, $pop30
 	i32.load	$push28=, 0($pop29)
-	tee_local	$push27=, $9=, $pop28
+	tee_local	$push27=, $8=, $pop28
 	i32.const	$push65=, 0
 	i32.eq  	$push66=, $pop27, $pop65
-	br_if   	2, $pop66       # 2: down to label4
+	br_if   	2, $pop66       # 2: down to label7
 # BB#4:                                 # %if.else
                                         #   in Loop: Header=BB0_3 Depth=2
-	i32.const	$17=, 104
-	i32.add 	$17=, $20, $17
-	copy_local	$6=, $17
-	copy_local	$7=, $1
+	i32.const	$16=, 104
+	i32.add 	$16=, $19, $16
+	copy_local	$6=, $16
+	copy_local	$2=, $1
 	block
 	block
 	i32.const	$push67=, 0
-	i32.eq  	$push68=, $8, $pop67
-	br_if   	0, $pop68       # 0: down to label8
+	i32.eq  	$push68=, $7, $pop67
+	br_if   	0, $pop68       # 0: down to label11
 .LBB0_5:                                # %while.body.lr.ph.i
                                         #   Parent Loop BB0_2 Depth=1
                                         #     Parent Loop BB0_3 Depth=2
                                         # =>    This Loop Header: Depth=3
                                         #         Child Loop BB0_6 Depth 4
-	loop                            # label9:
-	i32.load	$2=, 0($9)
+	block
+	loop                            # label13:
+	i32.load	$2=, 0($8)
 .LBB0_6:                                # %while.body.i
                                         #   Parent Loop BB0_2 Depth=1
                                         #     Parent Loop BB0_3 Depth=2
                                         #       Parent Loop BB0_5 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop                            # label11:
-	i32.load	$push2=, 0($8)
+	loop                            # label15:
+	i32.load	$push2=, 0($7)
 	i32.lt_u	$push3=, $2, $pop2
-	br_if   	1, $pop3        # 1: down to label12
+	br_if   	1, $pop3        # 1: down to label16
 # BB#7:                                 # %if.else.i
                                         #   in Loop: Header=BB0_6 Depth=4
-	i32.const	$push34=, 28
-	i32.add 	$push4=, $6, $pop34
-	i32.store	$6=, 0($pop4), $8
-	i32.load	$8=, 28($6)
 	i32.const	$push33=, 28
-	i32.add 	$7=, $6, $pop33
-	br_if   	0, $8           # 0: up to label11
-	br      	4               # 4: down to label8
+	i32.add 	$push4=, $6, $pop33
+	i32.store	$6=, 0($pop4), $7
+	i32.load	$7=, 28($6)
+	br_if   	0, $7           # 0: up to label15
+	br      	4               # 4: down to label12
 .LBB0_8:                                # %if.then.i
                                         #   in Loop: Header=BB0_5 Depth=3
-	end_loop                        # label12:
+	end_loop                        # label16:
 	i32.const	$push32=, 28
 	i32.add 	$push5=, $6, $pop32
-	i32.store	$6=, 0($pop5), $9
-	i32.load	$9=, 28($6)
+	i32.store	$6=, 0($pop5), $8
+	i32.load	$8=, 28($6)
 	i32.const	$push69=, 0
-	i32.eq  	$push70=, $8, $pop69
-	br_if   	1, $pop70       # 1: down to label10
+	i32.eq  	$push70=, $7, $pop69
+	br_if   	1, $pop70       # 1: down to label14
 # BB#9:                                 # %if.then.i
                                         #   in Loop: Header=BB0_5 Depth=3
-	br_if   	0, $9           # 0: up to label9
+	br_if   	0, $8           # 0: up to label13
 .LBB0_10:                               # %while.end.i
                                         #   in Loop: Header=BB0_3 Depth=2
-	end_loop                        # label10:
+	end_loop                        # label14:
 	i32.const	$push35=, 28
-	i32.add 	$7=, $6, $pop35
-	br_if   	0, $9           # 0: down to label8
+	i32.add 	$2=, $6, $pop35
+	br_if   	1, $8           # 1: down to label11
 # BB#11:                                # %if.else9.i
                                         #   in Loop: Header=BB0_3 Depth=2
 	block
-	i32.const	$push71=, 0
-	i32.eq  	$push72=, $8, $pop71
-	br_if   	0, $pop72       # 0: down to label13
-# BB#12:                                # %if.then11.i
+	br_if   	0, $7           # 0: down to label17
+# BB#12:                                # %if.else13.i
                                         #   in Loop: Header=BB0_3 Depth=2
-	i32.store	$discard=, 0($7), $8
-	br      	2               # 2: down to label7
-.LBB0_13:                               # %if.else13.i
+	i32.store	$discard=, 0($2), $3
+	br      	3               # 3: down to label10
+.LBB0_13:                               # %if.then11.i
                                         #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label13:
-	i32.store	$discard=, 0($7), $3
-	br      	1               # 1: down to label7
-.LBB0_14:                               # %if.then7.i
+	end_block                       # label17:
+	i32.store	$discard=, 0($2), $7
+	br      	2               # 2: down to label10
+.LBB0_14:                               #   in Loop: Header=BB0_3 Depth=2
+	end_block                       # label12:
+	i32.const	$push34=, 28
+	i32.add 	$2=, $6, $pop34
+.LBB0_15:                               # %if.then7.i
                                         #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label8:
-	i32.store	$discard=, 0($7), $9
-.LBB0_15:                               # %merge_pagelist.exit
+	end_block                       # label11:
+	i32.store	$discard=, 0($2), $8
+.LBB0_16:                               # %merge_pagelist.exit
                                         #   in Loop: Header=BB0_3 Depth=2
-	end_block                       # label7:
+	end_block                       # label10:
 	i32.const	$push40=, 28
-	i32.const	$18=, 104
-	i32.add 	$18=, $20, $18
-	i32.add 	$push39=, $18, $pop40
-	tee_local	$push38=, $7=, $pop39
-	i32.load	$8=, 0($pop38)
-	i32.store	$6=, 0($10), $3
+	i32.const	$17=, 104
+	i32.add 	$17=, $19, $17
+	i32.add 	$push39=, $17, $pop40
+	tee_local	$push38=, $2=, $pop39
+	i32.load	$7=, 0($pop38)
+	i32.store	$6=, 0($9), $3
 	i32.const	$push37=, 1
 	i32.add 	$5=, $5, $pop37
 	i32.const	$push36=, 24
 	i32.lt_s	$push6=, $5, $pop36
-	br_if   	0, $pop6        # 0: up to label5
-# BB#16:                                # %for.end
+	br_if   	0, $pop6        # 0: up to label8
+# BB#17:                                # %for.end
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_loop                        # label6:
+	end_loop                        # label9:
 	i32.const	$push41=, 24
 	i32.ne  	$push7=, $5, $pop41
-	br_if   	1, $pop7        # 1: down to label3
-# BB#17:                                # %if.then7
-                                        #   in Loop: Header=BB0_2 Depth=1
-	i32.load	$push43=, 0($4):p2align=4
-	tee_local	$push42=, $10=, $pop43
-	i32.ne  	$5=, $pop42, $6
-	i32.ne  	$3=, $8, $6
-	i32.const	$19=, 104
-	i32.add 	$19=, $20, $19
-	copy_local	$2=, $19
-	block
-	block
-	block
-	i32.const	$push73=, 0
-	i32.eq  	$push74=, $8, $pop73
-	br_if   	0, $pop74       # 0: down to label16
+	br_if   	4, $pop7        # 4: down to label3
 # BB#18:                                # %if.then7
                                         #   in Loop: Header=BB0_2 Depth=1
-	i32.const	$push75=, 0
-	i32.eq  	$push76=, $10, $pop75
-	br_if   	0, $pop76       # 0: down to label16
-.LBB0_19:                               # %while.body.lr.ph.i85
+	i32.load	$push43=, 0($4):p2align=4
+	tee_local	$push42=, $9=, $pop43
+	i32.ne  	$5=, $pop42, $6
+	i32.ne  	$3=, $7, $6
+	i32.const	$18=, 104
+	i32.add 	$18=, $19, $18
+	copy_local	$8=, $18
+	block
+	i32.const	$push71=, 0
+	i32.eq  	$push72=, $7, $pop71
+	br_if   	0, $pop72       # 0: down to label18
+# BB#19:                                # %if.then7
+                                        #   in Loop: Header=BB0_2 Depth=1
+	i32.const	$push73=, 0
+	i32.eq  	$push74=, $9, $pop73
+	br_if   	0, $pop74       # 0: down to label18
+.LBB0_20:                               # %while.body.lr.ph.i85
                                         #   Parent Loop BB0_2 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB0_20 Depth 3
-	loop                            # label17:
-	i32.load	$5=, 0($10)
-.LBB0_20:                               # %while.body.i91
-                                        #   Parent Loop BB0_2 Depth=1
-                                        #     Parent Loop BB0_19 Depth=2
-                                        # =>    This Inner Loop Header: Depth=3
+                                        #       Child Loop BB0_21 Depth 3
 	loop                            # label19:
-	i32.load	$push9=, 0($8)
+	i32.load	$5=, 0($9)
+.LBB0_21:                               # %while.body.i91
+                                        #   Parent Loop BB0_2 Depth=1
+                                        #     Parent Loop BB0_20 Depth=2
+                                        # =>    This Inner Loop Header: Depth=3
+	loop                            # label21:
+	i32.load	$push9=, 0($7)
 	i32.lt_u	$push10=, $5, $pop9
-	br_if   	1, $pop10       # 1: down to label20
-# BB#21:                                # %if.else.i98
-                                        #   in Loop: Header=BB0_20 Depth=3
-	i32.const	$push46=, 28
-	i32.add 	$push11=, $2, $pop46
-	i32.store	$2=, 0($pop11), $8
-	i32.load	$8=, 28($2)
+	br_if   	1, $pop10       # 1: down to label22
+# BB#22:                                # %if.else.i98
+                                        #   in Loop: Header=BB0_21 Depth=3
 	i32.const	$push45=, 28
-	i32.add 	$9=, $2, $pop45
-	br_if   	0, $8           # 0: up to label19
-	br      	5               # 5: down to label15
-.LBB0_22:                               # %if.then.i95
-                                        #   in Loop: Header=BB0_19 Depth=2
-	end_loop                        # label20:
+	i32.add 	$push11=, $8, $pop45
+	i32.store	$8=, 0($pop11), $7
+	i32.load	$7=, 28($8)
+	br_if   	0, $7           # 0: up to label21
+	br      	6               # 6: down to label6
+.LBB0_23:                               # %if.then.i95
+                                        #   in Loop: Header=BB0_20 Depth=2
+	end_loop                        # label22:
 	i32.const	$push44=, 28
-	i32.add 	$push12=, $2, $pop44
-	i32.store	$2=, 0($pop12), $10
-	i32.load	$10=, 28($2)
-	i32.ne  	$5=, $10, $6
-	i32.ne  	$3=, $8, $6
-	i32.const	$push77=, 0
-	i32.eq  	$push78=, $8, $pop77
-	br_if   	1, $pop78       # 1: down to label18
-# BB#23:                                # %if.then.i95
-                                        #   in Loop: Header=BB0_19 Depth=2
-	br_if   	0, $10          # 0: up to label17
-.LBB0_24:                               # %while.end.i107
+	i32.add 	$push12=, $8, $pop44
+	i32.store	$8=, 0($pop12), $9
+	i32.load	$9=, 28($8)
+	i32.ne  	$5=, $9, $6
+	i32.ne  	$3=, $7, $6
+	i32.const	$push75=, 0
+	i32.eq  	$push76=, $7, $pop75
+	br_if   	1, $pop76       # 1: down to label20
+# BB#24:                                # %if.then.i95
+                                        #   in Loop: Header=BB0_20 Depth=2
+	br_if   	0, $9           # 0: up to label19
+.LBB0_25:                               # %while.end.i107
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_loop                        # label18:
-	end_block                       # label16:
+	end_loop                        # label20:
+	end_block                       # label18:
 	i32.const	$push47=, 28
-	i32.add 	$9=, $2, $pop47
-	br_if   	0, $5           # 0: down to label15
-# BB#25:                                # %if.else9.i111
+	i32.add 	$8=, $8, $pop47
+	br_if   	2, $5           # 2: down to label5
+# BB#26:                                # %if.else9.i111
                                         #   in Loop: Header=BB0_2 Depth=1
 	block
-	i32.const	$push79=, 0
-	i32.eq  	$push80=, $3, $pop79
-	br_if   	0, $pop80       # 0: down to label21
-# BB#26:                                # %if.then11.i112
+	br_if   	0, $3           # 0: down to label23
+# BB#27:                                # %if.else13.i113
                                         #   in Loop: Header=BB0_2 Depth=1
-	i32.store	$discard=, 0($9), $8
-	br      	2               # 2: down to label14
-.LBB0_27:                               # %if.else13.i113
+	i32.store	$discard=, 0($8), $6
+	br      	4               # 4: down to label4
+.LBB0_28:                               # %if.then11.i112
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label21:
-	i32.store	$discard=, 0($9), $6
-	br      	1               # 1: down to label14
-.LBB0_28:                               # %if.then7.i110
+	end_block                       # label23:
+	i32.store	$discard=, 0($8), $7
+	br      	3               # 3: down to label4
+.LBB0_29:                               # %for.end.thread
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label15:
-	i32.store	$discard=, 0($9), $10
-.LBB0_29:                               # %merge_pagelist.exit115
+	end_block                       # label7:
+	i32.store	$discard=, 0($9), $7
+	br      	3               # 3: down to label3
+.LBB0_30:                               #   in Loop: Header=BB0_2 Depth=1
+	end_block                       # label6:
+	i32.const	$push46=, 28
+	i32.add 	$8=, $8, $pop46
+.LBB0_31:                               # %if.then7.i110
                                         #   in Loop: Header=BB0_2 Depth=1
-	end_block                       # label14:
-	i32.load	$push13=, 0($7)
-	i32.store	$discard=, 0($4):p2align=4, $pop13
-	br      	1               # 1: down to label3
-.LBB0_30:                               # %for.end.thread
+	end_block                       # label5:
+	i32.store	$discard=, 0($8), $9
+.LBB0_32:                               # %merge_pagelist.exit115
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label4:
-	i32.store	$discard=, 0($10), $8
-.LBB0_31:                               # %while.cond.backedge
+	i32.load	$push13=, 0($2)
+	i32.store	$discard=, 0($4):p2align=4, $pop13
+.LBB0_33:                               # %while.cond.backedge
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label3:
 	br_if   	0, $0           # 0: up to label1
-# BB#32:                                # %while.end.loopexit
+# BB#34:                                # %while.end.loopexit
 	end_loop                        # label2:
-	i32.load	$9=, 0($20):p2align=4
-.LBB0_33:                               # %while.end
+	i32.load	$8=, 0($19):p2align=4
+.LBB0_35:                               # %while.end
 	end_block                       # label0:
 	i32.const	$5=, 1
-.LBB0_34:                               # %for.body15
+.LBB0_36:                               # %for.body15
                                         # =>This Loop Header: Depth=1
-                                        #     Child Loop BB0_36 Depth 2
-                                        #       Child Loop BB0_37 Depth 3
-	loop                            # label22:
+                                        #     Child Loop BB0_38 Depth 2
+                                        #       Child Loop BB0_39 Depth 3
+	loop                            # label24:
 	i32.const	$push52=, 0
-	i32.ne  	$2=, $9, $pop52
+	i32.ne  	$2=, $8, $pop52
 	i32.const	$push51=, 2
 	i32.shl 	$push14=, $5, $pop51
-	i32.add 	$push15=, $20, $pop14
+	i32.add 	$push15=, $19, $pop14
 	i32.load	$push50=, 0($pop15)
-	tee_local	$push49=, $8=, $pop50
+	tee_local	$push49=, $7=, $pop50
 	i32.const	$push48=, 0
-	i32.ne  	$10=, $pop49, $pop48
-	i32.const	$14=, 104
-	i32.add 	$14=, $20, $14
-	copy_local	$6=, $14
+	i32.ne  	$9=, $pop49, $pop48
+	i32.const	$13=, 104
+	i32.add 	$13=, $19, $13
+	copy_local	$6=, $13
 	block
 	block
 	block
-	i32.const	$push81=, 0
-	i32.eq  	$push82=, $9, $pop81
-	br_if   	0, $pop82       # 0: down to label26
-# BB#35:                                # %for.body15
-                                        #   in Loop: Header=BB0_34 Depth=1
-	i32.const	$push83=, 0
-	i32.eq  	$push84=, $8, $pop83
-	br_if   	0, $pop84       # 0: down to label26
-.LBB0_36:                               # %while.body.lr.ph.i47
-                                        #   Parent Loop BB0_34 Depth=1
+	block
+	i32.const	$push77=, 0
+	i32.eq  	$push78=, $8, $pop77
+	br_if   	0, $pop78       # 0: down to label29
+# BB#37:                                # %for.body15
+                                        #   in Loop: Header=BB0_36 Depth=1
+	i32.const	$push79=, 0
+	i32.eq  	$push80=, $7, $pop79
+	br_if   	0, $pop80       # 0: down to label29
+.LBB0_38:                               # %while.body.lr.ph.i47
+                                        #   Parent Loop BB0_36 Depth=1
                                         # =>  This Loop Header: Depth=2
-                                        #       Child Loop BB0_37 Depth 3
-	loop                            # label27:
-	i32.load	$2=, 0($9)
-.LBB0_37:                               # %while.body.i53
-                                        #   Parent Loop BB0_34 Depth=1
-                                        #     Parent Loop BB0_36 Depth=2
+                                        #       Child Loop BB0_39 Depth 3
+	loop                            # label30:
+	i32.load	$2=, 0($8)
+.LBB0_39:                               # %while.body.i53
+                                        #   Parent Loop BB0_36 Depth=1
+                                        #     Parent Loop BB0_38 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop                            # label29:
-	i32.load	$push16=, 0($8)
+	loop                            # label32:
+	i32.load	$push16=, 0($7)
 	i32.lt_u	$push17=, $2, $pop16
-	br_if   	1, $pop17       # 1: down to label30
-# BB#38:                                # %if.else.i60
-                                        #   in Loop: Header=BB0_37 Depth=3
-	i32.const	$push57=, 28
-	i32.add 	$push18=, $6, $pop57
-	i32.store	$6=, 0($pop18), $8
-	i32.load	$8=, 28($6)
+	br_if   	1, $pop17       # 1: down to label33
+# BB#40:                                # %if.else.i60
+                                        #   in Loop: Header=BB0_39 Depth=3
 	i32.const	$push56=, 28
-	i32.add 	$7=, $6, $pop56
-	br_if   	0, $8           # 0: up to label29
-	br      	5               # 5: down to label25
-.LBB0_39:                               # %if.then.i57
-                                        #   in Loop: Header=BB0_36 Depth=2
-	end_loop                        # label30:
+	i32.add 	$push18=, $6, $pop56
+	i32.store	$6=, 0($pop18), $7
+	i32.load	$7=, 28($6)
+	br_if   	0, $7           # 0: up to label32
+	br      	5               # 5: down to label28
+.LBB0_41:                               # %if.then.i57
+                                        #   in Loop: Header=BB0_38 Depth=2
+	end_loop                        # label33:
 	i32.const	$push55=, 28
 	i32.add 	$push19=, $6, $pop55
-	i32.store	$6=, 0($pop19), $9
-	i32.load	$9=, 28($6)
+	i32.store	$6=, 0($pop19), $8
+	i32.load	$8=, 28($6)
 	i32.const	$push54=, 0
-	i32.ne  	$2=, $9, $pop54
+	i32.ne  	$2=, $8, $pop54
 	i32.const	$push53=, 0
-	i32.ne  	$10=, $8, $pop53
-	i32.const	$push85=, 0
-	i32.eq  	$push86=, $8, $pop85
-	br_if   	1, $pop86       # 1: down to label28
-# BB#40:                                # %if.then.i57
-                                        #   in Loop: Header=BB0_36 Depth=2
-	br_if   	0, $9           # 0: up to label27
-.LBB0_41:                               # %while.end.i69
-                                        #   in Loop: Header=BB0_34 Depth=1
-	end_loop                        # label28:
-	end_block                       # label26:
+	i32.ne  	$9=, $7, $pop53
+	i32.const	$push81=, 0
+	i32.eq  	$push82=, $7, $pop81
+	br_if   	1, $pop82       # 1: down to label31
+# BB#42:                                # %if.then.i57
+                                        #   in Loop: Header=BB0_38 Depth=2
+	br_if   	0, $8           # 0: up to label30
+.LBB0_43:                               # %while.end.i69
+                                        #   in Loop: Header=BB0_36 Depth=1
+	end_loop                        # label31:
+	end_block                       # label29:
 	i32.const	$push58=, 28
-	i32.add 	$7=, $6, $pop58
-	br_if   	0, $2           # 0: down to label25
-# BB#42:                                # %if.else9.i73
-                                        #   in Loop: Header=BB0_34 Depth=1
+	i32.add 	$6=, $6, $pop58
+	br_if   	1, $2           # 1: down to label27
+# BB#44:                                # %if.else9.i73
+                                        #   in Loop: Header=BB0_36 Depth=1
 	block
-	i32.const	$push87=, 0
-	i32.eq  	$push88=, $10, $pop87
-	br_if   	0, $pop88       # 0: down to label31
-# BB#43:                                # %if.then11.i74
-                                        #   in Loop: Header=BB0_34 Depth=1
-	i32.store	$discard=, 0($7), $8
-	br      	2               # 2: down to label24
-.LBB0_44:                               # %if.else13.i75
-                                        #   in Loop: Header=BB0_34 Depth=1
-	end_block                       # label31:
+	br_if   	0, $9           # 0: down to label34
+# BB#45:                                # %if.else13.i75
+                                        #   in Loop: Header=BB0_36 Depth=1
 	i32.const	$push59=, 0
-	i32.store	$discard=, 0($7), $pop59
-	br      	1               # 1: down to label24
-.LBB0_45:                               # %if.then7.i72
-                                        #   in Loop: Header=BB0_34 Depth=1
-	end_block                       # label25:
-	i32.store	$discard=, 0($7), $9
-.LBB0_46:                               # %merge_pagelist.exit77
-                                        #   in Loop: Header=BB0_34 Depth=1
-	end_block                       # label24:
+	i32.store	$discard=, 0($6), $pop59
+	br      	3               # 3: down to label26
+.LBB0_46:                               # %if.then11.i74
+                                        #   in Loop: Header=BB0_36 Depth=1
+	end_block                       # label34:
+	i32.store	$discard=, 0($6), $7
+	br      	2               # 2: down to label26
+.LBB0_47:                               #   in Loop: Header=BB0_36 Depth=1
+	end_block                       # label28:
+	i32.const	$push57=, 28
+	i32.add 	$6=, $6, $pop57
+.LBB0_48:                               # %if.then7.i72
+                                        #   in Loop: Header=BB0_36 Depth=1
+	end_block                       # label27:
+	i32.store	$discard=, 0($6), $8
+.LBB0_49:                               # %merge_pagelist.exit77
+                                        #   in Loop: Header=BB0_36 Depth=1
+	end_block                       # label26:
 	i32.const	$push62=, 28
-	i32.const	$15=, 104
-	i32.add 	$15=, $20, $15
-	i32.add 	$push20=, $15, $pop62
-	i32.load	$9=, 0($pop20)
+	i32.const	$14=, 104
+	i32.add 	$14=, $19, $14
+	i32.add 	$push20=, $14, $pop62
+	i32.load	$8=, 0($pop20)
 	i32.const	$push61=, 1
 	i32.add 	$5=, $5, $pop61
 	i32.const	$push60=, 25
 	i32.ne  	$push21=, $5, $pop60
-	br_if   	0, $pop21       # 0: up to label22
-# BB#47:                                # %for.end20
-	end_loop                        # label23:
-	i32.const	$13=, 144
-	i32.add 	$20=, $20, $13
-	i32.const	$13=, __stack_pointer
-	i32.store	$20=, 0($13), $20
-	return  	$9
+	br_if   	0, $pop21       # 0: up to label24
+# BB#50:                                # %for.end20
+	end_loop                        # label25:
+	i32.const	$12=, 144
+	i32.add 	$19=, $19, $12
+	i32.const	$12=, __stack_pointer
+	i32.store	$19=, 0($12), $19
+	return  	$8
 	.endfunc
 .Lfunc_end0:
 	.size	sort_pagelist, .Lfunc_end0-sort_pagelist
@@ -425,7 +428,7 @@ main:                                   # @main
 	block
 	i32.load	$push17=, 28($1)
 	i32.eq  	$push18=, $1, $pop17
-	br_if   	0, $pop18       # 0: down to label32
+	br_if   	0, $pop18       # 0: down to label35
 # BB#1:                                 # %if.end
 	i32.const	$4=, 208
 	i32.add 	$5=, $5, $4
@@ -433,7 +436,7 @@ main:                                   # @main
 	i32.store	$5=, 0($4), $5
 	return  	$0
 .LBB1_2:                                # %if.then
-	end_block                       # label32:
+	end_block                       # label35:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/pr39100.c.s
+++ b/test/torture-s/pr39100.c.s
@@ -17,72 +17,74 @@ foo:                                    # @foo
 	i32.store	$16=, 0($10), $16
 	i32.const	$12=, 12
 	i32.add 	$12=, $16, $12
-	copy_local	$7=, $12
+	copy_local	$8=, $12
 	i32.const	$13=, 8
 	i32.add 	$13=, $16, $13
-	copy_local	$8=, $13
+	copy_local	$7=, $13
 	i32.const	$push0=, 0
 	i32.store	$push1=, 12($16), $pop0
-	i32.store	$2=, 8($16), $pop1
+	i32.store	$3=, 8($16), $pop1
 	block
 	i32.const	$push15=, 0
 	i32.eq  	$push16=, $1, $pop15
 	br_if   	0, $pop16       # 0: down to label0
 # BB#1:                                 # %while.body.lr.ph.lr.ph
 	i32.const	$push4=, 6
-	i32.add 	$3=, $0, $pop4
+	i32.add 	$4=, $0, $pop4
 	i32.const	$14=, 8
 	i32.add 	$14=, $16, $14
-	copy_local	$6=, $14
+	copy_local	$7=, $14
 	i32.const	$15=, 12
 	i32.add 	$15=, $16, $15
-	copy_local	$7=, $15
+	copy_local	$8=, $15
 .LBB0_2:                                # %while.body.lr.ph
                                         # =>This Loop Header: Depth=1
                                         #     Child Loop BB0_3 Depth 2
 	loop                            # label1:
-	copy_local	$5=, $1
+	copy_local	$6=, $1
 .LBB0_3:                                # %while.body
                                         #   Parent Loop BB0_2 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop                            # label3:
-	i32.load	$1=, 4($5)
+	i32.load	$1=, 4($6)
 	i32.const	$push11=, 4
-	i32.add 	$8=, $5, $pop11
-	i32.load8_u	$push2=, 0($5):p2align=2
+	i32.add 	$2=, $6, $pop11
+	i32.load8_u	$push2=, 0($6):p2align=2
 	i32.const	$push10=, 1
 	i32.and 	$push3=, $pop2, $pop10
 	br_if   	1, $pop3        # 1: down to label4
 # BB#4:                                 # %if.else
                                         #   in Loop: Header=BB0_3 Depth=2
 	i32.const	$push14=, 4
-	i32.add 	$4=, $0, $pop14
-	i32.load16_u	$push6=, 0($4):p2align=2
+	i32.add 	$5=, $0, $pop14
+	i32.load16_u	$push6=, 0($5):p2align=2
 	i32.const	$push13=, 1
 	i32.add 	$push7=, $pop6, $pop13
-	i32.store16	$discard=, 0($4):p2align=2, $pop7
-	i32.store	$discard=, 0($6), $5
-	copy_local	$5=, $1
-	copy_local	$6=, $8
+	i32.store16	$discard=, 0($5):p2align=2, $pop7
+	i32.store	$discard=, 0($7), $6
+	copy_local	$6=, $1
+	copy_local	$7=, $2
 	br_if   	0, $1           # 0: up to label3
 	br      	3               # 3: down to label2
 .LBB0_5:                                # %if.then
                                         #   in Loop: Header=BB0_2 Depth=1
 	end_loop                        # label4:
-	i32.load16_u	$4=, 0($3)
-	i32.store	$discard=, 0($7), $5
+	i32.load16_u	$5=, 0($4)
+	i32.store	$discard=, 0($8), $6
 	i32.const	$push12=, 1
-	i32.add 	$push5=, $4, $pop12
-	i32.store16	$discard=, 0($3), $pop5
-	copy_local	$7=, $8
-	copy_local	$8=, $6
+	i32.add 	$push5=, $5, $pop12
+	i32.store16	$discard=, 0($4), $pop5
+	copy_local	$8=, $2
 	br_if   	0, $1           # 0: up to label1
-.LBB0_6:                                # %while.end
+	br      	2               # 2: down to label0
+.LBB0_6:
 	end_loop                        # label2:
+	copy_local	$7=, $2
+.LBB0_7:                                # %while.end
 	end_block                       # label0:
 	i32.load	$push8=, 8($16)
-	i32.store	$discard=, 0($7), $pop8
-	i32.store	$discard=, 0($8), $2
+	i32.store	$discard=, 0($8), $pop8
+	i32.store	$discard=, 0($7), $3
 	i32.load	$push9=, 12($16)
 	i32.store	$discard=, 0($0), $pop9
 	i32.const	$11=, 16
@@ -130,29 +132,26 @@ main:                                   # @main
 	i32.const	$5=, 24
 	i32.add 	$5=, $6, $5
 	block
-	block
-	block
-	block
 	i32.or  	$push10=, $5, $pop24
 	i32.load	$push11=, 0($pop10)
 	i32.const	$push12=, 65537
 	i32.ne  	$push13=, $pop11, $pop12
-	br_if   	0, $pop13       # 0: down to label8
+	br_if   	0, $pop13       # 0: down to label5
 # BB#1:                                 # %if.end
 	i32.load	$push14=, 24($6):p2align=3
 	i32.ne  	$push15=, $pop14, $0
-	br_if   	1, $pop15       # 1: down to label7
+	br_if   	0, $pop15       # 0: down to label5
 # BB#2:                                 # %if.end13
 	i32.const	$push16=, 12
 	i32.or  	$push17=, $6, $pop16
 	i32.load	$push18=, 0($pop17)
 	i32.ne  	$push19=, $pop18, $6
-	br_if   	2, $pop19       # 2: down to label6
+	br_if   	0, $pop19       # 0: down to label5
 # BB#3:                                 # %if.end20
 	i32.const	$push20=, 4
 	i32.or  	$push21=, $6, $pop20
 	i32.load	$push22=, 0($pop21)
-	br_if   	3, $pop22       # 3: down to label5
+	br_if   	0, $pop22       # 0: down to label5
 # BB#4:                                 # %if.end24
 	i32.const	$push23=, 0
 	i32.const	$3=, 32
@@ -160,19 +159,7 @@ main:                                   # @main
 	i32.const	$3=, __stack_pointer
 	i32.store	$6=, 0($3), $6
 	return  	$pop23
-.LBB1_5:                                # %if.then
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_6:                                # %if.then12
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_7:                                # %if.then19
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_8:                                # %if.then23
+.LBB1_5:                                # %if.then23
 	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr39228.c.s
+++ b/test/torture-s/pr39228.c.s
@@ -8,37 +8,27 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	f64.const	$push0=, infinity
 	i32.call	$push1=, __builtin_isinff@FUNCTION, $pop0
 	i32.const	$push2=, 0
 	i32.le_s	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label2
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push4=, 1
 	i32.const	$push11=, 0
 	i32.eq  	$push12=, $pop4, $pop11
-	br_if   	1, $pop12       # 1: down to label1
+	br_if   	0, $pop12       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i64.const	$push6=, 0
 	i64.const	$push5=, 9223090561878065152
 	i32.call	$push7=, __builtin_isinfl@FUNCTION, $pop6, $pop5
 	i32.const	$push9=, 0
 	i32.le_s	$push8=, $pop7, $pop9
-	br_if   	2, $pop8        # 2: down to label0
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.const	$push10=, 0
 	return  	$pop10
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then3
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then7
+.LBB0_4:                                # %if.then7
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr39240.c.s
+++ b/test/torture-s/pr39240.c.s
@@ -194,76 +194,51 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push20=, -10
 	i32.call	$push0=, bar1@FUNCTION, $pop20
 	i32.const	$push19=, 0
 	i32.load	$push1=, l1($pop19)
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label5
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push22=, -10
 	i32.call	$push3=, bar2@FUNCTION, $pop22
 	i32.const	$push21=, 0
 	i32.load	$push4=, l2($pop21)
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label4
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end5
 	i32.const	$push24=, -10
 	i32.call	$push6=, bar3@FUNCTION, $pop24
 	i32.const	$push23=, 0
 	i32.load	$push7=, l3($pop23)
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label3
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end11
 	i32.const	$push26=, -10
 	i32.call	$push9=, bar4@FUNCTION, $pop26
 	i32.const	$push25=, 0
 	i32.load	$push10=, l4($pop25)
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label2
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end16
 	i32.const	$push28=, -10
 	i32.call	$push12=, bar5@FUNCTION, $pop28
 	i32.const	$push27=, 0
 	i32.load	$push13=, l5($pop27)
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	4, $pop14       # 4: down to label1
+	br_if   	0, $pop14       # 0: down to label0
 # BB#5:                                 # %if.end22
 	i32.const	$push30=, -10
 	i32.call	$push15=, bar6@FUNCTION, $pop30
 	i32.const	$push29=, 0
 	i32.load	$push16=, l6($pop29)
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	5, $pop17       # 5: down to label0
+	br_if   	0, $pop17       # 0: down to label0
 # BB#6:                                 # %if.end28
 	i32.const	$push18=, 0
 	return  	$pop18
-.LBB12_7:                               # %if.then
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_8:                               # %if.then4
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_9:                               # %if.then10
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_10:                              # %if.then15
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_11:                              # %if.then21
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_12:                              # %if.then27
+.LBB12_7:                               # %if.then27
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr39339.c.s
+++ b/test/torture-s/pr39339.c.s
@@ -132,12 +132,11 @@ main:                                   # @main
 	i32.const	$14=, 16
 	i32.add 	$14=, $16, $14
 	block
-	block
 	i32.or  	$push19=, $14, $1
 	i32.load	$push22=, 0($pop19)
 	i32.const	$push29=, 1434451954
 	i32.ne  	$push23=, $pop22, $pop29
-	br_if   	0, $pop23       # 0: down to label4
+	br_if   	0, $pop23       # 0: down to label3
 # BB#1:                                 # %if.end
 	i32.const	$push24=, 12
 	i32.const	$15=, 16
@@ -146,7 +145,7 @@ main:                                   # @main
 	i32.load	$push26=, 0($pop25)
 	i32.const	$push36=, 1434451954
 	i32.ne  	$push27=, $pop26, $pop36
-	br_if   	1, $pop27       # 1: down to label3
+	br_if   	0, $pop27       # 0: down to label3
 # BB#2:                                 # %if.end13
 	i32.const	$push28=, 0
 	i32.const	$4=, 64
@@ -154,11 +153,7 @@ main:                                   # @main
 	i32.const	$4=, __stack_pointer
 	i32.store	$16=, 0($4), $16
 	return  	$pop28
-.LBB1_3:                                # %if.then
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_4:                                # %if.then12
+.LBB1_3:                                # %if.then12
 	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr39501.c.s
+++ b/test/torture-s/pr39501.c.s
@@ -128,581 +128,348 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
+	block
 	f32.const	$push99=, 0x0p0
 	f32.const	$push98=, -0x1p0
 	f32.call	$push0=, float_min1@FUNCTION, $pop99, $pop98
 	f32.const	$push97=, -0x1p0
-	f32.eq  	$push1=, $pop0, $pop97
-	br_if   	0, $pop1        # 0: down to label0
-# BB#1:                                 # %if.then
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_2:                                # %if.end
-	end_block                       # label0:
-	block
+	f32.ne  	$push1=, $pop0, $pop97
+	br_if   	0, $pop1        # 0: down to label1
+# BB#1:                                 # %if.end
 	f32.const	$push102=, -0x1p0
 	f32.const	$push101=, 0x0p0
 	f32.call	$push2=, float_min1@FUNCTION, $pop102, $pop101
 	f32.const	$push100=, -0x1p0
-	f32.eq  	$push3=, $pop2, $pop100
+	f32.ne  	$push3=, $pop2, $pop100
 	br_if   	0, $pop3        # 0: down to label1
-# BB#3:                                 # %if.then3
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_4:                                # %if.end4
-	end_block                       # label1:
-	block
+# BB#2:                                 # %if.end4
 	f32.const	$push105=, 0x0p0
 	f32.const	$push104=, 0x1p0
 	f32.call	$push4=, float_min1@FUNCTION, $pop105, $pop104
 	f32.const	$push103=, 0x0p0
-	f32.eq  	$push5=, $pop4, $pop103
-	br_if   	0, $pop5        # 0: down to label2
-# BB#5:                                 # %if.then7
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_6:                                # %if.end8
-	end_block                       # label2:
-	block
+	f32.ne  	$push5=, $pop4, $pop103
+	br_if   	0, $pop5        # 0: down to label1
+# BB#3:                                 # %if.end8
 	f32.const	$push108=, 0x1p0
 	f32.const	$push107=, 0x0p0
 	f32.call	$push6=, float_min1@FUNCTION, $pop108, $pop107
 	f32.const	$push106=, 0x0p0
-	f32.eq  	$push7=, $pop6, $pop106
-	br_if   	0, $pop7        # 0: down to label3
-# BB#7:                                 # %if.then11
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_8:                                # %if.end12
-	end_block                       # label3:
-	block
+	f32.ne  	$push7=, $pop6, $pop106
+	br_if   	0, $pop7        # 0: down to label1
+# BB#4:                                 # %if.end12
 	f32.const	$push111=, -0x1p0
 	f32.const	$push110=, 0x1p0
 	f32.call	$push8=, float_min1@FUNCTION, $pop111, $pop110
 	f32.const	$push109=, -0x1p0
-	f32.eq  	$push9=, $pop8, $pop109
-	br_if   	0, $pop9        # 0: down to label4
-# BB#9:                                 # %if.then15
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_10:                               # %if.end16
-	end_block                       # label4:
-	block
+	f32.ne  	$push9=, $pop8, $pop109
+	br_if   	0, $pop9        # 0: down to label1
+# BB#5:                                 # %if.end16
 	f32.const	$push114=, 0x1p0
 	f32.const	$push113=, -0x1p0
 	f32.call	$push10=, float_min1@FUNCTION, $pop114, $pop113
 	f32.const	$push112=, -0x1p0
-	f32.eq  	$push11=, $pop10, $pop112
-	br_if   	0, $pop11       # 0: down to label5
-# BB#11:                                # %if.then19
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_12:                               # %if.end20
-	end_block                       # label5:
-	block
+	f32.ne  	$push11=, $pop10, $pop112
+	br_if   	0, $pop11       # 0: down to label1
+# BB#6:                                 # %if.end20
 	f32.const	$push117=, 0x0p0
 	f32.const	$push116=, -0x1p0
 	f32.call	$push12=, float_max1@FUNCTION, $pop117, $pop116
 	f32.const	$push115=, 0x0p0
-	f32.eq  	$push13=, $pop12, $pop115
-	br_if   	0, $pop13       # 0: down to label6
-# BB#13:                                # %if.then23
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_14:                               # %if.end24
-	end_block                       # label6:
-	block
+	f32.ne  	$push13=, $pop12, $pop115
+	br_if   	0, $pop13       # 0: down to label1
+# BB#7:                                 # %if.end24
 	f32.const	$push120=, -0x1p0
 	f32.const	$push119=, 0x0p0
 	f32.call	$push14=, float_max1@FUNCTION, $pop120, $pop119
 	f32.const	$push118=, 0x0p0
-	f32.eq  	$push15=, $pop14, $pop118
-	br_if   	0, $pop15       # 0: down to label7
-# BB#15:                                # %if.then27
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_16:                               # %if.end28
-	end_block                       # label7:
-	block
+	f32.ne  	$push15=, $pop14, $pop118
+	br_if   	0, $pop15       # 0: down to label1
+# BB#8:                                 # %if.end28
 	f32.const	$push123=, 0x0p0
 	f32.const	$push122=, 0x1p0
 	f32.call	$push16=, float_max1@FUNCTION, $pop123, $pop122
 	f32.const	$push121=, 0x1p0
-	f32.eq  	$push17=, $pop16, $pop121
-	br_if   	0, $pop17       # 0: down to label8
-# BB#17:                                # %if.then31
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_18:                               # %if.end32
-	end_block                       # label8:
-	block
+	f32.ne  	$push17=, $pop16, $pop121
+	br_if   	0, $pop17       # 0: down to label1
+# BB#9:                                 # %if.end32
 	f32.const	$push126=, 0x1p0
 	f32.const	$push125=, 0x0p0
 	f32.call	$push18=, float_max1@FUNCTION, $pop126, $pop125
 	f32.const	$push124=, 0x1p0
-	f32.eq  	$push19=, $pop18, $pop124
-	br_if   	0, $pop19       # 0: down to label9
-# BB#19:                                # %if.then35
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_20:                               # %if.end36
-	end_block                       # label9:
-	block
+	f32.ne  	$push19=, $pop18, $pop124
+	br_if   	0, $pop19       # 0: down to label1
+# BB#10:                                # %if.end36
 	f32.const	$push129=, -0x1p0
 	f32.const	$push128=, 0x1p0
 	f32.call	$push20=, float_max1@FUNCTION, $pop129, $pop128
 	f32.const	$push127=, 0x1p0
-	f32.eq  	$push21=, $pop20, $pop127
-	br_if   	0, $pop21       # 0: down to label10
-# BB#21:                                # %if.then39
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_22:                               # %if.end40
-	end_block                       # label10:
-	block
+	f32.ne  	$push21=, $pop20, $pop127
+	br_if   	0, $pop21       # 0: down to label1
+# BB#11:                                # %if.end40
 	f32.const	$push132=, 0x1p0
 	f32.const	$push131=, -0x1p0
 	f32.call	$push22=, float_max1@FUNCTION, $pop132, $pop131
 	f32.const	$push130=, 0x1p0
-	f32.eq  	$push23=, $pop22, $pop130
-	br_if   	0, $pop23       # 0: down to label11
-# BB#23:                                # %if.then43
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_24:                               # %if.end44
-	end_block                       # label11:
-	block
+	f32.ne  	$push23=, $pop22, $pop130
+	br_if   	0, $pop23       # 0: down to label1
+# BB#12:                                # %if.end44
 	f32.const	$push135=, 0x0p0
 	f32.const	$push134=, -0x1p0
 	f32.call	$push24=, float_min2@FUNCTION, $pop135, $pop134
 	f32.const	$push133=, -0x1p0
-	f32.eq  	$push25=, $pop24, $pop133
-	br_if   	0, $pop25       # 0: down to label12
-# BB#25:                                # %if.then47
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_26:                               # %if.end48
-	end_block                       # label12:
-	block
+	f32.ne  	$push25=, $pop24, $pop133
+	br_if   	0, $pop25       # 0: down to label1
+# BB#13:                                # %if.end48
 	f32.const	$push138=, -0x1p0
 	f32.const	$push137=, 0x0p0
 	f32.call	$push26=, float_min2@FUNCTION, $pop138, $pop137
 	f32.const	$push136=, -0x1p0
-	f32.eq  	$push27=, $pop26, $pop136
-	br_if   	0, $pop27       # 0: down to label13
-# BB#27:                                # %if.then51
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_28:                               # %if.end52
-	end_block                       # label13:
-	block
+	f32.ne  	$push27=, $pop26, $pop136
+	br_if   	0, $pop27       # 0: down to label1
+# BB#14:                                # %if.end52
 	f32.const	$push141=, 0x0p0
 	f32.const	$push140=, 0x1p0
 	f32.call	$push28=, float_min2@FUNCTION, $pop141, $pop140
 	f32.const	$push139=, 0x0p0
-	f32.eq  	$push29=, $pop28, $pop139
-	br_if   	0, $pop29       # 0: down to label14
-# BB#29:                                # %if.then55
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_30:                               # %if.end56
-	end_block                       # label14:
-	block
+	f32.ne  	$push29=, $pop28, $pop139
+	br_if   	0, $pop29       # 0: down to label1
+# BB#15:                                # %if.end56
 	f32.const	$push144=, 0x1p0
 	f32.const	$push143=, 0x0p0
 	f32.call	$push30=, float_min2@FUNCTION, $pop144, $pop143
 	f32.const	$push142=, 0x0p0
-	f32.eq  	$push31=, $pop30, $pop142
-	br_if   	0, $pop31       # 0: down to label15
-# BB#31:                                # %if.then59
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_32:                               # %if.end60
-	end_block                       # label15:
-	block
+	f32.ne  	$push31=, $pop30, $pop142
+	br_if   	0, $pop31       # 0: down to label1
+# BB#16:                                # %if.end60
 	f32.const	$push147=, -0x1p0
 	f32.const	$push146=, 0x1p0
 	f32.call	$push32=, float_min2@FUNCTION, $pop147, $pop146
 	f32.const	$push145=, -0x1p0
-	f32.eq  	$push33=, $pop32, $pop145
-	br_if   	0, $pop33       # 0: down to label16
-# BB#33:                                # %if.then63
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_34:                               # %if.end64
-	end_block                       # label16:
-	block
+	f32.ne  	$push33=, $pop32, $pop145
+	br_if   	0, $pop33       # 0: down to label1
+# BB#17:                                # %if.end64
 	f32.const	$push150=, 0x1p0
 	f32.const	$push149=, -0x1p0
 	f32.call	$push34=, float_min2@FUNCTION, $pop150, $pop149
 	f32.const	$push148=, -0x1p0
-	f32.eq  	$push35=, $pop34, $pop148
-	br_if   	0, $pop35       # 0: down to label17
-# BB#35:                                # %if.then67
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_36:                               # %if.end68
-	end_block                       # label17:
-	block
+	f32.ne  	$push35=, $pop34, $pop148
+	br_if   	0, $pop35       # 0: down to label1
+# BB#18:                                # %if.end68
 	f32.const	$push153=, 0x0p0
 	f32.const	$push152=, -0x1p0
 	f32.call	$push36=, float_max2@FUNCTION, $pop153, $pop152
 	f32.const	$push151=, 0x0p0
-	f32.eq  	$push37=, $pop36, $pop151
-	br_if   	0, $pop37       # 0: down to label18
-# BB#37:                                # %if.then71
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_38:                               # %if.end72
-	end_block                       # label18:
-	block
+	f32.ne  	$push37=, $pop36, $pop151
+	br_if   	0, $pop37       # 0: down to label1
+# BB#19:                                # %if.end72
 	f32.const	$push156=, -0x1p0
 	f32.const	$push155=, 0x0p0
 	f32.call	$push38=, float_max2@FUNCTION, $pop156, $pop155
 	f32.const	$push154=, 0x0p0
-	f32.eq  	$push39=, $pop38, $pop154
-	br_if   	0, $pop39       # 0: down to label19
-# BB#39:                                # %if.then75
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_40:                               # %if.end76
-	end_block                       # label19:
-	block
+	f32.ne  	$push39=, $pop38, $pop154
+	br_if   	0, $pop39       # 0: down to label1
+# BB#20:                                # %if.end76
 	f32.const	$push159=, 0x0p0
 	f32.const	$push158=, 0x1p0
 	f32.call	$push40=, float_max2@FUNCTION, $pop159, $pop158
 	f32.const	$push157=, 0x1p0
-	f32.eq  	$push41=, $pop40, $pop157
-	br_if   	0, $pop41       # 0: down to label20
-# BB#41:                                # %if.then79
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_42:                               # %if.end80
-	end_block                       # label20:
-	block
+	f32.ne  	$push41=, $pop40, $pop157
+	br_if   	0, $pop41       # 0: down to label1
+# BB#21:                                # %if.end80
 	f32.const	$push162=, 0x1p0
 	f32.const	$push161=, 0x0p0
 	f32.call	$push42=, float_max2@FUNCTION, $pop162, $pop161
 	f32.const	$push160=, 0x1p0
-	f32.eq  	$push43=, $pop42, $pop160
-	br_if   	0, $pop43       # 0: down to label21
-# BB#43:                                # %if.then83
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_44:                               # %if.end84
-	end_block                       # label21:
-	block
+	f32.ne  	$push43=, $pop42, $pop160
+	br_if   	0, $pop43       # 0: down to label1
+# BB#22:                                # %if.end84
 	f32.const	$push165=, -0x1p0
 	f32.const	$push164=, 0x1p0
 	f32.call	$push44=, float_max2@FUNCTION, $pop165, $pop164
 	f32.const	$push163=, 0x1p0
-	f32.eq  	$push45=, $pop44, $pop163
-	br_if   	0, $pop45       # 0: down to label22
-# BB#45:                                # %if.then87
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_46:                               # %if.end88
-	end_block                       # label22:
-	block
+	f32.ne  	$push45=, $pop44, $pop163
+	br_if   	0, $pop45       # 0: down to label1
+# BB#23:                                # %if.end88
 	f32.const	$push168=, 0x1p0
 	f32.const	$push167=, -0x1p0
 	f32.call	$push46=, float_max2@FUNCTION, $pop168, $pop167
 	f32.const	$push166=, 0x1p0
-	f32.eq  	$push47=, $pop46, $pop166
-	br_if   	0, $pop47       # 0: down to label23
-# BB#47:                                # %if.then91
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_48:                               # %if.end92
-	end_block                       # label23:
-	block
+	f32.ne  	$push47=, $pop46, $pop166
+	br_if   	0, $pop47       # 0: down to label1
+# BB#24:                                # %if.end92
 	f64.const	$push171=, 0x0p0
 	f64.const	$push170=, -0x1p0
 	f64.call	$push48=, double_min1@FUNCTION, $pop171, $pop170
 	f64.const	$push169=, -0x1p0
-	f64.eq  	$push49=, $pop48, $pop169
-	br_if   	0, $pop49       # 0: down to label24
-# BB#49:                                # %if.then95
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_50:                               # %if.end96
-	end_block                       # label24:
-	block
+	f64.ne  	$push49=, $pop48, $pop169
+	br_if   	0, $pop49       # 0: down to label1
+# BB#25:                                # %if.end96
 	f64.const	$push174=, -0x1p0
 	f64.const	$push173=, 0x0p0
 	f64.call	$push50=, double_min1@FUNCTION, $pop174, $pop173
 	f64.const	$push172=, -0x1p0
-	f64.eq  	$push51=, $pop50, $pop172
-	br_if   	0, $pop51       # 0: down to label25
-# BB#51:                                # %if.then99
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_52:                               # %if.end100
-	end_block                       # label25:
-	block
+	f64.ne  	$push51=, $pop50, $pop172
+	br_if   	0, $pop51       # 0: down to label1
+# BB#26:                                # %if.end100
 	f64.const	$push177=, 0x0p0
 	f64.const	$push176=, 0x1p0
 	f64.call	$push52=, double_min1@FUNCTION, $pop177, $pop176
 	f64.const	$push175=, 0x0p0
-	f64.eq  	$push53=, $pop52, $pop175
-	br_if   	0, $pop53       # 0: down to label26
-# BB#53:                                # %if.then103
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_54:                               # %if.end104
-	end_block                       # label26:
-	block
+	f64.ne  	$push53=, $pop52, $pop175
+	br_if   	0, $pop53       # 0: down to label1
+# BB#27:                                # %if.end104
 	f64.const	$push180=, 0x1p0
 	f64.const	$push179=, 0x0p0
 	f64.call	$push54=, double_min1@FUNCTION, $pop180, $pop179
 	f64.const	$push178=, 0x0p0
-	f64.eq  	$push55=, $pop54, $pop178
-	br_if   	0, $pop55       # 0: down to label27
-# BB#55:                                # %if.then107
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_56:                               # %if.end108
-	end_block                       # label27:
-	block
+	f64.ne  	$push55=, $pop54, $pop178
+	br_if   	0, $pop55       # 0: down to label1
+# BB#28:                                # %if.end108
 	f64.const	$push183=, -0x1p0
 	f64.const	$push182=, 0x1p0
 	f64.call	$push56=, double_min1@FUNCTION, $pop183, $pop182
 	f64.const	$push181=, -0x1p0
-	f64.eq  	$push57=, $pop56, $pop181
-	br_if   	0, $pop57       # 0: down to label28
-# BB#57:                                # %if.then111
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_58:                               # %if.end112
-	end_block                       # label28:
-	block
+	f64.ne  	$push57=, $pop56, $pop181
+	br_if   	0, $pop57       # 0: down to label1
+# BB#29:                                # %if.end112
 	f64.const	$push186=, 0x1p0
 	f64.const	$push185=, -0x1p0
 	f64.call	$push58=, double_min1@FUNCTION, $pop186, $pop185
 	f64.const	$push184=, -0x1p0
-	f64.eq  	$push59=, $pop58, $pop184
-	br_if   	0, $pop59       # 0: down to label29
-# BB#59:                                # %if.then115
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_60:                               # %if.end116
-	end_block                       # label29:
-	block
+	f64.ne  	$push59=, $pop58, $pop184
+	br_if   	0, $pop59       # 0: down to label1
+# BB#30:                                # %if.end116
 	f64.const	$push189=, 0x0p0
 	f64.const	$push188=, -0x1p0
 	f64.call	$push60=, double_max1@FUNCTION, $pop189, $pop188
 	f64.const	$push187=, 0x0p0
-	f64.eq  	$push61=, $pop60, $pop187
-	br_if   	0, $pop61       # 0: down to label30
-# BB#61:                                # %if.then119
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_62:                               # %if.end120
-	end_block                       # label30:
-	block
+	f64.ne  	$push61=, $pop60, $pop187
+	br_if   	0, $pop61       # 0: down to label1
+# BB#31:                                # %if.end120
 	f64.const	$push192=, -0x1p0
 	f64.const	$push191=, 0x0p0
 	f64.call	$push62=, double_max1@FUNCTION, $pop192, $pop191
 	f64.const	$push190=, 0x0p0
-	f64.eq  	$push63=, $pop62, $pop190
-	br_if   	0, $pop63       # 0: down to label31
-# BB#63:                                # %if.then123
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_64:                               # %if.end124
-	end_block                       # label31:
-	block
+	f64.ne  	$push63=, $pop62, $pop190
+	br_if   	0, $pop63       # 0: down to label1
+# BB#32:                                # %if.end124
 	f64.const	$push195=, 0x0p0
 	f64.const	$push194=, 0x1p0
 	f64.call	$push64=, double_max1@FUNCTION, $pop195, $pop194
 	f64.const	$push193=, 0x1p0
-	f64.eq  	$push65=, $pop64, $pop193
-	br_if   	0, $pop65       # 0: down to label32
-# BB#65:                                # %if.then127
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_66:                               # %if.end128
-	end_block                       # label32:
-	block
+	f64.ne  	$push65=, $pop64, $pop193
+	br_if   	0, $pop65       # 0: down to label1
+# BB#33:                                # %if.end128
 	f64.const	$push198=, 0x1p0
 	f64.const	$push197=, 0x0p0
 	f64.call	$push66=, double_max1@FUNCTION, $pop198, $pop197
 	f64.const	$push196=, 0x1p0
-	f64.eq  	$push67=, $pop66, $pop196
-	br_if   	0, $pop67       # 0: down to label33
-# BB#67:                                # %if.then131
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_68:                               # %if.end132
-	end_block                       # label33:
-	block
+	f64.ne  	$push67=, $pop66, $pop196
+	br_if   	0, $pop67       # 0: down to label1
+# BB#34:                                # %if.end132
 	f64.const	$push201=, -0x1p0
 	f64.const	$push200=, 0x1p0
 	f64.call	$push68=, double_max1@FUNCTION, $pop201, $pop200
 	f64.const	$push199=, 0x1p0
-	f64.eq  	$push69=, $pop68, $pop199
-	br_if   	0, $pop69       # 0: down to label34
-# BB#69:                                # %if.then135
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_70:                               # %if.end136
-	end_block                       # label34:
-	block
+	f64.ne  	$push69=, $pop68, $pop199
+	br_if   	0, $pop69       # 0: down to label1
+# BB#35:                                # %if.end136
 	f64.const	$push204=, 0x1p0
 	f64.const	$push203=, -0x1p0
 	f64.call	$push70=, double_max1@FUNCTION, $pop204, $pop203
 	f64.const	$push202=, 0x1p0
-	f64.eq  	$push71=, $pop70, $pop202
-	br_if   	0, $pop71       # 0: down to label35
-# BB#71:                                # %if.then139
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_72:                               # %if.end140
-	end_block                       # label35:
-	block
+	f64.ne  	$push71=, $pop70, $pop202
+	br_if   	0, $pop71       # 0: down to label1
+# BB#36:                                # %if.end140
 	f64.const	$push207=, 0x0p0
 	f64.const	$push206=, -0x1p0
 	f64.call	$push72=, double_min2@FUNCTION, $pop207, $pop206
 	f64.const	$push205=, -0x1p0
-	f64.eq  	$push73=, $pop72, $pop205
-	br_if   	0, $pop73       # 0: down to label36
-# BB#73:                                # %if.then143
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_74:                               # %if.end144
-	end_block                       # label36:
-	block
+	f64.ne  	$push73=, $pop72, $pop205
+	br_if   	0, $pop73       # 0: down to label1
+# BB#37:                                # %if.end144
 	f64.const	$push210=, -0x1p0
 	f64.const	$push209=, 0x0p0
 	f64.call	$push74=, double_min2@FUNCTION, $pop210, $pop209
 	f64.const	$push208=, -0x1p0
-	f64.eq  	$push75=, $pop74, $pop208
-	br_if   	0, $pop75       # 0: down to label37
-# BB#75:                                # %if.then147
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_76:                               # %if.end148
-	end_block                       # label37:
-	block
+	f64.ne  	$push75=, $pop74, $pop208
+	br_if   	0, $pop75       # 0: down to label1
+# BB#38:                                # %if.end148
 	f64.const	$push213=, 0x0p0
 	f64.const	$push212=, 0x1p0
 	f64.call	$push76=, double_min2@FUNCTION, $pop213, $pop212
 	f64.const	$push211=, 0x0p0
-	f64.eq  	$push77=, $pop76, $pop211
-	br_if   	0, $pop77       # 0: down to label38
-# BB#77:                                # %if.then151
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_78:                               # %if.end152
-	end_block                       # label38:
-	block
+	f64.ne  	$push77=, $pop76, $pop211
+	br_if   	0, $pop77       # 0: down to label1
+# BB#39:                                # %if.end152
 	f64.const	$push216=, 0x1p0
 	f64.const	$push215=, 0x0p0
 	f64.call	$push78=, double_min2@FUNCTION, $pop216, $pop215
 	f64.const	$push214=, 0x0p0
-	f64.eq  	$push79=, $pop78, $pop214
-	br_if   	0, $pop79       # 0: down to label39
-# BB#79:                                # %if.then155
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_80:                               # %if.end156
-	end_block                       # label39:
-	block
+	f64.ne  	$push79=, $pop78, $pop214
+	br_if   	0, $pop79       # 0: down to label1
+# BB#40:                                # %if.end156
 	f64.const	$push219=, -0x1p0
 	f64.const	$push218=, 0x1p0
 	f64.call	$push80=, double_min2@FUNCTION, $pop219, $pop218
 	f64.const	$push217=, -0x1p0
-	f64.eq  	$push81=, $pop80, $pop217
-	br_if   	0, $pop81       # 0: down to label40
-# BB#81:                                # %if.then159
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_82:                               # %if.end160
-	end_block                       # label40:
-	block
+	f64.ne  	$push81=, $pop80, $pop217
+	br_if   	0, $pop81       # 0: down to label1
+# BB#41:                                # %if.end160
 	f64.const	$push222=, 0x1p0
 	f64.const	$push221=, -0x1p0
 	f64.call	$push82=, double_min2@FUNCTION, $pop222, $pop221
 	f64.const	$push220=, -0x1p0
-	f64.eq  	$push83=, $pop82, $pop220
-	br_if   	0, $pop83       # 0: down to label41
-# BB#83:                                # %if.then163
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_84:                               # %if.end164
-	end_block                       # label41:
-	block
+	f64.ne  	$push83=, $pop82, $pop220
+	br_if   	0, $pop83       # 0: down to label1
+# BB#42:                                # %if.end164
 	f64.const	$push225=, 0x0p0
 	f64.const	$push224=, -0x1p0
 	f64.call	$push84=, double_max2@FUNCTION, $pop225, $pop224
 	f64.const	$push223=, 0x0p0
-	f64.eq  	$push85=, $pop84, $pop223
-	br_if   	0, $pop85       # 0: down to label42
-# BB#85:                                # %if.then167
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_86:                               # %if.end168
-	end_block                       # label42:
-	block
+	f64.ne  	$push85=, $pop84, $pop223
+	br_if   	0, $pop85       # 0: down to label1
+# BB#43:                                # %if.end168
 	f64.const	$push228=, -0x1p0
 	f64.const	$push227=, 0x0p0
 	f64.call	$push86=, double_max2@FUNCTION, $pop228, $pop227
 	f64.const	$push226=, 0x0p0
-	f64.eq  	$push87=, $pop86, $pop226
-	br_if   	0, $pop87       # 0: down to label43
-# BB#87:                                # %if.then171
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_88:                               # %if.end172
-	end_block                       # label43:
-	block
+	f64.ne  	$push87=, $pop86, $pop226
+	br_if   	0, $pop87       # 0: down to label1
+# BB#44:                                # %if.end172
 	f64.const	$push231=, 0x0p0
 	f64.const	$push230=, 0x1p0
 	f64.call	$push88=, double_max2@FUNCTION, $pop231, $pop230
 	f64.const	$push229=, 0x1p0
-	f64.eq  	$push89=, $pop88, $pop229
-	br_if   	0, $pop89       # 0: down to label44
-# BB#89:                                # %if.then175
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_90:                               # %if.end176
-	end_block                       # label44:
-	block
+	f64.ne  	$push89=, $pop88, $pop229
+	br_if   	0, $pop89       # 0: down to label1
+# BB#45:                                # %if.end176
 	f64.const	$push234=, 0x1p0
 	f64.const	$push233=, 0x0p0
 	f64.call	$push90=, double_max2@FUNCTION, $pop234, $pop233
 	f64.const	$push232=, 0x1p0
-	f64.eq  	$push91=, $pop90, $pop232
-	br_if   	0, $pop91       # 0: down to label45
-# BB#91:                                # %if.then179
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_92:                               # %if.end180
-	end_block                       # label45:
-	block
+	f64.ne  	$push91=, $pop90, $pop232
+	br_if   	0, $pop91       # 0: down to label1
+# BB#46:                                # %if.end180
 	f64.const	$push237=, -0x1p0
 	f64.const	$push236=, 0x1p0
 	f64.call	$push92=, double_max2@FUNCTION, $pop237, $pop236
 	f64.const	$push235=, 0x1p0
-	f64.eq  	$push93=, $pop92, $pop235
-	br_if   	0, $pop93       # 0: down to label46
-# BB#93:                                # %if.then183
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_94:                               # %if.end184
-	end_block                       # label46:
-	block
+	f64.ne  	$push93=, $pop92, $pop235
+	br_if   	0, $pop93       # 0: down to label1
+# BB#47:                                # %if.end184
 	f64.const	$push240=, 0x1p0
 	f64.const	$push239=, -0x1p0
 	f64.call	$push94=, double_max2@FUNCTION, $pop240, $pop239
 	f64.const	$push238=, 0x1p0
 	f64.eq  	$push95=, $pop94, $pop238
-	br_if   	0, $pop95       # 0: down to label47
-# BB#95:                                # %if.then187
+	br_if   	1, $pop95       # 1: down to label0
+.LBB8_48:                               # %if.then187
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB8_96:                               # %if.end188
-	end_block                       # label47:
+.LBB8_49:                               # %if.end188
+	end_block                       # label0:
 	i32.const	$push96=, 0
 	call    	exit@FUNCTION, $pop96
 	unreachable

--- a/test/torture-s/pr40057.c.s
+++ b/test/torture-s/pr40057.c.s
@@ -40,44 +40,29 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
 	i64.const	$push0=, 6042589866
 	i32.call	$push1=, foo@FUNCTION, $pop0
-	br_if   	0, $pop1        # 0: down to label3
+	br_if   	0, $pop1        # 0: down to label0
 # BB#1:                                 # %if.end
 	i64.const	$push2=, 6579460778
 	i32.call	$push3=, foo@FUNCTION, $pop2
 	i32.const	$push9=, 0
 	i32.eq  	$push10=, $pop3, $pop9
-	br_if   	1, $pop10       # 1: down to label2
+	br_if   	0, $pop10       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i64.const	$push4=, 6042589866
 	i32.call	$push5=, bar@FUNCTION, $pop4
-	br_if   	2, $pop5        # 2: down to label1
+	br_if   	0, $pop5        # 0: down to label0
 # BB#3:                                 # %if.end8
 	i64.const	$push6=, 6579460778
 	i32.call	$push7=, bar@FUNCTION, $pop6
 	i32.const	$push11=, 0
 	i32.eq  	$push12=, $pop7, $pop11
-	br_if   	3, $pop12       # 3: down to label0
+	br_if   	0, $pop12       # 0: down to label0
 # BB#4:                                 # %if.end12
 	i32.const	$push8=, 0
 	return  	$pop8
-.LBB2_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_6:                                # %if.then3
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_7:                                # %if.then7
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_8:                                # %if.then11
+.LBB2_5:                                # %if.then11
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr40386.c.s
+++ b/test/torture-s/pr40386.c.s
@@ -9,26 +9,6 @@ main:                                   # @main
 	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i64, i64, i64, i64, i64, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push0=, 0
 	i32.load8_s	$push125=, c($pop0)
 	tee_local	$push124=, $2=, $pop125
@@ -43,7 +23,7 @@ main:                                   # @main
 	i32.or  	$push4=, $pop3, $pop1
 	i32.const	$push118=, 835
 	i32.ne  	$push5=, $pop4, $pop118
-	br_if   	0, $pop5        # 0: down to label20
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 4
 	i32.shr_s	$push7=, $2, $pop6
@@ -52,7 +32,7 @@ main:                                   # @main
 	i32.or  	$push9=, $pop7, $pop8
 	i32.const	$push126=, 835
 	i32.ne  	$push10=, $pop9, $pop126
-	br_if   	1, $pop10       # 1: down to label19
+	br_if   	0, $pop10       # 0: down to label0
 # BB#2:                                 # %if.end11
 	i32.const	$push11=, 0
 	i32.load16_s	$push132=, s($pop11)
@@ -65,7 +45,7 @@ main:                                   # @main
 	i32.or  	$push15=, $pop12, $pop14
 	i32.const	$push128=, -221
 	i32.ne  	$push16=, $pop15, $pop128
-	br_if   	2, $pop16       # 2: down to label18
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end21
 	i32.const	$push17=, 4
 	i32.shr_s	$push18=, $4, $pop17
@@ -74,7 +54,7 @@ main:                                   # @main
 	i32.or  	$push21=, $pop18, $pop20
 	i32.const	$push133=, -221
 	i32.ne  	$push22=, $pop21, $pop133
-	br_if   	3, $pop22       # 3: down to label17
+	br_if   	0, $pop22       # 0: down to label0
 # BB#4:                                 # %if.end30
 	i32.const	$push23=, 0
 	i32.load	$push138=, i($pop23)
@@ -87,7 +67,7 @@ main:                                   # @main
 	i32.or  	$push27=, $pop24, $pop26
 	i32.const	$push134=, 1073745699
 	i32.ne  	$push28=, $pop27, $pop134
-	br_if   	4, $pop28       # 4: down to label16
+	br_if   	0, $pop28       # 0: down to label0
 # BB#5:                                 # %if.end38
 	i32.const	$push29=, 4
 	i32.shr_s	$push30=, $6, $pop29
@@ -96,7 +76,7 @@ main:                                   # @main
 	i32.or  	$push33=, $pop30, $pop32
 	i32.const	$push139=, 1073745699
 	i32.ne  	$push34=, $pop33, $pop139
-	br_if   	5, $pop34       # 5: down to label15
+	br_if   	0, $pop34       # 0: down to label0
 # BB#6:                                 # %if.end45
 	i32.const	$push35=, 0
 	i32.load	$push142=, l($pop35)
@@ -106,7 +86,7 @@ main:                                   # @main
 	i32.or  	$push38=, $pop36, $pop37
 	i32.const	$push140=, -14465689
 	i32.ne  	$push39=, $pop38, $pop140
-	br_if   	6, $pop39       # 6: down to label14
+	br_if   	0, $pop39       # 0: down to label0
 # BB#7:                                 # %if.end53
 	i32.const	$push40=, 4
 	i32.shr_s	$push41=, $7, $pop40
@@ -115,7 +95,7 @@ main:                                   # @main
 	i32.or  	$push44=, $pop41, $pop43
 	i32.const	$push143=, -14465689
 	i32.ne  	$push45=, $pop44, $pop143
-	br_if   	7, $pop45       # 7: down to label13
+	br_if   	0, $pop45       # 0: down to label0
 # BB#8:                                 # %if.end60
 	i32.const	$push46=, 0
 	i64.load	$push150=, ll($pop46)
@@ -131,7 +111,7 @@ main:                                   # @main
 	i64.or  	$push51=, $pop47, $pop50
 	i64.const	$push144=, 68174490360335855
 	i64.ne  	$push52=, $pop51, $pop144
-	br_if   	8, $pop52       # 8: down to label12
+	br_if   	0, $pop52       # 0: down to label0
 # BB#9:                                 # %if.end69
 	i64.const	$push53=, 4
 	i64.shr_s	$push54=, $10, $pop53
@@ -140,7 +120,7 @@ main:                                   # @main
 	i64.or  	$push57=, $pop54, $pop56
 	i64.const	$push151=, 68174490360335855
 	i64.ne  	$push58=, $pop57, $pop151
-	br_if   	9, $pop58       # 9: down to label11
+	br_if   	0, $pop58       # 0: down to label0
 # BB#10:                                # %if.end76
 	i32.const	$push61=, 64
 	i32.const	$push59=, 0
@@ -156,7 +136,7 @@ main:                                   # @main
 	i64.or  	$push64=, $pop63, $pop60
 	i64.const	$push152=, -994074541463572736
 	i64.ne  	$push65=, $pop64, $pop152
-	br_if   	10, $pop65      # 10: down to label10
+	br_if   	0, $pop65       # 0: down to label0
 # BB#11:                                # %if.end86
 	i64.const	$push66=, 60
 	i64.shr_s	$push67=, $10, $pop66
@@ -165,21 +145,21 @@ main:                                   # @main
 	i64.or  	$push70=, $pop67, $pop69
 	i64.const	$push159=, -994074541463572736
 	i64.ne  	$push71=, $pop70, $pop159
-	br_if   	11, $pop71      # 11: down to label9
+	br_if   	0, $pop71       # 0: down to label0
 # BB#12:                                # %if.end93
 	i32.shr_s	$push73=, $2, $0
 	i32.shl 	$push72=, $2, $1
 	i32.or  	$push74=, $pop73, $pop72
 	i32.const	$push75=, 835
 	i32.ne  	$push76=, $pop74, $pop75
-	br_if   	12, $pop76      # 12: down to label8
+	br_if   	0, $pop76       # 0: down to label0
 # BB#13:                                # %if.end112
 	i32.shl 	$push77=, $4, $1
 	i32.shr_s	$push78=, $4, $3
 	i32.or  	$push79=, $pop77, $pop78
 	i32.const	$push160=, -1
 	i32.ne  	$push80=, $pop79, $pop160
-	br_if   	13, $pop80      # 13: down to label7
+	br_if   	0, $pop80       # 0: down to label0
 # BB#14:                                # %if.end122
 	i32.const	$push81=, 4
 	i32.shl 	$push82=, $4, $pop81
@@ -188,14 +168,14 @@ main:                                   # @main
 	i32.or  	$push85=, $pop82, $pop84
 	i32.const	$push161=, -1
 	i32.ne  	$push86=, $pop85, $pop161
-	br_if   	14, $pop86      # 14: down to label6
+	br_if   	0, $pop86       # 0: down to label0
 # BB#15:                                # %if.end131
 	i32.shl 	$push87=, $6, $1
 	i32.shr_s	$push88=, $6, $5
 	i32.or  	$push89=, $pop87, $pop88
 	i32.const	$push162=, 992064
 	i32.ne  	$push90=, $pop89, $pop162
-	br_if   	15, $pop90      # 15: down to label5
+	br_if   	0, $pop90       # 0: down to label0
 # BB#16:                                # %if.end139
 	i32.const	$push91=, 4
 	i32.shl 	$push92=, $6, $pop91
@@ -204,14 +184,14 @@ main:                                   # @main
 	i32.or  	$push95=, $pop92, $pop94
 	i32.const	$push163=, 992064
 	i32.ne  	$push96=, $pop95, $pop163
-	br_if   	16, $pop96      # 16: down to label4
+	br_if   	0, $pop96       # 0: down to label0
 # BB#17:                                # %if.end146
 	i32.shl 	$push97=, $7, $1
 	i32.shr_s	$push98=, $7, $5
 	i32.or  	$push99=, $pop97, $pop98
 	i32.const	$push164=, -1
 	i32.ne  	$push100=, $pop99, $pop164
-	br_if   	17, $pop100     # 17: down to label3
+	br_if   	0, $pop100      # 0: down to label0
 # BB#18:                                # %if.end154
 	i32.const	$push101=, 4
 	i32.shl 	$push102=, $7, $pop101
@@ -220,106 +200,26 @@ main:                                   # @main
 	i32.or  	$push105=, $pop102, $pop104
 	i32.const	$push165=, -1
 	i32.ne  	$push106=, $pop105, $pop165
-	br_if   	18, $pop106     # 18: down to label2
+	br_if   	0, $pop106      # 0: down to label0
 # BB#19:                                # %if.end161
 	i64.shl 	$push107=, $10, $9
 	i64.shr_s	$push108=, $10, $8
 	i64.or  	$push109=, $pop107, $pop108
 	i64.const	$push110=, -994074541463572736
 	i64.ne  	$push111=, $pop109, $pop110
-	br_if   	19, $pop111     # 19: down to label1
+	br_if   	0, $pop111      # 0: down to label0
 # BB#20:                                # %if.end178
 	i64.shr_s	$push113=, $10, $12
 	i64.shl 	$push112=, $10, $11
 	i64.or  	$push114=, $pop113, $pop112
 	i64.const	$push115=, 68174490360335855
 	i64.ne  	$push116=, $pop114, $pop115
-	br_if   	20, $pop116     # 20: down to label0
+	br_if   	0, $pop116      # 0: down to label0
 # BB#21:                                # %if.end195
 	i32.const	$push117=, 0
 	call    	exit@FUNCTION, $pop117
 	unreachable
-.LBB0_22:                               # %if.then
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_23:                               # %if.then10
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_24:                               # %if.then20
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then29
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then37
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_27:                               # %if.then44
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_28:                               # %if.then52
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_29:                               # %if.then59
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_30:                               # %if.then68
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_31:                               # %if.then75
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_32:                               # %if.then85
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_33:                               # %if.then92
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_34:                               # %if.then102
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_35:                               # %if.then121
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_36:                               # %if.then130
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_37:                               # %if.then138
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_38:                               # %if.then145
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_39:                               # %if.then153
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_40:                               # %if.then160
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_41:                               # %if.then170
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_42:                               # %if.then187
+.LBB0_22:                               # %if.then187
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr42614.c.s
+++ b/test/torture-s/pr42614.c.s
@@ -22,21 +22,16 @@ expect_func:                            # @expect_func
 	.param  	i32, i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push0=, 0
 	i32.eq  	$push1=, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label1
+	br_if   	0, $pop1        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push2=, 0
 	i32.eq  	$push3=, $1, $pop2
-	br_if   	1, $pop3        # 1: down to label0
+	br_if   	0, $pop3        # 0: down to label0
 # BB#2:                                 # %if.end6
 	return
-.LBB1_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_4:                                # %if.then5
+.LBB1_3:                                # %if.then5
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr43385.c.s
+++ b/test/torture-s/pr43385.c.s
@@ -66,127 +66,72 @@ main:                                   # @main
 	tee_local	$push26=, $1=, $pop27
 	call    	foo@FUNCTION, $pop29, $pop26
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push25=, 0
 	i32.load	$push1=, e($pop25)
 	i32.const	$push24=, 1
 	i32.ne  	$push2=, $pop1, $pop24
-	br_if   	0, $pop2        # 0: down to label12
+	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %if.end
 	call    	foo@FUNCTION, $2, $0
 	i32.const	$push32=, 0
 	i32.load	$push3=, e($pop32)
 	i32.const	$push31=, 1
 	i32.ne  	$push4=, $pop3, $pop31
-	br_if   	1, $pop4        # 1: down to label11
+	br_if   	0, $pop4        # 0: down to label1
 # BB#2:                                 # %if.end5
 	call    	foo@FUNCTION, $1, $1
 	i32.const	$push34=, 0
 	i32.load	$push5=, e($pop34)
 	i32.const	$push33=, 2
 	i32.ne  	$push6=, $pop5, $pop33
-	br_if   	2, $pop6        # 2: down to label10
+	br_if   	0, $pop6        # 0: down to label1
 # BB#3:                                 # %if.end10
 	call    	foo@FUNCTION, $1, $0
 	i32.const	$push36=, 0
 	i32.load	$push7=, e($pop36)
 	i32.const	$push35=, 2
 	i32.ne  	$push8=, $pop7, $pop35
-	br_if   	3, $pop8        # 3: down to label9
+	br_if   	0, $pop8        # 0: down to label1
 # BB#4:                                 # %if.end14
 	call    	foo@FUNCTION, $0, $1
 	i32.const	$push38=, 0
 	i32.load	$push9=, e($pop38)
 	i32.const	$push37=, 2
 	i32.ne  	$push10=, $pop9, $pop37
-	br_if   	4, $pop10       # 4: down to label8
+	br_if   	0, $pop10       # 0: down to label1
 # BB#5:                                 # %if.end18
 	call    	foo@FUNCTION, $0, $0
 	i32.const	$push40=, 0
 	i32.load	$push11=, e($pop40)
 	i32.const	$push39=, 2
 	i32.ne  	$push12=, $pop11, $pop39
-	br_if   	5, $pop12       # 5: down to label7
+	br_if   	0, $pop12       # 0: down to label1
 # BB#6:                                 # %if.end21
 	i32.call	$push13=, bar@FUNCTION, $2, $1
 	i32.const	$push14=, 1
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	6, $pop15       # 6: down to label6
+	br_if   	0, $pop15       # 0: down to label1
 # BB#7:                                 # %if.end26
 	i32.call	$push16=, bar@FUNCTION, $2, $0
-	br_if   	7, $pop16       # 7: down to label5
+	br_if   	0, $pop16       # 0: down to label1
 # BB#8:                                 # %if.end31
 	i32.call	$push17=, bar@FUNCTION, $1, $1
 	i32.const	$push18=, 1
 	i32.ne  	$push19=, $pop17, $pop18
-	br_if   	8, $pop19       # 8: down to label4
+	br_if   	0, $pop19       # 0: down to label1
 # BB#9:                                 # %if.end37
 	i32.call	$push20=, bar@FUNCTION, $1, $0
-	br_if   	9, $pop20       # 9: down to label3
+	br_if   	0, $pop20       # 0: down to label1
 # BB#10:                                # %if.end42
 	i32.call	$push21=, bar@FUNCTION, $0, $1
-	br_if   	10, $pop21      # 10: down to label2
+	br_if   	0, $pop21       # 0: down to label1
 # BB#11:                                # %if.end47
 	i32.call	$push22=, bar@FUNCTION, $0, $0
-	br_if   	11, $pop22      # 11: down to label1
+	br_if   	0, $pop22       # 0: down to label1
 # BB#12:                                # %if.end51
 	i32.const	$push23=, 0
 	return  	$pop23
-.LBB2_13:                               # %if.then
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_14:                               # %if.then4
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_15:                               # %if.then9
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_16:                               # %if.then13
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_17:                               # %if.then17
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_18:                               # %if.then20
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_19:                               # %if.then25
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_20:                               # %if.then30
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_21:                               # %if.then36
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_22:                               # %if.then41
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_23:                               # %if.then46
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_24:                               # %if.then50
+.LBB2_13:                               # %if.then50
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr43560.c.s
+++ b/test/torture-s/pr43560.c.s
@@ -9,38 +9,38 @@ test:                                   # @test
 	.local  	i32, i32, i32
 # BB#0:                                 # %entry
 	block
-	i32.load	$push13=, 4($0)
-	tee_local	$push12=, $1=, $pop13
+	i32.load	$push8=, 4($0)
+	tee_local	$push7=, $2=, $pop8
 	i32.const	$push0=, 2
-	i32.lt_s	$push1=, $pop12, $pop0
+	i32.lt_s	$push1=, $pop7, $pop0
 	br_if   	0, $pop1        # 0: down to label0
-.LBB0_1:                                # %land.rhs
+# BB#1:
+	i32.const	$push5=, 4
+	i32.add 	$1=, $0, $pop5
+.LBB0_2:                                # %land.rhs
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push2=, -1
-	i32.add 	$push17=, $1, $pop2
-	tee_local	$push16=, $1=, $pop17
-	i32.add 	$push3=, $0, $pop16
-	i32.const	$push4=, 8
-	i32.add 	$push15=, $pop3, $pop4
-	tee_local	$push14=, $2=, $pop15
-	i32.load8_u	$push5=, 0($pop14)
-	i32.const	$push6=, 47
-	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label2
-# BB#2:                                 # %while.body
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push8=, 4
-	i32.add 	$push19=, $0, $pop8
-	tee_local	$push18=, $3=, $pop19
-	i32.store	$discard=, 0($pop18), $1
-	i32.const	$push9=, 0
-	i32.store8	$discard=, 0($2), $pop9
-	i32.load	$1=, 0($3)
-	i32.const	$push10=, 1
-	i32.gt_s	$push11=, $1, $pop10
-	br_if   	0, $pop11       # 0: up to label1
-.LBB0_3:                                # %while.end
+	i32.const	$push15=, -1
+	i32.add 	$push14=, $2, $pop15
+	tee_local	$push13=, $2=, $pop14
+	i32.add 	$push2=, $0, $pop13
+	i32.const	$push12=, 8
+	i32.add 	$push11=, $pop2, $pop12
+	tee_local	$push10=, $3=, $pop11
+	i32.load8_u	$push3=, 0($pop10)
+	i32.const	$push9=, 47
+	i32.ne  	$push4=, $pop3, $pop9
+	br_if   	1, $pop4        # 1: down to label2
+# BB#3:                                 # %while.body
+                                        #   in Loop: Header=BB0_2 Depth=1
+	i32.store	$discard=, 0($1), $2
+	i32.const	$push17=, 0
+	i32.store8	$discard=, 0($3), $pop17
+	i32.load	$2=, 0($1)
+	i32.const	$push16=, 1
+	i32.gt_s	$push6=, $2, $pop16
+	br_if   	0, $pop6        # 0: up to label1
+.LBB0_4:                                # %while.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	return

--- a/test/torture-s/pr44468.c.s
+++ b/test/torture-s/pr44468.c.s
@@ -72,13 +72,11 @@ main:                                   # @main
 	i64.const	$push0=, 8589934593
 	i64.store	$0=, s+4($pop12):p2align=2, $pop0
 	block
-	block
-	block
 	i32.const	$push11=, s
 	i32.call	$push1=, test1@FUNCTION, $pop11
 	i32.const	$push10=, 3
 	i32.ne  	$push2=, $pop1, $pop10
-	br_if   	0, $pop2        # 0: down to label2
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push15=, 0
 	i64.store	$discard=, s+4($pop15):p2align=2, $0
@@ -86,7 +84,7 @@ main:                                   # @main
 	i32.call	$push3=, test2@FUNCTION, $pop14
 	i32.const	$push13=, 3
 	i32.ne  	$push4=, $pop3, $pop13
-	br_if   	1, $pop4        # 1: down to label1
+	br_if   	0, $pop4        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push16=, 0
 	i64.const	$push5=, 8589934593
@@ -95,19 +93,11 @@ main:                                   # @main
 	i32.call	$push7=, test3@FUNCTION, $pop6
 	i32.const	$push8=, 3
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	2, $pop9        # 2: down to label0
+	br_if   	0, $pop9        # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.const	$push17=, 0
 	return  	$pop17
-.LBB3_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_5:                                # %if.then3
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_6:                                # %if.then7
+.LBB3_4:                                # %if.then7
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr45695.c.s
+++ b/test/torture-s/pr45695.c.s
@@ -44,7 +44,6 @@ main:                                   # @main
 	#APP
 	#NO_APP
 	block
-	block
 	i32.const	$push11=, 1
 	i32.add 	$push10=, $0, $pop11
 	tee_local	$push9=, $2=, $pop10
@@ -54,20 +53,16 @@ main:                                   # @main
 	i32.call	$push1=, f@FUNCTION, $0, $pop9, $pop7
 	i32.const	$push2=, -1
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label1
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.call	$push4=, f@FUNCTION, $1, $2, $1
 	i32.const	$push12=, 1
 	i32.ne  	$push5=, $pop4, $pop12
-	br_if   	1, $pop5        # 1: down to label0
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end9
 	i32.const	$push6=, 0
 	return  	$pop6
-.LBB2_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_4:                                # %if.then8
+.LBB2_3:                                # %if.then8
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr47538.c.s
+++ b/test/torture-s/pr47538.c.s
@@ -49,15 +49,14 @@ foo:                                    # @foo
 	end_block                       # label1:
 	i32.load	$4=, 16($1):p2align=3
 	i32.load	$5=, 16($0):p2align=3
-	f64.const	$9=, 0x0p0
-	f64.const	$8=, 0x1p0
+	block
 	block
 	i32.const	$push6=, -1
 	i32.add 	$push40=, $2, $pop6
 	tee_local	$push39=, $11=, $pop40
 	i32.const	$push53=, 0
 	i32.eq  	$push54=, $pop39, $pop53
-	br_if   	0, $pop54       # 0: down to label3
+	br_if   	0, $pop54       # 0: down to label4
 # BB#5:                                 # %for.body.preheader
 	f64.const	$9=, 0x0p0
 	i32.const	$push41=, 8
@@ -67,7 +66,7 @@ foo:                                    # @foo
 	f64.const	$8=, 0x1p0
 .LBB0_6:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label4:
+	loop                            # label5:
 	f64.load	$push7=, 0($1)
 	i32.const	$push47=, 16
 	i32.add 	$push8=, $1, $pop47
@@ -88,9 +87,14 @@ foo:                                    # @foo
 	i32.add 	$0=, $0, $pop44
 	copy_local	$7=, $6
 	i32.le_u	$push16=, $6, $11
-	br_if   	0, $pop16       # 0: up to label4
-.LBB0_7:                                # %for.end
-	end_loop                        # label5:
+	br_if   	0, $pop16       # 0: up to label5
+	br      	3               # 3: down to label3
+.LBB0_7:
+	end_loop                        # label6:
+	end_block                       # label4:
+	f64.const	$9=, 0x0p0
+	f64.const	$8=, 0x1p0
+.LBB0_8:                                # %for.end
 	end_block                       # label3:
 	i32.const	$push17=, 3
 	i32.shl 	$push26=, $2, $pop17
@@ -110,7 +114,7 @@ foo:                                    # @foo
 	tee_local	$push48=, $8=, $pop49
 	f64.add 	$push30=, $pop48, $8
 	f64.store	$discard=, 0($5), $pop30
-.LBB0_8:                                # %if.end53
+.LBB0_9:                                # %if.end53
 	end_block                       # label0:
 	return
 	.endfunc
@@ -195,28 +199,25 @@ main:                                   # @main
 	i32.add 	$12=, $22, $12
 	call    	foo@FUNCTION, $11, $12
 	block
-	block
-	block
-	block
 	f64.load	$push23=, 0($22):p2align=4
 	f64.const	$push24=, 0x0p0
 	f64.ne  	$push25=, $pop23, $pop24
-	br_if   	0, $pop25       # 0: down to label9
+	br_if   	0, $pop25       # 0: down to label7
 # BB#1:                                 # %lor.lhs.false
 	f64.load	$push26=, 0($3)
 	f64.const	$push27=, 0x1.4p4
 	f64.ne  	$push28=, $pop26, $pop27
-	br_if   	0, $pop28       # 0: down to label9
+	br_if   	0, $pop28       # 0: down to label7
 # BB#2:                                 # %lor.lhs.false9
 	f64.load	$push29=, 16($22):p2align=4
 	f64.const	$push30=, 0x1.4p3
 	f64.ne  	$push31=, $pop29, $pop30
-	br_if   	0, $pop31       # 0: down to label9
+	br_if   	0, $pop31       # 0: down to label7
 # BB#3:                                 # %lor.lhs.false12
 	f64.load	$push32=, 24($22)
 	f64.const	$push33=, -0x1.4p3
 	f64.ne  	$push34=, $pop32, $pop33
-	br_if   	0, $pop34       # 0: down to label9
+	br_if   	0, $pop34       # 0: down to label7
 # BB#4:                                 # %if.end
 	i32.const	$push38=, 20
 	i32.const	$13=, 64
@@ -258,22 +259,22 @@ main:                                   # @main
 	f64.load	$push52=, 0($22):p2align=4
 	f64.const	$push53=, 0x1.ep5
 	f64.ne  	$push54=, $pop52, $pop53
-	br_if   	1, $pop54       # 1: down to label8
+	br_if   	0, $pop54       # 0: down to label7
 # BB#5:                                 # %if.end
 	f64.load	$push35=, 0($3)
 	f64.const	$push55=, 0x1.4p4
 	f64.ne  	$push56=, $pop35, $pop55
-	br_if   	1, $pop56       # 1: down to label8
+	br_if   	0, $pop56       # 0: down to label7
 # BB#6:                                 # %if.end
 	f64.load	$push36=, 0($0):p2align=4
 	f64.const	$push57=, -0x1.4p3
 	f64.ne  	$push58=, $pop36, $pop57
-	br_if   	1, $pop58       # 1: down to label8
+	br_if   	0, $pop58       # 0: down to label7
 # BB#7:                                 # %if.end
 	f64.load	$push37=, 0($1)
 	f64.const	$push59=, 0x1.d8p6
 	f64.ne  	$push60=, $pop37, $pop59
-	br_if   	1, $pop60       # 1: down to label8
+	br_if   	0, $pop60       # 0: down to label7
 # BB#8:                                 # %if.end30
 	i32.const	$push64=, 20
 	i32.const	$16=, 64
@@ -315,22 +316,22 @@ main:                                   # @main
 	f64.load	$push78=, 0($22):p2align=4
 	f64.const	$push79=, -0x1.4p4
 	f64.ne  	$push80=, $pop78, $pop79
-	br_if   	2, $pop80       # 2: down to label7
+	br_if   	0, $pop80       # 0: down to label7
 # BB#9:                                 # %if.end30
 	f64.load	$push61=, 0($3)
 	f64.const	$push81=, -0x1.4p3
 	f64.ne  	$push82=, $pop61, $pop81
-	br_if   	2, $pop82       # 2: down to label7
+	br_if   	0, $pop82       # 0: down to label7
 # BB#10:                                # %if.end30
 	f64.load	$push62=, 0($0):p2align=4
 	f64.const	$push142=, 0x1.d8p6
 	f64.ne  	$push83=, $pop62, $pop142
-	br_if   	2, $pop83       # 2: down to label7
+	br_if   	0, $pop83       # 0: down to label7
 # BB#11:                                # %if.end30
 	f64.load	$push63=, 0($1)
 	f64.const	$push143=, 0x1.d8p6
 	f64.ne  	$push84=, $pop63, $pop143
-	br_if   	2, $pop84       # 2: down to label7
+	br_if   	0, $pop84       # 0: down to label7
 # BB#12:                                # %if.end46
 	i32.const	$push91=, 28
 	i32.add 	$push92=, $22, $pop91
@@ -368,22 +369,22 @@ main:                                   # @main
 	f64.load	$push101=, 0($22):p2align=4
 	f64.const	$push102=, 0x0p0
 	f64.ne  	$push103=, $pop101, $pop102
-	br_if   	3, $pop103      # 3: down to label6
+	br_if   	0, $pop103      # 0: down to label7
 # BB#13:                                # %if.end46
 	f64.load	$push85=, 0($0)
 	f64.const	$push152=, 0x1.d8p6
 	f64.ne  	$push104=, $pop85, $pop152
-	br_if   	3, $pop104      # 3: down to label6
+	br_if   	0, $pop104      # 0: down to label7
 # BB#14:                                # %if.end46
 	f64.load	$push86=, 0($1):p2align=4
 	f64.const	$push153=, 0x1.d8p6
 	f64.ne  	$push105=, $pop86, $pop153
-	br_if   	3, $pop105      # 3: down to label6
+	br_if   	0, $pop105      # 0: down to label7
 # BB#15:                                # %if.end46
 	f64.load	$push87=, 0($2)
 	f64.const	$push106=, 0x1.d8p6
 	f64.ne  	$push107=, $pop87, $pop106
-	br_if   	3, $pop107      # 3: down to label6
+	br_if   	0, $pop107      # 0: down to label7
 # BB#16:                                # %if.end62
 	i32.const	$push108=, 0
 	i32.const	$6=, 112
@@ -391,20 +392,8 @@ main:                                   # @main
 	i32.const	$6=, __stack_pointer
 	i32.store	$22=, 0($6), $22
 	return  	$pop108
-.LBB1_17:                               # %if.then
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_18:                               # %if.then29
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_19:                               # %if.then45
+.LBB1_17:                               # %if.then61
 	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_20:                               # %if.then61
-	end_block                       # label6:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/pr48809.c.s
+++ b/test/torture-s/pr48809.c.s
@@ -41,187 +41,182 @@ foo:                                    # @foo
 	block
 	block
 	block
-	block
 	i32.const	$push0=, 32
 	i32.gt_u	$push1=, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label32
+	br_if   	0, $pop1        # 0: down to label31
 # BB#1:                                 # %entry
 	block
-	tableswitch	$0, 0, 0, 2, 33, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 33, 19, 20, 21, 22, 23, 24, 32, 25, 26, 27, 28, 29, 30 # 0: down to label33
-                                        # 2: down to label31
-                                        # 33: down to label0
-                                        # 3: down to label30
-                                        # 4: down to label29
-                                        # 5: down to label28
-                                        # 6: down to label27
-                                        # 7: down to label26
-                                        # 8: down to label25
-                                        # 9: down to label24
-                                        # 10: down to label23
-                                        # 11: down to label22
-                                        # 12: down to label21
-                                        # 13: down to label20
-                                        # 14: down to label19
-                                        # 15: down to label18
-                                        # 16: down to label17
-                                        # 17: down to label16
-                                        # 18: down to label15
-                                        # 19: down to label14
-                                        # 20: down to label13
-                                        # 21: down to label12
-                                        # 22: down to label11
-                                        # 23: down to label10
-                                        # 24: down to label9
-                                        # 32: down to label1
-                                        # 25: down to label8
-                                        # 26: down to label7
-                                        # 27: down to label6
-                                        # 28: down to label5
-                                        # 29: down to label4
-                                        # 30: down to label3
+	tableswitch	$0, 0, 0, 3, 32, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 32, 19, 20, 21, 22, 23, 24, 31, 25, 26, 27, 28, 29, 30 # 0: down to label32
+                                        # 3: down to label29
+                                        # 32: down to label0
+                                        # 2: down to label30
+                                        # 4: down to label28
+                                        # 5: down to label27
+                                        # 6: down to label26
+                                        # 7: down to label25
+                                        # 8: down to label24
+                                        # 9: down to label23
+                                        # 10: down to label22
+                                        # 11: down to label21
+                                        # 12: down to label20
+                                        # 13: down to label19
+                                        # 14: down to label18
+                                        # 15: down to label17
+                                        # 16: down to label16
+                                        # 17: down to label15
+                                        # 18: down to label14
+                                        # 19: down to label13
+                                        # 20: down to label12
+                                        # 21: down to label11
+                                        # 22: down to label10
+                                        # 23: down to label9
+                                        # 24: down to label8
+                                        # 31: down to label1
+                                        # 25: down to label7
+                                        # 26: down to label6
+                                        # 27: down to label5
+                                        # 28: down to label4
+                                        # 29: down to label3
+                                        # 30: down to label2
 .LBB0_2:                                # %sw.bb
-	end_block                       # label33:
-	i32.const	$0=, 1
-	br      	32              # 32: down to label0
-.LBB0_3:                                # %entry
 	end_block                       # label32:
+	i32.const	$0=, 1
+	br      	31              # 31: down to label0
+.LBB0_3:                                # %entry
+	end_block                       # label31:
 	i32.const	$push2=, -62
 	i32.eq  	$push3=, $0, $pop2
-	br_if   	29, $pop3       # 29: down to label2
+	br_if   	0, $pop3        # 0: down to label30
 # BB#4:                                 # %entry
 	i32.const	$push4=, 98
 	i32.eq  	$1=, $0, $pop4
 	i32.const	$0=, 0
 	i32.const	$push5=, 0
 	i32.eq  	$push6=, $1, $pop5
-	br_if   	31, $pop6       # 31: down to label0
+	br_if   	30, $pop6       # 30: down to label0
 # BB#5:                                 # %sw.bb33
 	i32.const	$0=, 18
-	br      	31              # 31: down to label0
-.LBB0_6:                                # %sw.bb1
-	end_block                       # label31:
-	i32.const	$0=, 7
 	br      	30              # 30: down to label0
-.LBB0_7:                                # %sw.bb3
+.LBB0_6:                                # %sw.bb34
 	end_block                       # label30:
 	i32.const	$0=, 19
 	br      	29              # 29: down to label0
-.LBB0_8:                                # %sw.bb4
+.LBB0_7:                                # %sw.bb1
 	end_block                       # label29:
-	i32.const	$0=, 5
-	br      	28              # 28: down to label0
-.LBB0_9:                                # %sw.bb5
-	end_block                       # label28:
-	i32.const	$0=, 17
-	br      	27              # 27: down to label0
-.LBB0_10:                               # %sw.bb6
-	end_block                       # label27:
-	i32.const	$0=, 31
-	br      	26              # 26: down to label0
-.LBB0_11:                               # %sw.bb7
-	end_block                       # label26:
-	i32.const	$0=, 8
-	br      	25              # 25: down to label0
-.LBB0_12:                               # %sw.bb8
-	end_block                       # label25:
-	i32.const	$0=, 28
-	br      	24              # 24: down to label0
-.LBB0_13:                               # %sw.bb9
-	end_block                       # label24:
-	i32.const	$0=, 16
-	br      	23              # 23: down to label0
-.LBB0_14:                               # %sw.bb10
-	end_block                       # label23:
-	i32.const	$0=, 31
-	br      	22              # 22: down to label0
-.LBB0_15:                               # %sw.bb11
-	end_block                       # label22:
-	i32.const	$0=, 12
-	br      	21              # 21: down to label0
-.LBB0_16:                               # %sw.bb12
-	end_block                       # label21:
-	i32.const	$0=, 15
-	br      	20              # 20: down to label0
-.LBB0_17:                               # %sw.bb13
-	end_block                       # label20:
-	i32.const	$0=, 111
-	br      	19              # 19: down to label0
-.LBB0_18:                               # %sw.bb14
-	end_block                       # label19:
-	i32.const	$0=, 17
-	br      	18              # 18: down to label0
-.LBB0_19:                               # %sw.bb15
-	end_block                       # label18:
-	i32.const	$0=, 10
-	br      	17              # 17: down to label0
-.LBB0_20:                               # %sw.bb16
-	end_block                       # label17:
-	i32.const	$0=, 31
-	br      	16              # 16: down to label0
-.LBB0_21:                               # %sw.bb17
-	end_block                       # label16:
 	i32.const	$0=, 7
-	br      	15              # 15: down to label0
-.LBB0_22:                               # %sw.bb18
-	end_block                       # label15:
-	i32.const	$0=, 2
-	br      	14              # 14: down to label0
-.LBB0_23:                               # %sw.bb20
-	end_block                       # label14:
+	br      	28              # 28: down to label0
+.LBB0_8:                                # %sw.bb4
+	end_block                       # label28:
 	i32.const	$0=, 5
-	br      	13              # 13: down to label0
-.LBB0_24:                               # %sw.bb21
-	end_block                       # label13:
-	i32.const	$0=, 107
-	br      	12              # 12: down to label0
-.LBB0_25:                               # %sw.bb22
-	end_block                       # label12:
-	i32.const	$0=, 31
-	br      	11              # 11: down to label0
-.LBB0_26:                               # %sw.bb23
-	end_block                       # label11:
-	i32.const	$0=, 8
-	br      	10              # 10: down to label0
-.LBB0_27:                               # %sw.bb24
-	end_block                       # label10:
-	i32.const	$0=, 28
-	br      	9               # 9: down to label0
-.LBB0_28:                               # %sw.bb25
-	end_block                       # label9:
-	i32.const	$0=, 106
-	br      	8               # 8: down to label0
-.LBB0_29:                               # %sw.bb27
-	end_block                       # label8:
-	i32.const	$0=, 102
-	br      	7               # 7: down to label0
-.LBB0_30:                               # %sw.bb28
-	end_block                       # label7:
-	i32.const	$0=, 105
-	br      	6               # 6: down to label0
-.LBB0_31:                               # %sw.bb29
-	end_block                       # label6:
-	i32.const	$0=, 111
-	br      	5               # 5: down to label0
-.LBB0_32:                               # %sw.bb30
-	end_block                       # label5:
+	br      	27              # 27: down to label0
+.LBB0_9:                                # %sw.bb5
+	end_block                       # label27:
 	i32.const	$0=, 17
-	br      	4               # 4: down to label0
-.LBB0_33:                               # %sw.bb31
-	end_block                       # label4:
-	i32.const	$0=, 10
-	br      	3               # 3: down to label0
-.LBB0_34:                               # %sw.bb32
-	end_block                       # label3:
+	br      	26              # 26: down to label0
+.LBB0_10:                               # %sw.bb6
+	end_block                       # label26:
 	i32.const	$0=, 31
+	br      	25              # 25: down to label0
+.LBB0_11:                               # %sw.bb7
+	end_block                       # label25:
+	i32.const	$0=, 8
+	br      	24              # 24: down to label0
+.LBB0_12:                               # %sw.bb8
+	end_block                       # label24:
+	i32.const	$0=, 28
+	br      	23              # 23: down to label0
+.LBB0_13:                               # %sw.bb9
+	end_block                       # label23:
+	i32.const	$0=, 16
+	br      	22              # 22: down to label0
+.LBB0_14:                               # %sw.bb10
+	end_block                       # label22:
+	i32.const	$0=, 31
+	br      	21              # 21: down to label0
+.LBB0_15:                               # %sw.bb11
+	end_block                       # label21:
+	i32.const	$0=, 12
+	br      	20              # 20: down to label0
+.LBB0_16:                               # %sw.bb12
+	end_block                       # label20:
+	i32.const	$0=, 15
+	br      	19              # 19: down to label0
+.LBB0_17:                               # %sw.bb13
+	end_block                       # label19:
+	i32.const	$0=, 111
+	br      	18              # 18: down to label0
+.LBB0_18:                               # %sw.bb14
+	end_block                       # label18:
+	i32.const	$0=, 17
+	br      	17              # 17: down to label0
+.LBB0_19:                               # %sw.bb15
+	end_block                       # label17:
+	i32.const	$0=, 10
+	br      	16              # 16: down to label0
+.LBB0_20:                               # %sw.bb16
+	end_block                       # label16:
+	i32.const	$0=, 31
+	br      	15              # 15: down to label0
+.LBB0_21:                               # %sw.bb17
+	end_block                       # label15:
+	i32.const	$0=, 7
+	br      	14              # 14: down to label0
+.LBB0_22:                               # %sw.bb18
+	end_block                       # label14:
+	i32.const	$0=, 2
+	br      	13              # 13: down to label0
+.LBB0_23:                               # %sw.bb20
+	end_block                       # label13:
+	i32.const	$0=, 5
+	br      	12              # 12: down to label0
+.LBB0_24:                               # %sw.bb21
+	end_block                       # label12:
+	i32.const	$0=, 107
+	br      	11              # 11: down to label0
+.LBB0_25:                               # %sw.bb22
+	end_block                       # label11:
+	i32.const	$0=, 31
+	br      	10              # 10: down to label0
+.LBB0_26:                               # %sw.bb23
+	end_block                       # label10:
+	i32.const	$0=, 8
+	br      	9               # 9: down to label0
+.LBB0_27:                               # %sw.bb24
+	end_block                       # label9:
+	i32.const	$0=, 28
+	br      	8               # 8: down to label0
+.LBB0_28:                               # %sw.bb25
+	end_block                       # label8:
+	i32.const	$0=, 106
+	br      	7               # 7: down to label0
+.LBB0_29:                               # %sw.bb27
+	end_block                       # label7:
+	i32.const	$0=, 102
+	br      	6               # 6: down to label0
+.LBB0_30:                               # %sw.bb28
+	end_block                       # label6:
+	i32.const	$0=, 105
+	br      	5               # 5: down to label0
+.LBB0_31:                               # %sw.bb29
+	end_block                       # label5:
+	i32.const	$0=, 111
+	br      	4               # 4: down to label0
+.LBB0_32:                               # %sw.bb30
+	end_block                       # label4:
+	i32.const	$0=, 17
+	br      	3               # 3: down to label0
+.LBB0_33:                               # %sw.bb31
+	end_block                       # label3:
+	i32.const	$0=, 10
 	br      	2               # 2: down to label0
-.LBB0_35:                               # %sw.bb34
+.LBB0_34:                               # %sw.bb32
 	end_block                       # label2:
-	i32.const	$0=, 19
+	i32.const	$0=, 31
 	br      	1               # 1: down to label0
-.LBB0_36:                               # %sw.bb26
+.LBB0_35:                               # %sw.bb26
 	end_block                       # label1:
 	i32.const	$0=, 31
-.LBB0_37:                               # %sw.epilog
+.LBB0_36:                               # %sw.epilog
 	end_block                       # label0:
 	return  	$0
 	.endfunc

--- a/test/torture-s/pr49218.c.s
+++ b/test/torture-s/pr49218.c.s
@@ -14,29 +14,30 @@ main:                                   # @main
 	i32.sub 	$9=, $6, $7
 	i32.const	$7=, __stack_pointer
 	i32.store	$9=, 0($7), $9
-	i32.const	$push18=, 0
-	f32.load	$push0=, f($pop18)
+	i32.const	$push17=, 0
+	f32.load	$push0=, f($pop17)
 	call    	__fixsfti@FUNCTION, $9, $pop0
 	i64.const	$1=, 0
 	block
-	i64.load	$push17=, 0($9)
-	tee_local	$push16=, $5=, $pop17
+	i64.load	$push16=, 0($9)
+	tee_local	$push15=, $5=, $pop16
 	i64.const	$push5=, 10
-	i64.gt_u	$push6=, $pop16, $pop5
+	i64.gt_u	$push6=, $pop15, $pop5
 	i32.const	$push1=, 8
 	i32.add 	$push2=, $9, $pop1
-	i64.load	$push15=, 0($pop2)
-	tee_local	$push14=, $4=, $pop15
-	i64.const	$push13=, 0
-	i64.gt_s	$push4=, $pop14, $pop13
+	i64.load	$push14=, 0($pop2)
+	tee_local	$push13=, $4=, $pop14
 	i64.const	$push12=, 0
-	i64.eq  	$push3=, $4, $pop12
+	i64.gt_s	$push4=, $pop13, $pop12
+	i64.const	$push11=, 0
+	i64.eq  	$push3=, $4, $pop11
 	i32.select	$push7=, $pop6, $pop4, $pop3
 	br_if   	0, $pop7        # 0: down to label0
-.LBB0_1:                                # %do.body
+# BB#1:
+	i64.const	$2=, 1
+.LBB0_2:                                # %do.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i64.const	$2=, 1
 	i64.add 	$0=, $5, $2
 	i64.lt_u	$3=, $0, $5
 	i64.extend_u/i32	$5=, $3
@@ -46,13 +47,13 @@ main:                                   # @main
 	#APP
 	#NO_APP
 	copy_local	$5=, $0
-	i64.const	$push8=, 11
-	i64.xor 	$push9=, $0, $pop8
-	i64.or  	$push10=, $4, $pop9
-	i64.const	$push19=, 0
-	i64.ne  	$push11=, $pop10, $pop19
-	br_if   	0, $pop11       # 0: up to label1
-.LBB0_2:                                # %if.end
+	i64.const	$push19=, 11
+	i64.xor 	$push8=, $0, $pop19
+	i64.or  	$push9=, $4, $pop8
+	i64.const	$push18=, 0
+	i64.ne  	$push10=, $pop9, $pop18
+	br_if   	0, $pop10       # 0: up to label1
+.LBB0_3:                                # %if.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	i32.const	$push20=, 0

--- a/test/torture-s/pr49281.c.s
+++ b/test/torture-s/pr49281.c.s
@@ -42,50 +42,45 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push0=, 43
 	i32.call	$push1=, foo@FUNCTION, $pop0
 	i32.const	$push2=, 172
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label1
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %lor.lhs.false
 	i32.const	$push4=, 1
 	i32.call	$push5=, foo@FUNCTION, $pop4
 	i32.const	$push6=, 4
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	0, $pop7        # 0: down to label1
+	br_if   	0, $pop7        # 0: down to label0
 # BB#2:                                 # %lor.lhs.false3
 	i32.const	$push8=, 2
 	i32.call	$push9=, foo@FUNCTION, $pop8
 	i32.const	$push10=, 12
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	0, $pop11       # 0: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#3:                                 # %if.end
 	i32.const	$push12=, 43
 	i32.call	$push13=, bar@FUNCTION, $pop12
 	i32.const	$push14=, 175
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	1, $pop15       # 1: down to label0
+	br_if   	0, $pop15       # 0: down to label0
 # BB#4:                                 # %lor.lhs.false8
 	i32.const	$push16=, 1
 	i32.call	$push17=, bar@FUNCTION, $pop16
 	i32.const	$push18=, 7
 	i32.ne  	$push19=, $pop17, $pop18
-	br_if   	1, $pop19       # 1: down to label0
+	br_if   	0, $pop19       # 0: down to label0
 # BB#5:                                 # %lor.lhs.false11
 	i32.const	$push20=, 2
 	i32.call	$push21=, bar@FUNCTION, $pop20
 	i32.const	$push22=, 11
 	i32.ne  	$push23=, $pop21, $pop22
-	br_if   	1, $pop23       # 1: down to label0
+	br_if   	0, $pop23       # 0: down to label0
 # BB#6:                                 # %if.end15
 	i32.const	$push24=, 0
 	return  	$pop24
-.LBB2_7:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_8:                                # %if.then14
+.LBB2_7:                                # %if.then14
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr49390.c.s
+++ b/test/torture-s/pr49390.c.s
@@ -100,36 +100,38 @@ test:                                   # @test
 	br_if   	0, $pop73       # 0: down to label1
 # BB#1:                                 # %if.else
 	block
+	block
 	i32.load	$push53=, 4($0)
-	tee_local	$push52=, $5=, $pop53
+	tee_local	$push52=, $3=, $pop53
 	i32.const	$push6=, 8191
 	i32.and 	$push51=, $pop52, $pop6
-	tee_local	$push50=, $3=, $pop51
+	tee_local	$push50=, $2=, $pop51
 	i32.const	$push7=, 16
 	i32.lt_u	$push8=, $pop50, $pop7
-	br_if   	0, $pop8        # 0: down to label2
+	br_if   	0, $pop8        # 0: down to label3
 # BB#2:                                 # %if.else
-	copy_local	$2=, $0
 	i32.const	$push9=, 8192
-	i32.sub 	$push5=, $pop9, $3
+	i32.sub 	$push5=, $pop9, $2
 	i32.const	$push10=, 31
 	i32.gt_u	$push11=, $pop5, $pop10
-	br_if   	1, $pop11       # 1: down to label1
+	br_if   	1, $pop11       # 1: down to label2
 .LBB3_3:                                # %if.then5
-	end_block                       # label2:
+	end_block                       # label3:
 	i32.const	$push14=, 1
 	i32.const	$push13=, 0
 	i32.load	$push12=, 0($0)
-	call    	foo@FUNCTION, $pop14, $pop13, $pop12, $5
-	copy_local	$2=, $0
+	call    	foo@FUNCTION, $pop14, $pop13, $pop12, $3
 .LBB3_4:                                # %if.end7
+	end_block                       # label2:
+	copy_local	$2=, $0
+.LBB3_5:                                # %if.end7
 	end_block                       # label1:
 	block
 	i32.call	$push15=, baz@FUNCTION, $2
 	i32.const	$push74=, 0
 	i32.eq  	$push75=, $pop15, $pop74
-	br_if   	0, $pop75       # 0: down to label3
-# BB#5:                                 # %if.end9
+	br_if   	0, $pop75       # 0: down to label4
+# BB#6:                                 # %if.end9
 	i32.const	$push21=, 32
 	i32.const	$push62=, 4
 	i32.const	$push16=, 0
@@ -151,18 +153,18 @@ test:                                   # @test
 	tee_local	$push54=, $3=, $pop55
 	i32.const	$push76=, 0
 	i32.eq  	$push77=, $pop54, $pop76
-	br_if   	0, $pop77       # 0: down to label5
-# BB#6:                                 # %if.else17
+	br_if   	0, $pop77       # 0: down to label6
+# BB#7:                                 # %if.else17
 	i32.ge_u	$push23=, $3, $0
-	br_if   	1, $pop23       # 1: down to label4
-# BB#7:                                 # %if.then20
+	br_if   	1, $pop23       # 1: down to label5
+# BB#8:                                 # %if.then20
 	i32.const	$push26=, 2
 	i32.const	$push25=, 0
 	i32.load	$push24=, 0($2)
 	call    	foo@FUNCTION, $pop26, $pop25, $pop24, $4
-	br      	2               # 2: down to label3
-.LBB3_8:                                # %if.then15
-	end_block                       # label5:
+	br      	2               # 2: down to label4
+.LBB3_9:                                # %if.then15
+	end_block                       # label6:
 	i32.const	$push63=, 4
 	i32.const	$11=, 8
 	i32.add 	$11=, $12, $11
@@ -173,18 +175,18 @@ test:                                   # @test
 	i32.add 	$push28=, $pop0, $0
 	i32.store	$discard=, 0($pop27), $pop28
 	copy_local	$3=, $0
-.LBB3_9:                                # %if.end24
-	end_block                       # label4:
+.LBB3_10:                               # %if.end24
+	end_block                       # label5:
 	block
 	i32.ne  	$push31=, $3, $0
-	br_if   	0, $pop31       # 0: down to label6
-# BB#10:                                # %if.end24
+	br_if   	0, $pop31       # 0: down to label7
+# BB#11:                                # %if.end24
 	i32.const	$push30=, 1
 	i32.and 	$push29=, $5, $pop30
 	i32.const	$push78=, 0
 	i32.eq  	$push79=, $pop29, $pop78
-	br_if   	0, $pop79       # 0: down to label6
-# BB#11:                                # %if.then31
+	br_if   	0, $pop79       # 0: down to label7
+# BB#12:                                # %if.then31
 	i64.load	$push43=, 0($2):p2align=2
 	i64.store	$discard=, 0($12):p2align=2, $pop43
 	call    	bar@FUNCTION, $12
@@ -195,9 +197,9 @@ test:                                   # @test
 	i32.add 	$push45=, $2, $pop44
 	i32.load	$push47=, 0($pop45)
 	call    	foo@FUNCTION, $pop49, $pop48, $pop46, $pop47
-	br      	1               # 1: down to label3
-.LBB3_12:                               # %if.end34
-	end_block                       # label6:
+	br      	1               # 1: down to label4
+.LBB3_13:                               # %if.end34
+	end_block                       # label7:
 	i32.const	$push32=, 4
 	i32.add 	$push33=, $2, $pop32
 	i32.load	$push71=, 0($pop33)
@@ -211,23 +213,23 @@ test:                                   # @test
 	i32.load	$push65=, 0($2)
 	tee_local	$push64=, $2=, $pop65
 	i32.lt_u	$push36=, $pop66, $pop64
-	br_if   	0, $pop36       # 0: down to label3
-# BB#13:                                # %land.lhs.true41
+	br_if   	0, $pop36       # 0: down to label4
+# BB#14:                                # %land.lhs.true41
 	block
 	i32.ne  	$push37=, $5, $2
-	br_if   	0, $pop37       # 0: down to label7
-# BB#14:                                # %lor.lhs.false47
+	br_if   	0, $pop37       # 0: down to label8
+# BB#15:                                # %lor.lhs.false47
 	i32.const	$push38=, 8
 	i32.add 	$push39=, $3, $pop38
 	i32.load	$push40=, 0($pop39)
 	i32.lt_u	$push41=, $pop40, $0
-	br_if   	1, $pop41       # 1: down to label3
-.LBB3_15:                               # %if.then53
-	end_block                       # label7:
+	br_if   	1, $pop41       # 1: down to label4
+.LBB3_16:                               # %if.then53
+	end_block                       # label8:
 	i32.const	$push42=, 4
 	call    	foo@FUNCTION, $pop42, $3, $2, $0
-.LBB3_16:                               # %cleanup
-	end_block                       # label3:
+.LBB3_17:                               # %cleanup
+	end_block                       # label4:
 	i32.const	$9=, 16
 	i32.add 	$12=, $12, $9
 	i32.const	$9=, __stack_pointer
@@ -261,12 +263,12 @@ main:                                   # @main
 	i32.load	$push2=, v($pop5)
 	i32.const	$push3=, 16384
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label8
+	br_if   	0, $pop4        # 0: down to label9
 # BB#1:                                 # %if.end
 	i32.const	$push8=, 0
 	return  	$pop8
 .LBB4_2:                                # %if.then
-	end_block                       # label8:
+	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/pr49419.c.s
+++ b/test/torture-s/pr49419.c.s
@@ -17,82 +17,83 @@ foo:                                    # @foo
 	br_if   	0, $pop1        # 0: down to label1
 # BB#1:                                 # %for.cond.preheader
 	i32.const	$5=, 0
-	i32.const	$push25=, 0
-	i32.load	$4=, t($pop25)
+	i32.const	$push23=, 0
+	i32.load	$4=, t($pop23)
 	block
 	i32.const	$push6=, 1
 	i32.lt_s	$push7=, $3, $pop6
 	br_if   	0, $pop7        # 0: down to label2
 # BB#2:                                 # %for.cond.preheader
-	copy_local	$6=, $0
 	i32.const	$push3=, 12
 	i32.mul 	$push4=, $0, $pop3
 	i32.add 	$push5=, $4, $pop4
 	i32.load	$push2=, 0($pop5)
 	i32.ne  	$push8=, $pop2, $1
 	br_if   	0, $pop8        # 0: down to label2
-.LBB0_3:                                # %for.body
+# BB#3:
+	copy_local	$6=, $0
+.LBB0_4:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label3:
-	i32.const	$push13=, 1
-	i32.add 	$5=, $5, $pop13
-	i32.ge_s	$push16=, $5, $3
-	br_if   	1, $pop16       # 1: down to label4
-# BB#4:                                 # %for.body
-                                        #   in Loop: Header=BB0_3 Depth=1
-	i32.const	$push10=, 12
-	i32.mul 	$push11=, $6, $pop10
-	i32.add 	$push12=, $4, $pop11
-	i32.load	$6=, 4($pop12)
+	i32.const	$push24=, 1
+	i32.add 	$5=, $5, $pop24
+	i32.ge_s	$push14=, $5, $3
+	br_if   	1, $pop14       # 1: down to label4
+# BB#5:                                 # %for.body
+                                        #   in Loop: Header=BB0_4 Depth=1
 	i32.const	$push26=, 12
-	i32.mul 	$push14=, $6, $pop26
-	i32.add 	$push15=, $4, $pop14
-	i32.load	$push9=, 0($pop15)
-	i32.eq  	$push17=, $pop9, $1
-	br_if   	0, $pop17       # 0: up to label3
-.LBB0_5:                                # %for.end
+	i32.mul 	$push10=, $6, $pop26
+	i32.add 	$push11=, $4, $pop10
+	i32.load	$6=, 4($pop11)
+	i32.const	$push25=, 12
+	i32.mul 	$push12=, $6, $pop25
+	i32.add 	$push13=, $4, $pop12
+	i32.load	$push9=, 0($pop13)
+	i32.eq  	$push15=, $pop9, $1
+	br_if   	0, $pop15       # 0: up to label3
+.LBB0_6:                                # %for.end
 	end_loop                        # label4:
 	end_block                       # label2:
-	i32.eq  	$push18=, $5, $3
-	br_if   	1, $pop18       # 1: down to label0
-# BB#6:                                 # %if.end7
+	i32.eq  	$push16=, $5, $3
+	br_if   	1, $pop16       # 1: down to label0
+# BB#7:                                 # %if.end7
 	block
 	i32.const	$push27=, 1
-	i32.lt_s	$push19=, $5, $pop27
-	br_if   	0, $pop19       # 0: down to label5
-# BB#7:                                 # %for.body10.preheader
-	i32.const	$push20=, 2
-	i32.shl 	$push21=, $5, $pop20
-	i32.add 	$6=, $2, $pop21
+	i32.lt_s	$push17=, $5, $pop27
+	br_if   	0, $pop17       # 0: down to label5
+# BB#8:                                 # %for.body10.preheader
+	i32.const	$push18=, 2
+	i32.shl 	$push19=, $5, $pop18
+	i32.add 	$6=, $2, $pop19
 	i32.const	$push28=, 1
 	i32.add 	$3=, $5, $pop28
-.LBB0_8:                                # %for.body10
+.LBB0_9:                                # %for.body10
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label6:
 	i32.const	$push34=, 12
-	i32.mul 	$push22=, $0, $pop34
-	i32.add 	$push33=, $4, $pop22
+	i32.mul 	$push20=, $0, $pop34
+	i32.add 	$push33=, $4, $pop20
 	tee_local	$push32=, $0=, $pop33
-	i32.load	$push23=, 8($pop32)
-	i32.store	$discard=, 0($6), $pop23
+	i32.load	$push21=, 8($pop32)
+	i32.store	$discard=, 0($6), $pop21
 	i32.load	$0=, 4($0)
 	i32.const	$push31=, -1
 	i32.add 	$3=, $3, $pop31
 	i32.const	$push30=, -4
 	i32.add 	$6=, $6, $pop30
 	i32.const	$push29=, 1
-	i32.gt_s	$push24=, $3, $pop29
-	br_if   	0, $pop24       # 0: up to label6
-.LBB0_9:                                # %for.end16
+	i32.gt_s	$push22=, $3, $pop29
+	br_if   	0, $pop22       # 0: up to label6
+.LBB0_10:                               # %for.end16
 	end_loop                        # label7:
 	end_block                       # label5:
 	i32.store	$discard=, 0($2), $0
 	i32.const	$push35=, 1
 	i32.add 	$6=, $5, $pop35
-.LBB0_10:                               # %cleanup
+.LBB0_11:                               # %cleanup
 	end_block                       # label1:
 	return  	$6
-.LBB0_11:                               # %if.then6
+.LBB0_12:                               # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -106,143 +107,142 @@ foo:                                    # @foo
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %for.body.i.preheader
-	i32.const	$6=, __stack_pointer
-	i32.load	$6=, 0($6)
-	i32.const	$7=, 48
-	i32.sub 	$11=, $6, $7
-	i32.const	$7=, __stack_pointer
-	i32.store	$11=, 0($7), $11
+	i32.const	$4=, __stack_pointer
+	i32.load	$4=, 0($4)
+	i32.const	$5=, 48
+	i32.sub 	$9=, $4, $5
+	i32.const	$5=, __stack_pointer
+	i32.store	$9=, 0($5), $9
 	i32.const	$2=, 0
-	i32.const	$push37=, 0
+	i32.const	$push36=, 0
 	i32.const	$push1=, 36
-	i32.call	$discard=, memset@FUNCTION, $11, $pop37, $pop1
+	i32.call	$discard=, memset@FUNCTION, $9, $pop36, $pop1
 	i32.const	$push3=, 4
-	i32.or  	$push4=, $11, $pop3
+	i32.or  	$push4=, $9, $pop3
 	i32.const	$push0=, 1
-	i32.store	$push2=, 0($11):p2align=4, $pop0
+	i32.store	$push2=, 0($9):p2align=4, $pop0
 	i32.store	$0=, 0($pop4), $pop2
-	i32.const	$push36=, 12
-	i32.or  	$push8=, $11, $pop36
+	i32.const	$push35=, 12
+	i32.or  	$push8=, $9, $pop35
 	i32.load	$1=, 0($pop8)
 	i32.const	$push5=, 8
-	i32.or  	$push6=, $11, $pop5
+	i32.or  	$push6=, $9, $pop5
 	i32.const	$push7=, 2
-	i32.store	$5=, 0($pop6):p2align=3, $pop7
-	i32.const	$push35=, 0
-	i32.store	$discard=, t($pop35), $11
-	copy_local	$4=, $0
-	copy_local	$3=, $0
+	i32.store	$3=, 0($pop6):p2align=3, $pop7
+	i32.const	$push34=, 0
+	i32.store	$discard=, t($pop34), $9
+	block
 	block
 	i32.ne  	$push9=, $1, $0
-	br_if   	0, $pop9        # 0: down to label8
+	br_if   	0, $pop9        # 0: down to label9
 .LBB1_1:                                # %for.body.i.for.body.i_crit_edge
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label9:
-	i32.add 	$3=, $2, $5
-	i32.add 	$2=, $2, $0
-	i32.gt_s	$push15=, $3, $5
-	br_if   	1, $pop15       # 1: down to label10
+	loop                            # label10:
+	i32.add 	$1=, $2, $3
+	i32.const	$push37=, 1
+	i32.add 	$2=, $2, $pop37
+	i32.gt_s	$push15=, $1, $3
+	br_if   	3, $pop15       # 3: down to label8
 # BB#2:                                 # %for.body.i.for.body.i_crit_edge
                                         #   in Loop: Header=BB1_1 Depth=1
+	i32.const	$push40=, 12
+	i32.mul 	$push11=, $0, $pop40
+	i32.add 	$push12=, $9, $pop11
+	i32.load	$0=, 4($pop12)
 	i32.const	$push39=, 12
-	i32.mul 	$push11=, $4, $pop39
-	i32.add 	$push12=, $11, $pop11
-	i32.load	$4=, 4($pop12)
-	i32.const	$push38=, 12
-	i32.mul 	$push13=, $4, $pop38
-	i32.add 	$push14=, $11, $pop13
+	i32.mul 	$push13=, $0, $pop39
+	i32.add 	$push14=, $9, $pop13
 	i32.load	$push10=, 0($pop14)
-	i32.const	$push16=, 1
-	i32.eq  	$push17=, $pop10, $pop16
-	br_if   	0, $pop17       # 0: up to label9
-.LBB1_3:                                # %for.end.i
-	end_loop                        # label10:
+	i32.const	$push38=, 1
+	i32.eq  	$push16=, $pop10, $pop38
+	br_if   	0, $pop16       # 0: up to label10
+	br      	3               # 3: down to label8
+.LBB1_3:
+	end_loop                        # label11:
+	end_block                       # label9:
+	copy_local	$1=, $0
+.LBB1_4:                                # %for.end.i
 	end_block                       # label8:
 	block
 	block
 	block
-	i32.const	$push18=, 3
-	i32.eq  	$push19=, $3, $pop18
-	br_if   	0, $pop19       # 0: down to label13
-# BB#4:                                 # %if.end7.i
-	i32.const	$push40=, 0
-	i32.lt_s	$push20=, $2, $pop40
-	br_if   	1, $pop20       # 1: down to label12
-# BB#5:                                 # %for.body10.i.preheader
-	i32.const	$5=, 1
-	i32.const	$push21=, 2
-	i32.shl 	$push43=, $3, $pop21
-	tee_local	$push42=, $4=, $pop43
-	i32.const	$9=, 36
-	i32.add 	$9=, $11, $9
+	i32.const	$push17=, 3
+	i32.eq  	$push18=, $1, $pop17
+	br_if   	0, $pop18       # 0: down to label14
+# BB#5:                                 # %if.end7.i
+	i32.const	$push41=, 0
+	i32.lt_s	$push19=, $2, $pop41
+	br_if   	1, $pop19       # 1: down to label13
+# BB#6:                                 # %for.body10.i.preheader
+	i32.const	$3=, 1
+	i32.const	$push20=, 2
+	i32.shl 	$push44=, $1, $pop20
+	tee_local	$push43=, $0=, $pop44
+	i32.const	$7=, 36
+	i32.add 	$7=, $9, $7
 	block
-	i32.add 	$push22=, $9, $pop42
-	i32.const	$push41=, 2
-	i32.store	$push23=, 0($pop22), $pop41
-	i32.lt_s	$push24=, $3, $pop23
-	br_if   	0, $pop24       # 0: down to label14
-# BB#6:                                 # %for.body10.i.for.body10.i_crit_edge.preheader
-	i32.const	$10=, 36
-	i32.add 	$10=, $11, $10
-	i32.add 	$push25=, $4, $10
-	i32.const	$push44=, -4
-	i32.add 	$4=, $pop25, $pop44
-	i32.const	$5=, 1
-.LBB1_7:                                # %for.body10.i.for.body10.i_crit_edge
+	i32.add 	$push21=, $7, $pop43
+	i32.const	$push42=, 2
+	i32.store	$push22=, 0($pop21), $pop42
+	i32.lt_s	$push23=, $1, $pop22
+	br_if   	0, $pop23       # 0: down to label15
+# BB#7:                                 # %for.body10.i.for.body10.i_crit_edge.preheader
+	i32.const	$8=, 36
+	i32.add 	$8=, $9, $8
+	i32.add 	$push24=, $0, $8
+	i32.const	$push45=, -4
+	i32.add 	$0=, $pop24, $pop45
+	i32.const	$3=, 1
+.LBB1_8:                                # %for.body10.i.for.body10.i_crit_edge
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label15:
-	i32.const	$push51=, 12
-	i32.mul 	$push26=, $5, $pop51
-	i32.add 	$push50=, $11, $pop26
-	tee_local	$push49=, $5=, $pop50
-	i32.load	$push27=, 8($pop49)
-	i32.store	$discard=, 0($4), $pop27
-	i32.load	$5=, 4($5)
-	i32.const	$push48=, -1
-	i32.add 	$3=, $3, $pop48
-	i32.const	$push47=, -4
-	i32.add 	$4=, $4, $pop47
-	i32.const	$push46=, 1
-	i32.gt_s	$push28=, $3, $pop46
-	br_if   	0, $pop28       # 0: up to label15
-.LBB1_8:                                # %foo.exit
-	end_loop                        # label16:
-	end_block                       # label14:
-	i32.store	$3=, 36($11), $5
-	br_if   	2, $2           # 2: down to label11
-# BB#9:                                 # %if.end
-	block
-	i32.const	$push29=, 1
-	i32.ne  	$push30=, $3, $pop29
-	br_if   	0, $pop30       # 0: down to label17
-# BB#10:                                # %lor.lhs.false
-	i32.load	$push31=, 40($11)
-	i32.const	$push32=, 2
-	i32.ne  	$push33=, $pop31, $pop32
-	br_if   	0, $pop33       # 0: down to label17
-# BB#11:                                # %if.end6
-	i32.const	$push34=, 0
-	i32.const	$8=, 48
-	i32.add 	$11=, $11, $8
-	i32.const	$8=, __stack_pointer
-	i32.store	$11=, 0($8), $11
-	return  	$pop34
-.LBB1_12:                               # %if.then5
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
+	loop                            # label16:
+	i32.const	$push52=, 12
+	i32.mul 	$push25=, $3, $pop52
+	i32.add 	$push51=, $9, $pop25
+	tee_local	$push50=, $3=, $pop51
+	i32.load	$push26=, 8($pop50)
+	i32.store	$discard=, 0($0), $pop26
+	i32.load	$3=, 4($3)
+	i32.const	$push49=, -1
+	i32.add 	$1=, $1, $pop49
+	i32.const	$push48=, -4
+	i32.add 	$0=, $0, $pop48
+	i32.const	$push47=, 1
+	i32.gt_s	$push27=, $1, $pop47
+	br_if   	0, $pop27       # 0: up to label16
+.LBB1_9:                                # %foo.exit
+	end_loop                        # label17:
+	end_block                       # label15:
+	i32.store	$1=, 36($9), $3
+	br_if   	2, $2           # 2: down to label12
+# BB#10:                                # %if.end
+	i32.const	$push28=, 1
+	i32.ne  	$push29=, $1, $pop28
+	br_if   	2, $pop29       # 2: down to label12
+# BB#11:                                # %lor.lhs.false
+	i32.load	$push30=, 40($9)
+	i32.const	$push31=, 2
+	i32.ne  	$push32=, $pop30, $pop31
+	br_if   	2, $pop32       # 2: down to label12
+# BB#12:                                # %if.end6
+	i32.const	$push33=, 0
+	i32.const	$6=, 48
+	i32.add 	$9=, $9, $6
+	i32.const	$6=, __stack_pointer
+	i32.store	$9=, 0($6), $9
+	return  	$pop33
 .LBB1_13:                               # %if.then6.i
-	end_block                       # label13:
+	end_block                       # label14:
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_14:                               # %foo.exit.thread
+	end_block                       # label13:
+	i32.const	$push46=, 0
+	i32.store	$discard=, 36($9), $pop46
+.LBB1_15:                               # %if.then5
 	end_block                       # label12:
-	i32.const	$push45=, 0
-	i32.store	$discard=, 36($11), $pop45
-.LBB1_15:                               # %if.then
-	end_block                       # label11:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/pr49886.c.s
+++ b/test/torture-s/pr49886.c.s
@@ -54,34 +54,26 @@ mark_cell:                              # @mark_cell
 # BB#0:                                 # %entry
 	block
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push49=, 0
 	i32.eq  	$push50=, $0, $pop49
-	br_if   	0, $pop50       # 0: down to label9
+	br_if   	0, $pop50       # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push1=, 0
 	i32.load	$push0=, cond($pop1)
 	i32.const	$push51=, 0
 	i32.eq  	$push52=, $pop0, $pop51
-	br_if   	0, $pop52       # 0: down to label9
+	br_if   	0, $pop52       # 0: down to label1
 # BB#2:                                 # %land.lhs.true
 	i32.load	$push2=, 8($0)
 	i32.const	$push3=, 4
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label9
+	br_if   	0, $pop4        # 0: down to label1
 # BB#3:                                 # %land.lhs.true2
 	i32.load	$push38=, 0($0)
 	tee_local	$push37=, $0=, $pop38
 	i32.const	$push53=, 0
 	i32.eq  	$push54=, $pop37, $pop53
-	br_if   	0, $pop54       # 0: down to label9
+	br_if   	0, $pop54       # 0: down to label1
 # BB#4:                                 # %land.lhs.true4
 	i32.const	$push41=, 2
 	i32.add 	$push40=, $0, $pop41
@@ -91,14 +83,14 @@ mark_cell:                              # @mark_cell
 	i32.and 	$push7=, $pop5, $pop6
 	i32.const	$push55=, 0
 	i32.eq  	$push56=, $pop7, $pop55
-	br_if   	1, $pop56       # 1: down to label8
+	br_if   	1, $pop56       # 1: down to label0
 # BB#5:                                 # %land.lhs.true17
 	i32.load8_u	$push8=, 0($1):p2align=1
 	i32.const	$push42=, 2
 	i32.and 	$push9=, $pop8, $pop42
 	i32.const	$push57=, 0
 	i32.eq  	$push58=, $pop9, $pop57
-	br_if   	2, $pop58       # 2: down to label7
+	br_if   	1, $pop58       # 1: down to label0
 # BB#6:                                 # %land.lhs.true33
 	i32.const	$push10=, 2
 	i32.add 	$push11=, $0, $pop10
@@ -107,7 +99,7 @@ mark_cell:                              # @mark_cell
 	i32.and 	$push13=, $pop12, $pop43
 	i32.const	$push59=, 0
 	i32.eq  	$push60=, $pop13, $pop59
-	br_if   	3, $pop60       # 3: down to label6
+	br_if   	1, $pop60       # 1: down to label0
 # BB#7:                                 # %land.lhs.true49
 	i32.const	$push44=, 1
 	i32.add 	$push14=, $0, $pop44
@@ -116,7 +108,7 @@ mark_cell:                              # @mark_cell
 	i32.shr_u	$push17=, $pop15, $pop16
 	i32.const	$push61=, 0
 	i32.eq  	$push62=, $pop17, $pop61
-	br_if   	4, $pop62       # 4: down to label5
+	br_if   	1, $pop62       # 1: down to label0
 # BB#8:                                 # %land.lhs.true65
 	i32.const	$push18=, 1
 	i32.add 	$push46=, $0, $pop18
@@ -126,14 +118,14 @@ mark_cell:                              # @mark_cell
 	i32.and 	$push21=, $pop19, $pop20
 	i32.const	$push63=, 0
 	i32.eq  	$push64=, $pop21, $pop63
-	br_if   	5, $pop64       # 5: down to label4
+	br_if   	1, $pop64       # 1: down to label0
 # BB#9:                                 # %land.lhs.true81
 	i32.load8_u	$push22=, 0($1)
 	i32.const	$push23=, 32
 	i32.and 	$push24=, $pop22, $pop23
 	i32.const	$push65=, 0
 	i32.eq  	$push66=, $pop24, $pop65
-	br_if   	6, $pop66       # 6: down to label3
+	br_if   	1, $pop66       # 1: down to label0
 # BB#10:                                # %land.lhs.true97
 	i32.const	$push25=, 1
 	i32.add 	$push48=, $0, $pop25
@@ -143,14 +135,14 @@ mark_cell:                              # @mark_cell
 	i32.and 	$push28=, $pop26, $pop27
 	i32.const	$push67=, 0
 	i32.eq  	$push68=, $pop28, $pop67
-	br_if   	7, $pop68       # 7: down to label2
+	br_if   	1, $pop68       # 1: down to label0
 # BB#11:                                # %land.lhs.true113
 	i32.load8_u	$push29=, 0($1)
 	i32.const	$push30=, 8
 	i32.and 	$push31=, $pop29, $pop30
 	i32.const	$push69=, 0
 	i32.eq  	$push70=, $pop31, $pop69
-	br_if   	8, $pop70       # 8: down to label1
+	br_if   	1, $pop70       # 1: down to label0
 # BB#12:                                # %land.lhs.true129
 	i32.const	$push32=, 1
 	i32.add 	$push33=, $0, $pop32
@@ -159,43 +151,11 @@ mark_cell:                              # @mark_cell
 	i32.and 	$push36=, $pop34, $pop35
 	i32.const	$push71=, 0
 	i32.eq  	$push72=, $pop36, $pop71
-	br_if   	9, $pop72       # 9: down to label0
+	br_if   	1, $pop72       # 1: down to label0
 .LBB3_13:                               # %if.end137
-	end_block                       # label9:
-	return
-.LBB3_14:                               # %if.then7
-	end_block                       # label8:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_15:                               # %if.then22
-	end_block                       # label7:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_16:                               # %if.then38
-	end_block                       # label6:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_17:                               # %if.then54
-	end_block                       # label5:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_18:                               # %if.then70
-	end_block                       # label4:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_19:                               # %if.then86
-	end_block                       # label3:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_20:                               # %if.then102
-	end_block                       # label2:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_21:                               # %if.then118
 	end_block                       # label1:
-	call    	never_ever@FUNCTION, $0, $0
-	unreachable
-.LBB3_22:                               # %if.then134
+	return
+.LBB3_14:                               # %if.then134
 	end_block                       # label0:
 	call    	never_ever@FUNCTION, $0, $0
 	unreachable

--- a/test/torture-s/pr51877.c.s
+++ b/test/torture-s/pr51877.c.s
@@ -115,25 +115,23 @@ main:                                   # @main
 	i32.const	$push48=, 36
 	i32.call	$discard=, memcpy@FUNCTION, $pop3, $5, $pop48
 	block
-	block
-	block
 	i32.const	$push47=, 0
 	i32.load	$push4=, a($pop47)
 	i32.const	$push5=, 1
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	0, $pop6        # 0: down to label4
+	br_if   	0, $pop6        # 0: down to label2
 # BB#1:                                 # %lor.lhs.false
 	i32.const	$push51=, 0
 	i32.load8_u	$push9=, a+4($pop51):p2align=2
 	i32.const	$push50=, 3
 	i32.ne  	$push10=, $pop9, $pop50
-	br_if   	0, $pop10       # 0: down to label4
+	br_if   	0, $pop10       # 0: down to label2
 # BB#2:                                 # %lor.lhs.false
 	i32.const	$push52=, 0
 	i32.load	$push7=, b($pop52)
 	i32.const	$push11=, 2
 	i32.ne  	$push12=, $pop7, $pop11
-	br_if   	0, $pop12       # 0: down to label4
+	br_if   	0, $pop12       # 0: down to label2
 # BB#3:                                 # %lor.lhs.false
 	i32.const	$push53=, 0
 	i32.load8_u	$push8=, b+4($pop53):p2align=2
@@ -141,7 +139,7 @@ main:                                   # @main
 	i32.and 	$push14=, $pop8, $pop13
 	i32.const	$push15=, 4
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	0, $pop16       # 0: down to label4
+	br_if   	0, $pop16       # 0: down to label2
 # BB#4:                                 # %if.end
 	i32.const	$push17=, b
 	i32.const	$push55=, 0
@@ -150,19 +148,19 @@ main:                                   # @main
 	i32.load	$push18=, a($pop54)
 	i32.const	$push19=, 1
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	1, $pop20       # 1: down to label3
+	br_if   	0, $pop20       # 0: down to label2
 # BB#5:                                 # %lor.lhs.false13
 	i32.const	$push57=, 0
 	i32.load8_u	$push23=, a+4($pop57):p2align=2
 	i32.const	$push56=, 3
 	i32.ne  	$push24=, $pop23, $pop56
-	br_if   	1, $pop24       # 1: down to label3
+	br_if   	0, $pop24       # 0: down to label2
 # BB#6:                                 # %lor.lhs.false13
 	i32.const	$push59=, 0
 	i32.load	$push21=, b($pop59)
 	i32.const	$push58=, 3
 	i32.ne  	$push25=, $pop21, $pop58
-	br_if   	1, $pop25       # 1: down to label3
+	br_if   	0, $pop25       # 0: down to label2
 # BB#7:                                 # %lor.lhs.false13
 	i32.const	$push60=, 0
 	i32.load8_u	$push22=, b+4($pop60):p2align=2
@@ -170,7 +168,7 @@ main:                                   # @main
 	i32.and 	$push27=, $pop22, $pop26
 	i32.const	$push28=, 7
 	i32.ne  	$push29=, $pop27, $pop28
-	br_if   	1, $pop29       # 1: down to label3
+	br_if   	0, $pop29       # 0: down to label2
 # BB#8:                                 # %if.end25
 	i32.const	$push30=, b
 	i32.const	$push31=, 6
@@ -179,19 +177,19 @@ main:                                   # @main
 	i32.load	$push32=, a($pop61)
 	i32.const	$push33=, 4
 	i32.ne  	$push34=, $pop32, $pop33
-	br_if   	2, $pop34       # 2: down to label2
+	br_if   	0, $pop34       # 0: down to label2
 # BB#9:                                 # %lor.lhs.false28
 	i32.const	$push62=, 0
 	i32.load8_u	$push37=, a+4($pop62):p2align=2
 	i32.const	$push38=, 7
 	i32.ne  	$push39=, $pop37, $pop38
-	br_if   	2, $pop39       # 2: down to label2
+	br_if   	0, $pop39       # 0: down to label2
 # BB#10:                                # %lor.lhs.false28
 	i32.const	$push63=, 0
 	i32.load	$push35=, b($pop63)
 	i32.const	$push40=, 3
 	i32.ne  	$push41=, $pop35, $pop40
-	br_if   	2, $pop41       # 2: down to label2
+	br_if   	0, $pop41       # 0: down to label2
 # BB#11:                                # %lor.lhs.false28
 	i32.const	$push64=, 0
 	i32.load8_u	$push36=, b+4($pop64):p2align=2
@@ -199,7 +197,7 @@ main:                                   # @main
 	i32.and 	$push43=, $pop36, $pop42
 	i32.const	$push44=, 7
 	i32.ne  	$push45=, $pop43, $pop44
-	br_if   	2, $pop45       # 2: down to label2
+	br_if   	0, $pop45       # 0: down to label2
 # BB#12:                                # %if.end40
 	i32.const	$push46=, 0
 	i32.const	$2=, 80
@@ -207,15 +205,7 @@ main:                                   # @main
 	i32.const	$2=, __stack_pointer
 	i32.store	$5=, 0($2), $5
 	return  	$pop46
-.LBB3_13:                               # %if.then
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_14:                               # %if.then24
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_15:                               # %if.then39
+.LBB3_13:                               # %if.then39
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr51933.c.s
+++ b/test/torture-s/pr51933.c.s
@@ -30,41 +30,42 @@ bar:                                    # @bar
 	call    	foo@FUNCTION
 .LBB1_2:                                # %for.cond.preheader
 	end_block                       # label0:
+	block
+	i32.const	$push11=, 1
+	i32.lt_s	$push2=, $0, $pop11
+	br_if   	0, $pop2        # 0: down to label1
+# BB#3:
 	copy_local	$3=, $0
 	copy_local	$4=, $2
-	block
-	i32.const	$push17=, 1
-	i32.lt_s	$push2=, $0, $pop17
-	br_if   	0, $pop2        # 0: down to label1
-.LBB1_3:                                # %for.body
+.LBB1_4:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
 	i32.load16_u	$push20=, 0($1)
 	tee_local	$push19=, $5=, $pop20
-	i32.const	$push5=, v2
-	i32.add 	$push6=, $pop19, $pop5
-	i32.const	$push7=, 255
-	i32.and 	$push8=, $5, $pop7
-	i32.const	$push9=, v3
-	i32.add 	$push10=, $pop8, $pop9
-	i32.const	$push3=, 256
-	i32.lt_u	$push4=, $5, $pop3
-	i32.select	$push11=, $pop6, $pop10, $pop4
-	i32.load8_u	$push12=, 0($pop11)
-	i32.store8	$discard=, 0($4), $pop12
-	i32.const	$push13=, 2
-	i32.add 	$1=, $1, $pop13
-	i32.const	$push14=, -1
-	i32.add 	$3=, $3, $pop14
-	i32.const	$push18=, 1
-	i32.add 	$4=, $4, $pop18
+	i32.const	$push18=, v2
+	i32.add 	$push4=, $pop19, $pop18
+	i32.const	$push17=, 255
+	i32.and 	$push5=, $5, $pop17
+	i32.const	$push16=, v3
+	i32.add 	$push6=, $pop5, $pop16
+	i32.const	$push15=, 256
+	i32.lt_u	$push3=, $5, $pop15
+	i32.select	$push7=, $pop4, $pop6, $pop3
+	i32.load8_u	$push8=, 0($pop7)
+	i32.store8	$discard=, 0($4), $pop8
+	i32.const	$push14=, 2
+	i32.add 	$1=, $1, $pop14
+	i32.const	$push13=, 1
+	i32.add 	$4=, $4, $pop13
+	i32.const	$push12=, -1
+	i32.add 	$3=, $3, $pop12
 	br_if   	0, $3           # 0: up to label2
-.LBB1_4:                                # %for.end
+.LBB1_5:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:
-	i32.add 	$push15=, $2, $0
-	i32.const	$push16=, 0
-	i32.store8	$discard=, 0($pop15), $pop16
+	i32.add 	$push9=, $2, $0
+	i32.const	$push10=, 0
+	i32.store8	$discard=, 0($pop9), $pop10
 	return  	$0
 	.endfunc
 .Lfunc_end1:

--- a/test/torture-s/pr52760.c.s
+++ b/test/torture-s/pr52760.c.s
@@ -15,47 +15,47 @@ foo:                                    # @foo
 .LBB0_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
-	i32.const	$push6=, 2
-	i32.add 	$2=, $1, $pop6
-	i32.const	$push10=, 4
-	i32.add 	$push32=, $1, $pop10
-	tee_local	$push31=, $5=, $pop32
-	i32.load16_u	$3=, 0($pop31)
-	i32.load16_u	$push30=, 0($2)
-	tee_local	$push29=, $4=, $pop30
-	i32.const	$push2=, 8
-	i32.shr_u	$push7=, $pop29, $pop2
-	i32.const	$push28=, 8
-	i32.shl 	$push8=, $4, $pop28
-	i32.or  	$push9=, $pop7, $pop8
-	i32.store16	$discard=, 0($2), $pop9
-	i32.const	$push14=, 6
-	i32.add 	$push27=, $1, $pop14
-	tee_local	$push26=, $4=, $pop27
-	i32.load16_u	$2=, 0($pop26)
+	i32.const	$push32=, 2
+	i32.add 	$2=, $1, $pop32
+	i32.const	$push31=, 4
+	i32.add 	$push30=, $1, $pop31
+	tee_local	$push29=, $5=, $pop30
+	i32.load16_u	$3=, 0($pop29)
+	i32.load16_u	$push28=, 0($2)
+	tee_local	$push27=, $4=, $pop28
+	i32.const	$push26=, 8
+	i32.shr_u	$push5=, $pop27, $pop26
 	i32.const	$push25=, 8
-	i32.shr_u	$push11=, $3, $pop25
-	i32.const	$push24=, 8
-	i32.shl 	$push12=, $3, $pop24
-	i32.or  	$push13=, $pop11, $pop12
-	i32.store16	$discard=, 0($5), $pop13
-	i32.load16_u	$3=, 0($1)
-	i32.const	$push23=, 8
-	i32.shr_u	$push15=, $2, $pop23
-	i32.const	$push22=, 8
-	i32.shl 	$push16=, $2, $pop22
-	i32.or  	$push17=, $pop15, $pop16
-	i32.store16	$discard=, 0($4), $pop17
+	i32.shl 	$push6=, $4, $pop25
+	i32.or  	$push7=, $pop5, $pop6
+	i32.store16	$discard=, 0($2), $pop7
+	i32.const	$push24=, 6
+	i32.add 	$push23=, $1, $pop24
+	tee_local	$push22=, $4=, $pop23
+	i32.load16_u	$2=, 0($pop22)
 	i32.const	$push21=, 8
-	i32.shr_u	$push3=, $3, $pop21
+	i32.shr_u	$push8=, $3, $pop21
 	i32.const	$push20=, 8
-	i32.shl 	$push4=, $3, $pop20
-	i32.or  	$push5=, $pop3, $pop4
-	i32.store16	$discard=, 0($1), $pop5
-	i32.const	$push18=, -1
-	i32.add 	$0=, $0, $pop18
+	i32.shl 	$push9=, $3, $pop20
+	i32.or  	$push10=, $pop8, $pop9
+	i32.store16	$discard=, 0($5), $pop10
+	i32.load16_u	$3=, 0($1)
 	i32.const	$push19=, 8
-	i32.add 	$1=, $1, $pop19
+	i32.shr_u	$push11=, $2, $pop19
+	i32.const	$push18=, 8
+	i32.shl 	$push12=, $2, $pop18
+	i32.or  	$push13=, $pop11, $pop12
+	i32.store16	$discard=, 0($4), $pop13
+	i32.const	$push17=, 8
+	i32.shr_u	$push2=, $3, $pop17
+	i32.const	$push16=, 8
+	i32.shl 	$push3=, $3, $pop16
+	i32.or  	$push4=, $pop2, $pop3
+	i32.store16	$discard=, 0($1), $pop4
+	i32.const	$push15=, -1
+	i32.add 	$0=, $0, $pop15
+	i32.const	$push14=, 8
+	i32.add 	$1=, $1, $pop14
 	br_if   	0, $0           # 0: up to label1
 .LBB0_2:                                # %for.end
 	end_loop                        # label2:

--- a/test/torture-s/pr53465.c.s
+++ b/test/torture-s/pr53465.c.s
@@ -9,14 +9,15 @@ foo:                                    # @foo
 	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
 	i32.const	$3=, 0
+	block
+	block
+	i32.const	$push3=, 0
+	i32.le_s	$push0=, $1, $pop3
+	br_if   	0, $pop0        # 0: down to label1
+# BB#1:
                                         # implicit-def: %vreg19
 	i32.const	$5=, 0
-	block
-	block
-	i32.const	$push4=, 0
-	i32.le_s	$push0=, $1, $pop4
-	br_if   	0, $pop0        # 0: down to label1
-.LBB0_1:                                # %for.body
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
 	copy_local	$2=, $4
@@ -24,31 +25,31 @@ foo:                                    # @foo
 	i32.const	$push6=, 0
 	i32.eq  	$push7=, $4, $pop6
 	br_if   	1, $pop7        # 1: down to label3
-# BB#2:                                 # %if.end
-                                        #   in Loop: Header=BB0_1 Depth=1
+# BB#3:                                 # %if.end
+                                        #   in Loop: Header=BB0_2 Depth=1
 	block
 	i32.const	$push8=, 0
 	i32.eq  	$push9=, $5, $pop8
 	br_if   	0, $pop9        # 0: down to label4
-# BB#3:                                 # %if.end
-                                        #   in Loop: Header=BB0_1 Depth=1
+# BB#4:                                 # %if.end
+                                        #   in Loop: Header=BB0_2 Depth=1
 	i32.le_s	$push1=, $4, $2
 	br_if   	4, $pop1        # 4: down to label0
-.LBB0_4:                                # %for.cond
-                                        #   in Loop: Header=BB0_1 Depth=1
+.LBB0_5:                                # %for.cond
+                                        #   in Loop: Header=BB0_2 Depth=1
 	end_block                       # label4:
-	i32.const	$push2=, 4
-	i32.add 	$0=, $0, $pop2
-	i32.const	$5=, 1
 	i32.const	$push5=, 1
 	i32.add 	$3=, $3, $pop5
-	i32.lt_s	$push3=, $3, $1
-	br_if   	0, $pop3        # 0: up to label2
-.LBB0_5:                                # %for.end
+	i32.const	$push4=, 4
+	i32.add 	$0=, $0, $pop4
+	i32.const	$5=, 1
+	i32.lt_s	$push2=, $3, $1
+	br_if   	0, $pop2        # 0: up to label2
+.LBB0_6:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:
 	return
-.LBB0_6:                                # %if.then3
+.LBB0_7:                                # %if.then3
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr54471.c.s
+++ b/test/torture-s/pr54471.c.s
@@ -14,53 +14,54 @@ foo:                                    # @foo
 	i32.sub 	$11=, $6, $7
 	i32.const	$7=, __stack_pointer
 	i32.store	$11=, 0($7), $11
-	i64.const	$5=, 0
-	i64.const	$4=, 1
 	block
 	i32.const	$push14=, 0
 	i32.eq  	$push15=, $3, $pop14
 	br_if   	0, $pop15       # 0: down to label0
-.LBB0_1:                                # %for.body
+# BB#1:
+	i64.const	$5=, 0
+	i64.const	$4=, 1
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	call    	__multi3@FUNCTION, $11, $1, $2, $4, $5
-	i32.const	$push0=, 8
-	i32.add 	$push1=, $11, $pop0
-	i64.load	$5=, 0($pop1)
+	i32.const	$push9=, 8
+	i32.add 	$push0=, $11, $pop9
+	i64.load	$5=, 0($pop0)
 	i64.load	$4=, 0($11)
 	i32.const	$9=, 16
 	i32.add 	$9=, $11, $9
 	call    	__multi3@FUNCTION, $9, $1, $2, $1, $2
-	i32.const	$push9=, 8
+	i32.const	$push8=, 8
 	i32.const	$10=, 16
 	i32.add 	$10=, $11, $10
-	i32.add 	$push2=, $10, $pop9
-	i64.load	$2=, 0($pop2)
+	i32.add 	$push1=, $10, $pop8
+	i64.load	$2=, 0($pop1)
 	i64.load	$1=, 16($11)
-	i32.const	$push3=, -1
-	i32.add 	$3=, $3, $pop3
+	i32.const	$push7=, -1
+	i32.add 	$3=, $3, $pop7
 	br_if   	0, $3           # 0: up to label1
-# BB#2:                                 # %for.end
+# BB#3:                                 # %for.end
 	end_loop                        # label2:
 	i64.const	$push11=, 14348907
-	i64.xor 	$push4=, $4, $pop11
-	i64.or  	$push5=, $pop4, $5
+	i64.xor 	$push2=, $4, $pop11
+	i64.or  	$push3=, $pop2, $5
 	i64.const	$push10=, 0
-	i64.ne  	$push6=, $pop5, $pop10
-	br_if   	0, $pop6        # 0: down to label0
-# BB#3:                                 # %if.end
+	i64.ne  	$push4=, $pop3, $pop10
+	br_if   	0, $pop4        # 0: down to label0
+# BB#4:                                 # %if.end
 	i64.const	$push13=, 14348907
 	i64.store	$discard=, 0($0), $pop13
-	i32.const	$push7=, 8
-	i32.add 	$push8=, $0, $pop7
+	i32.const	$push5=, 8
+	i32.add 	$push6=, $0, $pop5
 	i64.const	$push12=, 0
-	i64.store	$discard=, 0($pop8), $pop12
+	i64.store	$discard=, 0($pop6), $pop12
 	i32.const	$8=, 32
 	i32.add 	$11=, $11, $8
 	i32.const	$8=, __stack_pointer
 	i32.store	$11=, 0($8), $11
 	return
-.LBB0_4:                                # %if.then
+.LBB0_5:                                # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr54937.c.s
+++ b/test/torture-s/pr54937.c.s
@@ -9,35 +9,36 @@ t:                                      # @t
 	.result 	i32
 	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$1=, 0
 	block
 	i32.const	$push0=, 1
 	i32.lt_s	$push1=, $0, $pop0
 	br_if   	0, $pop1        # 0: down to label0
-.LBB0_1:                                # %for.body
+# BB#1:
+	i32.const	$1=, 0
+.LBB0_2:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	block
 	i32.const	$push8=, 0
 	i32.eq  	$push9=, $1, $pop8
 	br_if   	0, $pop9        # 0: down to label3
-# BB#2:                                 # %if.then
-                                        #   in Loop: Header=BB0_1 Depth=1
-	i32.const	$push2=, 0
-	i32.load	$push3=, terminate_me($pop2)
-	i32.const	$push7=, 0
-	call_indirect	$pop3, $pop7
-.LBB0_3:                                # %if.end
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_block                       # label3:
+# BB#3:                                 # %if.then
+                                        #   in Loop: Header=BB0_2 Depth=1
 	i32.const	$push4=, 0
-	i32.store	$discard=, a($1), $pop4
-	i32.const	$push5=, 4
-	i32.add 	$1=, $1, $pop5
-	i32.const	$push6=, -1
-	i32.add 	$0=, $0, $pop6
+	i32.load	$push2=, terminate_me($pop4)
+	i32.const	$push3=, 0
+	call_indirect	$pop2, $pop3
+.LBB0_4:                                # %if.end
+                                        #   in Loop: Header=BB0_2 Depth=1
+	end_block                       # label3:
+	i32.const	$push7=, 0
+	i32.store	$discard=, a($1), $pop7
+	i32.const	$push6=, 4
+	i32.add 	$1=, $1, $pop6
+	i32.const	$push5=, -1
+	i32.add 	$0=, $0, $pop5
 	br_if   	0, $0           # 0: up to label1
-.LBB0_4:                                # %for.end
+.LBB0_5:                                # %for.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	return  	$1

--- a/test/torture-s/pr54985.c.s
+++ b/test/torture-s/pr54985.c.s
@@ -9,39 +9,47 @@ foo:                                    # @foo
 	.result 	i32
 	.local  	i32, i32, i32, i32
 # BB#0:                                 # %entry
-	i32.const	$4=, 0
+	block
+	block
 	block
 	i32.const	$push5=, 0
 	i32.eq  	$push6=, $1, $pop5
-	br_if   	0, $pop6        # 0: down to label0
+	br_if   	0, $pop6        # 0: down to label2
 # BB#1:                                 # %while.body.preheader
-	i32.load	$3=, 0($0)
+	i32.load	$4=, 0($0)
 	i32.const	$push0=, 4
 	i32.add 	$0=, $0, $pop0
 .LBB0_2:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label1:
+	loop                            # label3:
 	i32.const	$push1=, -1
 	i32.add 	$1=, $1, $pop1
-	i32.const	$4=, 0
 	i32.const	$push7=, 0
 	i32.eq  	$push8=, $1, $pop7
-	br_if   	1, $pop8        # 1: down to label2
+	br_if   	3, $pop8        # 3: down to label1
 # BB#3:                                 # %while.cond.while.body_crit_edge
                                         #   in Loop: Header=BB0_2 Depth=1
 	i32.const	$push4=, 4
-	i32.add 	$4=, $0, $pop4
+	i32.add 	$2=, $0, $pop4
 	i32.load	$push3=, 0($0)
 	tee_local	$push2=, $5=, $pop3
-	i32.lt_s	$2=, $pop2, $3
-	copy_local	$0=, $4
-	copy_local	$3=, $5
-	i32.const	$4=, 1
-	br_if   	0, $2           # 0: up to label1
-.LBB0_4:                                # %cleanup
-	end_loop                        # label2:
+	i32.lt_s	$3=, $pop2, $4
+	copy_local	$0=, $2
+	copy_local	$4=, $5
+	i32.const	$2=, 1
+	br_if   	0, $3           # 0: up to label3
+	br      	4               # 4: down to label0
+.LBB0_4:
+	end_loop                        # label4:
+	end_block                       # label2:
+	i32.const	$2=, 0
+	br      	1               # 1: down to label0
+.LBB0_5:
+	end_block                       # label1:
+	i32.const	$2=, 0
+.LBB0_6:                                # %cleanup
 	end_block                       # label0:
-	return  	$4
+	return  	$2
 	.endfunc
 .Lfunc_end0:
 	.size	foo, .Lfunc_end0-foo
@@ -67,7 +75,7 @@ main:                                   # @main
 	i32.add 	$3=, $4, $3
 	block
 	i32.call	$push2=, foo@FUNCTION, $3, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label5
 # BB#1:                                 # %if.end
 	i32.const	$push3=, 0
 	i32.const	$2=, 16
@@ -76,7 +84,7 @@ main:                                   # @main
 	i32.store	$4=, 0($2), $4
 	return  	$pop3
 .LBB1_2:                                # %if.then
-	end_block                       # label3:
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/pr56866.c.s
+++ b/test/torture-s/pr56866.c.s
@@ -6,249 +6,236 @@
 	.type	main,@function
 main:                                   # @main
 	.result 	i32
-	.local  	i32, i32, i32, i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
+	.local  	i32, i32, i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32
 # BB#0:                                 # %entry
+	i32.const	$3=, __stack_pointer
+	i32.load	$3=, 0($3)
+	i32.const	$4=, 7712
+	i32.sub 	$34=, $3, $4
 	i32.const	$4=, __stack_pointer
-	i32.load	$4=, 0($4)
-	i32.const	$5=, 7712
-	i32.sub 	$35=, $4, $5
-	i32.const	$5=, __stack_pointer
-	i32.store	$35=, 0($5), $35
-	i32.const	$2=, 2048
-	i32.const	$0=, 0
-	i32.const	$7=, 5664
-	i32.add 	$7=, $35, $7
-	i32.call	$discard=, memset@FUNCTION, $7, $0, $2
-	i32.const	$2=, 1024
-	i32.const	$8=, 2592
-	i32.add 	$8=, $35, $8
-	i32.call	$discard=, memset@FUNCTION, $8, $0, $2
-	i32.const	$2=, 512
-	i32.const	$9=, 1056
-	i32.add 	$9=, $35, $9
-	i32.call	$discard=, memset@FUNCTION, $9, $0, $2
-	i32.const	$2=, 256
-	i32.const	$10=, 288
-	i32.add 	$10=, $35, $10
-	i32.call	$discard=, memset@FUNCTION, $10, $0, $2
-	i32.const	$2=, 19088743
-	i32.store	$discard=, 2592($35):p2align=4, $2
-	i32.const	$2=, 17767
-	i32.store16	$discard=, 1056($35):p2align=4, $2
-	i32.const	$2=, 115
-	i32.store8	$discard=, 288($35):p2align=4, $2
-	i64.const	$3=, 81985529216486895
-	i64.store	$discard=, 5664($35):p2align=4, $3
-	i32.const	$11=, 5664
-	i32.add 	$11=, $35, $11
-	i32.store	$discard=, 28($35), $11
-	i32.const	$12=, 2592
-	i32.add 	$12=, $35, $12
-	i32.store	$discard=, 24($35), $12
-	i32.const	$13=, 1056
-	i32.add 	$13=, $35, $13
-	i32.store	$discard=, 20($35), $13
-	i32.const	$14=, 288
-	i32.add 	$14=, $35, $14
-	i32.store	$discard=, 16($35), $14
-	i32.const	$15=, 28
-	i32.add 	$15=, $35, $15
-	i32.const	$16=, 24
-	i32.add 	$16=, $35, $16
-	i32.const	$17=, 20
-	i32.add 	$17=, $35, $17
-	i32.const	$18=, 16
-	i32.add 	$18=, $35, $18
+	i32.store	$34=, 0($4), $34
+	i32.const	$0=, 2048
+	i32.const	$1=, 0
+	i32.const	$6=, 5664
+	i32.add 	$6=, $34, $6
+	i32.call	$discard=, memset@FUNCTION, $6, $1, $0
+	i32.const	$0=, 1024
+	i32.const	$7=, 2592
+	i32.add 	$7=, $34, $7
+	i32.call	$discard=, memset@FUNCTION, $7, $1, $0
+	i32.const	$0=, 512
+	i32.const	$8=, 1056
+	i32.add 	$8=, $34, $8
+	i32.call	$discard=, memset@FUNCTION, $8, $1, $0
+	i32.const	$0=, 256
+	i32.const	$9=, 288
+	i32.add 	$9=, $34, $9
+	i32.call	$discard=, memset@FUNCTION, $9, $1, $0
+	i32.const	$0=, 19088743
+	i32.store	$discard=, 2592($34):p2align=4, $0
+	i32.const	$0=, 17767
+	i32.store16	$discard=, 1056($34):p2align=4, $0
+	i32.const	$0=, 115
+	i32.store8	$discard=, 288($34):p2align=4, $0
+	i64.const	$2=, 81985529216486895
+	i64.store	$discard=, 5664($34):p2align=4, $2
+	i32.const	$10=, 5664
+	i32.add 	$10=, $34, $10
+	i32.store	$discard=, 28($34), $10
+	i32.const	$11=, 2592
+	i32.add 	$11=, $34, $11
+	i32.store	$discard=, 24($34), $11
+	i32.const	$12=, 1056
+	i32.add 	$12=, $34, $12
+	i32.store	$discard=, 20($34), $12
+	i32.const	$13=, 288
+	i32.add 	$13=, $34, $13
+	i32.store	$discard=, 16($34), $13
+	i32.const	$14=, 28
+	i32.add 	$14=, $34, $14
+	i32.const	$15=, 24
+	i32.add 	$15=, $34, $15
+	i32.const	$16=, 20
+	i32.add 	$16=, $34, $16
+	i32.const	$17=, 16
+	i32.add 	$17=, $34, $17
 	#APP
 	#NO_APP
-	i32.const	$2=, 0
+	i32.const	$0=, 0
 .LBB0_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label0:
-	i32.const	$19=, 3616
-	i32.add 	$19=, $35, $19
-	i32.add 	$push4=, $19, $2
-	i32.const	$20=, 5664
-	i32.add 	$20=, $35, $20
-	i32.add 	$push0=, $20, $2
-	i64.load	$push67=, 0($pop0)
-	tee_local	$push66=, $3=, $pop67
-	i64.const	$push65=, 8
-	i64.shr_u	$push1=, $pop66, $pop65
-	i64.const	$push64=, 56
-	i64.shl 	$push2=, $3, $pop64
+	i32.const	$18=, 3616
+	i32.add 	$18=, $34, $18
+	i32.add 	$push4=, $18, $0
+	i32.const	$19=, 5664
+	i32.add 	$19=, $34, $19
+	i32.add 	$push0=, $19, $0
+	i64.load	$push55=, 0($pop0)
+	tee_local	$push54=, $2=, $pop55
+	i64.const	$push53=, 8
+	i64.shr_u	$push1=, $pop54, $pop53
+	i64.const	$push52=, 56
+	i64.shl 	$push2=, $2, $pop52
 	i64.or  	$push3=, $pop1, $pop2
 	i64.store	$discard=, 0($pop4), $pop3
-	i32.const	$push63=, 8
-	i32.add 	$2=, $2, $pop63
-	i32.const	$push62=, 2048
-	i32.ne  	$push5=, $2, $pop62
+	i32.const	$push51=, 8
+	i32.add 	$0=, $0, $pop51
+	i32.const	$push50=, 2048
+	i32.ne  	$push5=, $0, $pop50
 	br_if   	0, $pop5        # 0: up to label0
 .LBB0_2:                                # %for.body16
                                         # =>This Inner Loop Header: Depth=1
 	end_loop                        # label1:
 	loop                            # label2:
-	i32.const	$21=, 1568
-	i32.add 	$21=, $35, $21
-	i32.add 	$push12=, $21, $0
-	i32.const	$22=, 2592
-	i32.add 	$22=, $35, $22
-	i32.add 	$push6=, $22, $0
-	i32.load	$push69=, 0($pop6)
-	tee_local	$push68=, $2=, $pop69
-	i32.const	$push7=, 8
-	i32.shr_u	$push8=, $pop68, $pop7
-	i32.const	$push9=, 24
-	i32.shl 	$push10=, $2, $pop9
-	i32.or  	$push11=, $pop8, $pop10
-	i32.store	$discard=, 0($pop12), $pop11
-	i32.const	$push13=, 4
-	i32.add 	$0=, $0, $pop13
-	i32.const	$2=, 0
-	i32.const	$1=, 0
-	i32.const	$push14=, 1024
-	i32.ne  	$push15=, $0, $pop14
-	br_if   	0, $pop15       # 0: up to label2
-.LBB0_3:                                # %for.body28
-                                        # =>This Inner Loop Header: Depth=1
+	i32.const	$20=, 1568
+	i32.add 	$20=, $34, $20
+	i32.add 	$push10=, $20, $1
+	i32.const	$21=, 2592
+	i32.add 	$21=, $34, $21
+	i32.add 	$push6=, $21, $1
+	i32.load	$push61=, 0($pop6)
+	tee_local	$push60=, $0=, $pop61
+	i32.const	$push59=, 8
+	i32.shr_u	$push7=, $pop60, $pop59
+	i32.const	$push58=, 24
+	i32.shl 	$push8=, $0, $pop58
+	i32.or  	$push9=, $pop7, $pop8
+	i32.store	$discard=, 0($pop10), $pop9
+	i32.const	$push57=, 4
+	i32.add 	$1=, $1, $pop57
+	i32.const	$push56=, 1024
+	i32.ne  	$push11=, $1, $pop56
+	br_if   	0, $pop11       # 0: up to label2
+# BB#3:
 	end_loop                        # label3:
-	loop                            # label4:
-	i32.const	$23=, 544
-	i32.add 	$23=, $35, $23
-	i32.add 	$push22=, $23, $1
-	i32.const	$24=, 1056
-	i32.add 	$24=, $35, $24
-	i32.add 	$push16=, $24, $1
-	i32.load16_u	$push71=, 0($pop16)
-	tee_local	$push70=, $0=, $pop71
-	i32.const	$push17=, 9
-	i32.shr_u	$push18=, $pop70, $pop17
-	i32.const	$push19=, 7
-	i32.shl 	$push20=, $0, $pop19
-	i32.or  	$push21=, $pop18, $pop20
-	i32.store16	$discard=, 0($pop22), $pop21
-	i32.const	$push23=, 2
-	i32.add 	$1=, $1, $pop23
-	i32.const	$push24=, 512
-	i32.ne  	$push25=, $1, $pop24
-	br_if   	0, $pop25       # 0: up to label4
-.LBB0_4:                                # %for.body43
+	i32.const	$1=, 0
+.LBB0_4:                                # %for.body28
                                         # =>This Inner Loop Header: Depth=1
+	loop                            # label4:
+	i32.const	$22=, 544
+	i32.add 	$22=, $34, $22
+	i32.add 	$push16=, $22, $1
+	i32.const	$23=, 1056
+	i32.add 	$23=, $34, $23
+	i32.add 	$push12=, $23, $1
+	i32.load16_u	$push67=, 0($pop12)
+	tee_local	$push66=, $0=, $pop67
+	i32.const	$push65=, 9
+	i32.shr_u	$push13=, $pop66, $pop65
+	i32.const	$push64=, 7
+	i32.shl 	$push14=, $0, $pop64
+	i32.or  	$push15=, $pop13, $pop14
+	i32.store16	$discard=, 0($pop16), $pop15
+	i32.const	$push63=, 2
+	i32.add 	$1=, $1, $pop63
+	i32.const	$push62=, 512
+	i32.ne  	$push17=, $1, $pop62
+	br_if   	0, $pop17       # 0: up to label4
+# BB#5:
 	end_loop                        # label5:
+	i32.const	$1=, 0
+.LBB0_6:                                # %for.body43
+                                        # =>This Inner Loop Header: Depth=1
 	loop                            # label6:
-	i32.const	$25=, 32
-	i32.add 	$25=, $35, $25
-	i32.add 	$push32=, $25, $2
-	i32.const	$26=, 288
-	i32.add 	$26=, $35, $26
-	i32.add 	$push26=, $26, $2
-	i32.load8_u	$push73=, 0($pop26)
-	tee_local	$push72=, $1=, $pop73
-	i32.const	$push27=, 5
-	i32.shr_u	$push28=, $pop72, $pop27
-	i32.const	$push29=, 3
-	i32.shl 	$push30=, $1, $pop29
-	i32.or  	$push31=, $pop28, $pop30
-	i32.store8	$discard=, 0($pop32), $pop31
-	i32.const	$push33=, 1
-	i32.add 	$2=, $2, $pop33
-	i32.const	$push34=, 256
-	i32.ne  	$push35=, $2, $pop34
-	br_if   	0, $pop35       # 0: up to label6
-# BB#5:                                 # %for.end55
+	i32.const	$24=, 32
+	i32.add 	$24=, $34, $24
+	i32.add 	$push22=, $24, $1
+	i32.const	$25=, 288
+	i32.add 	$25=, $34, $25
+	i32.add 	$push18=, $25, $1
+	i32.load8_u	$push73=, 0($pop18)
+	tee_local	$push72=, $0=, $pop73
+	i32.const	$push71=, 5
+	i32.shr_u	$push19=, $pop72, $pop71
+	i32.const	$push70=, 3
+	i32.shl 	$push20=, $0, $pop70
+	i32.or  	$push21=, $pop19, $pop20
+	i32.store8	$discard=, 0($pop22), $pop21
+	i32.const	$push69=, 1
+	i32.add 	$1=, $1, $pop69
+	i32.const	$push68=, 256
+	i32.ne  	$push23=, $1, $pop68
+	br_if   	0, $pop23       # 0: up to label6
+# BB#7:                                 # %for.end55
 	end_loop                        # label7:
-	i32.const	$27=, 3616
-	i32.add 	$27=, $35, $27
-	i32.store	$discard=, 12($35), $27
-	i32.const	$28=, 1568
-	i32.add 	$28=, $35, $28
-	i32.store	$discard=, 8($35), $28
-	i32.const	$29=, 544
-	i32.add 	$29=, $35, $29
-	i32.store	$discard=, 4($35), $29
-	i32.const	$30=, 32
-	i32.add 	$30=, $35, $30
-	i32.store	$discard=, 0($35), $30
-	i32.const	$31=, 12
-	i32.add 	$31=, $35, $31
-	i32.const	$32=, 8
-	i32.add 	$32=, $35, $32
-	i32.const	$33=, 4
-	i32.add 	$33=, $35, $33
+	i32.const	$26=, 3616
+	i32.add 	$26=, $34, $26
+	i32.store	$discard=, 12($34), $26
+	i32.const	$27=, 1568
+	i32.add 	$27=, $34, $27
+	i32.store	$discard=, 8($34), $27
+	i32.const	$28=, 544
+	i32.add 	$28=, $34, $28
+	i32.store	$discard=, 4($34), $28
+	i32.const	$29=, 32
+	i32.add 	$29=, $34, $29
+	i32.store	$discard=, 0($34), $29
+	i32.const	$30=, 12
+	i32.add 	$30=, $34, $30
+	i32.const	$31=, 8
+	i32.add 	$31=, $34, $31
+	i32.const	$32=, 4
+	i32.add 	$32=, $34, $32
 	#APP
 	#NO_APP
 	block
-	block
-	block
-	block
-	i64.load	$push36=, 3616($35):p2align=4
-	i64.const	$push37=, -1224658842671273011
-	i64.ne  	$push38=, $pop36, $pop37
-	br_if   	0, $pop38       # 0: down to label11
-# BB#6:                                 # %lor.lhs.false
-	i32.const	$push39=, 8
-	i32.const	$34=, 3616
-	i32.add 	$34=, $35, $34
-	i32.or  	$push40=, $34, $pop39
-	i64.load	$push41=, 0($pop40)
-	i64.const	$push42=, 0
-	i64.ne  	$push43=, $pop41, $pop42
-	br_if   	0, $pop43       # 0: down to label11
-# BB#7:                                 # %if.end
-	i64.load	$push75=, 1568($35):p2align=4
-	tee_local	$push74=, $3=, $pop75
-	i32.wrap/i64	$push44=, $pop74
-	i32.const	$push45=, 1728127813
+	i64.load	$push24=, 3616($34):p2align=4
+	i64.const	$push25=, -1224658842671273011
+	i64.ne  	$push26=, $pop24, $pop25
+	br_if   	0, $pop26       # 0: down to label8
+# BB#8:                                 # %lor.lhs.false
+	i32.const	$push27=, 8
+	i32.const	$33=, 3616
+	i32.add 	$33=, $34, $33
+	i32.or  	$push28=, $33, $pop27
+	i64.load	$push29=, 0($pop28)
+	i64.const	$push30=, 0
+	i64.ne  	$push31=, $pop29, $pop30
+	br_if   	0, $pop31       # 0: down to label8
+# BB#9:                                 # %if.end
+	i64.load	$push75=, 1568($34):p2align=4
+	tee_local	$push74=, $2=, $pop75
+	i32.wrap/i64	$push32=, $pop74
+	i32.const	$push33=, 1728127813
+	i32.ne  	$push34=, $pop32, $pop33
+	br_if   	0, $pop34       # 0: down to label8
+# BB#10:                                # %if.end
+	i64.const	$push35=, 4294967296
+	i64.ge_u	$push36=, $2, $pop35
+	br_if   	0, $pop36       # 0: down to label8
+# BB#11:                                # %if.end71
+	i32.load	$push77=, 544($34):p2align=4
+	tee_local	$push76=, $1=, $pop77
+	i32.const	$push37=, 65535
+	i32.and 	$push38=, $pop76, $pop37
+	i32.const	$push39=, 45986
+	i32.ne  	$push40=, $pop38, $pop39
+	br_if   	0, $pop40       # 0: down to label8
+# BB#12:                                # %if.end71
+	i32.const	$push41=, 65536
+	i32.ge_u	$push42=, $1, $pop41
+	br_if   	0, $pop42       # 0: down to label8
+# BB#13:                                # %if.end81
+	i32.load16_u	$push79=, 32($34):p2align=4
+	tee_local	$push78=, $1=, $pop79
+	i32.const	$push43=, 255
+	i32.and 	$push44=, $pop78, $pop43
+	i32.const	$push45=, 155
 	i32.ne  	$push46=, $pop44, $pop45
-	br_if   	1, $pop46       # 1: down to label10
-# BB#8:                                 # %if.end
-	i64.const	$push47=, 4294967296
-	i64.ge_u	$push48=, $3, $pop47
-	br_if   	1, $pop48       # 1: down to label10
-# BB#9:                                 # %if.end71
-	i32.load	$push77=, 544($35):p2align=4
-	tee_local	$push76=, $2=, $pop77
-	i32.const	$push49=, 65535
-	i32.and 	$push50=, $pop76, $pop49
-	i32.const	$push51=, 45986
-	i32.ne  	$push52=, $pop50, $pop51
-	br_if   	2, $pop52       # 2: down to label9
-# BB#10:                                # %if.end71
-	i32.const	$push53=, 65536
-	i32.ge_u	$push54=, $2, $pop53
-	br_if   	2, $pop54       # 2: down to label9
-# BB#11:                                # %if.end81
-	i32.load16_u	$push79=, 32($35):p2align=4
-	tee_local	$push78=, $2=, $pop79
-	i32.const	$push55=, 255
-	i32.and 	$push56=, $pop78, $pop55
-	i32.const	$push57=, 155
-	i32.ne  	$push58=, $pop56, $pop57
-	br_if   	3, $pop58       # 3: down to label8
-# BB#12:                                # %if.end81
-	i32.const	$push59=, 256
-	i32.ge_u	$push60=, $2, $pop59
-	br_if   	3, $pop60       # 3: down to label8
-# BB#13:                                # %if.end91
-	i32.const	$push61=, 0
-	i32.const	$6=, 7712
-	i32.add 	$35=, $35, $6
-	i32.const	$6=, __stack_pointer
-	i32.store	$35=, 0($6), $35
-	return  	$pop61
-.LBB0_14:                               # %if.then
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then70
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then80
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then90
+	br_if   	0, $pop46       # 0: down to label8
+# BB#14:                                # %if.end81
+	i32.const	$push47=, 256
+	i32.ge_u	$push48=, $1, $pop47
+	br_if   	0, $pop48       # 0: down to label8
+# BB#15:                                # %if.end91
+	i32.const	$push49=, 0
+	i32.const	$5=, 7712
+	i32.add 	$34=, $34, $5
+	i32.const	$5=, __stack_pointer
+	i32.store	$34=, 0($5), $34
+	return  	$pop49
+.LBB0_16:                               # %if.then90
 	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr57344-1.c.s
+++ b/test/torture-s/pr57344-1.c.s
@@ -31,56 +31,56 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$push23=, 0
-	i32.load	$0=, i($pop23)
-	i32.const	$push22=, 0
+	i32.const	$push18=, 0
+	i32.load	$0=, i($pop18)
+	i32.const	$push17=, 0
 	i64.const	$push0=, 8583460864
-	i64.store	$discard=, s+8($pop22), $pop0
+	i64.store	$discard=, s+8($pop17), $pop0
 	block
-	i32.const	$push21=, 0
-	i32.gt_s	$push1=, $0, $pop21
+	i32.const	$push16=, 0
+	i32.gt_s	$push1=, $0, $pop16
 	br_if   	0, $pop1        # 0: down to label1
 # BB#1:                                 # %for.body.preheader
 	i32.const	$push2=, -3161
 	call    	foo@FUNCTION, $pop2
-	i32.const	$push28=, 0
-	i32.const	$push27=, 0
-	i32.load	$push26=, i($pop27)
-	tee_local	$push25=, $0=, $pop26
-	i32.const	$push24=, 1
-	i32.add 	$push3=, $pop25, $pop24
-	i32.store	$discard=, i($pop28), $pop3
+	i32.const	$push23=, 0
+	i32.const	$push22=, 0
+	i32.load	$push21=, i($pop22)
+	tee_local	$push20=, $0=, $pop21
+	i32.const	$push19=, 1
+	i32.add 	$push3=, $pop20, $pop19
+	i32.store	$discard=, i($pop23), $pop3
 	i32.const	$push4=, -1
 	i32.gt_s	$push5=, $0, $pop4
 	br_if   	0, $pop5        # 0: down to label1
 .LBB1_2:                                # %for.body.for.body_crit_edge
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.const	$push6=, 0
-	i64.load32_u	$push10=, s+8($pop6):p2align=3
 	i32.const	$push35=, 0
-	i64.load8_u	$push7=, s+12($pop35):p2align=2
-	i64.const	$push8=, 32
-	i64.shl 	$push9=, $pop7, $pop8
-	i64.or  	$push11=, $pop10, $pop9
-	i64.const	$push12=, 31
-	i64.shl 	$push13=, $pop11, $pop12
-	i64.const	$push14=, 24
-	i64.shr_s	$push15=, $pop13, $pop14
-	i64.const	$push16=, 18
-	i64.shr_u	$push17=, $pop15, $pop16
-	i32.wrap/i64	$push18=, $pop17
-	call    	foo@FUNCTION, $pop18
+	i64.load32_u	$push8=, s+8($pop35):p2align=3
 	i32.const	$push34=, 0
-	i32.const	$push33=, 0
-	i32.load	$push32=, i($pop33)
-	tee_local	$push31=, $0=, $pop32
-	i32.const	$push30=, 1
-	i32.add 	$push19=, $pop31, $pop30
-	i32.store	$discard=, i($pop34), $pop19
+	i64.load8_u	$push6=, s+12($pop34):p2align=2
+	i64.const	$push33=, 32
+	i64.shl 	$push7=, $pop6, $pop33
+	i64.or  	$push9=, $pop8, $pop7
+	i64.const	$push32=, 31
+	i64.shl 	$push10=, $pop9, $pop32
+	i64.const	$push31=, 24
+	i64.shr_s	$push11=, $pop10, $pop31
+	i64.const	$push30=, 18
+	i64.shr_u	$push12=, $pop11, $pop30
+	i32.wrap/i64	$push13=, $pop12
+	call    	foo@FUNCTION, $pop13
 	i32.const	$push29=, 0
-	i32.lt_s	$push20=, $0, $pop29
-	br_if   	0, $pop20       # 0: up to label2
+	i32.const	$push28=, 0
+	i32.load	$push27=, i($pop28)
+	tee_local	$push26=, $0=, $pop27
+	i32.const	$push25=, 1
+	i32.add 	$push14=, $pop26, $pop25
+	i32.store	$discard=, i($pop29), $pop14
+	i32.const	$push24=, 0
+	i32.lt_s	$push15=, $0, $pop24
+	br_if   	0, $pop15       # 0: up to label2
 .LBB1_3:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:

--- a/test/torture-s/pr57344-2.c.s
+++ b/test/torture-s/pr57344-2.c.s
@@ -31,59 +31,59 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$push25=, 0
-	i32.load	$0=, i($pop25)
-	i32.const	$push24=, 0
+	i32.const	$push20=, 0
+	i32.load	$0=, i($pop20)
+	i32.const	$push19=, 0
 	i64.const	$push0=, 562525691183104
-	i64.store	$discard=, s+8($pop24), $pop0
+	i64.store	$discard=, s+8($pop19), $pop0
 	block
-	i32.const	$push23=, 0
-	i32.gt_s	$push1=, $0, $pop23
+	i32.const	$push18=, 0
+	i32.gt_s	$push1=, $0, $pop18
 	br_if   	0, $pop1        # 0: down to label1
 # BB#1:                                 # %for.body.preheader
 	i32.const	$push2=, -3161
 	call    	foo@FUNCTION, $pop2
-	i32.const	$push30=, 0
-	i32.const	$push29=, 0
-	i32.load	$push28=, i($pop29)
-	tee_local	$push27=, $0=, $pop28
-	i32.const	$push26=, 1
-	i32.add 	$push3=, $pop27, $pop26
-	i32.store	$discard=, i($pop30), $pop3
+	i32.const	$push25=, 0
+	i32.const	$push24=, 0
+	i32.load	$push23=, i($pop24)
+	tee_local	$push22=, $0=, $pop23
+	i32.const	$push21=, 1
+	i32.add 	$push3=, $pop22, $pop21
+	i32.store	$discard=, i($pop25), $pop3
 	i32.const	$push4=, -1
 	i32.gt_s	$push5=, $0, $pop4
 	br_if   	0, $pop5        # 0: down to label1
 .LBB1_2:                                # %for.body.for.body_crit_edge
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.const	$push6=, 0
-	i64.load32_u	$push14=, s+8($pop6):p2align=3
 	i32.const	$push38=, 0
-	i64.load16_u	$push10=, s+12($pop38):p2align=2
+	i64.load32_u	$push11=, s+8($pop38):p2align=3
 	i32.const	$push37=, 0
-	i64.load8_u	$push7=, s+14($pop37):p2align=1
-	i64.const	$push8=, 16
-	i64.shl 	$push9=, $pop7, $pop8
-	i64.or  	$push11=, $pop10, $pop9
-	i64.const	$push12=, 32
-	i64.shl 	$push13=, $pop11, $pop12
-	i64.or  	$push15=, $pop14, $pop13
-	i64.const	$push16=, 15
-	i64.shl 	$push17=, $pop15, $pop16
-	i64.const	$push18=, 42
-	i64.shr_s	$push19=, $pop17, $pop18
-	i32.wrap/i64	$push20=, $pop19
-	call    	foo@FUNCTION, $pop20
+	i64.load16_u	$push8=, s+12($pop37):p2align=2
 	i32.const	$push36=, 0
-	i32.const	$push35=, 0
-	i32.load	$push34=, i($pop35)
-	tee_local	$push33=, $0=, $pop34
-	i32.const	$push32=, 1
-	i32.add 	$push21=, $pop33, $pop32
-	i32.store	$discard=, i($pop36), $pop21
+	i64.load8_u	$push6=, s+14($pop36):p2align=1
+	i64.const	$push35=, 16
+	i64.shl 	$push7=, $pop6, $pop35
+	i64.or  	$push9=, $pop8, $pop7
+	i64.const	$push34=, 32
+	i64.shl 	$push10=, $pop9, $pop34
+	i64.or  	$push12=, $pop11, $pop10
+	i64.const	$push33=, 15
+	i64.shl 	$push13=, $pop12, $pop33
+	i64.const	$push32=, 42
+	i64.shr_s	$push14=, $pop13, $pop32
+	i32.wrap/i64	$push15=, $pop14
+	call    	foo@FUNCTION, $pop15
 	i32.const	$push31=, 0
-	i32.lt_s	$push22=, $0, $pop31
-	br_if   	0, $pop22       # 0: up to label2
+	i32.const	$push30=, 0
+	i32.load	$push29=, i($pop30)
+	tee_local	$push28=, $0=, $pop29
+	i32.const	$push27=, 1
+	i32.add 	$push16=, $pop28, $pop27
+	i32.store	$discard=, i($pop31), $pop16
+	i32.const	$push26=, 0
+	i32.lt_s	$push17=, $0, $pop26
+	br_if   	0, $pop17       # 0: up to label2
 .LBB1_3:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:

--- a/test/torture-s/pr57344-3.c.s
+++ b/test/torture-s/pr57344-3.c.s
@@ -31,68 +31,68 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32, i64
 # BB#0:                                 # %entry
-	i32.const	$push30=, 0
-	i32.load	$0=, i($pop30)
-	i32.const	$push29=, 0
-	i32.const	$push28=, 0
-	i64.load	$push0=, .Lmain.t+8($pop28):p2align=0
-	i64.store	$discard=, s+24($pop29), $pop0
-	i32.const	$push27=, 0
-	i32.const	$push26=, 0
-	i64.load	$push1=, .Lmain.t($pop26):p2align=0
-	i64.store	$discard=, s+16($pop27):p2align=4, $pop1
+	i32.const	$push24=, 0
+	i32.load	$0=, i($pop24)
+	i32.const	$push23=, 0
+	i32.const	$push22=, 0
+	i64.load	$push0=, .Lmain.t+8($pop22):p2align=0
+	i64.store	$discard=, s+24($pop23), $pop0
+	i32.const	$push21=, 0
+	i32.const	$push20=, 0
+	i64.load	$push1=, .Lmain.t($pop20):p2align=0
+	i64.store	$discard=, s+16($pop21):p2align=4, $pop1
 	block
-	i32.const	$push25=, 0
-	i32.gt_s	$push2=, $0, $pop25
+	i32.const	$push19=, 0
+	i32.gt_s	$push2=, $0, $pop19
 	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %for.body.preheader
 	i64.const	$push3=, -3161
 	call    	foo@FUNCTION, $pop3
-	i32.const	$push35=, 0
-	i32.const	$push34=, 0
-	i32.load	$push33=, i($pop34)
-	tee_local	$push32=, $0=, $pop33
-	i32.const	$push31=, 1
-	i32.add 	$push4=, $pop32, $pop31
-	i32.store	$discard=, i($pop35), $pop4
+	i32.const	$push29=, 0
+	i32.const	$push28=, 0
+	i32.load	$push27=, i($pop28)
+	tee_local	$push26=, $0=, $pop27
+	i32.const	$push25=, 1
+	i32.add 	$push4=, $pop26, $pop25
+	i32.store	$discard=, i($pop29), $pop4
 	i32.const	$push5=, -1
 	i32.gt_s	$push6=, $0, $pop5
 	br_if   	0, $pop6        # 0: down to label1
 .LBB1_2:                                # %for.body.for.body_crit_edge
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.const	$push7=, 0
-	i64.load	$push46=, s+16($pop7):p2align=4
-	tee_local	$push45=, $1=, $pop46
-	i64.const	$push11=, 7
-	i64.shl 	$push17=, $pop45, $pop11
-	i64.const	$push20=, 50
-	i64.shr_u	$push21=, $pop17, $pop20
-	i32.const	$push44=, 0
-	i64.load8_u	$push8=, s+24($pop44):p2align=3
+	i32.const	$push46=, 0
+	i64.load	$push45=, s+16($pop46):p2align=4
+	tee_local	$push44=, $1=, $pop45
 	i64.const	$push43=, 7
-	i64.shl 	$push12=, $pop8, $pop43
-	i64.const	$push9=, 57
-	i64.shr_u	$push10=, $1, $pop9
-	i64.or  	$push13=, $pop12, $pop10
-	i64.const	$push14=, 56
-	i64.shl 	$push15=, $pop13, $pop14
-	i64.const	$push42=, 56
-	i64.shr_s	$push16=, $pop15, $pop42
-	i64.const	$push18=, 14
-	i64.shl 	$push19=, $pop16, $pop18
-	i64.or  	$push22=, $pop21, $pop19
-	call    	foo@FUNCTION, $pop22
+	i64.shl 	$push13=, $pop44, $pop43
+	i64.const	$push42=, 50
+	i64.shr_u	$push15=, $pop13, $pop42
 	i32.const	$push41=, 0
-	i32.const	$push40=, 0
-	i32.load	$push39=, i($pop40)
-	tee_local	$push38=, $0=, $pop39
-	i32.const	$push37=, 1
-	i32.add 	$push23=, $pop38, $pop37
-	i32.store	$discard=, i($pop41), $pop23
-	i32.const	$push36=, 0
-	i32.lt_s	$push24=, $0, $pop36
-	br_if   	0, $pop24       # 0: up to label2
+	i64.load8_u	$push7=, s+24($pop41):p2align=3
+	i64.const	$push40=, 7
+	i64.shl 	$push9=, $pop7, $pop40
+	i64.const	$push39=, 57
+	i64.shr_u	$push8=, $1, $pop39
+	i64.or  	$push10=, $pop9, $pop8
+	i64.const	$push38=, 56
+	i64.shl 	$push11=, $pop10, $pop38
+	i64.const	$push37=, 56
+	i64.shr_s	$push12=, $pop11, $pop37
+	i64.const	$push36=, 14
+	i64.shl 	$push14=, $pop12, $pop36
+	i64.or  	$push16=, $pop15, $pop14
+	call    	foo@FUNCTION, $pop16
+	i32.const	$push35=, 0
+	i32.const	$push34=, 0
+	i32.load	$push33=, i($pop34)
+	tee_local	$push32=, $0=, $pop33
+	i32.const	$push31=, 1
+	i32.add 	$push17=, $pop32, $pop31
+	i32.store	$discard=, i($pop35), $pop17
+	i32.const	$push30=, 0
+	i32.lt_s	$push18=, $0, $pop30
+	br_if   	0, $pop18       # 0: up to label2
 .LBB1_3:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:

--- a/test/torture-s/pr57344-4.c.s
+++ b/test/torture-s/pr57344-4.c.s
@@ -31,70 +31,70 @@ main:                                   # @main
 	.result 	i32
 	.local  	i32
 # BB#0:                                 # %entry
-	i32.const	$push34=, 0
-	i32.load	$0=, i($pop34)
-	i32.const	$push33=, 0
-	i32.const	$push32=, 0
-	i64.load	$push0=, .Lmain.t+8($pop32):p2align=0
-	i64.store	$discard=, s+24($pop33), $pop0
-	i32.const	$push31=, 0
-	i32.const	$push30=, 0
-	i64.load	$push1=, .Lmain.t($pop30):p2align=0
-	i64.store	$discard=, s+16($pop31):p2align=4, $pop1
+	i32.const	$push27=, 0
+	i32.load	$0=, i($pop27)
+	i32.const	$push26=, 0
+	i32.const	$push25=, 0
+	i64.load	$push0=, .Lmain.t+8($pop25):p2align=0
+	i64.store	$discard=, s+24($pop26), $pop0
+	i32.const	$push24=, 0
+	i32.const	$push23=, 0
+	i64.load	$push1=, .Lmain.t($pop23):p2align=0
+	i64.store	$discard=, s+16($pop24):p2align=4, $pop1
 	block
-	i32.const	$push29=, 0
-	i32.gt_s	$push2=, $0, $pop29
+	i32.const	$push22=, 0
+	i32.gt_s	$push2=, $0, $pop22
 	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %for.body.preheader
 	i64.const	$push3=, -1220975898975746
 	call    	foo@FUNCTION, $pop3
-	i32.const	$push39=, 0
-	i32.const	$push38=, 0
-	i32.load	$push37=, i($pop38)
-	tee_local	$push36=, $0=, $pop37
-	i32.const	$push35=, 1
-	i32.add 	$push4=, $pop36, $pop35
-	i32.store	$discard=, i($pop39), $pop4
+	i32.const	$push32=, 0
+	i32.const	$push31=, 0
+	i32.load	$push30=, i($pop31)
+	tee_local	$push29=, $0=, $pop30
+	i32.const	$push28=, 1
+	i32.add 	$push4=, $pop29, $pop28
+	i32.store	$discard=, i($pop32), $pop4
 	i32.const	$push5=, -1
 	i32.gt_s	$push6=, $0, $pop5
 	br_if   	0, $pop6        # 0: down to label1
 .LBB1_2:                                # %for.body.for.body_crit_edge
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label2:
-	i32.const	$push7=, 0
-	i64.load32_u	$push15=, s+24($pop7):p2align=3
 	i32.const	$push48=, 0
-	i64.load16_u	$push11=, s+28($pop48):p2align=2
+	i64.load32_u	$push12=, s+24($pop48):p2align=3
 	i32.const	$push47=, 0
-	i64.load8_u	$push8=, s+30($pop47):p2align=1
-	i64.const	$push9=, 16
-	i64.shl 	$push10=, $pop8, $pop9
-	i64.or  	$push12=, $pop11, $pop10
-	i64.const	$push13=, 32
-	i64.shl 	$push14=, $pop12, $pop13
-	i64.or  	$push16=, $pop15, $pop14
-	i64.const	$push20=, 7
-	i64.shl 	$push21=, $pop16, $pop20
+	i64.load16_u	$push9=, s+28($pop47):p2align=2
 	i32.const	$push46=, 0
-	i64.load	$push17=, s+16($pop46):p2align=4
-	i64.const	$push18=, 57
-	i64.shr_u	$push19=, $pop17, $pop18
-	i64.or  	$push22=, $pop21, $pop19
-	i64.const	$push23=, 8
-	i64.shl 	$push24=, $pop22, $pop23
-	i64.const	$push25=, 10
-	i64.shr_s	$push26=, $pop24, $pop25
-	call    	foo@FUNCTION, $pop26
-	i32.const	$push45=, 0
-	i32.const	$push44=, 0
-	i32.load	$push43=, i($pop44)
-	tee_local	$push42=, $0=, $pop43
-	i32.const	$push41=, 1
-	i32.add 	$push27=, $pop42, $pop41
-	i32.store	$discard=, i($pop45), $pop27
-	i32.const	$push40=, 0
-	i32.lt_s	$push28=, $0, $pop40
-	br_if   	0, $pop28       # 0: up to label2
+	i64.load8_u	$push7=, s+30($pop46):p2align=1
+	i64.const	$push45=, 16
+	i64.shl 	$push8=, $pop7, $pop45
+	i64.or  	$push10=, $pop9, $pop8
+	i64.const	$push44=, 32
+	i64.shl 	$push11=, $pop10, $pop44
+	i64.or  	$push13=, $pop12, $pop11
+	i64.const	$push43=, 7
+	i64.shl 	$push16=, $pop13, $pop43
+	i32.const	$push42=, 0
+	i64.load	$push14=, s+16($pop42):p2align=4
+	i64.const	$push41=, 57
+	i64.shr_u	$push15=, $pop14, $pop41
+	i64.or  	$push17=, $pop16, $pop15
+	i64.const	$push40=, 8
+	i64.shl 	$push18=, $pop17, $pop40
+	i64.const	$push39=, 10
+	i64.shr_s	$push19=, $pop18, $pop39
+	call    	foo@FUNCTION, $pop19
+	i32.const	$push38=, 0
+	i32.const	$push37=, 0
+	i32.load	$push36=, i($pop37)
+	tee_local	$push35=, $0=, $pop36
+	i32.const	$push34=, 1
+	i32.add 	$push20=, $pop35, $pop34
+	i32.store	$discard=, i($pop38), $pop20
+	i32.const	$push33=, 0
+	i32.lt_s	$push21=, $0, $pop33
+	br_if   	0, $pop21       # 0: up to label2
 .LBB1_3:                                # %for.end
 	end_loop                        # label3:
 	end_block                       # label1:

--- a/test/torture-s/pr58831.c.s
+++ b/test/torture-s/pr58831.c.s
@@ -41,8 +41,8 @@ fn1:                                    # @fn1
 	.param  	i32
 # BB#0:                                 # %entry
 	block
-	i32.const	$push8=, 0
-	i32.load	$push0=, p($pop8)
+	i32.const	$push7=, 0
+	i32.load	$push0=, p($pop7)
 	i32.const	$push13=, 0
 	i32.eq  	$push14=, $pop0, $pop13
 	br_if   	0, $pop14       # 0: down to label0
@@ -50,21 +50,21 @@ fn1:                                    # @fn1
                                         # =>This Inner Loop Header: Depth=1
 	loop                            # label1:
 	i32.const	$push10=, 0
-	i32.const	$push1=, 1
-	i32.store	$push2=, 0($0), $pop1
-	i32.const	$push9=, 0
-	i32.load	$push3=, p($pop9)
-	i32.add 	$push4=, $pop2, $pop3
-	i32.store	$push5=, p($pop10), $pop4
-	br_if   	0, $pop5        # 0: up to label1
+	i32.const	$push9=, 1
+	i32.store	$push1=, 0($0), $pop9
+	i32.const	$push8=, 0
+	i32.load	$push2=, p($pop8)
+	i32.add 	$push3=, $pop1, $pop2
+	i32.store	$push4=, p($pop10), $pop3
+	br_if   	0, $pop4        # 0: up to label1
 .LBB2_2:                                # %for.end
 	end_loop                        # label2:
 	end_block                       # label0:
 	i32.const	$push12=, 0
 	i32.const	$push11=, 0
-	i32.const	$push6=, d
-	i32.store	$push7=, r($pop11), $pop6
-	i32.store	$discard=, b($pop12), $pop7
+	i32.const	$push5=, d
+	i32.store	$push6=, r($pop11), $pop5
+	i32.store	$discard=, b($pop12), $pop6
 	return
 	.endfunc
 .Lfunc_end2:

--- a/test/torture-s/pr58984.c.s
+++ b/test/torture-s/pr58984.c.s
@@ -24,14 +24,13 @@ main:                                   # @main
 .LBB0_2:                                # %foo.exit
 	end_block                       # label0:
 	block
-	block
 	i32.const	$push19=, 0
 	i32.load	$push5=, a($pop19)
 	i32.const	$push18=, 0
 	i32.const	$push17=, 1
 	i32.store	$push4=, m($pop18), $pop17
 	i32.ne  	$push6=, $pop5, $pop4
-	br_if   	0, $pop6        # 0: down to label2
+	br_if   	0, $pop6        # 0: down to label1
 # BB#3:                                 # %bar.exit
 	i32.const	$push7=, 0
 	i32.const	$push23=, 0
@@ -47,14 +46,10 @@ main:                                   # @main
 	i32.const	$push20=, 1
 	i32.or  	$push12=, $pop11, $pop20
 	i32.store	$discard=, m($1), $pop12
-	br_if   	1, $0           # 1: down to label1
+	br_if   	0, $0           # 0: down to label1
 # BB#4:                                 # %if.end11
 	return  	$1
-.LBB0_5:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then10
+.LBB0_5:                                # %if.then10
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr59229.c.s
+++ b/test/torture-s/pr59229.c.s
@@ -9,7 +9,6 @@ bar:                                    # @bar
 	.local  	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push0=, 0
 	i32.load	$push17=, i($pop0)
 	tee_local	$push16=, $1=, $pop17
@@ -17,13 +16,13 @@ bar:                                    # @bar
 	i32.add 	$push2=, $pop16, $pop1
 	i32.const	$push3=, 6
 	i32.ge_u	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label1
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push7=, .L.str
 	i32.const	$push5=, 1
 	i32.add 	$push6=, $1, $pop5
 	i32.call	$push8=, memcmp@FUNCTION, $0, $pop7, $pop6
-	br_if   	1, $pop8        # 1: down to label0
+	br_if   	0, $pop8        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push9=, 538976288
 	i32.store	$discard=, 0($0):p2align=0, $pop9
@@ -36,11 +35,7 @@ bar:                                    # @bar
 	i32.const	$push15=, 8224
 	i32.store16	$discard=, 0($pop14):p2align=0, $pop15
 	return
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.then3
+.LBB0_3:                                # %if.then3
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -67,7 +62,7 @@ foo:                                    # @foo
 	i32.add 	$push1=, $1, $pop0
 	i32.const	$push2=, 5
 	i32.gt_u	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label2
+	br_if   	0, $pop3        # 0: down to label1
 # BB#1:                                 # %if.end
 	i32.const	$push4=, 1
 	i32.add 	$push5=, $1, $pop4
@@ -78,7 +73,7 @@ foo:                                    # @foo
 	i32.add 	$6=, $7, $6
 	call    	bar@FUNCTION, $6
 .LBB1_2:                                # %return
-	end_block                       # label2:
+	end_block                       # label1:
 	i32.const	$4=, 16
 	i32.add 	$7=, $7, $4
 	i32.const	$4=, __stack_pointer
@@ -102,7 +97,7 @@ main:                                   # @main
 	copy_local	$1=, $0
 .LBB2_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label3:
+	loop                            # label2:
 	i32.const	$push8=, .L.str.1
 	call    	foo@FUNCTION, $pop8, $1
 	i32.load	$push2=, i($0)
@@ -111,9 +106,9 @@ main:                                   # @main
 	i32.store	$1=, i($0), $pop0
 	i32.const	$push6=, 16
 	i32.lt_s	$push3=, $1, $pop6
-	br_if   	0, $pop3        # 0: up to label3
+	br_if   	0, $pop3        # 0: up to label2
 # BB#2:                                 # %for.end
-	end_loop                        # label4:
+	end_loop                        # label3:
 	i32.const	$push4=, 0
 	return  	$pop4
 	.endfunc

--- a/test/torture-s/pr59358.c.s
+++ b/test/torture-s/pr59358.c.s
@@ -10,25 +10,33 @@ foo:                                    # @foo
 	.local  	i32
 # BB#0:                                 # %entry
 	i32.load	$2=, 0($0)
-	copy_local	$0=, $2
+	block
+	block
 	block
 	i32.const	$push0=, 16
 	i32.gt_s	$push1=, $1, $pop0
-	br_if   	0, $pop1        # 0: down to label0
+	br_if   	0, $pop1        # 0: down to label2
 # BB#1:                                 # %entry
-	copy_local	$0=, $2
 	i32.ge_s	$push2=, $2, $1
-	br_if   	0, $pop2        # 0: down to label0
+	br_if   	1, $pop2        # 1: down to label1
 .LBB0_2:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
-	loop                            # label1:
+	loop                            # label3:
 	copy_local	$0=, $2
 	i32.const	$push4=, 1
 	i32.shl 	$2=, $0, $pop4
 	i32.lt_s	$push3=, $0, $1
-	br_if   	0, $pop3        # 0: up to label1
-.LBB0_3:                                # %if.end
-	end_loop                        # label2:
+	br_if   	0, $pop3        # 0: up to label3
+	br      	4               # 4: down to label0
+.LBB0_3:
+	end_loop                        # label4:
+	end_block                       # label2:
+	copy_local	$0=, $2
+	br      	1               # 1: down to label0
+.LBB0_4:
+	end_block                       # label1:
+	copy_local	$0=, $2
+.LBB0_5:                                # %if.end
 	end_block                       # label0:
 	return  	$0
 	.endfunc
@@ -57,8 +65,7 @@ main:                                   # @main
 .LBB1_1:                                # %for.body
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label5:
+	loop                            # label6:
 	i32.const	$push18=, 16
 	i32.const	$10=, 12
 	i32.add 	$10=, $12, $10
@@ -72,7 +79,7 @@ main:                                   # @main
 	i32.and 	$push1=, $pop15, $pop14
 	i32.const	$push13=, 8
 	i32.eq  	$push2=, $pop1, $pop13
-	br_if   	0, $pop2        # 0: down to label7
+	br_if   	0, $pop2        # 0: down to label8
 # BB#2:                                 # %if.else
                                         #   in Loop: Header=BB1_1 Depth=1
 	block
@@ -80,15 +87,15 @@ main:                                   # @main
 	i32.and 	$push3=, $6, $pop20
 	i32.const	$push19=, 4
 	i32.ne  	$push4=, $pop3, $pop19
-	br_if   	0, $pop4        # 0: down to label8
+	br_if   	0, $pop4        # 0: down to label9
 # BB#3:                                 # %if.then6
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push21=, 2
 	i32.shl 	$5=, $2, $pop21
-	br      	1               # 1: down to label7
+	br      	1               # 1: down to label8
 .LBB1_4:                                # %if.else10
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label8:
+	end_block                       # label9:
 	i32.const	$push24=, 24
 	i32.const	$push23=, 16
 	i32.const	$push22=, 4
@@ -96,9 +103,9 @@ main:                                   # @main
 	i32.select	$5=, $pop24, $pop23, $pop5
 .LBB1_5:                                # %if.end15
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label7:
+	end_block                       # label8:
 	i32.ne  	$push6=, $3, $5
-	br_if   	2, $pop6        # 2: down to label4
+	br_if   	2, $pop6        # 2: down to label5
 # BB#6:                                 # %if.end18
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push26=, 7
@@ -109,13 +116,13 @@ main:                                   # @main
 	block
 	i32.const	$push25=, 6
 	i32.gt_s	$push7=, $6, $pop25
-	br_if   	0, $pop7        # 0: down to label9
+	br_if   	0, $pop7        # 0: down to label10
 # BB#7:                                 # %if.else22
                                         #   in Loop: Header=BB1_1 Depth=1
 	copy_local	$5=, $0
 	i32.const	$push27=, 3
 	i32.gt_s	$push8=, $6, $pop27
-	br_if   	0, $pop8        # 0: down to label9
+	br_if   	0, $pop8        # 0: down to label10
 # BB#8:                                 # %if.else28
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.const	$push30=, 12
@@ -125,9 +132,9 @@ main:                                   # @main
 	i32.select	$5=, $pop30, $pop29, $pop9
 .LBB1_9:                                # %if.end34
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_block                       # label9:
+	end_block                       # label10:
 	i32.ne  	$push10=, $3, $5
-	br_if   	3, $pop10       # 3: down to label3
+	br_if   	2, $pop10       # 2: down to label5
 # BB#10:                                # %if.end37
                                         #   in Loop: Header=BB1_1 Depth=1
 	i32.add 	$2=, $2, $4
@@ -138,21 +145,17 @@ main:                                   # @main
 	i32.add 	$1=, $pop32, $4
 	i32.const	$push31=, 17
 	i32.lt_s	$push11=, $6, $pop31
-	br_if   	0, $pop11       # 0: up to label5
+	br_if   	0, $pop11       # 0: up to label6
 # BB#11:                                # %for.end
-	end_loop                        # label6:
+	end_loop                        # label7:
 	i32.const	$push12=, 0
 	i32.const	$9=, 16
 	i32.add 	$12=, $12, $9
 	i32.const	$9=, __stack_pointer
 	i32.store	$12=, 0($9), $12
 	return  	$pop12
-.LBB1_12:                               # %if.then17
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_13:                               # %if.then36
-	end_block                       # label3:
+.LBB1_12:                               # %if.then36
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/pr60960.c.s
+++ b/test/torture-s/pr60960.c.s
@@ -159,8 +159,6 @@ main:                                   # @main
 	i32.const	$6=, 12
 	i32.add 	$6=, $15, $6
 	block
-	block
-	block
 	i32.or  	$push0=, $6, $pop57
 	i32.load8_u	$push1=, 0($pop0)
 	i32.const	$push56=, 8
@@ -171,7 +169,7 @@ main:                                   # @main
 	i32.or  	$push13=, $pop12, $pop6
 	i32.const	$push54=, 33686018
 	i32.ne  	$push14=, $pop13, $pop54
-	br_if   	0, $pop14       # 0: down to label2
+	br_if   	0, $pop14       # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push77=, 5
 	i32.const	$push76=, 5
@@ -209,7 +207,7 @@ main:                                   # @main
 	i32.or  	$push28=, $pop27, $pop21
 	i32.const	$push66=, 33686018
 	i32.ne  	$push29=, $pop28, $pop66
-	br_if   	1, $pop29       # 1: down to label1
+	br_if   	0, $pop29       # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.const	$push31=, 5
 	i32.const	$push85=, 5
@@ -251,7 +249,7 @@ main:                                   # @main
 	i32.or  	$push50=, $pop49, $pop41
 	i32.const	$push51=, 33686018
 	i32.ne  	$push52=, $pop50, $pop51
-	br_if   	2, $pop52       # 2: down to label0
+	br_if   	0, $pop52       # 0: down to label0
 # BB#3:                                 # %if.end11
 	i32.const	$push53=, 0
 	i32.const	$2=, 16
@@ -259,15 +257,7 @@ main:                                   # @main
 	i32.const	$2=, __stack_pointer
 	i32.store	$15=, 0($2), $15
 	return  	$pop53
-.LBB3_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_5:                                # %if.then5
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_6:                                # %if.then10
+.LBB3_4:                                # %if.then10
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr61673.c.s
+++ b/test/torture-s/pr61673.c.s
@@ -88,13 +88,10 @@ main:                                   # @main
 	i32.const	$push1=, main.c
 	call    	foo@FUNCTION, $pop1
 	block
-	block
-	block
-	block
 	i32.const	$push17=, 0
 	i32.load8_u	$push2=, e($pop17)
 	i32.ne  	$push3=, $0, $pop2
-	br_if   	0, $pop3        # 0: down to label7
+	br_if   	0, $pop3        # 0: down to label4
 # BB#1:                                 # %if.end
 	i32.const	$push4=, main.c+1
 	call    	foo@FUNCTION, $pop4
@@ -102,7 +99,7 @@ main:                                   # @main
 	i32.load8_u	$push5=, e($pop19)
 	i32.const	$push6=, 135
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label6
+	br_if   	0, $pop7        # 0: down to label4
 # BB#2:                                 # %if.end6
 	i32.const	$push21=, 0
 	i32.const	$push8=, 33
@@ -112,7 +109,7 @@ main:                                   # @main
 	i32.const	$push20=, 0
 	i32.load8_u	$push10=, e($pop20)
 	i32.ne  	$push11=, $0, $pop10
-	br_if   	2, $pop11       # 2: down to label5
+	br_if   	0, $pop11       # 0: down to label4
 # BB#3:                                 # %if.end11
 	i32.const	$push12=, main.c+1
 	call    	baz@FUNCTION, $pop12
@@ -120,23 +117,11 @@ main:                                   # @main
 	i32.load8_u	$push13=, e($pop22)
 	i32.const	$push14=, 135
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	3, $pop15       # 3: down to label4
+	br_if   	0, $pop15       # 0: down to label4
 # BB#4:                                 # %if.end16
 	i32.const	$push16=, 0
 	return  	$pop16
-.LBB3_5:                                # %if.then
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_6:                                # %if.then5
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_7:                                # %if.then10
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_8:                                # %if.then15
+.LBB3_5:                                # %if.then15
 	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/pr63302.c.s
+++ b/test/torture-s/pr63302.c.s
@@ -56,111 +56,106 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i64.const	$push52=, 0
 	i64.const	$push51=, 0
 	i32.call	$push0=, foo@FUNCTION, $pop52, $pop51
 	i32.const	$push1=, 1
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %lor.lhs.false
 	i64.const	$push3=, 1
 	i64.const	$push53=, 0
 	i32.call	$push4=, foo@FUNCTION, $pop3, $pop53
-	br_if   	0, $pop4        # 0: down to label1
+	br_if   	0, $pop4        # 0: down to label0
 # BB#2:                                 # %lor.lhs.false3
 	i64.const	$push5=, 2048
 	i64.const	$push54=, 0
 	i32.call	$push6=, foo@FUNCTION, $pop5, $pop54
 	i32.const	$push7=, 1
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	0, $pop8        # 0: down to label1
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %lor.lhs.false6
 	i64.const	$push9=, 2049
 	i64.const	$push55=, 0
 	i32.call	$push10=, foo@FUNCTION, $pop9, $pop55
-	br_if   	0, $pop10       # 0: down to label1
+	br_if   	0, $pop10       # 0: down to label0
 # BB#4:                                 # %lor.lhs.false9
 	i64.const	$push56=, -9223372036854775808
 	i64.const	$push11=, 0
 	i32.call	$push12=, foo@FUNCTION, $pop56, $pop11
-	br_if   	0, $pop12       # 0: down to label1
+	br_if   	0, $pop12       # 0: down to label0
 # BB#5:                                 # %lor.lhs.false12
 	i64.const	$push58=, -9223372036854775808
 	i64.const	$push57=, -1
 	i32.call	$push13=, foo@FUNCTION, $pop58, $pop57
 	i32.const	$push14=, 1
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	0, $pop15       # 0: down to label1
+	br_if   	0, $pop15       # 0: down to label0
 # BB#6:                                 # %lor.lhs.false15
 	i64.const	$push16=, -9223372036854775807
 	i64.const	$push59=, -1
 	i32.call	$push17=, foo@FUNCTION, $pop16, $pop59
-	br_if   	0, $pop17       # 0: down to label1
+	br_if   	0, $pop17       # 0: down to label0
 # BB#7:                                 # %lor.lhs.false18
 	i64.const	$push18=, -9223372036854773760
 	i64.const	$push60=, -1
 	i32.call	$push19=, foo@FUNCTION, $pop18, $pop60
 	i32.const	$push20=, 1
 	i32.ne  	$push21=, $pop19, $pop20
-	br_if   	0, $pop21       # 0: down to label1
+	br_if   	0, $pop21       # 0: down to label0
 # BB#8:                                 # %lor.lhs.false21
 	i64.const	$push22=, -9223372036854773759
 	i64.const	$push61=, -1
 	i32.call	$push23=, foo@FUNCTION, $pop22, $pop61
-	br_if   	0, $pop23       # 0: down to label1
+	br_if   	0, $pop23       # 0: down to label0
 # BB#9:                                 # %if.end
 	i64.const	$push24=, 0
 	i32.call	$push25=, bar@FUNCTION, $pop24
 	i32.const	$push26=, 1
 	i32.ne  	$push27=, $pop25, $pop26
-	br_if   	1, $pop27       # 1: down to label0
+	br_if   	0, $pop27       # 0: down to label0
 # BB#10:                                # %lor.lhs.false26
 	i64.const	$push28=, 1
 	i32.call	$push29=, bar@FUNCTION, $pop28
-	br_if   	1, $pop29       # 1: down to label0
+	br_if   	0, $pop29       # 0: down to label0
 # BB#11:                                # %lor.lhs.false29
 	i64.const	$push30=, 2048
 	i32.call	$push31=, bar@FUNCTION, $pop30
 	i32.const	$push32=, 1
 	i32.ne  	$push33=, $pop31, $pop32
-	br_if   	1, $pop33       # 1: down to label0
+	br_if   	0, $pop33       # 0: down to label0
 # BB#12:                                # %lor.lhs.false32
 	i64.const	$push34=, 2049
 	i32.call	$push35=, bar@FUNCTION, $pop34
-	br_if   	1, $pop35       # 1: down to label0
+	br_if   	0, $pop35       # 0: down to label0
 # BB#13:                                # %lor.lhs.false35
 	i64.const	$push36=, 2147483648
 	i32.call	$push37=, bar@FUNCTION, $pop36
-	br_if   	1, $pop37       # 1: down to label0
+	br_if   	0, $pop37       # 0: down to label0
 # BB#14:                                # %lor.lhs.false38
 	i64.const	$push38=, -2147483648
 	i32.call	$push39=, bar@FUNCTION, $pop38
 	i32.const	$push40=, 1
 	i32.ne  	$push41=, $pop39, $pop40
-	br_if   	1, $pop41       # 1: down to label0
+	br_if   	0, $pop41       # 0: down to label0
 # BB#15:                                # %lor.lhs.false41
 	i64.const	$push42=, -2147483647
 	i32.call	$push43=, bar@FUNCTION, $pop42
-	br_if   	1, $pop43       # 1: down to label0
+	br_if   	0, $pop43       # 0: down to label0
 # BB#16:                                # %lor.lhs.false44
 	i64.const	$push44=, -2147481600
 	i32.call	$push45=, bar@FUNCTION, $pop44
 	i32.const	$push46=, 1
 	i32.ne  	$push47=, $pop45, $pop46
-	br_if   	1, $pop47       # 1: down to label0
+	br_if   	0, $pop47       # 0: down to label0
 # BB#17:                                # %lor.lhs.false47
 	i64.const	$push48=, -2147481599
 	i32.call	$push49=, bar@FUNCTION, $pop48
-	br_if   	1, $pop49       # 1: down to label0
+	br_if   	0, $pop49       # 0: down to label0
 # BB#18:                                # %if.end51
 	i32.const	$push50=, 0
 	return  	$pop50
-.LBB2_19:                               # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_20:                               # %if.then50
+.LBB2_19:                               # %if.then50
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/printf-1.c.s
+++ b/test/torture-s/printf-1.c.s
@@ -18,21 +18,12 @@ main:                                   # @main
 	i32.const	$push44=, 0
 	i32.call	$discard=, printf@FUNCTION, $pop45, $pop44
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push43=, .Lstr
 	i32.const	$push42=, 0
 	i32.call	$push0=, printf@FUNCTION, $pop43, $pop42
 	i32.const	$push1=, 5
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label9
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push47=, .Lstr
 	i32.call	$discard=, puts@FUNCTION, $pop47
@@ -41,7 +32,7 @@ main:                                   # @main
 	i32.call	$push4=, printf@FUNCTION, $pop3, $pop46
 	i32.const	$push5=, 6
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	1, $pop6        # 1: down to label8
+	br_if   	0, $pop6        # 0: down to label0
 # BB#2:                                 # %if.end6
 	i32.const	$push7=, 97
 	i32.call	$discard=, putchar@FUNCTION, $pop7
@@ -50,7 +41,7 @@ main:                                   # @main
 	i32.call	$push10=, printf@FUNCTION, $pop8, $pop9
 	i32.const	$push11=, 1
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	2, $pop12       # 2: down to label7
+	br_if   	0, $pop12       # 0: down to label0
 # BB#3:                                 # %if.end16
 	i32.const	$push13=, .Lstr
 	i32.store	$0=, 176($15):p2align=4, $pop13
@@ -65,7 +56,7 @@ main:                                   # @main
 	i32.call	$push14=, printf@FUNCTION, $pop48, $5
 	i32.const	$push15=, 5
 	i32.ne  	$push16=, $pop14, $pop15
-	br_if   	3, $pop16       # 3: down to label6
+	br_if   	0, $pop16       # 0: down to label0
 # BB#4:                                 # %if.end21
 	i32.const	$push17=, .L.str.1
 	i32.store	$0=, 144($15):p2align=4, $pop17
@@ -80,7 +71,7 @@ main:                                   # @main
 	i32.call	$push18=, printf@FUNCTION, $pop50, $7
 	i32.const	$push19=, 6
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	4, $pop20       # 4: down to label5
+	br_if   	0, $pop20       # 0: down to label0
 # BB#5:                                 # %if.end26
 	i32.const	$push21=, .L.str.2
 	i32.store	$0=, 112($15):p2align=4, $pop21
@@ -95,7 +86,7 @@ main:                                   # @main
 	i32.call	$push22=, printf@FUNCTION, $pop52, $9
 	i32.const	$push23=, 1
 	i32.ne  	$push24=, $pop22, $pop23
-	br_if   	5, $pop24       # 5: down to label4
+	br_if   	0, $pop24       # 0: down to label0
 # BB#6:                                 # %if.end31
 	i32.const	$push25=, .L.str.3
 	i32.store	$0=, 80($15):p2align=4, $pop25
@@ -108,7 +99,7 @@ main:                                   # @main
 	i32.const	$11=, 64
 	i32.add 	$11=, $15, $11
 	i32.call	$push26=, printf@FUNCTION, $pop54, $11
-	br_if   	6, $pop26       # 6: down to label3
+	br_if   	0, $pop26       # 0: down to label0
 # BB#7:                                 # %if.end36
 	i32.const	$push27=, 120
 	i32.call	$discard=, putchar@FUNCTION, $pop27
@@ -120,7 +111,7 @@ main:                                   # @main
 	i32.call	$push29=, printf@FUNCTION, $pop28, $12
 	i32.const	$push30=, 1
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	7, $pop31       # 7: down to label2
+	br_if   	0, $pop31       # 0: down to label0
 # BB#8:                                 # %if.end41
 	i32.const	$push32=, .L.str.1
 	i32.call	$discard=, puts@FUNCTION, $pop32
@@ -132,7 +123,7 @@ main:                                   # @main
 	i32.call	$push34=, printf@FUNCTION, $pop33, $13
 	i32.const	$push35=, 7
 	i32.ne  	$push36=, $pop34, $pop35
-	br_if   	8, $pop36       # 8: down to label1
+	br_if   	0, $pop36       # 0: down to label0
 # BB#9:                                 # %if.end46
 	i32.const	$push37=, 0
 	i32.store	$0=, 16($15):p2align=4, $pop37
@@ -145,50 +136,14 @@ main:                                   # @main
 	i32.call	$push39=, printf@FUNCTION, $pop58, $15
 	i32.const	$push40=, 2
 	i32.ne  	$push41=, $pop39, $pop40
-	br_if   	9, $pop41       # 9: down to label0
+	br_if   	0, $pop41       # 0: down to label0
 # BB#10:                                # %if.end51
 	i32.const	$3=, 192
 	i32.add 	$15=, $15, $3
 	i32.const	$3=, __stack_pointer
 	i32.store	$15=, 0($3), $15
 	return  	$0
-.LBB0_11:                               # %if.then
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then5
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then10
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then20
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then25
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then30
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then35
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then40
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then45
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_20:                               # %if.then50
+.LBB0_11:                               # %if.then50
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/printf-chk-1.c.s
+++ b/test/torture-s/printf-chk-1.c.s
@@ -61,55 +61,23 @@ main:                                   # @main
 	tee_local	$push74=, $1=, $pop75
 	i32.call	$discard=, __printf_chk@FUNCTION, $1, $pop77, $pop74
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load	$push1=, should_optimize($1)
 	i32.const	$push142=, 0
 	i32.eq  	$push143=, $pop1, $pop142
-	br_if   	0, $pop143      # 0: down to label33
+	br_if   	0, $pop143      # 0: down to label1
 # BB#1:                                 # %if.end
 	i32.const	$push78=, .L.str
 	i32.store	$push2=, should_optimize($1), $1
 	i32.call	$push3=, __printf_chk@FUNCTION, $1, $pop78, $pop2
 	i32.const	$push4=, 5
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label32
+	br_if   	0, $pop5        # 0: down to label1
 # BB#2:                                 # %if.end3
 	i32.const	$push79=, 0
 	i32.load	$push6=, should_optimize($pop79)
 	i32.const	$push144=, 0
 	i32.eq  	$push145=, $pop6, $pop144
-	br_if   	2, $pop145      # 2: down to label31
+	br_if   	0, $pop145      # 0: down to label1
 # BB#3:                                 # %if.end6
 	i32.const	$push83=, 0
 	i32.const	$push7=, 1
@@ -121,7 +89,7 @@ main:                                   # @main
 	i32.load	$push8=, should_optimize($pop80)
 	i32.const	$push146=, 0
 	i32.eq  	$push147=, $pop8, $pop146
-	br_if   	3, $pop147      # 3: down to label30
+	br_if   	0, $pop147      # 0: down to label1
 # BB#4:                                 # %if.end10
 	i32.const	$push87=, .L.str.1
 	i32.const	$push9=, 0
@@ -131,12 +99,12 @@ main:                                   # @main
 	i32.call	$push10=, __printf_chk@FUNCTION, $1, $pop87, $pop84
 	i32.const	$push11=, 6
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	4, $pop12       # 4: down to label29
+	br_if   	0, $pop12       # 0: down to label1
 # BB#5:                                 # %if.end14
 	i32.load	$push13=, should_optimize($1)
 	i32.const	$push148=, 0
 	i32.eq  	$push149=, $pop13, $pop148
-	br_if   	5, $pop149      # 5: down to label28
+	br_if   	0, $pop149      # 0: down to label1
 # BB#6:                                 # %if.end17
 	i32.const	$push91=, 0
 	i32.const	$push14=, 1
@@ -148,7 +116,7 @@ main:                                   # @main
 	i32.load	$push15=, should_optimize($pop88)
 	i32.const	$push150=, 0
 	i32.eq  	$push151=, $pop15, $pop150
-	br_if   	6, $pop151      # 6: down to label27
+	br_if   	0, $pop151      # 0: down to label1
 # BB#7:                                 # %if.end21
 	i32.const	$push94=, .L.str.2
 	i32.const	$push93=, 0
@@ -156,13 +124,13 @@ main:                                   # @main
 	i32.store	$push16=, should_optimize($pop93), $pop92
 	i32.call	$push17=, __printf_chk@FUNCTION, $1, $pop94, $pop16
 	i32.ne  	$push18=, $pop17, $1
-	br_if   	7, $pop18       # 7: down to label26
+	br_if   	0, $pop18       # 0: down to label1
 # BB#8:                                 # %if.end25
 	i32.const	$push95=, 0
 	i32.load	$push19=, should_optimize($pop95)
 	i32.const	$push152=, 0
 	i32.eq  	$push153=, $pop19, $pop152
-	br_if   	8, $pop153      # 8: down to label25
+	br_if   	0, $pop153      # 0: down to label1
 # BB#9:                                 # %if.end28
 	i32.const	$push99=, 0
 	i32.const	$push20=, 1
@@ -174,7 +142,7 @@ main:                                   # @main
 	i32.load	$push21=, should_optimize($pop96)
 	i32.const	$push154=, 0
 	i32.eq  	$push155=, $pop21, $pop154
-	br_if   	9, $pop155      # 9: down to label24
+	br_if   	0, $pop155      # 0: down to label1
 # BB#10:                                # %if.end32
 	i32.const	$push103=, .L.str.3
 	i32.const	$push22=, 0
@@ -182,12 +150,12 @@ main:                                   # @main
 	i32.store	$push101=, should_optimize($pop22), $pop102
 	tee_local	$push100=, $1=, $pop101
 	i32.call	$push23=, __printf_chk@FUNCTION, $1, $pop103, $pop100
-	br_if   	10, $pop23      # 10: down to label23
+	br_if   	0, $pop23       # 0: down to label1
 # BB#11:                                # %if.end36
 	i32.load	$push24=, should_optimize($1)
 	i32.const	$push156=, 0
 	i32.eq  	$push157=, $pop24, $pop156
-	br_if   	11, $pop157     # 11: down to label22
+	br_if   	0, $pop157      # 0: down to label1
 # BB#12:                                # %if.end39
 	i32.const	$push25=, 0
 	i32.const	$push105=, 0
@@ -201,7 +169,7 @@ main:                                   # @main
 	i32.load	$push27=, should_optimize($1)
 	i32.const	$push158=, 0
 	i32.eq  	$push159=, $pop27, $pop158
-	br_if   	12, $pop159     # 12: down to label21
+	br_if   	0, $pop159      # 0: down to label1
 # BB#13:                                # %if.end43
 	i32.store	$discard=, should_optimize($1), $1
 	i32.store	$discard=, 192($18):p2align=4, $0
@@ -211,13 +179,13 @@ main:                                   # @main
 	i32.call	$push28=, __printf_chk@FUNCTION, $1, $pop106, $6
 	i32.const	$push29=, 5
 	i32.ne  	$push30=, $pop28, $pop29
-	br_if   	13, $pop30      # 13: down to label20
+	br_if   	0, $pop30       # 0: down to label1
 # BB#14:                                # %if.end47
 	i32.const	$push107=, 0
 	i32.load	$push31=, should_optimize($pop107)
 	i32.const	$push160=, 0
 	i32.eq  	$push161=, $pop31, $pop160
-	br_if   	14, $pop161     # 14: down to label19
+	br_if   	0, $pop161      # 0: down to label1
 # BB#15:                                # %if.end50
 	i32.const	$push110=, 0
 	i32.const	$push32=, 1
@@ -232,7 +200,7 @@ main:                                   # @main
 	i32.load	$push34=, should_optimize($pop108)
 	i32.const	$push162=, 0
 	i32.eq  	$push163=, $pop34, $pop162
-	br_if   	15, $pop163     # 15: down to label18
+	br_if   	0, $pop163      # 0: down to label1
 # BB#16:                                # %if.end54
 	i32.const	$push35=, 0
 	i32.const	$push112=, 0
@@ -244,12 +212,12 @@ main:                                   # @main
 	i32.call	$push36=, __printf_chk@FUNCTION, $1, $pop111, $8
 	i32.const	$push37=, 6
 	i32.ne  	$push38=, $pop36, $pop37
-	br_if   	16, $pop38      # 16: down to label17
+	br_if   	0, $pop38       # 0: down to label1
 # BB#17:                                # %if.end58
 	i32.load	$push39=, should_optimize($0)
 	i32.const	$push164=, 0
 	i32.eq  	$push165=, $pop39, $pop164
-	br_if   	17, $pop165     # 17: down to label16
+	br_if   	0, $pop165      # 0: down to label1
 # BB#18:                                # %if.end61
 	i32.const	$push115=, 0
 	i32.const	$push40=, 1
@@ -264,7 +232,7 @@ main:                                   # @main
 	i32.load	$push42=, should_optimize($pop113)
 	i32.const	$push166=, 0
 	i32.eq  	$push167=, $pop42, $pop166
-	br_if   	18, $pop167     # 18: down to label15
+	br_if   	0, $pop167      # 0: down to label1
 # BB#19:                                # %if.end65
 	i32.const	$push118=, 0
 	i32.const	$push117=, 0
@@ -275,13 +243,13 @@ main:                                   # @main
 	i32.add 	$10=, $18, $10
 	i32.call	$push43=, __printf_chk@FUNCTION, $1, $pop116, $10
 	i32.ne  	$push44=, $pop43, $1
-	br_if   	19, $pop44      # 19: down to label14
+	br_if   	0, $pop44       # 0: down to label1
 # BB#20:                                # %if.end69
 	i32.const	$push119=, 0
 	i32.load	$push45=, should_optimize($pop119)
 	i32.const	$push168=, 0
 	i32.eq  	$push169=, $pop45, $pop168
-	br_if   	20, $pop169     # 20: down to label13
+	br_if   	0, $pop169      # 0: down to label1
 # BB#21:                                # %if.end72
 	i32.const	$push122=, 0
 	i32.const	$push46=, 1
@@ -296,7 +264,7 @@ main:                                   # @main
 	i32.load	$push48=, should_optimize($pop120)
 	i32.const	$push170=, 0
 	i32.eq  	$push171=, $pop48, $pop170
-	br_if   	21, $pop171     # 21: down to label12
+	br_if   	0, $pop171      # 0: down to label1
 # BB#22:                                # %if.end76
 	i32.const	$push49=, 0
 	i32.const	$push124=, 0
@@ -306,12 +274,12 @@ main:                                   # @main
 	i32.const	$12=, 96
 	i32.add 	$12=, $18, $12
 	i32.call	$push50=, __printf_chk@FUNCTION, $1, $pop123, $12
-	br_if   	22, $pop50      # 22: down to label11
+	br_if   	0, $pop50       # 0: down to label1
 # BB#23:                                # %if.end80
 	i32.load	$push51=, should_optimize($0)
 	i32.const	$push172=, 0
 	i32.eq  	$push173=, $pop51, $pop172
-	br_if   	23, $pop173     # 23: down to label10
+	br_if   	0, $pop173      # 0: down to label1
 # BB#24:                                # %if.end83
 	i32.const	$push127=, 0
 	i32.const	$push52=, 1
@@ -326,7 +294,7 @@ main:                                   # @main
 	i32.load	$push54=, should_optimize($pop125)
 	i32.const	$push174=, 0
 	i32.eq  	$push175=, $pop54, $pop174
-	br_if   	24, $pop175     # 24: down to label9
+	br_if   	0, $pop175      # 0: down to label1
 # BB#25:                                # %if.end87
 	i32.const	$push130=, 0
 	i32.const	$push129=, 0
@@ -337,13 +305,13 @@ main:                                   # @main
 	i32.add 	$14=, $18, $14
 	i32.call	$push55=, __printf_chk@FUNCTION, $1, $pop128, $14
 	i32.ne  	$push56=, $pop55, $1
-	br_if   	25, $pop56      # 25: down to label8
+	br_if   	0, $pop56       # 0: down to label1
 # BB#26:                                # %if.end91
 	i32.const	$push131=, 0
 	i32.load	$push57=, should_optimize($pop131)
 	i32.const	$push176=, 0
 	i32.eq  	$push177=, $pop57, $pop176
-	br_if   	26, $pop177     # 26: down to label7
+	br_if   	0, $pop177      # 0: down to label1
 # BB#27:                                # %if.end94
 	i32.const	$push134=, 0
 	i32.const	$push58=, 1
@@ -358,7 +326,7 @@ main:                                   # @main
 	i32.load	$push60=, should_optimize($pop132)
 	i32.const	$push178=, 0
 	i32.eq  	$push179=, $pop60, $pop178
-	br_if   	27, $pop179     # 27: down to label6
+	br_if   	0, $pop179      # 0: down to label1
 # BB#28:                                # %if.end98
 	i32.const	$push61=, 0
 	i32.const	$push136=, 0
@@ -370,12 +338,12 @@ main:                                   # @main
 	i32.call	$push62=, __printf_chk@FUNCTION, $1, $pop135, $16
 	i32.const	$push63=, 7
 	i32.ne  	$push64=, $pop62, $pop63
-	br_if   	28, $pop64      # 28: down to label5
+	br_if   	0, $pop64       # 0: down to label1
 # BB#29:                                # %if.end102
 	i32.load	$push65=, should_optimize($0)
 	i32.const	$push180=, 0
 	i32.eq  	$push181=, $pop65, $pop180
-	br_if   	29, $pop181     # 29: down to label4
+	br_if   	0, $pop181      # 0: down to label1
 # BB#30:                                # %if.end105
 	i32.const	$push66=, 0
 	i32.const	$push138=, 0
@@ -388,7 +356,7 @@ main:                                   # @main
 	i32.load	$push68=, should_optimize($1)
 	i32.const	$push182=, 0
 	i32.eq  	$push183=, $pop68, $pop182
-	br_if   	30, $pop183     # 30: down to label3
+	br_if   	0, $pop183      # 0: down to label1
 # BB#31:                                # %if.end109
 	i32.store	$push69=, should_optimize($1), $1
 	i32.store	$discard=, 0($18):p2align=4, $pop69
@@ -396,13 +364,13 @@ main:                                   # @main
 	i32.call	$push70=, __printf_chk@FUNCTION, $1, $pop139, $18
 	i32.const	$push71=, 2
 	i32.ne  	$push72=, $pop70, $pop71
-	br_if   	31, $pop72      # 31: down to label2
+	br_if   	0, $pop72       # 0: down to label1
 # BB#32:                                # %if.end113
 	i32.const	$push140=, 0
 	i32.load	$push73=, should_optimize($pop140)
 	i32.const	$push184=, 0
 	i32.eq  	$push185=, $pop73, $pop184
-	br_if   	32, $pop185     # 32: down to label1
+	br_if   	0, $pop185      # 0: down to label1
 # BB#33:                                # %if.end116
 	i32.const	$push141=, 0
 	i32.const	$4=, 224
@@ -410,135 +378,7 @@ main:                                   # @main
 	i32.const	$4=, __stack_pointer
 	i32.store	$18=, 0($4), $18
 	return  	$pop141
-.LBB1_34:                               # %if.then
-	end_block                       # label33:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_35:                               # %if.then2
-	end_block                       # label32:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_36:                               # %if.then5
-	end_block                       # label31:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_37:                               # %if.then9
-	end_block                       # label30:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_38:                               # %if.then13
-	end_block                       # label29:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_39:                               # %if.then16
-	end_block                       # label28:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_40:                               # %if.then20
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_41:                               # %if.then24
-	end_block                       # label26:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_42:                               # %if.then27
-	end_block                       # label25:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_43:                               # %if.then31
-	end_block                       # label24:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_44:                               # %if.then35
-	end_block                       # label23:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_45:                               # %if.then38
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_46:                               # %if.then42
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_47:                               # %if.then46
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_48:                               # %if.then49
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_49:                               # %if.then53
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_50:                               # %if.then57
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_51:                               # %if.then60
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_52:                               # %if.then64
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_53:                               # %if.then68
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_54:                               # %if.then71
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_55:                               # %if.then75
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_56:                               # %if.then79
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_57:                               # %if.then82
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_58:                               # %if.then86
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_59:                               # %if.then90
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_60:                               # %if.then93
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_61:                               # %if.then97
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_62:                               # %if.then101
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_63:                               # %if.then104
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_64:                               # %if.then108
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_65:                               # %if.then112
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_66:                               # %if.then115
+.LBB1_34:                               # %if.then115
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/simd-1.c.s
+++ b/test/torture-s/simd-1.c.s
@@ -76,30 +76,23 @@ main:                                   # @main
 	i32.const	$push104=, 0
 	i32.store	$4=, res+4($pop104), $6
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push103=, 0
 	i32.store	$push5=, res($pop103):p2align=4, $7
 	i32.const	$push6=, 160
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	0, $pop7        # 0: down to label8
+	br_if   	0, $pop7        # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push8=, 113
 	i32.ne  	$push9=, $4, $pop8
-	br_if   	0, $pop9        # 0: down to label8
+	br_if   	0, $pop9        # 0: down to label1
 # BB#2:                                 # %entry
 	i32.const	$push10=, 170
 	i32.ne  	$push11=, $5, $pop10
-	br_if   	0, $pop11       # 0: down to label8
+	br_if   	0, $pop11       # 0: down to label1
 # BB#3:                                 # %entry
 	i32.const	$push12=, 230
 	i32.ne  	$push13=, $8, $pop12
-	br_if   	0, $pop13       # 0: down to label8
+	br_if   	0, $pop13       # 0: down to label1
 # BB#4:                                 # %verify.exit
 	i32.const	$push18=, 0
 	i32.mul 	$push17=, $2, $0
@@ -123,19 +116,19 @@ main:                                   # @main
 	i32.store	$discard=, res+12($pop126), $7
 	i32.const	$push19=, 1500
 	i32.ne  	$push20=, $4, $pop19
-	br_if   	1, $pop20       # 1: down to label7
+	br_if   	0, $pop20       # 0: down to label1
 # BB#5:                                 # %verify.exit
 	i32.const	$push21=, 1300
 	i32.ne  	$push22=, $5, $pop21
-	br_if   	1, $pop22       # 1: down to label7
+	br_if   	0, $pop22       # 0: down to label1
 # BB#6:                                 # %verify.exit
 	i32.const	$push23=, 3000
 	i32.ne  	$push24=, $6, $pop23
-	br_if   	1, $pop24       # 1: down to label7
+	br_if   	0, $pop24       # 0: down to label1
 # BB#7:                                 # %verify.exit
 	i32.const	$push25=, 6000
 	i32.ne  	$push26=, $7, $pop25
-	br_if   	1, $pop26       # 1: down to label7
+	br_if   	0, $pop26       # 0: down to label1
 # BB#8:                                 # %verify.exit9
 	i32.div_s	$4=, $11, $12
 	i32.div_s	$5=, $9, $10
@@ -159,19 +152,19 @@ main:                                   # @main
 	i32.store	$discard=, res+12($pop133), $4
 	i32.const	$push29=, 15
 	i32.ne  	$push30=, $7, $pop29
-	br_if   	2, $pop30       # 2: down to label6
+	br_if   	0, $pop30       # 0: down to label1
 # BB#9:                                 # %verify.exit9
 	i32.const	$push140=, 7
 	i32.ne  	$push31=, $6, $pop140
-	br_if   	2, $pop31       # 2: down to label6
+	br_if   	0, $pop31       # 0: down to label1
 # BB#10:                                # %verify.exit9
 	i32.const	$push141=, 7
 	i32.ne  	$push32=, $5, $pop141
-	br_if   	2, $pop32       # 2: down to label6
+	br_if   	0, $pop32       # 0: down to label1
 # BB#11:                                # %verify.exit9
 	i32.const	$push33=, 6
 	i32.ne  	$push34=, $4, $pop33
-	br_if   	2, $pop34       # 2: down to label6
+	br_if   	0, $pop34       # 0: down to label1
 # BB#12:                                # %verify.exit18
 	i32.const	$push39=, 0
 	i32.and 	$push38=, $2, $0
@@ -195,19 +188,19 @@ main:                                   # @main
 	i32.store	$discard=, res+12($pop142), $7
 	i32.const	$push40=, 2
 	i32.ne  	$push41=, $4, $pop40
-	br_if   	3, $pop41       # 3: down to label5
+	br_if   	0, $pop41       # 0: down to label1
 # BB#13:                                # %verify.exit18
 	i32.const	$push42=, 4
 	i32.ne  	$push43=, $5, $pop42
-	br_if   	3, $pop43       # 3: down to label5
+	br_if   	0, $pop43       # 0: down to label1
 # BB#14:                                # %verify.exit18
 	i32.const	$push44=, 20
 	i32.ne  	$push45=, $6, $pop44
-	br_if   	3, $pop45       # 3: down to label5
+	br_if   	0, $pop45       # 0: down to label1
 # BB#15:                                # %verify.exit18
 	i32.const	$push46=, 8
 	i32.ne  	$push47=, $7, $pop46
-	br_if   	3, $pop47       # 3: down to label5
+	br_if   	0, $pop47       # 0: down to label1
 # BB#16:                                # %verify.exit27
 	i32.const	$push52=, 0
 	i32.or  	$push51=, $2, $0
@@ -231,19 +224,19 @@ main:                                   # @main
 	i32.store	$discard=, res+12($pop149), $7
 	i32.const	$push53=, 158
 	i32.ne  	$push54=, $4, $pop53
-	br_if   	4, $pop54       # 4: down to label4
+	br_if   	0, $pop54       # 0: down to label1
 # BB#17:                                # %verify.exit27
 	i32.const	$push55=, 109
 	i32.ne  	$push56=, $5, $pop55
-	br_if   	4, $pop56       # 4: down to label4
+	br_if   	0, $pop56       # 0: down to label1
 # BB#18:                                # %verify.exit27
 	i32.const	$push57=, 150
 	i32.ne  	$push58=, $6, $pop57
-	br_if   	4, $pop58       # 4: down to label4
+	br_if   	0, $pop58       # 0: down to label1
 # BB#19:                                # %verify.exit27
 	i32.const	$push59=, 222
 	i32.ne  	$push60=, $7, $pop59
-	br_if   	4, $pop60       # 4: down to label4
+	br_if   	0, $pop60       # 0: down to label1
 # BB#20:                                # %verify.exit36
 	i32.const	$push65=, 0
 	i32.xor 	$push64=, $0, $2
@@ -267,19 +260,19 @@ main:                                   # @main
 	i32.store	$discard=, res+12($pop156), $5
 	i32.const	$push66=, 156
 	i32.ne  	$push67=, $2, $pop66
-	br_if   	5, $pop67       # 5: down to label3
+	br_if   	0, $pop67       # 0: down to label1
 # BB#21:                                # %verify.exit36
 	i32.const	$push68=, 105
 	i32.ne  	$push69=, $3, $pop68
-	br_if   	5, $pop69       # 5: down to label3
+	br_if   	0, $pop69       # 0: down to label1
 # BB#22:                                # %verify.exit36
 	i32.const	$push70=, 130
 	i32.ne  	$push71=, $4, $pop70
-	br_if   	5, $pop71       # 5: down to label3
+	br_if   	0, $pop71       # 0: down to label1
 # BB#23:                                # %verify.exit36
 	i32.const	$push72=, 214
 	i32.ne  	$push73=, $5, $pop72
-	br_if   	5, $pop73       # 5: down to label3
+	br_if   	0, $pop73       # 0: down to label1
 # BB#24:                                # %verify.exit45
 	i32.const	$push77=, 0
 	i32.const	$push173=, 0
@@ -307,19 +300,19 @@ main:                                   # @main
 	i32.store	$discard=, res+12($pop163), $5
 	i32.const	$push79=, -150
 	i32.ne  	$push80=, $3, $pop79
-	br_if   	6, $pop80       # 6: down to label2
+	br_if   	0, $pop80       # 0: down to label1
 # BB#25:                                # %verify.exit45
 	i32.const	$push81=, -100
 	i32.ne  	$push82=, $2, $pop81
-	br_if   	6, $pop82       # 6: down to label2
+	br_if   	0, $pop82       # 0: down to label1
 # BB#26:                                # %verify.exit45
 	i32.const	$push83=, -150
 	i32.ne  	$push84=, $4, $pop83
-	br_if   	6, $pop84       # 6: down to label2
+	br_if   	0, $pop84       # 0: down to label1
 # BB#27:                                # %verify.exit45
 	i32.const	$push85=, -200
 	i32.ne  	$push86=, $5, $pop85
-	br_if   	6, $pop86       # 6: down to label2
+	br_if   	0, $pop86       # 0: down to label1
 # BB#28:                                # %verify.exit54
 	i32.const	$push92=, 0
 	i32.const	$push183=, 0
@@ -347,52 +340,24 @@ main:                                   # @main
 	i32.store	$discard=, res+12($pop174), $2
 	i32.const	$push94=, 150
 	i32.ne  	$push95=, $0, $pop94
-	br_if   	7, $pop95       # 7: down to label1
+	br_if   	0, $pop95       # 0: down to label1
 # BB#29:                                # %verify.exit54
 	i32.const	$push96=, -101
 	i32.ne  	$push97=, $1, $pop96
-	br_if   	7, $pop97       # 7: down to label1
+	br_if   	0, $pop97       # 0: down to label1
 # BB#30:                                # %verify.exit54
 	i32.const	$push98=, -151
 	i32.ne  	$push99=, $3, $pop98
-	br_if   	7, $pop99       # 7: down to label1
+	br_if   	0, $pop99       # 0: down to label1
 # BB#31:                                # %verify.exit54
 	i32.const	$push100=, -201
 	i32.ne  	$push101=, $2, $pop100
-	br_if   	7, $pop101      # 7: down to label1
+	br_if   	0, $pop101      # 0: down to label1
 # BB#32:                                # %verify.exit63
 	i32.const	$push102=, 0
 	call    	exit@FUNCTION, $pop102
 	unreachable
-.LBB1_33:                               # %if.then.i
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_34:                               # %if.then.i8
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_35:                               # %if.then.i17
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_36:                               # %if.then.i26
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_37:                               # %if.then.i35
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_38:                               # %if.then.i44
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_39:                               # %if.then.i53
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_40:                               # %if.then.i62
+.LBB1_33:                               # %if.then.i62
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/simd-2.c.s
+++ b/test/torture-s/simd-2.c.s
@@ -112,38 +112,31 @@ main:                                   # @main
 	i32.const	$push220=, 0
 	i32.store16	$12=, res+2($pop220), $14
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push219=, 0
 	i32.store16	$push11=, res($pop219):p2align=4, $15
 	i32.const	$push218=, 65535
 	i32.and 	$push12=, $pop11, $pop218
 	i32.const	$push13=, 160
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	0, $pop14       # 0: down to label8
+	br_if   	0, $pop14       # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push258=, 65535
 	i32.and 	$push15=, $12, $pop258
 	i32.const	$push16=, 113
 	i32.ne  	$push17=, $pop15, $pop16
-	br_if   	0, $pop17       # 0: down to label8
+	br_if   	0, $pop17       # 0: down to label1
 # BB#2:                                 # %entry
 	i32.const	$push259=, 65535
 	i32.and 	$push18=, $13, $pop259
 	i32.const	$push19=, 170
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	0, $pop20       # 0: down to label8
+	br_if   	0, $pop20       # 0: down to label1
 # BB#3:                                 # %entry
 	i32.const	$push260=, 65535
 	i32.and 	$push21=, $16, $pop260
 	i32.const	$push22=, 230
 	i32.ne  	$push23=, $pop21, $pop22
-	br_if   	0, $pop23       # 0: down to label8
+	br_if   	0, $pop23       # 0: down to label1
 # BB#4:                                 # %verify.exit
 	i32.const	$push32=, 0
 	i32.mul 	$push31=, $6, $0
@@ -189,25 +182,25 @@ main:                                   # @main
 	i32.and 	$push36=, $12, $pop261
 	i32.const	$push37=, 1500
 	i32.ne  	$push38=, $pop36, $pop37
-	br_if   	1, $pop38       # 1: down to label7
+	br_if   	0, $pop38       # 0: down to label1
 # BB#5:                                 # %verify.exit
 	i32.const	$push277=, 65535
 	i32.and 	$push39=, $13, $pop277
 	i32.const	$push40=, 1300
 	i32.ne  	$push41=, $pop39, $pop40
-	br_if   	1, $pop41       # 1: down to label7
+	br_if   	0, $pop41       # 0: down to label1
 # BB#6:                                 # %verify.exit
 	i32.const	$push278=, 65535
 	i32.and 	$push42=, $14, $pop278
 	i32.const	$push43=, 3000
 	i32.ne  	$push44=, $pop42, $pop43
-	br_if   	1, $pop44       # 1: down to label7
+	br_if   	0, $pop44       # 0: down to label1
 # BB#7:                                 # %verify.exit
 	i32.const	$push279=, 65535
 	i32.and 	$push45=, $15, $pop279
 	i32.const	$push46=, 6000
 	i32.ne  	$push47=, $pop45, $pop46
-	br_if   	1, $pop47       # 1: down to label7
+	br_if   	0, $pop47       # 0: down to label1
 # BB#8:                                 # %verify.exit40
 	i32.const	$push48=, 16
 	i32.shl 	$push51=, $22, $pop48
@@ -317,25 +310,25 @@ main:                                   # @main
 	i32.and 	$push86=, $19, $pop280
 	i32.const	$push87=, 15
 	i32.ne  	$push88=, $pop86, $pop87
-	br_if   	2, $pop88       # 2: down to label6
+	br_if   	0, $pop88       # 0: down to label1
 # BB#9:                                 # %verify.exit40
 	i32.const	$push328=, 65535
 	i32.and 	$push89=, $17, $pop328
 	i32.const	$push327=, 7
 	i32.ne  	$push90=, $pop89, $pop327
-	br_if   	2, $pop90       # 2: down to label6
+	br_if   	0, $pop90       # 0: down to label1
 # BB#10:                                # %verify.exit40
 	i32.const	$push330=, 65535
 	i32.and 	$push91=, $18, $pop330
 	i32.const	$push329=, 7
 	i32.ne  	$push92=, $pop91, $pop329
-	br_if   	2, $pop92       # 2: down to label6
+	br_if   	0, $pop92       # 0: down to label1
 # BB#11:                                # %verify.exit40
 	i32.const	$push331=, 65535
 	i32.and 	$push93=, $16, $pop331
 	i32.const	$push94=, 6
 	i32.ne  	$push95=, $pop93, $pop94
-	br_if   	2, $pop95       # 2: down to label6
+	br_if   	0, $pop95       # 0: down to label1
 # BB#12:                                # %verify.exit49
 	i32.const	$push104=, 0
 	i32.and 	$push103=, $6, $0
@@ -381,25 +374,25 @@ main:                                   # @main
 	i32.and 	$push108=, $12, $pop332
 	i32.const	$push109=, 2
 	i32.ne  	$push110=, $pop108, $pop109
-	br_if   	3, $pop110      # 3: down to label5
+	br_if   	0, $pop110      # 0: down to label1
 # BB#13:                                # %verify.exit49
 	i32.const	$push348=, 65535
 	i32.and 	$push111=, $13, $pop348
 	i32.const	$push112=, 4
 	i32.ne  	$push113=, $pop111, $pop112
-	br_if   	3, $pop113      # 3: down to label5
+	br_if   	0, $pop113      # 0: down to label1
 # BB#14:                                # %verify.exit49
 	i32.const	$push349=, 65535
 	i32.and 	$push114=, $14, $pop349
 	i32.const	$push115=, 20
 	i32.ne  	$push116=, $pop114, $pop115
-	br_if   	3, $pop116      # 3: down to label5
+	br_if   	0, $pop116      # 0: down to label1
 # BB#15:                                # %verify.exit49
 	i32.const	$push350=, 65535
 	i32.and 	$push117=, $15, $pop350
 	i32.const	$push118=, 8
 	i32.ne  	$push119=, $pop117, $pop118
-	br_if   	3, $pop119      # 3: down to label5
+	br_if   	0, $pop119      # 0: down to label1
 # BB#16:                                # %verify.exit58
 	i32.const	$push128=, 0
 	i32.or  	$push127=, $6, $0
@@ -445,25 +438,25 @@ main:                                   # @main
 	i32.and 	$push132=, $12, $pop351
 	i32.const	$push133=, 158
 	i32.ne  	$push134=, $pop132, $pop133
-	br_if   	4, $pop134      # 4: down to label4
+	br_if   	0, $pop134      # 0: down to label1
 # BB#17:                                # %verify.exit58
 	i32.const	$push367=, 65535
 	i32.and 	$push135=, $13, $pop367
 	i32.const	$push136=, 109
 	i32.ne  	$push137=, $pop135, $pop136
-	br_if   	4, $pop137      # 4: down to label4
+	br_if   	0, $pop137      # 0: down to label1
 # BB#18:                                # %verify.exit58
 	i32.const	$push368=, 65535
 	i32.and 	$push138=, $14, $pop368
 	i32.const	$push139=, 150
 	i32.ne  	$push140=, $pop138, $pop139
-	br_if   	4, $pop140      # 4: down to label4
+	br_if   	0, $pop140      # 0: down to label1
 # BB#19:                                # %verify.exit58
 	i32.const	$push369=, 65535
 	i32.and 	$push141=, $15, $pop369
 	i32.const	$push142=, 222
 	i32.ne  	$push143=, $pop141, $pop142
-	br_if   	4, $pop143      # 4: down to label4
+	br_if   	0, $pop143      # 0: down to label1
 # BB#20:                                # %verify.exit67
 	i32.const	$push152=, 0
 	i32.xor 	$push151=, $0, $6
@@ -509,25 +502,25 @@ main:                                   # @main
 	i32.and 	$push156=, $6, $pop370
 	i32.const	$push157=, 156
 	i32.ne  	$push158=, $pop156, $pop157
-	br_if   	5, $pop158      # 5: down to label3
+	br_if   	0, $pop158      # 0: down to label1
 # BB#21:                                # %verify.exit67
 	i32.const	$push386=, 65535
 	i32.and 	$push159=, $7, $pop386
 	i32.const	$push160=, 105
 	i32.ne  	$push161=, $pop159, $pop160
-	br_if   	5, $pop161      # 5: down to label3
+	br_if   	0, $pop161      # 0: down to label1
 # BB#22:                                # %verify.exit67
 	i32.const	$push387=, 65535
 	i32.and 	$push162=, $12, $pop387
 	i32.const	$push163=, 130
 	i32.ne  	$push164=, $pop162, $pop163
-	br_if   	5, $pop164      # 5: down to label3
+	br_if   	0, $pop164      # 0: down to label1
 # BB#23:                                # %verify.exit67
 	i32.const	$push388=, 65535
 	i32.and 	$push165=, $8, $pop388
 	i32.const	$push166=, 214
 	i32.ne  	$push167=, $pop165, $pop166
-	br_if   	5, $pop167      # 5: down to label3
+	br_if   	0, $pop167      # 0: down to label1
 # BB#24:                                # %verify.exit76
 	i32.const	$push171=, 0
 	i32.const	$push412=, 0
@@ -581,25 +574,25 @@ main:                                   # @main
 	i32.and 	$push180=, $11, $pop389
 	i32.const	$push181=, 65386
 	i32.ne  	$push182=, $pop180, $pop181
-	br_if   	6, $pop182      # 6: down to label2
+	br_if   	0, $pop182      # 0: down to label1
 # BB#25:                                # %verify.exit76
 	i32.const	$push413=, 65535
 	i32.and 	$push183=, $10, $pop413
 	i32.const	$push184=, 65436
 	i32.ne  	$push185=, $pop183, $pop184
-	br_if   	6, $pop185      # 6: down to label2
+	br_if   	0, $pop185      # 0: down to label1
 # BB#26:                                # %verify.exit76
 	i32.const	$push414=, 65535
 	i32.and 	$push186=, $9, $pop414
 	i32.const	$push187=, 65386
 	i32.ne  	$push188=, $pop186, $pop187
-	br_if   	6, $pop188      # 6: down to label2
+	br_if   	0, $pop188      # 0: down to label1
 # BB#27:                                # %verify.exit76
 	i32.const	$push415=, 65535
 	i32.and 	$push189=, $8, $pop415
 	i32.const	$push190=, 65336
 	i32.ne  	$push191=, $pop189, $pop190
-	br_if   	6, $pop191      # 6: down to label2
+	br_if   	0, $pop191      # 0: down to label1
 # BB#28:                                # %verify.exit85
 	i32.const	$push201=, 0
 	i32.const	$push195=, -1
@@ -653,58 +646,30 @@ main:                                   # @main
 	i32.and 	$push205=, $0, $pop416
 	i32.const	$push206=, 65385
 	i32.ne  	$push207=, $pop205, $pop206
-	br_if   	7, $pop207      # 7: down to label1
+	br_if   	0, $pop207      # 0: down to label1
 # BB#29:                                # %verify.exit85
 	i32.const	$push439=, 65535
 	i32.and 	$push208=, $1, $pop439
 	i32.const	$push209=, 65435
 	i32.ne  	$push210=, $pop208, $pop209
-	br_if   	7, $pop210      # 7: down to label1
+	br_if   	0, $pop210      # 0: down to label1
 # BB#30:                                # %verify.exit85
 	i32.const	$push440=, 65535
 	i32.and 	$push211=, $11, $pop440
 	i32.const	$push212=, 65385
 	i32.ne  	$push213=, $pop211, $pop212
-	br_if   	7, $pop213      # 7: down to label1
+	br_if   	0, $pop213      # 0: down to label1
 # BB#31:                                # %verify.exit85
 	i32.const	$push441=, 65535
 	i32.and 	$push214=, $2, $pop441
 	i32.const	$push215=, 65335
 	i32.ne  	$push216=, $pop214, $pop215
-	br_if   	7, $pop216      # 7: down to label1
+	br_if   	0, $pop216      # 0: down to label1
 # BB#32:                                # %verify.exit94
 	i32.const	$push217=, 0
 	call    	exit@FUNCTION, $pop217
 	unreachable
-.LBB1_33:                               # %if.then.i
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_34:                               # %if.then.i39
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_35:                               # %if.then.i48
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_36:                               # %if.then.i57
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_37:                               # %if.then.i66
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_38:                               # %if.then.i75
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_39:                               # %if.then.i84
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_40:                               # %if.then.i93
+.LBB1_33:                               # %if.then.i93
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/simd-5.c.s
+++ b/test/torture-s/simd-5.c.s
@@ -193,52 +193,37 @@ main:                                   # @main
 # BB#0:                                 # %entry
 	call    	func2@FUNCTION
 	block
-	block
-	block
-	block
 	i32.const	$push14=, 0
 	i64.load	$push0=, w1($pop14)
 	i32.const	$push13=, 0
 	i64.load	$push1=, w3($pop13)
 	i64.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push16=, 0
 	i64.load	$push3=, w2($pop16)
 	i32.const	$push15=, 0
 	i64.load	$push4=, w4($pop15)
 	i64.ne  	$push5=, $pop3, $pop4
-	br_if   	1, $pop5        # 1: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push18=, 0
 	i64.load	$push6=, z1($pop18)
 	i32.const	$push17=, 0
 	i64.load	$push7=, z3($pop17)
 	i64.ne  	$push8=, $pop6, $pop7
-	br_if   	2, $pop8        # 2: down to label1
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.const	$push20=, 0
 	i64.load	$push9=, z2($pop20)
 	i32.const	$push19=, 0
 	i64.load	$push10=, z4($pop19)
 	i64.ne  	$push11=, $pop9, $pop10
-	br_if   	3, $pop11       # 3: down to label0
+	br_if   	0, $pop11       # 0: down to label0
 # BB#4:                                 # %if.end12
 	i32.const	$push12=, 0
 	return  	$pop12
-.LBB3_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_6:                                # %if.then3
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_7:                                # %if.then7
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_8:                                # %if.then11
+.LBB3_5:                                # %if.then11
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/stdarg-1.c.s
+++ b/test/torture-s/stdarg-1.c.s
@@ -223,16 +223,15 @@ f2:                                     # @f2
 	block
 	block
 	block
-	block
 	i32.trunc_s/f64	$push106=, $2
 	tee_local	$push105=, $1=, $pop106
 	i32.const	$push1=, 16392
 	i32.eq  	$push2=, $pop105, $pop1
-	br_if   	0, $pop2        # 0: down to label8
+	br_if   	0, $pop2        # 0: down to label7
 # BB#1:                                 # %entry
 	i32.const	$push3=, 16390
 	i32.ne  	$push4=, $1, $pop3
-	br_if   	1, $pop4        # 1: down to label7
+	br_if   	1, $pop4        # 1: down to label6
 # BB#2:                                 # %if.then.i
 	i32.const	$push111=, 0
 	i32.const	$push110=, 0
@@ -249,7 +248,7 @@ f2:                                     # @f2
 	f64.load	$push38=, 0($5)
 	f64.const	$push39=, 0x1.1p4
 	f64.ne  	$push40=, $pop38, $pop39
-	br_if   	0, $pop40       # 0: down to label9
+	br_if   	0, $pop40       # 0: down to label8
 # BB#3:                                 # %lor.lhs.false.i
 	i32.const	$push115=, 0
 	i32.const	$push114=, 0
@@ -265,13 +264,13 @@ f2:                                     # @f2
 	i32.load	$push47=, 0($5)
 	i32.const	$push48=, 129
 	i32.eq  	$push49=, $pop47, $pop48
-	br_if   	2, $pop49       # 2: down to label7
+	br_if   	2, $pop49       # 2: down to label6
 .LBB4_4:                                # %if.then3.i
-	end_block                       # label9:
+	end_block                       # label8:
 	call    	abort@FUNCTION
 	unreachable
 .LBB4_5:                                # %if.then5.i
-	end_block                       # label8:
+	end_block                       # label7:
 	i32.const	$push119=, 0
 	i32.load	$5=, pap($pop119)
 	i32.load	$push5=, 0($5)
@@ -286,7 +285,7 @@ f2:                                     # @f2
 	i64.load	$push10=, 0($3)
 	i64.const	$push11=, 14
 	i64.ne  	$push12=, $pop10, $pop11
-	br_if   	1, $pop12       # 1: down to label6
+	br_if   	1, $pop12       # 1: down to label5
 # BB#6:                                 # %lor.lhs.false7.i
 	i32.const	$push124=, 0
 	i32.load	$5=, pap($pop124)
@@ -307,7 +306,7 @@ f2:                                     # @f2
 	i64.const	$push21=, 0
 	i64.const	$push20=, 4613381465357418496
 	i32.call	$push22=, __netf2@FUNCTION, $4, $pop19, $pop21, $pop20
-	br_if   	1, $pop22       # 1: down to label6
+	br_if   	1, $pop22       # 1: down to label5
 # BB#7:                                 # %lor.lhs.false9.i
 	i32.const	$push127=, 0
 	i32.load	$5=, pap($pop127)
@@ -323,9 +322,9 @@ f2:                                     # @f2
 	i32.load	$push29=, 0($3)
 	i32.const	$push30=, 17
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	1, $pop31       # 1: down to label6
+	br_if   	1, $pop31       # 1: down to label5
 .LBB4_8:                                # %bar.exit
-	end_block                       # label7:
+	end_block                       # label6:
 	i32.load	$5=, 12($10)
 	i32.const	$push133=, 0
 	i32.store	$discard=, bar_arg($pop133), $1
@@ -345,11 +344,11 @@ f2:                                     # @f2
 	tee_local	$push128=, $1=, $pop129
 	i32.const	$push55=, 16392
 	i32.eq  	$push56=, $pop128, $pop55
-	br_if   	0, $pop56       # 0: down to label11
+	br_if   	0, $pop56       # 0: down to label10
 # BB#9:                                 # %bar.exit
 	i32.const	$push57=, 16390
 	i32.ne  	$push58=, $1, $pop57
-	br_if   	1, $pop58       # 1: down to label10
+	br_if   	1, $pop58       # 1: down to label9
 # BB#10:                                # %if.then.i4
 	i32.const	$push137=, 0
 	i32.const	$push136=, 0
@@ -366,7 +365,7 @@ f2:                                     # @f2
 	f64.load	$push92=, 0($5)
 	f64.const	$push93=, 0x1.1p4
 	f64.ne  	$push94=, $pop92, $pop93
-	br_if   	0, $pop94       # 0: down to label12
+	br_if   	0, $pop94       # 0: down to label11
 # BB#11:                                # %lor.lhs.false.i6
 	i32.const	$push141=, 0
 	i32.const	$push140=, 0
@@ -382,13 +381,13 @@ f2:                                     # @f2
 	i32.load	$push101=, 0($5)
 	i32.const	$push102=, 129
 	i32.eq  	$push103=, $pop101, $pop102
-	br_if   	2, $pop103      # 2: down to label10
+	br_if   	2, $pop103      # 2: down to label9
 .LBB4_12:                               # %if.then3.i7
-	end_block                       # label12:
+	end_block                       # label11:
 	call    	abort@FUNCTION
 	unreachable
 .LBB4_13:                               # %if.then5.i9
-	end_block                       # label11:
+	end_block                       # label10:
 	i32.const	$push145=, 0
 	i32.load	$5=, pap($pop145)
 	i32.load	$push59=, 0($5)
@@ -403,7 +402,7 @@ f2:                                     # @f2
 	i64.load	$push64=, 0($3)
 	i64.const	$push65=, 14
 	i64.ne  	$push66=, $pop64, $pop65
-	br_if   	2, $pop66       # 2: down to label5
+	br_if   	1, $pop66       # 1: down to label5
 # BB#14:                                # %lor.lhs.false7.i11
 	i32.const	$push150=, 0
 	i32.load	$5=, pap($pop150)
@@ -424,7 +423,7 @@ f2:                                     # @f2
 	i64.const	$push75=, 0
 	i64.const	$push74=, 4613381465357418496
 	i32.call	$push76=, __netf2@FUNCTION, $4, $pop73, $pop75, $pop74
-	br_if   	2, $pop76       # 2: down to label5
+	br_if   	1, $pop76       # 1: down to label5
 # BB#15:                                # %lor.lhs.false9.i13
 	i32.const	$push153=, 0
 	i32.load	$5=, pap($pop153)
@@ -440,9 +439,9 @@ f2:                                     # @f2
 	i32.load	$push83=, 0($3)
 	i32.const	$push84=, 17
 	i32.ne  	$push85=, $pop83, $pop84
-	br_if   	2, $pop85       # 2: down to label5
+	br_if   	1, $pop85       # 1: down to label5
 .LBB4_16:                               # %bar.exit15
-	end_block                       # label10:
+	end_block                       # label9:
 	i32.const	$push104=, 0
 	i32.store	$discard=, bar_arg($pop104), $1
 	i32.const	$9=, 16
@@ -450,11 +449,7 @@ f2:                                     # @f2
 	i32.const	$9=, __stack_pointer
 	i32.store	$10=, 0($9), $10
 	return
-.LBB4_17:                               # %if.then11.i
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_18:                               # %if.then11.i14
+.LBB4_17:                               # %if.then11.i14
 	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
@@ -528,7 +523,7 @@ f4:                                     # @f4
 	block
 	i32.const	$push8=, 5
 	i32.ne  	$push9=, $0, $pop8
-	br_if   	0, $pop9        # 0: down to label13
+	br_if   	0, $pop9        # 0: down to label12
 # BB#1:                                 # %foo.exit
 	i32.load	$push10=, 12($6)
 	i32.const	$push11=, 3
@@ -548,7 +543,7 @@ f4:                                     # @f4
 	i32.store	$6=, 0($5), $6
 	return
 .LBB6_2:                                # %sw.default.i
-	end_block                       # label13:
+	end_block                       # label12:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -577,11 +572,11 @@ f5:                                     # @f5
 	block
 	i32.const	$push1=, 16392
 	i32.eq  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label16
+	br_if   	0, $pop2        # 0: down to label15
 # BB#1:                                 # %entry
 	i32.const	$push3=, 16390
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	1, $pop4        # 1: down to label15
+	br_if   	1, $pop4        # 1: down to label14
 # BB#2:                                 # %if.then.i
 	i32.const	$push55=, 0
 	i32.const	$push54=, 0
@@ -598,7 +593,7 @@ f5:                                     # @f5
 	f64.load	$push38=, 0($1)
 	f64.const	$push39=, 0x1.1p4
 	f64.ne  	$push40=, $pop38, $pop39
-	br_if   	0, $pop40       # 0: down to label17
+	br_if   	0, $pop40       # 0: down to label16
 # BB#3:                                 # %lor.lhs.false.i
 	i32.const	$push59=, 0
 	i32.const	$push58=, 0
@@ -614,13 +609,13 @@ f5:                                     # @f5
 	i32.load	$push47=, 0($1)
 	i32.const	$push48=, 129
 	i32.eq  	$push49=, $pop47, $pop48
-	br_if   	2, $pop49       # 2: down to label15
+	br_if   	2, $pop49       # 2: down to label14
 .LBB7_4:                                # %if.then3.i
-	end_block                       # label17:
+	end_block                       # label16:
 	call    	abort@FUNCTION
 	unreachable
 .LBB7_5:                                # %if.then5.i
-	end_block                       # label16:
+	end_block                       # label15:
 	i32.const	$push63=, 0
 	i32.load	$1=, pap($pop63)
 	i32.load	$push5=, 0($1)
@@ -635,7 +630,7 @@ f5:                                     # @f5
 	i64.load	$push10=, 0($2)
 	i64.const	$push11=, 14
 	i64.ne  	$push12=, $pop10, $pop11
-	br_if   	1, $pop12       # 1: down to label14
+	br_if   	1, $pop12       # 1: down to label13
 # BB#6:                                 # %lor.lhs.false7.i
 	i32.const	$push68=, 0
 	i32.load	$1=, pap($pop68)
@@ -656,7 +651,7 @@ f5:                                     # @f5
 	i64.const	$push21=, 0
 	i64.const	$push20=, 4613381465357418496
 	i32.call	$push22=, __netf2@FUNCTION, $3, $pop19, $pop21, $pop20
-	br_if   	1, $pop22       # 1: down to label14
+	br_if   	1, $pop22       # 1: down to label13
 # BB#7:                                 # %lor.lhs.false9.i
 	i32.const	$push71=, 0
 	i32.load	$1=, pap($pop71)
@@ -672,9 +667,9 @@ f5:                                     # @f5
 	i32.load	$push29=, 0($2)
 	i32.const	$push30=, 17
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	1, $pop31       # 1: down to label14
+	br_if   	1, $pop31       # 1: down to label13
 .LBB7_8:                                # %bar.exit
-	end_block                       # label15:
+	end_block                       # label14:
 	i32.const	$push50=, 0
 	i32.store	$discard=, bar_arg($pop50), $0
 	i32.const	$7=, 16
@@ -683,7 +678,7 @@ f5:                                     # @f5
 	i32.store	$8=, 0($7), $8
 	return
 .LBB7_9:                                # %if.then11.i
-	end_block                       # label14:
+	end_block                       # label13:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -710,16 +705,15 @@ f6:                                     # @f6
 	block
 	block
 	block
-	block
 	i32.trunc_s/f64	$push109=, $2
 	tee_local	$push108=, $1=, $pop109
 	i32.const	$push1=, 16392
 	i32.eq  	$push2=, $pop108, $pop1
-	br_if   	0, $pop2        # 0: down to label21
+	br_if   	0, $pop2        # 0: down to label19
 # BB#1:                                 # %entry
 	i32.const	$push3=, 16390
 	i32.ne  	$push4=, $1, $pop3
-	br_if   	1, $pop4        # 1: down to label20
+	br_if   	1, $pop4        # 1: down to label18
 # BB#2:                                 # %if.then.i
 	i32.const	$push114=, 0
 	i32.const	$push113=, 0
@@ -736,7 +730,7 @@ f6:                                     # @f6
 	f64.load	$push38=, 0($5)
 	f64.const	$push39=, 0x1.1p4
 	f64.ne  	$push40=, $pop38, $pop39
-	br_if   	0, $pop40       # 0: down to label22
+	br_if   	0, $pop40       # 0: down to label20
 # BB#3:                                 # %lor.lhs.false.i
 	i32.const	$push118=, 0
 	i32.const	$push117=, 0
@@ -752,13 +746,13 @@ f6:                                     # @f6
 	i32.load	$push47=, 0($5)
 	i32.const	$push48=, 129
 	i32.eq  	$push49=, $pop47, $pop48
-	br_if   	2, $pop49       # 2: down to label20
+	br_if   	2, $pop49       # 2: down to label18
 .LBB8_4:                                # %if.then3.i
-	end_block                       # label22:
+	end_block                       # label20:
 	call    	abort@FUNCTION
 	unreachable
 .LBB8_5:                                # %if.then5.i
-	end_block                       # label21:
+	end_block                       # label19:
 	i32.const	$push122=, 0
 	i32.load	$5=, pap($pop122)
 	i32.load	$push5=, 0($5)
@@ -773,7 +767,7 @@ f6:                                     # @f6
 	i64.load	$push10=, 0($3)
 	i64.const	$push11=, 14
 	i64.ne  	$push12=, $pop10, $pop11
-	br_if   	1, $pop12       # 1: down to label19
+	br_if   	1, $pop12       # 1: down to label17
 # BB#6:                                 # %lor.lhs.false7.i
 	i32.const	$push127=, 0
 	i32.load	$5=, pap($pop127)
@@ -794,7 +788,7 @@ f6:                                     # @f6
 	i64.const	$push21=, 0
 	i64.const	$push20=, 4613381465357418496
 	i32.call	$push22=, __netf2@FUNCTION, $4, $pop19, $pop21, $pop20
-	br_if   	1, $pop22       # 1: down to label19
+	br_if   	1, $pop22       # 1: down to label17
 # BB#7:                                 # %lor.lhs.false9.i
 	i32.const	$push130=, 0
 	i32.load	$5=, pap($pop130)
@@ -810,9 +804,9 @@ f6:                                     # @f6
 	i32.load	$push29=, 0($3)
 	i32.const	$push30=, 17
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	1, $pop31       # 1: down to label19
+	br_if   	1, $pop31       # 1: down to label17
 .LBB8_8:                                # %bar.exit
-	end_block                       # label20:
+	end_block                       # label18:
 	i32.load	$5=, 12($10)
 	i32.const	$push146=, 0
 	i32.store	$discard=, bar_arg($pop146), $1
@@ -848,11 +842,11 @@ f6:                                     # @f6
 	tee_local	$push131=, $1=, $pop132
 	i32.const	$push59=, 16392
 	i32.eq  	$push60=, $pop131, $pop59
-	br_if   	0, $pop60       # 0: down to label24
+	br_if   	0, $pop60       # 0: down to label22
 # BB#9:                                 # %bar.exit
 	i32.const	$push61=, 16390
 	i32.ne  	$push62=, $1, $pop61
-	br_if   	1, $pop62       # 1: down to label23
+	br_if   	1, $pop62       # 1: down to label21
 # BB#10:                                # %if.then.i4
 	i32.const	$push150=, 0
 	i32.const	$push149=, 0
@@ -869,7 +863,7 @@ f6:                                     # @f6
 	f64.load	$push95=, 0($5)
 	f64.const	$push96=, 0x1.1p4
 	f64.ne  	$push97=, $pop95, $pop96
-	br_if   	0, $pop97       # 0: down to label25
+	br_if   	0, $pop97       # 0: down to label23
 # BB#11:                                # %lor.lhs.false.i6
 	i32.const	$push154=, 0
 	i32.const	$push153=, 0
@@ -885,13 +879,13 @@ f6:                                     # @f6
 	i32.load	$push104=, 0($5)
 	i32.const	$push105=, 129
 	i32.eq  	$push106=, $pop104, $pop105
-	br_if   	2, $pop106      # 2: down to label23
+	br_if   	2, $pop106      # 2: down to label21
 .LBB8_12:                               # %if.then3.i7
-	end_block                       # label25:
+	end_block                       # label23:
 	call    	abort@FUNCTION
 	unreachable
 .LBB8_13:                               # %if.then5.i9
-	end_block                       # label24:
+	end_block                       # label22:
 	i32.const	$push159=, 0
 	i32.load	$5=, pap($pop159)
 	i32.load	$push63=, 0($5)
@@ -906,7 +900,7 @@ f6:                                     # @f6
 	i64.load	$push67=, 0($3)
 	i64.const	$push68=, 14
 	i64.ne  	$push69=, $pop67, $pop68
-	br_if   	2, $pop69       # 2: down to label18
+	br_if   	1, $pop69       # 1: down to label17
 # BB#14:                                # %lor.lhs.false7.i11
 	i32.const	$push164=, 0
 	i32.load	$5=, pap($pop164)
@@ -927,7 +921,7 @@ f6:                                     # @f6
 	i64.const	$push78=, 0
 	i64.const	$push77=, 4613381465357418496
 	i32.call	$push79=, __netf2@FUNCTION, $4, $pop76, $pop78, $pop77
-	br_if   	2, $pop79       # 2: down to label18
+	br_if   	1, $pop79       # 1: down to label17
 # BB#15:                                # %lor.lhs.false9.i13
 	i32.const	$push167=, 0
 	i32.load	$5=, pap($pop167)
@@ -943,9 +937,9 @@ f6:                                     # @f6
 	i32.load	$push86=, 0($3)
 	i32.const	$push87=, 17
 	i32.ne  	$push88=, $pop86, $pop87
-	br_if   	2, $pop88       # 2: down to label18
+	br_if   	1, $pop88       # 1: down to label17
 .LBB8_16:                               # %bar.exit15
-	end_block                       # label23:
+	end_block                       # label21:
 	i32.const	$push107=, 0
 	i32.store	$discard=, bar_arg($pop107), $1
 	i32.const	$9=, 16
@@ -953,12 +947,8 @@ f6:                                     # @f6
 	i32.const	$9=, __stack_pointer
 	i32.store	$10=, 0($9), $10
 	return
-.LBB8_17:                               # %if.then11.i
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_18:                               # %if.then11.i14
-	end_block                       # label18:
+.LBB8_17:                               # %if.then11.i14
+	end_block                       # label17:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -989,11 +979,11 @@ f7:                                     # @f7
 	block
 	i32.const	$push1=, 16392
 	i32.eq  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label28
+	br_if   	0, $pop2        # 0: down to label26
 # BB#1:                                 # %entry
 	i32.const	$push3=, 16390
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	1, $pop4        # 1: down to label27
+	br_if   	1, $pop4        # 1: down to label25
 # BB#2:                                 # %if.then.i
 	i32.const	$push54=, 0
 	i32.const	$push53=, 0
@@ -1010,7 +1000,7 @@ f7:                                     # @f7
 	f64.load	$push38=, 0($1)
 	f64.const	$push39=, 0x1.1p4
 	f64.ne  	$push40=, $pop38, $pop39
-	br_if   	0, $pop40       # 0: down to label29
+	br_if   	0, $pop40       # 0: down to label27
 # BB#3:                                 # %lor.lhs.false.i
 	i32.const	$push58=, 0
 	i32.const	$push57=, 0
@@ -1026,13 +1016,13 @@ f7:                                     # @f7
 	i32.load	$push47=, 0($1)
 	i32.const	$push48=, 129
 	i32.eq  	$push49=, $pop47, $pop48
-	br_if   	2, $pop49       # 2: down to label27
+	br_if   	2, $pop49       # 2: down to label25
 .LBB9_4:                                # %if.then3.i
-	end_block                       # label29:
+	end_block                       # label27:
 	call    	abort@FUNCTION
 	unreachable
 .LBB9_5:                                # %if.then5.i
-	end_block                       # label28:
+	end_block                       # label26:
 	i32.load	$push5=, 12($8)
 	i32.const	$push6=, 7
 	i32.add 	$push7=, $pop5, $pop6
@@ -1045,7 +1035,7 @@ f7:                                     # @f7
 	i64.load	$push10=, 0($1)
 	i64.const	$push11=, 14
 	i64.ne  	$push12=, $pop10, $pop11
-	br_if   	1, $pop12       # 1: down to label26
+	br_if   	1, $pop12       # 1: down to label24
 # BB#6:                                 # %lor.lhs.false7.i
 	i32.load	$push13=, 12($8)
 	i32.const	$push14=, 15
@@ -1064,7 +1054,7 @@ f7:                                     # @f7
 	i64.const	$push21=, 0
 	i64.const	$push20=, 4613381465357418496
 	i32.call	$push22=, __netf2@FUNCTION, $2, $pop19, $pop21, $pop20
-	br_if   	1, $pop22       # 1: down to label26
+	br_if   	1, $pop22       # 1: down to label24
 # BB#7:                                 # %lor.lhs.false9.i
 	i32.load	$push23=, 12($8)
 	i32.const	$push24=, 3
@@ -1078,9 +1068,9 @@ f7:                                     # @f7
 	i32.load	$push29=, 0($1)
 	i32.const	$push30=, 17
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	1, $pop31       # 1: down to label26
+	br_if   	1, $pop31       # 1: down to label24
 .LBB9_8:                                # %bar.exit
-	end_block                       # label27:
+	end_block                       # label25:
 	i32.const	$push50=, 0
 	i32.store	$discard=, bar_arg($pop50), $0
 	i32.const	$6=, 16
@@ -1089,7 +1079,7 @@ f7:                                     # @f7
 	i32.store	$8=, 0($6), $8
 	return
 .LBB9_9:                                # %if.then11.i
-	end_block                       # label26:
+	end_block                       # label24:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1120,11 +1110,11 @@ f8:                                     # @f8
 	block
 	i32.const	$push1=, 16392
 	i32.eq  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label32
+	br_if   	0, $pop2        # 0: down to label30
 # BB#1:                                 # %entry
 	i32.const	$push3=, 16390
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	1, $pop4        # 1: down to label31
+	br_if   	1, $pop4        # 1: down to label29
 # BB#2:                                 # %if.then.i
 	i32.const	$push60=, 0
 	i32.const	$push59=, 0
@@ -1141,7 +1131,7 @@ f8:                                     # @f8
 	f64.load	$push38=, 0($1)
 	f64.const	$push39=, 0x1.1p4
 	f64.ne  	$push40=, $pop38, $pop39
-	br_if   	0, $pop40       # 0: down to label33
+	br_if   	0, $pop40       # 0: down to label31
 # BB#3:                                 # %lor.lhs.false.i
 	i32.const	$push64=, 0
 	i32.const	$push63=, 0
@@ -1157,13 +1147,13 @@ f8:                                     # @f8
 	i32.load	$push47=, 0($1)
 	i32.const	$push48=, 129
 	i32.eq  	$push49=, $pop47, $pop48
-	br_if   	2, $pop49       # 2: down to label31
+	br_if   	2, $pop49       # 2: down to label29
 .LBB10_4:                               # %if.then3.i
-	end_block                       # label33:
+	end_block                       # label31:
 	call    	abort@FUNCTION
 	unreachable
 .LBB10_5:                               # %if.then5.i
-	end_block                       # label32:
+	end_block                       # label30:
 	i32.load	$push5=, 12($8)
 	i32.const	$push6=, 7
 	i32.add 	$push7=, $pop5, $pop6
@@ -1176,7 +1166,7 @@ f8:                                     # @f8
 	i64.load	$push10=, 0($1)
 	i64.const	$push11=, 14
 	i64.ne  	$push12=, $pop10, $pop11
-	br_if   	1, $pop12       # 1: down to label30
+	br_if   	1, $pop12       # 1: down to label28
 # BB#6:                                 # %lor.lhs.false7.i
 	i32.load	$push13=, 12($8)
 	i32.const	$push14=, 15
@@ -1195,7 +1185,7 @@ f8:                                     # @f8
 	i64.const	$push21=, 0
 	i64.const	$push20=, 4613381465357418496
 	i32.call	$push22=, __netf2@FUNCTION, $2, $pop19, $pop21, $pop20
-	br_if   	1, $pop22       # 1: down to label30
+	br_if   	1, $pop22       # 1: down to label28
 # BB#7:                                 # %lor.lhs.false9.i
 	i32.load	$push23=, 12($8)
 	i32.const	$push24=, 3
@@ -1209,9 +1199,9 @@ f8:                                     # @f8
 	i32.load	$push29=, 0($1)
 	i32.const	$push30=, 17
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	1, $pop31       # 1: down to label30
+	br_if   	1, $pop31       # 1: down to label28
 .LBB10_8:                               # %bar.exit
-	end_block                       # label31:
+	end_block                       # label29:
 	i32.load	$1=, 12($8)
 	i32.const	$push50=, 0
 	i32.store	$discard=, bar_arg($pop50), $0
@@ -1232,7 +1222,7 @@ f8:                                     # @f8
 	i32.store	$8=, 0($6), $8
 	return
 .LBB10_9:                               # %if.then11.i
-	end_block                       # label30:
+	end_block                       # label28:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1264,21 +1254,15 @@ main:                                   # @main
 	i32.add 	$7=, $20, $7
 	call    	f2@FUNCTION, $0, $7
 	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push53=, 0
 	i32.load	$push3=, bar_arg($pop53)
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	0, $pop4        # 0: down to label40
+	br_if   	0, $pop4        # 0: down to label32
 # BB#1:                                 # %entry
 	i32.const	$push56=, 0
 	i32.load	$push0=, x($pop56)
 	i32.ne  	$push5=, $pop0, $0
-	br_if   	0, $pop5        # 0: down to label40
+	br_if   	0, $pop5        # 0: down to label32
 # BB#2:                                 # %if.end
 	i64.const	$push6=, 4638813169307877376
 	i64.store	$discard=, 144($20):p2align=4, $pop6
@@ -1289,7 +1273,7 @@ main:                                   # @main
 	f64.load	$push7=, d($pop57)
 	f64.const	$push8=, 0x1.06p7
 	f64.ne  	$push9=, $pop7, $pop8
-	br_if   	1, $pop9        # 1: down to label39
+	br_if   	0, $pop9        # 0: down to label32
 # BB#3:                                 # %if.end4
 	i32.const	$push11=, 8
 	i32.const	$9=, 128
@@ -1307,12 +1291,12 @@ main:                                   # @main
 	i32.load	$push16=, x($pop58)
 	i32.const	$push17=, 16
 	i32.ne  	$push18=, $pop16, $pop17
-	br_if   	2, $pop18       # 2: down to label38
+	br_if   	0, $pop18       # 0: down to label32
 # BB#4:                                 # %if.end4
 	i32.const	$push59=, 0
 	i32.load	$push10=, foo_arg($pop59)
 	i32.ne  	$push19=, $pop10, $0
-	br_if   	2, $pop19       # 2: down to label38
+	br_if   	0, $pop19       # 0: down to label32
 # BB#5:                                 # %if.end9
 	i32.const	$push62=, 8
 	i32.const	$11=, 112
@@ -1330,7 +1314,7 @@ main:                                   # @main
 	i32.load	$push24=, bar_arg($pop61)
 	i32.const	$push60=, 16390
 	i32.ne  	$push25=, $pop24, $pop60
-	br_if   	3, $pop25       # 3: down to label37
+	br_if   	0, $pop25       # 0: down to label32
 # BB#6:                                 # %if.end12
 	i32.const	$push64=, 8
 	i32.const	$13=, 96
@@ -1346,7 +1330,7 @@ main:                                   # @main
 	i32.const	$push63=, 0
 	i32.load	$push29=, bar_arg($pop63)
 	i32.ne  	$push30=, $0, $pop29
-	br_if   	4, $pop30       # 4: down to label36
+	br_if   	0, $pop30       # 0: down to label32
 # BB#7:                                 # %if.end15
 	i32.const	$push71=, 32
 	i32.const	$15=, 48
@@ -1382,7 +1366,7 @@ main:                                   # @main
 	i32.load	$push40=, bar_arg($pop66)
 	i32.const	$push65=, 16392
 	i32.ne  	$push41=, $pop40, $pop65
-	br_if   	5, $pop41       # 5: down to label35
+	br_if   	0, $pop41       # 0: down to label32
 # BB#8:                                 # %if.end18
 	i32.const	$push78=, 32
 	i32.add 	$push43=, $20, $pop78
@@ -1404,13 +1388,13 @@ main:                                   # @main
 	i32.load	$push48=, bar_arg($pop73)
 	i32.const	$push72=, 16392
 	i32.ne  	$push49=, $pop48, $pop72
-	br_if   	6, $pop49       # 6: down to label34
+	br_if   	0, $pop49       # 0: down to label32
 # BB#9:                                 # %if.end18
 	i32.const	$push79=, 0
 	f64.load	$push42=, d($pop79)
 	f64.const	$push50=, 0x1.bp4
 	f64.ne  	$push51=, $pop42, $pop50
-	br_if   	6, $pop51       # 6: down to label34
+	br_if   	0, $pop51       # 0: down to label32
 # BB#10:                                # %if.end23
 	i32.const	$push52=, 0
 	i32.const	$6=, 176
@@ -1418,32 +1402,8 @@ main:                                   # @main
 	i32.const	$6=, __stack_pointer
 	i32.store	$20=, 0($6), $20
 	return  	$pop52
-.LBB11_11:                              # %if.then
-	end_block                       # label40:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_12:                              # %if.then3
-	end_block                       # label39:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_13:                              # %if.then8
-	end_block                       # label38:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_14:                              # %if.then11
-	end_block                       # label37:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_15:                              # %if.then14
-	end_block                       # label36:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_16:                              # %if.then17
-	end_block                       # label35:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_17:                              # %if.then22
-	end_block                       # label34:
+.LBB11_11:                              # %if.then22
+	end_block                       # label32:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/stdarg-2.c.s
+++ b/test/torture-s/stdarg-2.c.s
@@ -1110,20 +1110,10 @@ main:                                   # @main
 	i32.add 	$4=, $16, $4
 	call    	f1@FUNCTION, $0, $4
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push58=, 0
 	i32.load	$push1=, x($pop58)
 	i32.ne  	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label36
+	br_if   	0, $pop2        # 0: down to label26
 # BB#1:                                 # %if.end
 	i32.const	$push3=, 8
 	i32.const	$5=, 144
@@ -1141,7 +1131,7 @@ main:                                   # @main
 	i32.load	$push8=, bar_arg($pop60)
 	i32.const	$push59=, 16386
 	i32.ne  	$push9=, $pop8, $pop59
-	br_if   	1, $pop9        # 1: down to label35
+	br_if   	0, $pop9        # 0: down to label26
 # BB#2:                                 # %if.end3
 	i32.const	$push10=, 2031
 	i32.store	$0=, 128($16):p2align=4, $pop10
@@ -1151,7 +1141,7 @@ main:                                   # @main
 	i32.const	$push61=, 0
 	i32.load	$push11=, x($pop61)
 	i32.ne  	$push12=, $0, $pop11
-	br_if   	2, $pop12       # 2: down to label34
+	br_if   	0, $pop12       # 0: down to label26
 # BB#3:                                 # %if.end6
 	i32.const	$push13=, 18
 	i32.store	$discard=, 112($16):p2align=4, $pop13
@@ -1163,7 +1153,7 @@ main:                                   # @main
 	i32.load	$push15=, bar_arg($pop63)
 	i32.const	$push62=, 4
 	i32.ne  	$push16=, $pop15, $pop62
-	br_if   	3, $pop16       # 3: down to label33
+	br_if   	0, $pop16       # 0: down to label26
 # BB#4:                                 # %if.end9
 	i32.const	$push17=, 16
 	i32.const	$9=, 80
@@ -1187,7 +1177,7 @@ main:                                   # @main
 	i32.load	$push25=, foo_arg($pop64)
 	i32.const	$push26=, 38
 	i32.ne  	$push27=, $pop25, $pop26
-	br_if   	4, $pop27       # 4: down to label32
+	br_if   	0, $pop27       # 0: down to label26
 # BB#5:                                 # %if.end12
 	i32.const	$push28=, 18
 	i32.store	$0=, 64($16):p2align=4, $pop28
@@ -1197,7 +1187,7 @@ main:                                   # @main
 	i32.const	$push65=, 0
 	i32.load	$push29=, x($pop65)
 	i32.ne  	$push30=, $0, $pop29
-	br_if   	5, $pop30       # 5: down to label31
+	br_if   	0, $pop30       # 0: down to label26
 # BB#6:                                 # %if.end15
 	i32.const	$push31=, 7
 	i32.const	$push68=, 0
@@ -1206,7 +1196,7 @@ main:                                   # @main
 	i32.load	$push32=, bar_arg($pop67)
 	i32.const	$push66=, 7
 	i32.ne  	$push33=, $pop32, $pop66
-	br_if   	6, $pop33       # 6: down to label30
+	br_if   	0, $pop33       # 0: down to label26
 # BB#7:                                 # %if.end18
 	i32.const	$push34=, 8
 	i32.const	$13=, 48
@@ -1224,7 +1214,7 @@ main:                                   # @main
 	i32.load	$push38=, foo_arg($pop69)
 	i32.const	$push39=, 2044
 	i32.ne  	$push40=, $pop38, $pop39
-	br_if   	7, $pop40       # 7: down to label29
+	br_if   	0, $pop40       # 0: down to label26
 # BB#8:                                 # %if.end21
 	i32.const	$push41=, 180
 	i32.store	$0=, 32($16):p2align=4, $pop41
@@ -1234,7 +1224,7 @@ main:                                   # @main
 	i32.const	$push71=, 0
 	i32.load	$push42=, x($pop71)
 	i32.ne  	$push43=, $0, $pop42
-	br_if   	8, $pop43       # 8: down to label28
+	br_if   	0, $pop43       # 0: down to label26
 # BB#9:                                 # %if.end24
 	i32.const	$push44=, 10
 	i32.const	$push74=, 0
@@ -1243,7 +1233,7 @@ main:                                   # @main
 	i32.load	$push45=, bar_arg($pop73)
 	i32.const	$push72=, 10
 	i32.ne  	$push46=, $pop45, $pop72
-	br_if   	9, $pop46       # 9: down to label27
+	br_if   	0, $pop46       # 0: down to label26
 # BB#10:                                # %if.end27
 	i32.const	$push47=, 16
 	i32.add 	$push48=, $16, $pop47
@@ -1261,7 +1251,7 @@ main:                                   # @main
 	i32.load	$push55=, foo_arg($pop75)
 	i32.const	$push56=, 2042
 	i32.ne  	$push57=, $pop55, $pop56
-	br_if   	10, $pop57      # 10: down to label26
+	br_if   	0, $pop57       # 0: down to label26
 # BB#11:                                # %if.end30
 	i32.const	$push76=, 0
 	i32.const	$3=, 176
@@ -1269,47 +1259,7 @@ main:                                   # @main
 	i32.const	$3=, __stack_pointer
 	i32.store	$16=, 0($3), $16
 	return  	$pop76
-.LBB13_12:                              # %if.then
-	end_block                       # label36:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_13:                              # %if.then2
-	end_block                       # label35:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_14:                              # %if.then5
-	end_block                       # label34:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_15:                              # %if.then8
-	end_block                       # label33:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_16:                              # %if.then11
-	end_block                       # label32:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_17:                              # %if.then14
-	end_block                       # label31:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_18:                              # %if.then17
-	end_block                       # label30:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_19:                              # %if.then20
-	end_block                       # label29:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_20:                              # %if.then23
-	end_block                       # label28:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_21:                              # %if.then26
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_22:                              # %if.then29
+.LBB13_12:                              # %if.then29
 	end_block                       # label26:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/stdarg-4.c.s
+++ b/test/torture-s/stdarg-4.c.s
@@ -634,19 +634,11 @@ main:                                   # @main
 	i32.add 	$7=, $23, $7
 	call    	f1@FUNCTION, $0, $7
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push85=, 0
 	i32.load	$push5=, x($pop85)
 	i32.const	$push6=, 176
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	0, $pop7        # 0: down to label17
+	br_if   	0, $pop7        # 0: down to label9
 # BB#1:                                 # %if.end
 	i32.const	$push9=, 32
 	i32.const	$8=, 144
@@ -681,18 +673,18 @@ main:                                   # @main
 	i32.load	$push20=, x($pop88)
 	i32.const	$push21=, 100
 	i32.ne  	$push22=, $pop20, $pop21
-	br_if   	1, $pop22       # 1: down to label16
+	br_if   	0, $pop22       # 0: down to label9
 # BB#2:                                 # %if.end
 	i32.const	$push91=, 0
 	i32.load	$push8=, y($pop91)
 	i32.const	$push23=, 30
 	i32.ne  	$push24=, $pop8, $pop23
-	br_if   	1, $pop24       # 1: down to label16
+	br_if   	0, $pop24       # 0: down to label9
 # BB#3:                                 # %if.end4
 	i32.const	$push25=, 0
 	i32.const	$push92=, 0
 	i32.call	$push26=, f3@FUNCTION, $pop25, $pop92
-	br_if   	2, $pop26       # 2: down to label15
+	br_if   	0, $pop26       # 0: down to label9
 # BB#4:                                 # %if.end7
 	i32.const	$push27=, 18
 	i32.store	$discard=, 128($23):p2align=4, $pop27
@@ -702,7 +694,7 @@ main:                                   # @main
 	i32.call	$push29=, f3@FUNCTION, $pop28, $13
 	i32.const	$push30=, 19
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	3, $pop31       # 3: down to label14
+	br_if   	0, $pop31       # 0: down to label9
 # BB#5:                                 # %if.end11
 	i64.const	$push32=, 429496729618
 	i64.store	$1=, 112($23):p2align=4, $pop32
@@ -712,7 +704,7 @@ main:                                   # @main
 	i32.call	$push34=, f3@FUNCTION, $pop33, $14
 	i32.const	$push35=, 120
 	i32.ne  	$push36=, $pop34, $pop35
-	br_if   	4, $pop36       # 4: down to label13
+	br_if   	0, $pop36       # 0: down to label9
 # BB#6:                                 # %if.end15
 	i32.const	$push93=, 8
 	i32.const	$15=, 96
@@ -727,7 +719,7 @@ main:                                   # @main
 	i32.call	$push40=, f3@FUNCTION, $pop39, $16
 	i32.const	$push41=, 421
 	i32.ne  	$push42=, $pop40, $pop41
-	br_if   	5, $pop42       # 5: down to label12
+	br_if   	0, $pop42       # 0: down to label9
 # BB#7:                                 # %if.end19
 	i32.const	$push95=, 8
 	i32.const	$17=, 80
@@ -743,7 +735,7 @@ main:                                   # @main
 	i32.call	$push46=, f3@FUNCTION, $pop94, $18
 	i32.const	$push47=, 243
 	i32.ne  	$push48=, $pop46, $pop47
-	br_if   	6, $pop48       # 6: down to label11
+	br_if   	0, $pop48       # 0: down to label9
 # BB#8:                                 # %if.end23
 	i32.const	$push50=, 24
 	i32.const	$19=, 48
@@ -773,13 +765,13 @@ main:                                   # @main
 	i32.load	$push59=, x($pop96)
 	i32.const	$push60=, 43
 	i32.ne  	$push61=, $pop59, $pop60
-	br_if   	7, $pop61       # 7: down to label10
+	br_if   	0, $pop61       # 0: down to label9
 # BB#9:                                 # %if.end23
 	i32.const	$push99=, 0
 	i32.load	$push49=, y($pop99)
 	i32.const	$push62=, 6
 	i32.ne  	$push63=, $pop49, $pop62
-	br_if   	7, $pop63       # 7: down to label10
+	br_if   	0, $pop63       # 0: down to label9
 # BB#10:                                # %if.end28
 	i32.const	$push65=, 32
 	i32.add 	$push66=, $23, $pop65
@@ -805,13 +797,13 @@ main:                                   # @main
 	i32.load	$push79=, x($pop100)
 	i32.const	$push80=, 144
 	i32.ne  	$push81=, $pop79, $pop80
-	br_if   	8, $pop81       # 8: down to label9
+	br_if   	0, $pop81       # 0: down to label9
 # BB#11:                                # %if.end28
 	i32.const	$push101=, 0
 	i32.load	$push64=, y($pop101)
 	i32.const	$push82=, 28
 	i32.ne  	$push83=, $pop64, $pop82
-	br_if   	8, $pop83       # 8: down to label9
+	br_if   	0, $pop83       # 0: down to label9
 # BB#12:                                # %if.end33
 	i32.const	$push84=, 0
 	i32.const	$4=, 224
@@ -819,39 +811,7 @@ main:                                   # @main
 	i32.const	$4=, __stack_pointer
 	i32.store	$23=, 0($4), $23
 	return  	$pop84
-.LBB7_13:                               # %if.then
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_14:                               # %if.then3
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_15:                               # %if.then6
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_16:                               # %if.then10
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_17:                               # %if.then14
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_18:                               # %if.then18
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_19:                               # %if.then22
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_20:                               # %if.then27
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_21:                               # %if.then32
+.LBB7_13:                               # %if.then32
 	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/strcmp-1.c.s
+++ b/test/torture-s/strcmp-1.c.s
@@ -10,43 +10,33 @@ test:                                   # @test
 	i32.call	$1=, strcmp@FUNCTION, $0, $1
 	block
 	block
-	block
-	block
 	i32.const	$push0=, -1
 	i32.gt_s	$push1=, $2, $pop0
-	br_if   	0, $pop1        # 0: down to label3
+	br_if   	0, $pop1        # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push2=, 0
 	i32.ge_s	$push3=, $1, $pop2
-	br_if   	1, $pop3        # 1: down to label2
+	br_if   	1, $pop3        # 1: down to label0
 .LBB0_2:                                # %if.else
-	end_block                       # label3:
+	end_block                       # label1:
 	block
-	br_if   	0, $2           # 0: down to label4
+	br_if   	0, $2           # 0: down to label2
 # BB#3:                                 # %if.else
-	br_if   	2, $1           # 2: down to label1
+	br_if   	1, $1           # 1: down to label0
 .LBB0_4:                                # %if.else6
-	end_block                       # label4:
+	end_block                       # label2:
 	block
 	i32.const	$push4=, 1
 	i32.lt_s	$push5=, $2, $pop4
-	br_if   	0, $pop5        # 0: down to label5
+	br_if   	0, $pop5        # 0: down to label3
 # BB#5:                                 # %if.else6
 	i32.const	$push6=, 0
 	i32.le_s	$push7=, $1, $pop6
-	br_if   	3, $pop7        # 3: down to label0
+	br_if   	1, $pop7        # 1: down to label0
 .LBB0_6:                                # %if.end12
-	end_block                       # label5:
+	end_block                       # label3:
 	return
-.LBB0_7:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then5
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then10
+.LBB0_7:                                # %if.then10
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -70,32 +60,25 @@ main:                                   # @main
                                         #       Child Loop BB1_3 Depth 3
 	block
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label15:
+	loop                            # label6:
 	i32.const	$2=, 0
 	i32.const	$3=, u2
 .LBB1_2:                                # %for.cond4.preheader
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Loop Header: Depth=2
                                         #       Child Loop BB1_3 Depth 3
-	loop                            # label17:
+	loop                            # label8:
 	i32.const	$4=, 0
 .LBB1_3:                                # %for.cond7.preheader
                                         #   Parent Loop BB1_1 Depth=1
                                         #     Parent Loop BB1_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop                            # label19:
+	loop                            # label10:
 	i32.const	$5=, u1
 	block
 	i32.const	$push50=, 0
 	i32.eq  	$push51=, $0, $pop50
-	br_if   	0, $pop51       # 0: down to label21
+	br_if   	0, $pop51       # 0: down to label12
 # BB#4:                                 # %for.body9.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push29=, u1
@@ -104,12 +87,12 @@ main:                                   # @main
 	copy_local	$5=, $1
 .LBB1_5:                                # %for.cond10.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label21:
+	end_block                       # label12:
 	copy_local	$6=, $5
 	block
 	i32.const	$push52=, 0
 	i32.eq  	$push53=, $4, $pop52
-	br_if   	0, $pop53       # 0: down to label22
+	br_if   	0, $pop53       # 0: down to label13
 # BB#6:                                 # %for.body12.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push30=, 97
@@ -117,7 +100,7 @@ main:                                   # @main
 	i32.add 	$6=, $pop0, $4
 .LBB1_7:                                # %for.cond17.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label22:
+	end_block                       # label13:
 	i64.const	$push33=, 8680820740569200760
 	i64.store	$9=, 0($6):p2align=0, $pop33
 	i32.const	$push32=, 8
@@ -128,7 +111,7 @@ main:                                   # @main
 	block
 	i32.const	$push54=, 0
 	i32.eq  	$push55=, $2, $pop54
-	br_if   	0, $pop55       # 0: down to label23
+	br_if   	0, $pop55       # 0: down to label14
 # BB#8:                                 # %for.body26.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push35=, u2
@@ -137,12 +120,12 @@ main:                                   # @main
 	copy_local	$7=, $3
 .LBB1_9:                                # %for.cond31.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label23:
+	end_block                       # label14:
 	copy_local	$8=, $7
 	block
 	i32.const	$push56=, 0
 	i32.eq  	$push57=, $4, $pop56
-	br_if   	0, $pop57       # 0: down to label24
+	br_if   	0, $pop57       # 0: down to label15
 # BB#10:                                # %for.body33.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push36=, 97
@@ -150,7 +133,7 @@ main:                                   # @main
 	i32.add 	$8=, $pop2, $4
 .LBB1_11:                               # %for.cond38.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label24:
+	end_block                       # label15:
 	i64.store	$discard=, 0($8):p2align=0, $9
 	i32.const	$push38=, 8
 	i32.add 	$push3=, $8, $pop38
@@ -159,7 +142,7 @@ main:                                   # @main
 	i32.store8	$push4=, 0($6), $pop37
 	i32.store8	$11=, 0($8), $pop4
 	i32.call	$push5=, strcmp@FUNCTION, $5, $7
-	br_if   	6, $pop5        # 6: down to label14
+	br_if   	6, $pop5        # 6: down to label5
 # BB#12:                                # %test.exit
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store8	$discard=, 0($8), $11
@@ -167,14 +150,14 @@ main:                                   # @main
 	i32.store16	$10=, 0($6):p2align=0, $pop39
 	i32.call	$push6=, strcmp@FUNCTION, $5, $7
 	i32.le_s	$push7=, $pop6, $11
-	br_if   	7, $pop7        # 7: down to label13
+	br_if   	6, $pop7        # 6: down to label5
 # BB#13:                                # %test.exit157
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($8):p2align=0, $10
 	i32.store8	$discard=, 0($6), $11
 	i32.call	$push8=, strcmp@FUNCTION, $5, $7
 	i32.ge_s	$push9=, $pop8, $11
-	br_if   	8, $pop9        # 8: down to label12
+	br_if   	6, $pop9        # 6: down to label5
 # BB#14:                                # %test.exit162
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push41=, 98
@@ -183,14 +166,14 @@ main:                                   # @main
 	i32.store16	$12=, 0($8):p2align=0, $pop40
 	i32.call	$push10=, strcmp@FUNCTION, $5, $7
 	i32.ge_s	$push11=, $pop10, $11
-	br_if   	9, $pop11       # 9: down to label11
+	br_if   	6, $pop11       # 6: down to label5
 # BB#15:                                # %test.exit168
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $12
 	i32.store16	$discard=, 0($8):p2align=0, $10
 	i32.call	$push12=, strcmp@FUNCTION, $5, $7
 	i32.le_s	$push13=, $pop12, $11
-	br_if   	10, $pop13      # 10: down to label10
+	br_if   	6, $pop13       # 6: down to label5
 # BB#16:                                # %test.exit174
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $10
@@ -198,14 +181,14 @@ main:                                   # @main
 	i32.store16	$12=, 0($8):p2align=0, $pop42
 	i32.call	$push14=, strcmp@FUNCTION, $5, $7
 	i32.ge_s	$push15=, $pop14, $11
-	br_if   	11, $pop15      # 11: down to label9
+	br_if   	6, $pop15       # 6: down to label5
 # BB#17:                                # %test.exit180
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($8):p2align=0, $10
 	i32.store16	$10=, 0($6):p2align=0, $12
 	i32.call	$push16=, strcmp@FUNCTION, $5, $7
 	i32.le_s	$push17=, $pop16, $11
-	br_if   	12, $pop17      # 12: down to label8
+	br_if   	6, $pop17       # 6: down to label5
 # BB#18:                                # %test.exit186
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $10
@@ -213,80 +196,52 @@ main:                                   # @main
 	i32.store16	$12=, 0($8):p2align=0, $pop43
 	i32.call	$push18=, strcmp@FUNCTION, $5, $7
 	i32.ge_s	$push19=, $pop18, $11
-	br_if   	13, $pop19      # 13: down to label7
+	br_if   	6, $pop19       # 6: down to label5
 # BB#19:                                # %test.exit192
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $12
 	i32.store16	$discard=, 0($8):p2align=0, $10
 	i32.call	$push20=, strcmp@FUNCTION, $5, $7
 	i32.le_s	$push21=, $pop20, $11
-	br_if   	14, $pop21      # 14: down to label6
+	br_if   	7, $pop21       # 7: down to label4
 # BB#20:                                # %for.cond4
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push27=, 1
 	i32.add 	$4=, $4, $pop27
 	i32.const	$push26=, 63
 	i32.le_u	$push22=, $4, $pop26
-	br_if   	0, $pop22       # 0: up to label19
+	br_if   	0, $pop22       # 0: up to label10
 # BB#21:                                # %for.inc79
                                         #   in Loop: Header=BB1_2 Depth=2
-	end_loop                        # label20:
+	end_loop                        # label11:
 	i32.const	$push46=, 1
 	i32.add 	$2=, $2, $pop46
 	i32.const	$push45=, 1
 	i32.add 	$3=, $3, $pop45
 	i32.const	$push44=, 8
 	i32.lt_u	$push23=, $2, $pop44
-	br_if   	0, $pop23       # 0: up to label17
+	br_if   	0, $pop23       # 0: up to label8
 # BB#22:                                # %for.inc82
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_loop                        # label18:
+	end_loop                        # label9:
 	i32.const	$push49=, 1
 	i32.add 	$0=, $0, $pop49
 	i32.const	$push48=, 1
 	i32.add 	$1=, $1, $pop48
 	i32.const	$push47=, 8
 	i32.lt_u	$push24=, $0, $pop47
-	br_if   	0, $pop24       # 0: up to label15
+	br_if   	0, $pop24       # 0: up to label6
 # BB#23:                                # %for.end84
-	end_loop                        # label16:
+	end_loop                        # label7:
 	i32.const	$push25=, 0
 	call    	exit@FUNCTION, $pop25
 	unreachable
-.LBB1_24:                               # %if.then5.i
-	end_block                       # label14:
+.LBB1_24:                               # %if.then.i189
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_25:                               # %if.then10.i
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_26:                               # %if.then.i
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_27:                               # %if.then.i165
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_28:                               # %if.then10.i173
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_29:                               # %if.then.i177
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_30:                               # %if.then10.i185
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_31:                               # %if.then.i189
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_32:                               # %if.then10.i197
-	end_block                       # label6:
+.LBB1_25:                               # %if.then10.i197
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/strcpy-1.c.s
+++ b/test/torture-s/strcpy-1.c.s
@@ -15,13 +15,10 @@ main:                                   # @main
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_7 Depth 4
-                                        #         Child Loop BB0_10 Depth 4
+                                        #         Child Loop BB0_11 Depth 4
 	block
 	block
-	block
-	block
-	block
-	loop                            # label5:
+	loop                            # label2:
 	i32.const	$push49=, u1
 	i32.add 	$1=, $0, $pop49
 	i32.const	$2=, 0
@@ -31,8 +28,8 @@ main:                                   # @main
                                         #       Child Loop BB0_3 Depth 3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_7 Depth 4
-                                        #         Child Loop BB0_10 Depth 4
-	loop                            # label7:
+                                        #         Child Loop BB0_11 Depth 4
+	loop                            # label4:
 	i32.const	$push51=, u2
 	i32.add 	$3=, $2, $pop51
 	i32.const	$push50=, 65
@@ -44,8 +41,8 @@ main:                                   # @main
                                         # =>    This Loop Header: Depth=3
                                         #         Child Loop BB0_4 Depth 4
                                         #         Child Loop BB0_7 Depth 4
-                                        #         Child Loop BB0_10 Depth 4
-	loop                            # label9:
+                                        #         Child Loop BB0_11 Depth 4
+	loop                            # label6:
 	i32.const	$push54=, u1
 	i32.const	$push53=, 97
 	i32.const	$push52=, 97
@@ -57,7 +54,7 @@ main:                                   # @main
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop                            # label11:
+	loop                            # label8:
 	i32.const	$push60=, 65
 	i32.const	$push59=, 24
 	i32.shl 	$push0=, $6, $pop59
@@ -71,16 +68,16 @@ main:                                   # @main
 	i32.add 	$6=, $pop4, $pop56
 	i32.const	$push55=, 1
 	i32.add 	$8=, $8, $pop55
-	br_if   	0, $8           # 0: up to label11
+	br_if   	0, $8           # 0: up to label8
 # BB#5:                                 # %for.end
                                         #   in Loop: Header=BB0_3 Depth=3
-	end_loop                        # label12:
+	end_loop                        # label9:
 	i32.add 	$push5=, $5, $2
 	i32.const	$push61=, 0
 	i32.store8	$discard=, u2($pop5), $pop61
 	i32.call	$push6=, strcpy@FUNCTION, $1, $3
 	i32.ne  	$push7=, $pop6, $1
-	br_if   	9, $pop7        # 9: down to label1
+	br_if   	6, $pop7        # 6: down to label1
 # BB#6:                                 # %for.cond21.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
 	i32.const	$8=, 0
@@ -88,177 +85,167 @@ main:                                   # @main
 	block
 	i32.const	$push62=, 0
 	i32.le_s	$push8=, $0, $pop62
-	br_if   	0, $pop8        # 0: down to label13
+	br_if   	0, $pop8        # 0: down to label10
 .LBB0_7:                                # %for.body24
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop                            # label14:
-	i32.load8_u	$push9=, u1($8)
+	loop                            # label11:
+	copy_local	$push65=, $8
+	tee_local	$push64=, $6=, $pop65
+	i32.load8_u	$push9=, u1($pop64)
 	i32.const	$push63=, 97
 	i32.ne  	$push10=, $pop9, $pop63
-	br_if   	10, $pop10      # 10: down to label3
+	br_if   	9, $pop10       # 9: down to label1
 # BB#8:                                 # %for.inc30
                                         #   in Loop: Header=BB0_7 Depth=4
-	i32.const	$push65=, u1+1
-	i32.add 	$7=, $8, $pop65
-	i32.const	$push64=, 1
-	i32.add 	$6=, $8, $pop64
-	copy_local	$8=, $6
-	i32.lt_s	$push11=, $6, $0
-	br_if   	0, $pop11       # 0: up to label14
-.LBB0_9:                                # %for.body38.preheader
+	i32.const	$push66=, 1
+	i32.add 	$8=, $6, $pop66
+	i32.lt_s	$push11=, $8, $0
+	br_if   	0, $pop11       # 0: up to label11
+# BB#9:                                 #   in Loop: Header=BB0_3 Depth=3
+	end_loop                        # label12:
+	i32.const	$push67=, u1+1
+	i32.add 	$7=, $6, $pop67
+.LBB0_10:                               # %for.body38.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
-	end_loop                        # label15:
-	end_block                       # label13:
+	end_block                       # label10:
 	i32.const	$8=, 0
 	copy_local	$6=, $4
-.LBB0_10:                               # %for.body38
+.LBB0_11:                               # %for.body38
                                         #   Parent Loop BB0_1 Depth=1
                                         #     Parent Loop BB0_2 Depth=2
                                         #       Parent Loop BB0_3 Depth=3
                                         # =>      This Inner Loop Header: Depth=4
-	loop                            # label16:
+	loop                            # label13:
 	i32.add 	$push16=, $7, $8
 	i32.load8_u	$push17=, 0($pop16)
-	i32.const	$push72=, 65
-	i32.const	$push71=, 24
-	i32.shl 	$push12=, $6, $pop71
-	i32.const	$push70=, 24
-	i32.shr_s	$push13=, $pop12, $pop70
-	i32.const	$push69=, 95
-	i32.gt_s	$push14=, $pop13, $pop69
-	i32.select	$push68=, $pop72, $6, $pop14
-	tee_local	$push67=, $6=, $pop68
-	i32.const	$push66=, 255
-	i32.and 	$push15=, $pop67, $pop66
+	i32.const	$push74=, 65
+	i32.const	$push73=, 24
+	i32.shl 	$push12=, $6, $pop73
+	i32.const	$push72=, 24
+	i32.shr_s	$push13=, $pop12, $pop72
+	i32.const	$push71=, 95
+	i32.gt_s	$push14=, $pop13, $pop71
+	i32.select	$push70=, $pop74, $6, $pop14
+	tee_local	$push69=, $6=, $pop70
+	i32.const	$push68=, 255
+	i32.and 	$push15=, $pop69, $pop68
 	i32.ne  	$push18=, $pop17, $pop15
-	br_if   	8, $pop18       # 8: down to label4
-# BB#11:                                # %for.inc50
-                                        #   in Loop: Header=BB0_10 Depth=4
-	i32.const	$push74=, 1
-	i32.add 	$8=, $8, $pop74
-	i32.const	$push73=, 1
-	i32.add 	$6=, $6, $pop73
+	br_if   	8, $pop18       # 8: down to label1
+# BB#12:                                # %for.inc50
+                                        #   in Loop: Header=BB0_11 Depth=4
+	i32.const	$push76=, 1
+	i32.add 	$8=, $8, $pop76
+	i32.const	$push75=, 1
+	i32.add 	$6=, $6, $pop75
 	i32.lt_s	$push19=, $8, $5
-	br_if   	0, $pop19       # 0: up to label16
-# BB#12:                                # %for.end54
+	br_if   	0, $pop19       # 0: up to label13
+# BB#13:                                # %for.end54
                                         #   in Loop: Header=BB0_3 Depth=3
-	end_loop                        # label17:
-	i32.add 	$push76=, $7, $8
-	tee_local	$push75=, $8=, $pop76
-	i32.load8_u	$push20=, 0($pop75)
-	br_if   	10, $pop20      # 10: down to label0
-# BB#13:                                # %for.cond61.preheader
+	end_loop                        # label14:
+	i32.add 	$push78=, $7, $8
+	tee_local	$push77=, $8=, $pop78
+	i32.load8_u	$push20=, 0($pop77)
+	br_if   	6, $pop20       # 6: down to label1
+# BB#14:                                # %for.cond61.preheader
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push78=, 1
-	i32.add 	$push21=, $8, $pop78
+	i32.const	$push80=, 1
+	i32.add 	$push21=, $8, $pop80
 	i32.load8_u	$push22=, 0($pop21)
-	i32.const	$push77=, 97
-	i32.ne  	$push23=, $pop22, $pop77
-	br_if   	8, $pop23       # 8: down to label2
-# BB#14:                                # %for.cond61
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push80=, 2
-	i32.add 	$push24=, $8, $pop80
-	i32.load8_u	$push25=, 0($pop24)
 	i32.const	$push79=, 97
-	i32.ne  	$push26=, $pop25, $pop79
-	br_if   	8, $pop26       # 8: down to label2
-# BB#15:                                # %for.cond61.1
+	i32.ne  	$push23=, $pop22, $pop79
+	br_if   	7, $pop23       # 7: down to label0
+# BB#15:                                # %for.cond61
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push86=, 3
-	i32.add 	$push27=, $8, $pop86
+	i32.const	$push82=, 2
+	i32.add 	$push24=, $8, $pop82
+	i32.load8_u	$push25=, 0($pop24)
+	i32.const	$push81=, 97
+	i32.ne  	$push26=, $pop25, $pop81
+	br_if   	7, $pop26       # 7: down to label0
+# BB#16:                                # %for.cond61.1
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push88=, 3
+	i32.add 	$push27=, $8, $pop88
 	i32.load8_u	$push28=, 0($pop27)
-	i32.const	$push85=, 97
-	i32.ne  	$push29=, $pop28, $pop85
-	br_if   	8, $pop29       # 8: down to label2
-# BB#16:                                # %for.cond61.2
-                                        #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push88=, 4
-	i32.add 	$push30=, $8, $pop88
-	i32.load8_u	$push31=, 0($pop30)
 	i32.const	$push87=, 97
-	i32.ne  	$push32=, $pop31, $pop87
-	br_if   	8, $pop32       # 8: down to label2
-# BB#17:                                # %for.cond61.3
+	i32.ne  	$push29=, $pop28, $pop87
+	br_if   	7, $pop29       # 7: down to label0
+# BB#17:                                # %for.cond61.2
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push90=, 5
-	i32.add 	$push33=, $8, $pop90
-	i32.load8_u	$push34=, 0($pop33)
+	i32.const	$push90=, 4
+	i32.add 	$push30=, $8, $pop90
+	i32.load8_u	$push31=, 0($pop30)
 	i32.const	$push89=, 97
-	i32.ne  	$push35=, $pop34, $pop89
-	br_if   	8, $pop35       # 8: down to label2
-# BB#18:                                # %for.cond61.4
+	i32.ne  	$push32=, $pop31, $pop89
+	br_if   	7, $pop32       # 7: down to label0
+# BB#18:                                # %for.cond61.3
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push92=, 6
-	i32.add 	$push36=, $8, $pop92
-	i32.load8_u	$push37=, 0($pop36)
+	i32.const	$push92=, 5
+	i32.add 	$push33=, $8, $pop92
+	i32.load8_u	$push34=, 0($pop33)
 	i32.const	$push91=, 97
-	i32.ne  	$push38=, $pop37, $pop91
-	br_if   	8, $pop38       # 8: down to label2
-# BB#19:                                # %for.cond61.5
+	i32.ne  	$push35=, $pop34, $pop91
+	br_if   	7, $pop35       # 7: down to label0
+# BB#19:                                # %for.cond61.4
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push94=, 7
-	i32.add 	$push39=, $8, $pop94
-	i32.load8_u	$push40=, 0($pop39)
+	i32.const	$push94=, 6
+	i32.add 	$push36=, $8, $pop94
+	i32.load8_u	$push37=, 0($pop36)
 	i32.const	$push93=, 97
-	i32.ne  	$push41=, $pop40, $pop93
-	br_if   	8, $pop41       # 8: down to label2
-# BB#20:                                # %for.cond61.6
+	i32.ne  	$push38=, $pop37, $pop93
+	br_if   	7, $pop38       # 7: down to label0
+# BB#20:                                # %for.cond61.5
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push96=, 8
-	i32.add 	$push42=, $8, $pop96
-	i32.load8_u	$push43=, 0($pop42)
+	i32.const	$push96=, 7
+	i32.add 	$push39=, $8, $pop96
+	i32.load8_u	$push40=, 0($pop39)
 	i32.const	$push95=, 97
-	i32.ne  	$push44=, $pop43, $pop95
-	br_if   	8, $pop44       # 8: down to label2
-# BB#21:                                # %for.cond61.7
+	i32.ne  	$push41=, $pop40, $pop95
+	br_if   	7, $pop41       # 7: down to label0
+# BB#21:                                # %for.cond61.6
                                         #   in Loop: Header=BB0_3 Depth=3
-	i32.const	$push98=, 1
-	i32.add 	$5=, $5, $pop98
-	i32.const	$push97=, 80
-	i32.lt_u	$push45=, $5, $pop97
-	br_if   	0, $pop45       # 0: up to label9
-# BB#22:                                # %for.inc77
+	i32.const	$push98=, 8
+	i32.add 	$push42=, $8, $pop98
+	i32.load8_u	$push43=, 0($pop42)
+	i32.const	$push97=, 97
+	i32.ne  	$push44=, $pop43, $pop97
+	br_if   	7, $pop44       # 7: down to label0
+# BB#22:                                # %for.cond61.7
+                                        #   in Loop: Header=BB0_3 Depth=3
+	i32.const	$push100=, 1
+	i32.add 	$5=, $5, $pop100
+	i32.const	$push99=, 80
+	i32.lt_u	$push45=, $5, $pop99
+	br_if   	0, $pop45       # 0: up to label6
+# BB#23:                                # %for.inc77
                                         #   in Loop: Header=BB0_2 Depth=2
-	end_loop                        # label10:
-	i32.const	$push82=, 1
-	i32.add 	$2=, $2, $pop82
-	i32.const	$push81=, 8
-	i32.lt_u	$push46=, $2, $pop81
-	br_if   	0, $pop46       # 0: up to label7
-# BB#23:                                # %for.inc80
-                                        #   in Loop: Header=BB0_1 Depth=1
-	end_loop                        # label8:
+	end_loop                        # label7:
 	i32.const	$push84=, 1
-	i32.add 	$0=, $0, $pop84
+	i32.add 	$2=, $2, $pop84
 	i32.const	$push83=, 8
-	i32.lt_u	$push47=, $0, $pop83
-	br_if   	0, $pop47       # 0: up to label5
-# BB#24:                                # %for.end82
-	end_loop                        # label6:
+	i32.lt_u	$push46=, $2, $pop83
+	br_if   	0, $pop46       # 0: up to label4
+# BB#24:                                # %for.inc80
+                                        #   in Loop: Header=BB0_1 Depth=1
+	end_loop                        # label5:
+	i32.const	$push86=, 1
+	i32.add 	$0=, $0, $pop86
+	i32.const	$push85=, 8
+	i32.lt_u	$push47=, $0, $pop85
+	br_if   	0, $pop47       # 0: up to label2
+# BB#25:                                # %for.end82
+	end_loop                        # label3:
 	i32.const	$push48=, 0
 	call    	exit@FUNCTION, $pop48
 	unreachable
-.LBB0_25:                               # %if.then48
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_26:                               # %if.then28
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_27:                               # %if.then68
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_28:                               # %if.then19
+.LBB0_26:                               # %if.then59
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
-.LBB0_29:                               # %if.then59
+.LBB0_27:                               # %if.then68
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/string-opt-17.c.s
+++ b/test/torture-s/string-opt-17.c.s
@@ -101,16 +101,14 @@ main:                                   # @main
 	i32.const	$3=, 4
 	i32.add 	$3=, $4, $3
 	block
-	block
-	block
 	i32.call	$push6=, memcmp@FUNCTION, $3, $pop4, $pop5
-	br_if   	0, $pop6        # 0: down to label4
+	br_if   	0, $pop6        # 0: down to label2
 # BB#1:                                 # %if.end
 	i32.const	$push15=, 0
 	i32.load	$push7=, check2.r($pop15)
 	i32.const	$push8=, 5
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	1, $pop9        # 1: down to label3
+	br_if   	0, $pop9        # 0: down to label2
 # BB#2:                                 # %test2.exit
 	i32.const	$push16=, 0
 	i32.const	$push10=, 6
@@ -120,20 +118,12 @@ main:                                   # @main
 	i32.const	$push12=, 1
 	i32.const	$push18=, 0
 	i32.eq  	$push19=, $pop12, $pop18
-	br_if   	2, $pop19       # 2: down to label2
+	br_if   	0, $pop19       # 0: down to label2
 # BB#3:                                 # %if.end8
 	i32.const	$push17=, 0
 	call    	exit@FUNCTION, $pop17
 	unreachable
-.LBB3_4:                                # %if.then
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_5:                                # %if.then.i.i
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_6:                                # %if.then7
+.LBB3_4:                                # %if.then7
 	end_block                       # label2:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/string-opt-5.c.s
+++ b/test/torture-s/string-opt-5.c.s
@@ -15,30 +15,13 @@ main:                                   # @main
 	i32.const	$5=, __stack_pointer
 	i32.store	$7=, 0($5), $7
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push138=, 0
 	i32.load	$push137=, bar($pop138)
 	tee_local	$push136=, $1=, $pop137
 	i32.call	$push5=, strlen@FUNCTION, $pop136
 	i32.const	$push6=, 8
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	0, $pop7        # 0: down to label17
+	br_if   	0, $pop7        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push144=, 0
 	i32.const	$push143=, 0
@@ -54,11 +37,11 @@ main:                                   # @main
 	i32.call	$push12=, strlen@FUNCTION, $pop11
 	i32.const	$push13=, 6
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	1, $pop14       # 1: down to label16
+	br_if   	0, $pop14       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push15=, 7
 	i32.ne  	$push16=, $2, $pop15
-	br_if   	2, $pop16       # 2: down to label15
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end16
 	i32.const	$push145=, 0
 	i32.const	$push17=, 3
@@ -71,7 +54,7 @@ main:                                   # @main
 	i32.call	$push24=, strlen@FUNCTION, $pop23
 	i32.const	$push25=, 10
 	i32.ne  	$push26=, $pop24, $pop25
-	br_if   	3, $pop26       # 3: down to label14
+	br_if   	0, $pop26       # 0: down to label0
 # BB#4:                                 # %if.end26
 	i32.const	$push146=, 0
 	i32.const	$push27=, -3
@@ -81,13 +64,13 @@ main:                                   # @main
 	i32.add 	$push29=, $3, $pop28
 	i32.const	$push30=, .L.str.2
 	i32.call	$push31=, strcmp@FUNCTION, $pop29, $pop30
-	br_if   	4, $pop31       # 4: down to label13
+	br_if   	0, $pop31       # 0: down to label0
 # BB#5:                                 # %if.end33
 	i32.const	$push148=, .L.str.1
 	i32.call	$push32=, strcmp@FUNCTION, $pop148, $1
 	i32.const	$push147=, 0
 	i32.ge_s	$push33=, $pop32, $pop147
-	br_if   	5, $pop33       # 5: down to label12
+	br_if   	0, $pop33       # 0: down to label0
 # BB#6:                                 # %if.end37
 	i32.const	$push151=, 0
 	i32.const	$push34=, -2
@@ -100,7 +83,7 @@ main:                                   # @main
 	i32.call	$push38=, strcmp@FUNCTION, $pop150, $pop37
 	i32.const	$push149=, 0
 	i32.ge_s	$push39=, $pop38, $pop149
-	br_if   	6, $pop39       # 6: down to label11
+	br_if   	0, $pop39       # 0: down to label0
 # BB#7:                                 # %if.end47
 	i32.const	$push41=, 0
 	i32.const	$push40=, -1
@@ -114,7 +97,7 @@ main:                                   # @main
 	i32.call	$push47=, strchr@FUNCTION, $pop45, $pop46
 	i32.const	$push48=, .L.str.1+9
 	i32.ne  	$push49=, $pop47, $pop48
-	br_if   	7, $pop49       # 7: down to label10
+	br_if   	0, $pop49       # 0: down to label0
 # BB#8:                                 # %if.end58
 	i32.const	$push50=, 111
 	i32.call	$push153=, strchr@FUNCTION, $1, $pop50
@@ -122,21 +105,21 @@ main:                                   # @main
 	i32.const	$push51=, 4
 	i32.add 	$push52=, $1, $pop51
 	i32.ne  	$push53=, $pop152, $pop52
-	br_if   	8, $pop53       # 8: down to label9
+	br_if   	0, $pop53       # 0: down to label0
 # BB#9:                                 # %if.end63
 	i32.call	$push54=, strlen@FUNCTION, $1
 	i32.const	$push55=, 8
 	i32.ne  	$push56=, $pop54, $pop55
-	br_if   	9, $pop56       # 9: down to label8
+	br_if   	0, $pop56       # 0: down to label0
 # BB#10:                                # %if.end68
 	i32.const	$push57=, 120
 	i32.call	$push58=, strrchr@FUNCTION, $1, $pop57
-	br_if   	10, $pop58      # 10: down to label7
+	br_if   	0, $pop58       # 0: down to label0
 # BB#11:                                # %if.end72
 	i32.const	$push59=, 111
 	i32.call	$push60=, strrchr@FUNCTION, $1, $pop59
 	i32.ne  	$push61=, $pop60, $0
-	br_if   	11, $pop61      # 11: down to label6
+	br_if   	0, $pop61       # 0: down to label0
 # BB#12:                                # %if.end77
 	i32.const	$push62=, 0
 	i32.const	$push156=, 0
@@ -155,13 +138,13 @@ main:                                   # @main
 	i32.const	$push70=, .L.str.3
 	i32.add 	$push71=, $pop69, $pop70
 	i32.call	$push72=, strcmp@FUNCTION, $pop66, $pop71
-	br_if   	12, $pop72      # 12: down to label5
+	br_if   	0, $pop72       # 0: down to label0
 # BB#13:                                # %if.end86
-	br_if   	13, $1          # 13: down to label4
+	br_if   	0, $1           # 0: down to label0
 # BB#14:                                # %if.end86
 	i32.const	$push157=, 6
 	i32.ne  	$push73=, $3, $pop157
-	br_if   	13, $pop73      # 13: down to label4
+	br_if   	0, $pop73       # 0: down to label0
 # BB#15:                                # %if.end90
 	i32.const	$push74=, 5
 	i32.or  	$push75=, $7, $pop74
@@ -182,7 +165,7 @@ main:                                   # @main
 	i32.store	$discard=, 0($pop158):p2align=0, $pop81
 	i32.const	$push82=, .L.str.4
 	i32.call	$push83=, strcmp@FUNCTION, $3, $pop82
-	br_if   	14, $pop83      # 14: down to label3
+	br_if   	0, $pop83       # 0: down to label0
 # BB#16:                                # %if.end108
 	i32.const	$push86=, 64
 	i32.call	$discard=, memset@FUNCTION, $7, $2, $pop86
@@ -190,28 +173,25 @@ main:                                   # @main
 	i32.store	$discard=, y($1), $pop88
 	i32.const	$push87=, 7
 	i32.store	$2=, x($1), $pop87
-	block
-	block
-	block
 	i32.const	$push90=, .L.str.5+1
 	i32.const	$push89=, 10
 	i32.call	$push91=, strncpy@FUNCTION, $3, $pop90, $pop89
 	i32.ne  	$push92=, $pop91, $3
-	br_if   	0, $pop92       # 0: down to label20
+	br_if   	0, $pop92       # 0: down to label0
 # BB#17:                                # %if.end108
 	i32.load	$push84=, x($1)
 	i32.ne  	$push93=, $pop84, $2
-	br_if   	0, $pop93       # 0: down to label20
+	br_if   	0, $pop93       # 0: down to label0
 # BB#18:                                # %if.end108
 	i32.load	$push85=, y($1)
 	i32.const	$push94=, 2
 	i32.ne  	$push95=, $pop85, $pop94
-	br_if   	0, $pop95       # 0: down to label20
+	br_if   	0, $pop95       # 0: down to label0
 # BB#19:                                # %lor.lhs.false125
 	i32.const	$push96=, .L.str.6
 	i32.const	$push97=, 12
 	i32.call	$push98=, memcmp@FUNCTION, $7, $pop96, $pop97
-	br_if   	0, $pop98       # 0: down to label20
+	br_if   	0, $pop98       # 0: down to label0
 # BB#20:                                # %if.end130
 	i32.const	$push100=, 32
 	i32.const	$push99=, 64
@@ -220,12 +200,12 @@ main:                                   # @main
 	i32.const	$push102=, 8
 	i32.call	$push103=, strncpy@FUNCTION, $7, $pop101, $pop102
 	i32.ne  	$push104=, $pop103, $7
-	br_if   	1, $pop104      # 1: down to label19
+	br_if   	0, $pop104      # 0: down to label0
 # BB#21:                                # %lor.lhs.false136
 	i32.const	$push105=, .L.str.8
 	i32.const	$push106=, 9
 	i32.call	$push107=, memcmp@FUNCTION, $7, $pop105, $pop106
-	br_if   	1, $pop107      # 1: down to label19
+	br_if   	0, $pop107      # 0: down to label0
 # BB#22:                                # %if.end141
 	i32.const	$push108=, buf
 	i32.const	$push110=, 32
@@ -244,12 +224,12 @@ main:                                   # @main
 	i32.call	$discard=, memset@FUNCTION, $3, $pop116, $1
 	i32.const	$push164=, 3
 	i32.ne  	$push117=, $1, $pop164
-	br_if   	2, $pop117      # 2: down to label18
+	br_if   	0, $pop117      # 0: down to label0
 # BB#23:                                # %lor.lhs.false148
 	i32.const	$push118=, .L.str.9
 	i32.const	$push167=, 3
 	i32.call	$push119=, memcmp@FUNCTION, $3, $pop118, $pop167
-	br_if   	2, $pop119      # 2: down to label18
+	br_if   	0, $pop119      # 0: down to label0
 # BB#24:                                # %lor.lhs.false158
 	i32.const	$push170=, 0
 	i32.const	$push120=, 4
@@ -261,7 +241,7 @@ main:                                   # @main
 	i32.const	$push123=, .L.str.10
 	i32.const	$push168=, 11
 	i32.call	$push124=, memcmp@FUNCTION, $pop122, $pop123, $pop168
-	br_if   	18, $pop124     # 18: down to label2
+	br_if   	0, $pop124      # 0: down to label0
 # BB#25:                                # %lor.lhs.false171
 	i32.const	$push175=, 0
 	i32.const	$push174=, 11
@@ -276,7 +256,7 @@ main:                                   # @main
 	i32.const	$push126=, .L.str.11
 	i32.const	$push127=, 7
 	i32.call	$push129=, memcmp@FUNCTION, $pop128, $pop126, $pop127
-	br_if   	19, $pop129     # 19: down to label1
+	br_if   	0, $pop129      # 0: down to label0
 # BB#26:                                # %lor.lhs.false180
 	i32.const	$push131=, 0
 	i32.const	$push130=, 15
@@ -290,94 +270,14 @@ main:                                   # @main
 	i32.const	$push132=, .L.str.12
 	i32.const	$push133=, 11
 	i32.call	$push135=, memcmp@FUNCTION, $pop134, $pop132, $pop133
-	br_if   	20, $pop135     # 20: down to label0
+	br_if   	0, $pop135      # 0: down to label0
 # BB#27:                                # %if.end184
 	i32.const	$6=, 64
 	i32.add 	$7=, $7, $6
 	i32.const	$6=, __stack_pointer
 	i32.store	$7=, 0($6), $7
 	return  	$1
-.LBB0_28:                               # %if.then129
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_29:                               # %if.then140
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_30:                               # %if.then151
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_31:                               # %if.then
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_32:                               # %if.then3
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_33:                               # %if.then6
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_34:                               # %if.then22
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_35:                               # %if.then29
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_36:                               # %if.then36
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_37:                               # %if.then43
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_38:                               # %if.then54
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_39:                               # %if.then62
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_40:                               # %if.then67
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_41:                               # %if.then71
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_42:                               # %if.then76
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_43:                               # %if.then85
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_44:                               # %if.then89
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_45:                               # %if.then107
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_46:                               # %if.then161
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_47:                               # %if.then174
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_48:                               # %if.then183
+.LBB0_28:                               # %if.then183
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/strlen-1.c.s
+++ b/test/torture-s/strlen-1.c.s
@@ -22,7 +22,7 @@ main:                                   # @main
                                         #   Parent Loop BB0_1 Depth=1
                                         # =>  This Inner Loop Header: Depth=2
 	loop                            # label3:
-	i32.const	$5=, u
+	i32.const	$4=, u
 	block
 	i32.const	$push19=, 0
 	i32.eq  	$push20=, $1, $pop19
@@ -32,41 +32,45 @@ main:                                   # @main
 	i32.const	$push10=, u
 	i32.const	$push9=, 0
 	i32.call	$discard=, memset@FUNCTION, $pop10, $pop9, $1
-	copy_local	$5=, $2
+	copy_local	$4=, $2
 .LBB0_4:                                # %for.cond7.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_block                       # label5:
-	i32.const	$push11=, 1
-	i32.add 	$4=, $5, $pop11
+	block
 	block
 	i32.const	$push21=, 0
 	i32.eq  	$push22=, $3, $pop21
-	br_if   	0, $pop22       # 0: down to label6
+	br_if   	0, $pop22       # 0: down to label7
 # BB#5:                                 # %for.body9.preheader
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push13=, 97
-	i32.call	$push0=, memset@FUNCTION, $5, $pop13, $3
-	i32.add 	$5=, $pop0, $3
+	i32.call	$push0=, memset@FUNCTION, $4, $pop13, $3
+	i32.add 	$4=, $pop0, $3
 	i32.const	$push12=, 1
-	i32.add 	$4=, $5, $pop12
-.LBB0_6:                                # %for.end13
+	i32.add 	$5=, $4, $pop12
+	br      	1               # 1: down to label6
+.LBB0_6:                                #   in Loop: Header=BB0_2 Depth=2
+	end_block                       # label7:
+	i32.const	$push11=, 1
+	i32.add 	$5=, $4, $pop11
+.LBB0_7:                                # %for.end13
                                         #   in Loop: Header=BB0_2 Depth=2
 	end_block                       # label6:
 	i32.const	$push15=, 0
-	i32.store8	$discard=, 0($5), $pop15
+	i32.store8	$discard=, 0($4), $pop15
 	i64.const	$push14=, 7089336938131513954
-	i64.store	$discard=, 0($4):p2align=0, $pop14
+	i64.store	$discard=, 0($5):p2align=0, $pop14
 	i32.call	$push1=, strlen@FUNCTION, $0
 	i32.ne  	$push2=, $3, $pop1
 	br_if   	4, $pop2        # 4: down to label0
-# BB#7:                                 # %for.cond1
+# BB#8:                                 # %for.cond1
                                         #   in Loop: Header=BB0_2 Depth=2
 	i32.const	$push8=, 1
 	i32.add 	$3=, $3, $pop8
 	i32.const	$push7=, 63
 	i32.le_u	$push3=, $3, $pop7
 	br_if   	0, $pop3        # 0: up to label3
-# BB#8:                                 # %for.inc26
+# BB#9:                                 # %for.inc26
                                         #   in Loop: Header=BB0_1 Depth=1
 	end_loop                        # label4:
 	i32.const	$push18=, 1
@@ -76,12 +80,12 @@ main:                                   # @main
 	i32.const	$push16=, 8
 	i32.lt_u	$push4=, $1, $pop16
 	br_if   	0, $pop4        # 0: up to label1
-# BB#9:                                 # %for.end28
+# BB#10:                                # %for.end28
 	end_loop                        # label2:
 	i32.const	$push5=, 0
 	call    	exit@FUNCTION, $pop5
 	unreachable
-.LBB0_10:                               # %if.then
+.LBB0_11:                               # %if.then
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/strncmp-1.c.s
+++ b/test/torture-s/strncmp-1.c.s
@@ -10,43 +10,33 @@ test:                                   # @test
 	i32.call	$2=, strncmp@FUNCTION, $0, $1, $2
 	block
 	block
-	block
-	block
 	i32.const	$push0=, -1
 	i32.gt_s	$push1=, $3, $pop0
-	br_if   	0, $pop1        # 0: down to label3
+	br_if   	0, $pop1        # 0: down to label1
 # BB#1:                                 # %entry
 	i32.const	$push2=, 0
 	i32.ge_s	$push3=, $2, $pop2
-	br_if   	1, $pop3        # 1: down to label2
+	br_if   	1, $pop3        # 1: down to label0
 .LBB0_2:                                # %if.else
-	end_block                       # label3:
+	end_block                       # label1:
 	block
-	br_if   	0, $3           # 0: down to label4
+	br_if   	0, $3           # 0: down to label2
 # BB#3:                                 # %if.else
-	br_if   	2, $2           # 2: down to label1
+	br_if   	1, $2           # 1: down to label0
 .LBB0_4:                                # %if.else6
-	end_block                       # label4:
+	end_block                       # label2:
 	block
 	i32.const	$push4=, 1
 	i32.lt_s	$push5=, $3, $pop4
-	br_if   	0, $pop5        # 0: down to label5
+	br_if   	0, $pop5        # 0: down to label3
 # BB#5:                                 # %if.else6
 	i32.const	$push6=, 0
 	i32.le_s	$push7=, $2, $pop6
-	br_if   	3, $pop7        # 3: down to label0
+	br_if   	1, $pop7        # 1: down to label0
 .LBB0_6:                                # %if.end12
-	end_block                       # label5:
+	end_block                       # label3:
 	return
-.LBB0_7:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then5
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then10
+.LBB0_7:                                # %if.then10
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -70,41 +60,25 @@ main:                                   # @main
                                         #       Child Loop BB1_3 Depth 3
 	block
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	loop                            # label24:
+	loop                            # label6:
 	i32.const	$2=, 0
 	i32.const	$3=, u2
 .LBB1_2:                                # %for.cond4.preheader
                                         #   Parent Loop BB1_1 Depth=1
                                         # =>  This Loop Header: Depth=2
                                         #       Child Loop BB1_3 Depth 3
-	loop                            # label26:
+	loop                            # label8:
 	i32.const	$4=, 0
 .LBB1_3:                                # %for.cond7.preheader
                                         #   Parent Loop BB1_1 Depth=1
                                         #     Parent Loop BB1_2 Depth=2
                                         # =>    This Inner Loop Header: Depth=3
-	loop                            # label28:
+	loop                            # label10:
 	i32.const	$5=, u1
 	block
 	i32.const	$push63=, 0
 	i32.eq  	$push64=, $0, $pop63
-	br_if   	0, $pop64       # 0: down to label30
+	br_if   	0, $pop64       # 0: down to label12
 # BB#4:                                 # %for.body9.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push36=, u1
@@ -113,12 +87,12 @@ main:                                   # @main
 	copy_local	$5=, $1
 .LBB1_5:                                # %for.cond10.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label30:
+	end_block                       # label12:
 	copy_local	$6=, $5
 	block
 	i32.const	$push65=, 0
 	i32.eq  	$push66=, $4, $pop65
-	br_if   	0, $pop66       # 0: down to label31
+	br_if   	0, $pop66       # 0: down to label13
 # BB#6:                                 # %for.body12.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push37=, 97
@@ -126,14 +100,14 @@ main:                                   # @main
 	i32.add 	$6=, $pop0, $4
 .LBB1_7:                                # %for.cond17.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label31:
+	end_block                       # label13:
 	i64.const	$push38=, 8680820740569200760
 	i64.store	$9=, 0($6):p2align=0, $pop38
 	i32.const	$7=, u2
 	block
 	i32.const	$push67=, 0
 	i32.eq  	$push68=, $2, $pop67
-	br_if   	0, $pop68       # 0: down to label32
+	br_if   	0, $pop68       # 0: down to label14
 # BB#8:                                 # %for.body26.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push40=, u2
@@ -142,12 +116,12 @@ main:                                   # @main
 	copy_local	$7=, $3
 .LBB1_9:                                # %for.cond31.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label32:
+	end_block                       # label14:
 	copy_local	$8=, $7
 	block
 	i32.const	$push69=, 0
 	i32.eq  	$push70=, $4, $pop69
-	br_if   	0, $pop70       # 0: down to label33
+	br_if   	0, $pop70       # 0: down to label15
 # BB#10:                                # %for.body33.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push41=, 97
@@ -155,18 +129,18 @@ main:                                   # @main
 	i32.add 	$8=, $pop1, $4
 .LBB1_11:                               # %for.cond38.preheader
                                         #   in Loop: Header=BB1_3 Depth=3
-	end_block                       # label33:
+	end_block                       # label15:
 	i64.store	$discard=, 0($8):p2align=0, $9
 	i32.const	$push43=, 0
 	i32.store8	$push2=, 0($6), $pop43
 	i32.store8	$11=, 0($8), $pop2
 	i32.const	$push42=, 80
 	i32.call	$push3=, strncmp@FUNCTION, $5, $7, $pop42
-	br_if   	6, $pop3        # 6: down to label23
+	br_if   	6, $pop3        # 6: down to label5
 # BB#12:                                # %test.exit
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push4=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	7, $pop4        # 7: down to label22
+	br_if   	6, $pop4        # 6: down to label5
 # BB#13:                                # %test.exit185
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store8	$discard=, 0($8), $11
@@ -175,11 +149,11 @@ main:                                   # @main
 	i32.const	$push44=, 80
 	i32.call	$push5=, strncmp@FUNCTION, $5, $7, $pop44
 	i32.le_s	$push6=, $pop5, $11
-	br_if   	8, $pop6        # 8: down to label21
+	br_if   	6, $pop6        # 6: down to label5
 # BB#14:                                # %test.exit190
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push7=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	9, $pop7        # 9: down to label20
+	br_if   	6, $pop7        # 6: down to label5
 # BB#15:                                # %test.exit196
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($8):p2align=0, $10
@@ -187,11 +161,11 @@ main:                                   # @main
 	i32.const	$push46=, 80
 	i32.call	$push8=, strncmp@FUNCTION, $5, $7, $pop46
 	i32.ge_s	$push9=, $pop8, $11
-	br_if   	10, $pop9       # 10: down to label19
+	br_if   	6, $pop9        # 6: down to label5
 # BB#16:                                # %test.exit201
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push10=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	11, $pop10      # 11: down to label18
+	br_if   	6, $pop10       # 6: down to label5
 # BB#17:                                # %test.exit207
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push49=, 98
@@ -201,11 +175,11 @@ main:                                   # @main
 	i32.const	$push47=, 80
 	i32.call	$push11=, strncmp@FUNCTION, $5, $7, $pop47
 	i32.ge_s	$push12=, $pop11, $11
-	br_if   	12, $pop12      # 12: down to label17
+	br_if   	6, $pop12       # 6: down to label5
 # BB#18:                                # %test.exit213
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push13=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	13, $pop13      # 13: down to label16
+	br_if   	6, $pop13       # 6: down to label5
 # BB#19:                                # %test.exit219
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $12
@@ -213,11 +187,11 @@ main:                                   # @main
 	i32.const	$push50=, 80
 	i32.call	$push14=, strncmp@FUNCTION, $5, $7, $pop50
 	i32.le_s	$push15=, $pop14, $11
-	br_if   	14, $pop15      # 14: down to label15
+	br_if   	6, $pop15       # 6: down to label5
 # BB#20:                                # %test.exit225
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push16=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	15, $pop16      # 15: down to label14
+	br_if   	6, $pop16       # 6: down to label5
 # BB#21:                                # %test.exit231
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $10
@@ -226,11 +200,11 @@ main:                                   # @main
 	i32.const	$push51=, 80
 	i32.call	$push17=, strncmp@FUNCTION, $5, $7, $pop51
 	i32.ge_s	$push18=, $pop17, $11
-	br_if   	16, $pop18      # 16: down to label13
+	br_if   	6, $pop18       # 6: down to label5
 # BB#22:                                # %test.exit237
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push19=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	17, $pop19      # 17: down to label12
+	br_if   	6, $pop19       # 6: down to label5
 # BB#23:                                # %test.exit243
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($8):p2align=0, $10
@@ -238,11 +212,11 @@ main:                                   # @main
 	i32.const	$push53=, 80
 	i32.call	$push20=, strncmp@FUNCTION, $5, $7, $pop53
 	i32.le_s	$push21=, $pop20, $11
-	br_if   	18, $pop21      # 18: down to label11
+	br_if   	6, $pop21       # 6: down to label5
 # BB#24:                                # %test.exit249
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push22=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	19, $pop22      # 19: down to label10
+	br_if   	6, $pop22       # 6: down to label5
 # BB#25:                                # %test.exit255
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $10
@@ -251,11 +225,11 @@ main:                                   # @main
 	i32.const	$push54=, 80
 	i32.call	$push23=, strncmp@FUNCTION, $5, $7, $pop54
 	i32.ge_s	$push24=, $pop23, $11
-	br_if   	20, $pop24      # 20: down to label9
+	br_if   	6, $pop24       # 6: down to label5
 # BB#26:                                # %test.exit261
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push25=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	21, $pop25      # 21: down to label8
+	br_if   	6, $pop25       # 6: down to label5
 # BB#27:                                # %test.exit267
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.store16	$discard=, 0($6):p2align=0, $12
@@ -263,113 +237,49 @@ main:                                   # @main
 	i32.const	$push56=, 80
 	i32.call	$push26=, strncmp@FUNCTION, $5, $7, $pop56
 	i32.le_s	$push27=, $pop26, $11
-	br_if   	22, $pop27      # 22: down to label7
+	br_if   	6, $pop27       # 6: down to label5
 # BB#28:                                # %test.exit273
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.call	$push28=, strncmp@FUNCTION, $5, $7, $4
-	br_if   	23, $pop28      # 23: down to label6
+	br_if   	7, $pop28       # 7: down to label4
 # BB#29:                                # %for.cond4
                                         #   in Loop: Header=BB1_3 Depth=3
 	i32.const	$push34=, 1
 	i32.add 	$4=, $4, $pop34
 	i32.const	$push33=, 63
 	i32.le_u	$push29=, $4, $pop33
-	br_if   	0, $pop29       # 0: up to label28
+	br_if   	0, $pop29       # 0: up to label10
 # BB#30:                                # %for.inc79
                                         #   in Loop: Header=BB1_2 Depth=2
-	end_loop                        # label29:
+	end_loop                        # label11:
 	i32.const	$push59=, 1
 	i32.add 	$2=, $2, $pop59
 	i32.const	$push58=, 1
 	i32.add 	$3=, $3, $pop58
 	i32.const	$push57=, 8
 	i32.lt_u	$push30=, $2, $pop57
-	br_if   	0, $pop30       # 0: up to label26
+	br_if   	0, $pop30       # 0: up to label8
 # BB#31:                                # %for.inc82
                                         #   in Loop: Header=BB1_1 Depth=1
-	end_loop                        # label27:
+	end_loop                        # label9:
 	i32.const	$push62=, 1
 	i32.add 	$0=, $0, $pop62
 	i32.const	$push61=, 1
 	i32.add 	$1=, $1, $pop61
 	i32.const	$push60=, 8
 	i32.lt_u	$push31=, $0, $pop60
-	br_if   	0, $pop31       # 0: up to label24
+	br_if   	0, $pop31       # 0: up to label6
 # BB#32:                                # %for.end84
-	end_loop                        # label25:
+	end_loop                        # label7:
 	i32.const	$push32=, 0
 	call    	exit@FUNCTION, $pop32
 	unreachable
-.LBB1_33:                               # %if.then5.i
-	end_block                       # label23:
+.LBB1_33:                               # %if.then10.i272
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_34:                               # %if.then5.i183
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_35:                               # %if.then10.i
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_36:                               # %if.then5.i194
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_37:                               # %if.then.i
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_38:                               # %if.then5.i205
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_39:                               # %if.then.i210
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_40:                               # %if.then5.i217
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_41:                               # %if.then10.i224
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_42:                               # %if.then5.i229
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_43:                               # %if.then.i234
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_44:                               # %if.then5.i241
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_45:                               # %if.then10.i248
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_46:                               # %if.then5.i253
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_47:                               # %if.then.i258
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_48:                               # %if.then5.i265
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_49:                               # %if.then10.i272
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_50:                               # %if.then5.i277
-	end_block                       # label6:
+.LBB1_34:                               # %if.then5.i277
+	end_block                       # label4:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/struct-ini-2.c.s
+++ b/test/torture-s/struct-ini-2.c.s
@@ -9,8 +9,6 @@ main:                                   # @main
 	.local  	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	i32.const	$push0=, 0
 	i32.load16_u	$push15=, x($pop0):p2align=2
 	tee_local	$push14=, $0=, $pop15
@@ -18,32 +16,24 @@ main:                                   # @main
 	i32.and 	$push2=, $pop14, $pop1
 	i32.const	$push3=, 2
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	0, $pop4        # 0: down to label2
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push5=, 3840
 	i32.and 	$push6=, $0, $pop5
 	i32.const	$push7=, 768
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	1, $pop8        # 1: down to label1
+	br_if   	0, $pop8        # 0: down to label0
 # BB#2:                                 # %if.end7
 	i32.const	$push9=, 61440
 	i32.and 	$push10=, $0, $pop9
 	i32.const	$push11=, 16384
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	2, $pop12       # 2: down to label0
+	br_if   	0, $pop12       # 0: down to label0
 # BB#3:                                 # %if.end13
 	i32.const	$push13=, 0
 	call    	exit@FUNCTION, $pop13
 	unreachable
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then6
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then12
+.LBB0_4:                                # %if.then12
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/usmul.c.s
+++ b/test/torture-s/usmul.c.s
@@ -36,101 +36,66 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push0=, -2
 	i32.const	$push33=, 65535
 	i32.call	$push1=, foo@FUNCTION, $pop0, $pop33
 	i32.const	$push2=, -131070
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label7
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push4=, 2
 	i32.const	$push34=, 65535
 	i32.call	$push5=, foo@FUNCTION, $pop4, $pop34
 	i32.const	$push6=, 131070
 	i32.ne  	$push7=, $pop5, $pop6
-	br_if   	1, $pop7        # 1: down to label6
+	br_if   	0, $pop7        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$push8=, -32768
 	i32.const	$push35=, 32768
 	i32.call	$push9=, foo@FUNCTION, $pop8, $pop35
 	i32.const	$push10=, -1073741824
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	2, $pop11       # 2: down to label5
+	br_if   	0, $pop11       # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.const	$push12=, 32767
 	i32.const	$push36=, 32768
 	i32.call	$push13=, foo@FUNCTION, $pop12, $pop36
 	i32.const	$push14=, 1073709056
 	i32.ne  	$push15=, $pop13, $pop14
-	br_if   	3, $pop15       # 3: down to label4
+	br_if   	0, $pop15       # 0: down to label0
 # BB#4:                                 # %if.end12
 	i32.const	$push37=, 65535
 	i32.const	$push16=, -2
 	i32.call	$push17=, bar@FUNCTION, $pop37, $pop16
 	i32.const	$push18=, -131070
 	i32.ne  	$push19=, $pop17, $pop18
-	br_if   	4, $pop19       # 4: down to label3
+	br_if   	0, $pop19       # 0: down to label0
 # BB#5:                                 # %if.end16
 	i32.const	$push38=, 65535
 	i32.const	$push20=, 2
 	i32.call	$push21=, bar@FUNCTION, $pop38, $pop20
 	i32.const	$push22=, 131070
 	i32.ne  	$push23=, $pop21, $pop22
-	br_if   	5, $pop23       # 5: down to label2
+	br_if   	0, $pop23       # 0: down to label0
 # BB#6:                                 # %if.end20
 	i32.const	$push39=, 32768
 	i32.const	$push24=, -32768
 	i32.call	$push25=, bar@FUNCTION, $pop39, $pop24
 	i32.const	$push26=, -1073741824
 	i32.ne  	$push27=, $pop25, $pop26
-	br_if   	6, $pop27       # 6: down to label1
+	br_if   	0, $pop27       # 0: down to label0
 # BB#7:                                 # %if.end24
 	i32.const	$push40=, 32768
 	i32.const	$push28=, 32767
 	i32.call	$push29=, bar@FUNCTION, $pop40, $pop28
 	i32.const	$push30=, 1073709056
 	i32.ne  	$push31=, $pop29, $pop30
-	br_if   	7, $pop31       # 7: down to label0
+	br_if   	0, $pop31       # 0: down to label0
 # BB#8:                                 # %if.end28
 	i32.const	$push32=, 0
 	call    	exit@FUNCTION, $pop32
 	unreachable
-.LBB2_9:                                # %if.then
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_10:                               # %if.then3
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_11:                               # %if.then7
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_12:                               # %if.then11
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_13:                               # %if.then15
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_14:                               # %if.then19
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_15:                               # %if.then23
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_16:                               # %if.then27
+.LBB2_9:                                # %if.then27
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-1.c.s
+++ b/test/torture-s/va-arg-1.c.s
@@ -25,12 +25,10 @@ f:                                      # @f
 	i32.add 	$push2=, $pop20, $pop19
 	i32.store	$discard=, 12($13), $pop2
 	block
-	block
-	block
 	i32.load	$push3=, 0($9)
 	i32.const	$push4=, 10
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($13)
 	i32.const	$push28=, 3
@@ -44,7 +42,7 @@ f:                                      # @f
 	i32.load	$push9=, 0($9)
 	i32.const	$push10=, 11
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($13)
 	i32.const	$push13=, 3
@@ -56,22 +54,14 @@ f:                                      # @f
 	i32.add 	$push17=, $pop29, $pop16
 	i32.store	$discard=, 12($13), $pop17
 	i32.load	$push18=, 0($9)
-	br_if   	2, $pop18       # 2: down to label0
+	br_if   	0, $pop18       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.const	$12=, 16
 	i32.add 	$13=, $13, $12
 	i32.const	$12=, __stack_pointer
 	i32.store	$13=, 0($12), $13
 	return  	$9
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then3
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then6
+.LBB0_4:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-10.c.s
+++ b/test/torture-s/va-arg-10.c.s
@@ -40,104 +40,95 @@ fap:                                    # @fap
 	i32.store	$discard=, 12($7), $2
 	i32.load	$push0=, 12($7)
 	i32.store	$discard=, 8($7), $pop0
-	copy_local	$2=, $1
 	block
 	i32.call	$push1=, strlen@FUNCTION, $1
-	i32.const	$push2=, 16
-	i32.sub 	$push3=, $pop2, $0
-	i32.ne  	$push4=, $pop1, $pop3
-	br_if   	0, $pop4        # 0: down to label1
-.LBB1_1:                                # %while.cond
+	i32.const	$push16=, 16
+	i32.sub 	$push2=, $pop16, $0
+	i32.ne  	$push3=, $pop1, $pop2
+	br_if   	0, $pop3        # 0: down to label1
+# BB#1:
+	copy_local	$0=, $1
+.LBB1_2:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	block
-	loop                            # label5:
-	i32.load8_u	$push28=, 0($2)
-	tee_local	$push27=, $0=, $pop28
+	loop                            # label3:
+	i32.load8_u	$push18=, 0($0)
+	tee_local	$push17=, $2=, $pop18
 	i32.const	$push39=, 0
-	i32.eq  	$push40=, $pop27, $pop39
-	br_if   	2, $pop40       # 2: down to label4
-# BB#2:                                 # %while.body
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push5=, 12($7)
-	i32.const	$push6=, 3
-	i32.add 	$push7=, $pop5, $pop6
-	i32.const	$push8=, -4
-	i32.and 	$push32=, $pop7, $pop8
-	tee_local	$push31=, $3=, $pop32
-	i32.const	$push9=, 4
-	i32.add 	$push10=, $pop31, $pop9
-	i32.store	$discard=, 12($7), $pop10
-	i32.load	$push30=, 0($3)
-	tee_local	$push29=, $3=, $pop30
-	i32.const	$push11=, 16
-	i32.ge_u	$push12=, $pop29, $pop11
-	br_if   	3, $pop12       # 3: down to label3
-# BB#3:                                 # %to_hex.exit
-                                        #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push13=, 1
-	i32.add 	$2=, $2, $pop13
-	i32.load8_u	$push14=, .L.str($3)
-	i32.eq  	$push15=, $0, $pop14
-	br_if   	0, $pop15       # 0: up to label5
-# BB#4:                                 # %if.then4
-	end_loop                        # label6:
+	i32.eq  	$push40=, $pop17, $pop39
+	br_if   	2, $pop40       # 2: down to label2
+# BB#3:                                 # %while.body
+                                        #   in Loop: Header=BB1_2 Depth=1
+	i32.load	$push4=, 12($7)
+	i32.const	$push26=, 3
+	i32.add 	$push5=, $pop4, $pop26
+	i32.const	$push25=, -4
+	i32.and 	$push24=, $pop5, $pop25
+	tee_local	$push23=, $3=, $pop24
+	i32.const	$push22=, 4
+	i32.add 	$push6=, $pop23, $pop22
+	i32.store	$discard=, 12($7), $pop6
+	i32.load	$push21=, 0($3)
+	tee_local	$push20=, $3=, $pop21
+	i32.const	$push19=, 16
+	i32.ge_u	$push7=, $pop20, $pop19
+	br_if   	3, $pop7        # 3: down to label1
+# BB#4:                                 # %to_hex.exit
+                                        #   in Loop: Header=BB1_2 Depth=1
+	i32.const	$push27=, 1
+	i32.add 	$0=, $0, $pop27
+	i32.load8_u	$push8=, .L.str($3)
+	i32.eq  	$push9=, $2, $pop8
+	br_if   	0, $pop9        # 0: up to label3
+# BB#5:                                 # %if.then4
+	end_loop                        # label4:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_5:                                # %while.cond6
+.LBB1_6:                                # %while.cond6
                                         # =>This Inner Loop Header: Depth=1
-	end_block                       # label4:
+	end_block                       # label2:
 	block
-	loop                            # label8:
-	i32.load8_u	$push34=, 0($1)
-	tee_local	$push33=, $2=, $pop34
+	loop                            # label6:
+	i32.load8_u	$push29=, 0($1)
+	tee_local	$push28=, $0=, $pop29
 	i32.const	$push41=, 0
-	i32.eq  	$push42=, $pop33, $pop41
-	br_if   	2, $pop42       # 2: down to label7
-# BB#6:                                 # %while.body8
-                                        #   in Loop: Header=BB1_5 Depth=1
-	i32.load	$push16=, 8($7)
-	i32.const	$push17=, 3
-	i32.add 	$push18=, $pop16, $pop17
-	i32.const	$push19=, -4
-	i32.and 	$push38=, $pop18, $pop19
-	tee_local	$push37=, $0=, $pop38
-	i32.const	$push20=, 4
-	i32.add 	$push21=, $pop37, $pop20
-	i32.store	$discard=, 8($7), $pop21
-	i32.load	$push36=, 0($0)
-	tee_local	$push35=, $0=, $pop36
-	i32.const	$push22=, 16
-	i32.ge_u	$push23=, $pop35, $pop22
-	br_if   	4, $pop23       # 4: down to label2
-# BB#7:                                 # %to_hex.exit26
-                                        #   in Loop: Header=BB1_5 Depth=1
-	i32.const	$push24=, 1
-	i32.add 	$1=, $1, $pop24
-	i32.load8_u	$push25=, .L.str($0)
-	i32.eq  	$push26=, $2, $pop25
-	br_if   	0, $pop26       # 0: up to label8
-# BB#8:                                 # %if.then14
-	end_loop                        # label9:
+	i32.eq  	$push42=, $pop28, $pop41
+	br_if   	2, $pop42       # 2: down to label5
+# BB#7:                                 # %while.body8
+                                        #   in Loop: Header=BB1_6 Depth=1
+	i32.load	$push10=, 8($7)
+	i32.const	$push37=, 3
+	i32.add 	$push11=, $pop10, $pop37
+	i32.const	$push36=, -4
+	i32.and 	$push35=, $pop11, $pop36
+	tee_local	$push34=, $2=, $pop35
+	i32.const	$push33=, 4
+	i32.add 	$push12=, $pop34, $pop33
+	i32.store	$discard=, 8($7), $pop12
+	i32.load	$push32=, 0($2)
+	tee_local	$push31=, $2=, $pop32
+	i32.const	$push30=, 16
+	i32.ge_u	$push13=, $pop31, $pop30
+	br_if   	3, $pop13       # 3: down to label1
+# BB#8:                                 # %to_hex.exit26
+                                        #   in Loop: Header=BB1_6 Depth=1
+	i32.const	$push38=, 1
+	i32.add 	$1=, $1, $pop38
+	i32.load8_u	$push14=, .L.str($2)
+	i32.eq  	$push15=, $0, $pop14
+	br_if   	0, $pop15       # 0: up to label6
+# BB#9:                                 # %if.then14
+	end_loop                        # label7:
 	call    	abort@FUNCTION
 	unreachable
-.LBB1_9:                                # %while.end16
-	end_block                       # label7:
+.LBB1_10:                               # %while.end16
+	end_block                       # label5:
 	i32.const	$6=, 16
 	i32.add 	$7=, $7, $6
 	i32.const	$6=, __stack_pointer
 	i32.store	$7=, 0($6), $7
 	return
-.LBB1_10:                               # %if.then.i
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
 .LBB1_11:                               # %if.then.i23
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_12:                               # %if.then
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-12.c.s
+++ b/test/torture-s/va-arg-12.c.s
@@ -24,12 +24,10 @@ f:                                      # @f
 	i32.add 	$push2=, $pop22, $pop21
 	i32.store	$discard=, 12($13), $pop2
 	block
-	block
-	block
 	f64.load	$push3=, 0($9)
 	f64.const	$push4=, 0x1.4p3
 	f64.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($13)
 	i32.const	$push30=, 7
@@ -43,7 +41,7 @@ f:                                      # @f
 	f64.load	$push9=, 0($9)
 	f64.const	$push10=, 0x1.6p3
 	f64.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($13)
 	i32.const	$push13=, 7
@@ -57,22 +55,14 @@ f:                                      # @f
 	f64.load	$push18=, 0($9)
 	f64.const	$push19=, 0x0p0
 	f64.ne  	$push20=, $pop18, $pop19
-	br_if   	2, $pop20       # 2: down to label0
+	br_if   	0, $pop20       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.const	$12=, 16
 	i32.add 	$13=, $13, $12
 	i32.const	$12=, __stack_pointer
 	i32.store	$13=, 0($12), $13
 	return
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then3
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then6
+.LBB0_4:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-13.c.s
+++ b/test/torture-s/va-arg-13.c.s
@@ -71,11 +71,10 @@ test:                                   # @test
 	i32.add 	$push2=, $pop13, $pop12
 	i32.store	$discard=, 12($7), $pop2
 	block
-	block
 	i32.load	$push3=, 0($1)
 	i32.const	$push11=, 1234
 	i32.ne  	$push4=, $pop3, $pop11
-	br_if   	0, $pop4        # 0: down to label2
+	br_if   	0, $pop4        # 0: down to label1
 # BB#1:                                 # %dummy.exit
 	i32.store	$discard=, 0($3), $2
 	i32.load	$push5=, 0($3)
@@ -91,18 +90,14 @@ test:                                   # @test
 	i32.load	$push9=, 0($3)
 	i32.const	$push22=, 1234
 	i32.ne  	$push10=, $pop9, $pop22
-	br_if   	1, $pop10       # 1: down to label1
+	br_if   	0, $pop10       # 0: down to label1
 # BB#2:                                 # %dummy.exit16
 	i32.const	$6=, 16
 	i32.add 	$7=, $7, $6
 	i32.const	$6=, __stack_pointer
 	i32.store	$7=, 0($6), $7
 	return
-.LBB1_3:                                # %if.then.i
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_4:                                # %if.then.i15
+.LBB1_3:                                # %if.then.i15
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-14.c.s
+++ b/test/torture-s/va-arg-14.c.s
@@ -29,16 +29,10 @@ vat:                                    # @vat
 	i32.store	$push0=, global($pop44), $1
 	i32.store	$2=, 12($6), $pop0
 	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load	$push3=, 0($0)
 	i32.const	$push43=, 1
 	i32.ne  	$push4=, $pop3, $pop43
-	br_if   	0, $pop4        # 0: down to label6
+	br_if   	0, $pop4        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push57=, 0
 	i32.const	$push56=, 0
@@ -54,7 +48,7 @@ vat:                                    # @vat
 	i32.load	$push8=, 0($1)
 	i32.const	$push50=, 1
 	i32.ne  	$push9=, $pop8, $pop50
-	br_if   	1, $pop9        # 1: down to label5
+	br_if   	0, $pop9        # 0: down to label0
 # BB#2:                                 # %if.end5
 	i32.load	$push10=, 12($6)
 	i32.const	$push63=, 3
@@ -68,7 +62,7 @@ vat:                                    # @vat
 	i32.load	$push13=, 0($1)
 	i32.const	$push58=, 1
 	i32.ne  	$push14=, $pop13, $pop58
-	br_if   	2, $pop14       # 2: down to label4
+	br_if   	0, $pop14       # 0: down to label0
 # BB#3:                                 # %if.end8
 	i32.const	$push70=, 0
 	i32.store	$push15=, 12($6), $2
@@ -85,7 +79,7 @@ vat:                                    # @vat
 	i32.load	$push20=, 0($1)
 	i32.const	$push64=, 1
 	i32.ne  	$push21=, $pop20, $pop64
-	br_if   	3, $pop21       # 3: down to label3
+	br_if   	0, $pop21       # 0: down to label0
 # BB#4:                                 # %if.end13
 	i32.const	$push77=, 0
 	i32.load	$push22=, global($pop77)
@@ -101,7 +95,7 @@ vat:                                    # @vat
 	i32.load	$push26=, 0($1)
 	i32.const	$push71=, 1
 	i32.ne  	$push27=, $pop26, $pop71
-	br_if   	4, $pop27       # 4: down to label2
+	br_if   	0, $pop27       # 0: down to label0
 # BB#5:                                 # %if.end17
 	i32.const	$push28=, 0
 	i32.const	$push84=, 0
@@ -117,7 +111,7 @@ vat:                                    # @vat
 	i32.load	$push32=, 0($1)
 	i32.const	$push78=, 1
 	i32.ne  	$push33=, $pop32, $pop78
-	br_if   	5, $pop33       # 5: down to label1
+	br_if   	0, $pop33       # 0: down to label0
 # BB#6:                                 # %if.end21
 	i32.load	$push34=, 12($6)
 	i32.const	$push35=, 3
@@ -131,38 +125,14 @@ vat:                                    # @vat
 	i32.load	$push40=, 0($1)
 	i32.const	$push41=, 1
 	i32.ne  	$push42=, $pop40, $pop41
-	br_if   	6, $pop42       # 6: down to label0
+	br_if   	0, $pop42       # 0: down to label0
 # BB#7:                                 # %if.end24
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
-.LBB0_8:                                # %if.then
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then4
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.then7
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then12
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then16
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then20
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then23
+.LBB0_8:                                # %if.then23
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-16.c.s
+++ b/test/torture-s/va-arg-16.c.s
@@ -16,23 +16,13 @@ vafunction:                             # @vafunction
 	i32.store	$6=, 0($4), $6
 	i32.store	$discard=, 12($6), $2
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	f64.const	$push0=, 0x1.bcp9
 	f64.ne  	$push1=, $0, $pop0
-	br_if   	0, $pop1        # 0: down to label10
+	br_if   	0, $pop1        # 0: down to label0
 # BB#1:                                 # %if.end
 	f64.const	$push2=, 0x1.f38p9
 	f64.ne  	$push3=, $1, $pop2
-	br_if   	1, $pop3        # 1: down to label9
+	br_if   	0, $pop3        # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push4=, 12($6)
 	i32.const	$push65=, 7
@@ -46,7 +36,7 @@ vafunction:                             # @vafunction
 	f64.load	$push7=, 0($2)
 	f64.const	$push8=, 0x1p0
 	f64.ne  	$push9=, $pop7, $pop8
-	br_if   	2, $pop9        # 2: down to label8
+	br_if   	0, $pop9        # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.load	$push10=, 12($6)
 	i32.const	$push70=, 7
@@ -60,7 +50,7 @@ vafunction:                             # @vafunction
 	f64.load	$push13=, 0($2)
 	f64.const	$push14=, 0x1p1
 	f64.ne  	$push15=, $pop13, $pop14
-	br_if   	3, $pop15       # 3: down to label7
+	br_if   	0, $pop15       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.load	$push16=, 12($6)
 	i32.const	$push75=, 7
@@ -74,7 +64,7 @@ vafunction:                             # @vafunction
 	f64.load	$push19=, 0($2)
 	f64.const	$push20=, 0x1.8p1
 	f64.ne  	$push21=, $pop19, $pop20
-	br_if   	4, $pop21       # 4: down to label6
+	br_if   	0, $pop21       # 0: down to label0
 # BB#5:                                 # %if.end13
 	i32.load	$push22=, 12($6)
 	i32.const	$push80=, 7
@@ -88,7 +78,7 @@ vafunction:                             # @vafunction
 	f64.load	$push25=, 0($2)
 	f64.const	$push26=, 0x1p2
 	f64.ne  	$push27=, $pop25, $pop26
-	br_if   	5, $pop27       # 5: down to label5
+	br_if   	0, $pop27       # 0: down to label0
 # BB#6:                                 # %if.end16
 	i32.load	$push28=, 12($6)
 	i32.const	$push85=, 7
@@ -102,7 +92,7 @@ vafunction:                             # @vafunction
 	f64.load	$push31=, 0($2)
 	f64.const	$push32=, 0x1.4p2
 	f64.ne  	$push33=, $pop31, $pop32
-	br_if   	6, $pop33       # 6: down to label4
+	br_if   	0, $pop33       # 0: down to label0
 # BB#7:                                 # %if.end19
 	i32.load	$push34=, 12($6)
 	i32.const	$push90=, 7
@@ -116,7 +106,7 @@ vafunction:                             # @vafunction
 	f64.load	$push37=, 0($2)
 	f64.const	$push38=, 0x1.8p2
 	f64.ne  	$push39=, $pop37, $pop38
-	br_if   	7, $pop39       # 7: down to label3
+	br_if   	0, $pop39       # 0: down to label0
 # BB#8:                                 # %if.end22
 	i32.load	$push40=, 12($6)
 	i32.const	$push95=, 7
@@ -130,7 +120,7 @@ vafunction:                             # @vafunction
 	f64.load	$push43=, 0($2)
 	f64.const	$push44=, 0x1.cp2
 	f64.ne  	$push45=, $pop43, $pop44
-	br_if   	8, $pop45       # 8: down to label2
+	br_if   	0, $pop45       # 0: down to label0
 # BB#9:                                 # %if.end25
 	i32.load	$push46=, 12($6)
 	i32.const	$push100=, 7
@@ -144,7 +134,7 @@ vafunction:                             # @vafunction
 	f64.load	$push49=, 0($2)
 	f64.const	$push50=, 0x1p3
 	f64.ne  	$push51=, $pop49, $pop50
-	br_if   	9, $pop51       # 9: down to label1
+	br_if   	0, $pop51       # 0: down to label0
 # BB#10:                                # %if.end28
 	i32.load	$push52=, 12($6)
 	i32.const	$push53=, 7
@@ -158,54 +148,14 @@ vafunction:                             # @vafunction
 	f64.load	$push58=, 0($2)
 	f64.const	$push59=, 0x1.2p3
 	f64.ne  	$push60=, $pop58, $pop59
-	br_if   	10, $pop60      # 10: down to label0
+	br_if   	0, $pop60       # 0: down to label0
 # BB#11:                                # %if.end31
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
-.LBB0_12:                               # %if.then
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then3
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then6
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then9
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then12
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then15
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then18
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_19:                               # %if.then21
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_20:                               # %if.then24
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_21:                               # %if.then27
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_22:                               # %if.then30
+.LBB0_12:                               # %if.then30
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-17.c.s
+++ b/test/torture-s/va-arg-17.c.s
@@ -24,18 +24,10 @@ vafunction:                             # @vafunction
 	i32.add 	$push2=, $pop58, $pop57
 	i32.store	$discard=, 12($5), $pop2
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	f64.load	$push3=, 0($1)
 	f64.const	$push4=, 0x1p0
 	f64.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label8
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($5)
 	i32.const	$push66=, 7
@@ -49,7 +41,7 @@ vafunction:                             # @vafunction
 	f64.load	$push9=, 0($1)
 	f64.const	$push10=, 0x1p1
 	f64.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label7
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($5)
 	i32.const	$push71=, 7
@@ -63,7 +55,7 @@ vafunction:                             # @vafunction
 	f64.load	$push15=, 0($1)
 	f64.const	$push16=, 0x1.8p1
 	f64.ne  	$push17=, $pop15, $pop16
-	br_if   	2, $pop17       # 2: down to label6
+	br_if   	0, $pop17       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.load	$push18=, 12($5)
 	i32.const	$push76=, 7
@@ -77,7 +69,7 @@ vafunction:                             # @vafunction
 	f64.load	$push21=, 0($1)
 	f64.const	$push22=, 0x1p2
 	f64.ne  	$push23=, $pop21, $pop22
-	br_if   	3, $pop23       # 3: down to label5
+	br_if   	0, $pop23       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.load	$push24=, 12($5)
 	i32.const	$push81=, 7
@@ -91,7 +83,7 @@ vafunction:                             # @vafunction
 	f64.load	$push27=, 0($1)
 	f64.const	$push28=, 0x1.4p2
 	f64.ne  	$push29=, $pop27, $pop28
-	br_if   	4, $pop29       # 4: down to label4
+	br_if   	0, $pop29       # 0: down to label0
 # BB#5:                                 # %if.end13
 	i32.load	$push30=, 12($5)
 	i32.const	$push86=, 7
@@ -105,7 +97,7 @@ vafunction:                             # @vafunction
 	f64.load	$push33=, 0($1)
 	f64.const	$push34=, 0x1.8p2
 	f64.ne  	$push35=, $pop33, $pop34
-	br_if   	5, $pop35       # 5: down to label3
+	br_if   	0, $pop35       # 0: down to label0
 # BB#6:                                 # %if.end16
 	i32.load	$push36=, 12($5)
 	i32.const	$push91=, 7
@@ -119,7 +111,7 @@ vafunction:                             # @vafunction
 	f64.load	$push39=, 0($1)
 	f64.const	$push40=, 0x1.cp2
 	f64.ne  	$push41=, $pop39, $pop40
-	br_if   	6, $pop41       # 6: down to label2
+	br_if   	0, $pop41       # 0: down to label0
 # BB#7:                                 # %if.end19
 	i32.load	$push42=, 12($5)
 	i32.const	$push96=, 7
@@ -133,7 +125,7 @@ vafunction:                             # @vafunction
 	f64.load	$push45=, 0($1)
 	f64.const	$push46=, 0x1p3
 	f64.ne  	$push47=, $pop45, $pop46
-	br_if   	7, $pop47       # 7: down to label1
+	br_if   	0, $pop47       # 0: down to label0
 # BB#8:                                 # %if.end22
 	i32.load	$push48=, 12($5)
 	i32.const	$push49=, 7
@@ -147,46 +139,14 @@ vafunction:                             # @vafunction
 	f64.load	$push54=, 0($1)
 	f64.const	$push55=, 0x1.2p3
 	f64.ne  	$push56=, $pop54, $pop55
-	br_if   	8, $pop56       # 8: down to label0
+	br_if   	0, $pop56       # 0: down to label0
 # BB#9:                                 # %if.end25
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
-.LBB0_10:                               # %if.then
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then3
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then6
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then9
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then12
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then15
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then18
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then21
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then24
+.LBB0_10:                               # %if.then24
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-18.c.s
+++ b/test/torture-s/va-arg-18.c.s
@@ -24,12 +24,10 @@ f:                                      # @f
 	i32.add 	$push2=, $pop22, $pop21
 	i32.store	$discard=, 12($13), $pop2
 	block
-	block
-	block
 	i32.load	$push3=, 0($9)
 	i32.const	$push4=, 10
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($13)
 	i32.const	$push30=, 3
@@ -43,7 +41,7 @@ f:                                      # @f
 	i32.load	$push9=, 0($9)
 	i32.const	$push10=, 11
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($13)
 	i32.const	$push13=, 3
@@ -57,22 +55,14 @@ f:                                      # @f
 	i32.load	$push18=, 0($9)
 	i32.const	$push19=, 12
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	2, $pop20       # 2: down to label0
+	br_if   	0, $pop20       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.const	$12=, 16
 	i32.add 	$13=, $13, $12
 	i32.const	$12=, __stack_pointer
 	i32.store	$13=, 0($12), $13
 	return
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then3
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then6
+.LBB0_4:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-19.c.s
+++ b/test/torture-s/va-arg-19.c.s
@@ -24,18 +24,10 @@ vafunction:                             # @vafunction
 	i32.add 	$push2=, $pop56, $pop55
 	i32.store	$discard=, 12($5), $pop2
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load	$push3=, 0($1)
 	i32.const	$push4=, 1
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label8
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($5)
 	i32.const	$push64=, 3
@@ -49,7 +41,7 @@ vafunction:                             # @vafunction
 	i32.load	$push9=, 0($1)
 	i32.const	$push10=, 2
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label7
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($5)
 	i32.const	$push70=, 3
@@ -63,7 +55,7 @@ vafunction:                             # @vafunction
 	i32.load	$push15=, 0($1)
 	i32.const	$push65=, 3
 	i32.ne  	$push16=, $pop15, $pop65
-	br_if   	2, $pop16       # 2: down to label6
+	br_if   	0, $pop16       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.load	$push17=, 12($5)
 	i32.const	$push76=, 3
@@ -77,7 +69,7 @@ vafunction:                             # @vafunction
 	i32.load	$push20=, 0($1)
 	i32.const	$push71=, 4
 	i32.ne  	$push21=, $pop20, $pop71
-	br_if   	3, $pop21       # 3: down to label5
+	br_if   	0, $pop21       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.load	$push22=, 12($5)
 	i32.const	$push81=, 3
@@ -91,7 +83,7 @@ vafunction:                             # @vafunction
 	i32.load	$push25=, 0($1)
 	i32.const	$push26=, 5
 	i32.ne  	$push27=, $pop25, $pop26
-	br_if   	4, $pop27       # 4: down to label4
+	br_if   	0, $pop27       # 0: down to label0
 # BB#5:                                 # %if.end13
 	i32.load	$push28=, 12($5)
 	i32.const	$push86=, 3
@@ -105,7 +97,7 @@ vafunction:                             # @vafunction
 	i32.load	$push31=, 0($1)
 	i32.const	$push32=, 6
 	i32.ne  	$push33=, $pop31, $pop32
-	br_if   	5, $pop33       # 5: down to label3
+	br_if   	0, $pop33       # 0: down to label0
 # BB#6:                                 # %if.end16
 	i32.load	$push34=, 12($5)
 	i32.const	$push91=, 3
@@ -119,7 +111,7 @@ vafunction:                             # @vafunction
 	i32.load	$push37=, 0($1)
 	i32.const	$push38=, 7
 	i32.ne  	$push39=, $pop37, $pop38
-	br_if   	6, $pop39       # 6: down to label2
+	br_if   	0, $pop39       # 0: down to label0
 # BB#7:                                 # %if.end19
 	i32.load	$push40=, 12($5)
 	i32.const	$push96=, 3
@@ -133,7 +125,7 @@ vafunction:                             # @vafunction
 	i32.load	$push43=, 0($1)
 	i32.const	$push44=, 8
 	i32.ne  	$push45=, $pop43, $pop44
-	br_if   	7, $pop45       # 7: down to label1
+	br_if   	0, $pop45       # 0: down to label0
 # BB#8:                                 # %if.end22
 	i32.load	$push46=, 12($5)
 	i32.const	$push47=, 3
@@ -147,46 +139,14 @@ vafunction:                             # @vafunction
 	i32.load	$push52=, 0($1)
 	i32.const	$push53=, 9
 	i32.ne  	$push54=, $pop52, $pop53
-	br_if   	8, $pop54       # 8: down to label0
+	br_if   	0, $pop54       # 0: down to label0
 # BB#9:                                 # %if.end25
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
-.LBB0_10:                               # %if.then
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then3
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then6
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then9
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then12
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then15
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then18
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then21
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then24
+.LBB0_10:                               # %if.then24
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-2.c.s
+++ b/test/torture-s/va-arg-2.c.s
@@ -40,58 +40,53 @@ f0:                                     # @f0
 	i32.store	$discard=, 12($6), $1
 	block
 	i32.call	$push0=, strlen@FUNCTION, $0
-	i32.const	$push1=, 16
-	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	i32.const	$push8=, 16
+	i32.ne  	$push1=, $pop0, $pop8
+	br_if   	0, $pop1        # 0: down to label1
 .LBB1_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label4:
-	i32.load8_u	$push15=, 0($0)
-	tee_local	$push14=, $1=, $pop15
+	loop                            # label3:
+	i32.load8_u	$push10=, 0($0)
+	tee_local	$push9=, $1=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label3
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label2
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push3=, 12($6)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $2=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($6), $pop8
-	i32.load	$push17=, 0($2)
-	tee_local	$push16=, $2=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label2
+	i32.load	$push2=, 12($6)
+	i32.const	$push18=, 3
+	i32.add 	$push3=, $pop2, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop3, $pop17
+	tee_local	$push15=, $2=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push4=, $pop15, $pop14
+	i32.store	$discard=, 12($6), $pop4
+	i32.load	$push13=, 0($2)
+	tee_local	$push12=, $2=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push5=, $pop12, $pop11
+	br_if   	3, $pop5        # 3: down to label1
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$0=, $0, $pop11
-	i32.load8_u	$push12=, .L.str($2)
-	i32.eq  	$push13=, $1, $pop12
-	br_if   	0, $pop13       # 0: up to label4
+	i32.const	$push19=, 1
+	i32.add 	$0=, $0, $pop19
+	i32.load8_u	$push6=, .L.str($2)
+	i32.eq  	$push7=, $1, $pop6
+	br_if   	0, $pop7        # 0: up to label3
 # BB#4:                                 # %if.then5
-	end_loop                        # label5:
+	end_loop                        # label4:
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_5:                                # %while.end
-	end_block                       # label3:
+	end_block                       # label2:
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
 .LBB1_6:                                # %if.then.i
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_7:                                # %if.then
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
@@ -118,57 +113,52 @@ f1:                                     # @f1
 	i32.call	$push0=, strlen@FUNCTION, $1
 	i32.const	$push1=, 15
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label6
+	br_if   	0, $pop2        # 0: down to label5
 .LBB2_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label9:
-	i32.load8_u	$push15=, 0($1)
-	tee_local	$push14=, $2=, $pop15
+	loop                            # label7:
+	i32.load8_u	$push10=, 0($1)
+	tee_local	$push9=, $2=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label8
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label6
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB2_1 Depth=1
 	i32.load	$push3=, 12($7)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $3=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($7), $pop8
-	i32.load	$push17=, 0($3)
-	tee_local	$push16=, $3=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label7
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $3=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($7), $pop5
+	i32.load	$push13=, 0($3)
+	tee_local	$push12=, $3=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label5
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$1=, $1, $pop11
-	i32.load8_u	$push12=, .L.str($3)
-	i32.eq  	$push13=, $2, $pop12
-	br_if   	0, $pop13       # 0: up to label9
+	i32.const	$push19=, 1
+	i32.add 	$1=, $1, $pop19
+	i32.load8_u	$push7=, .L.str($3)
+	i32.eq  	$push8=, $2, $pop7
+	br_if   	0, $pop8        # 0: up to label7
 # BB#4:                                 # %if.then5
-	end_loop                        # label10:
+	end_loop                        # label8:
 	call    	abort@FUNCTION
 	unreachable
 .LBB2_5:                                # %while.end
-	end_block                       # label8:
+	end_block                       # label6:
 	i32.const	$6=, 16
 	i32.add 	$7=, $7, $6
 	i32.const	$6=, __stack_pointer
 	i32.store	$7=, 0($6), $7
 	return
 .LBB2_6:                                # %if.then.i
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_7:                                # %if.then
-	end_block                       # label6:
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -194,57 +184,52 @@ f2:                                     # @f2
 	i32.call	$push0=, strlen@FUNCTION, $2
 	i32.const	$push1=, 14
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label11
+	br_if   	0, $pop2        # 0: down to label9
 .LBB3_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label14:
-	i32.load8_u	$push15=, 0($2)
-	tee_local	$push14=, $3=, $pop15
+	loop                            # label11:
+	i32.load8_u	$push10=, 0($2)
+	tee_local	$push9=, $3=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label13
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label10
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB3_1 Depth=1
 	i32.load	$push3=, 12($8)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $4=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($8), $pop8
-	i32.load	$push17=, 0($4)
-	tee_local	$push16=, $4=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label12
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $4=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($8), $pop5
+	i32.load	$push13=, 0($4)
+	tee_local	$push12=, $4=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label9
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB3_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$2=, $2, $pop11
-	i32.load8_u	$push12=, .L.str($4)
-	i32.eq  	$push13=, $3, $pop12
-	br_if   	0, $pop13       # 0: up to label14
+	i32.const	$push19=, 1
+	i32.add 	$2=, $2, $pop19
+	i32.load8_u	$push7=, .L.str($4)
+	i32.eq  	$push8=, $3, $pop7
+	br_if   	0, $pop8        # 0: up to label11
 # BB#4:                                 # %if.then5
-	end_loop                        # label15:
+	end_loop                        # label12:
 	call    	abort@FUNCTION
 	unreachable
 .LBB3_5:                                # %while.end
-	end_block                       # label13:
+	end_block                       # label10:
 	i32.const	$7=, 16
 	i32.add 	$8=, $8, $7
 	i32.const	$7=, __stack_pointer
 	i32.store	$8=, 0($7), $8
 	return
 .LBB3_6:                                # %if.then.i
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_7:                                # %if.then
-	end_block                       # label11:
+	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -270,57 +255,52 @@ f3:                                     # @f3
 	i32.call	$push0=, strlen@FUNCTION, $3
 	i32.const	$push1=, 13
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label16
+	br_if   	0, $pop2        # 0: down to label13
 .LBB4_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label19:
-	i32.load8_u	$push15=, 0($3)
-	tee_local	$push14=, $4=, $pop15
+	loop                            # label15:
+	i32.load8_u	$push10=, 0($3)
+	tee_local	$push9=, $4=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label18
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label14
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB4_1 Depth=1
 	i32.load	$push3=, 12($9)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $5=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($9), $pop8
-	i32.load	$push17=, 0($5)
-	tee_local	$push16=, $5=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label17
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $5=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($9), $pop5
+	i32.load	$push13=, 0($5)
+	tee_local	$push12=, $5=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label13
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB4_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$3=, $3, $pop11
-	i32.load8_u	$push12=, .L.str($5)
-	i32.eq  	$push13=, $4, $pop12
-	br_if   	0, $pop13       # 0: up to label19
+	i32.const	$push19=, 1
+	i32.add 	$3=, $3, $pop19
+	i32.load8_u	$push7=, .L.str($5)
+	i32.eq  	$push8=, $4, $pop7
+	br_if   	0, $pop8        # 0: up to label15
 # BB#4:                                 # %if.then5
-	end_loop                        # label20:
+	end_loop                        # label16:
 	call    	abort@FUNCTION
 	unreachable
 .LBB4_5:                                # %while.end
-	end_block                       # label18:
+	end_block                       # label14:
 	i32.const	$8=, 16
 	i32.add 	$9=, $9, $8
 	i32.const	$8=, __stack_pointer
 	i32.store	$9=, 0($8), $9
 	return
 .LBB4_6:                                # %if.then.i
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_7:                                # %if.then
-	end_block                       # label16:
+	end_block                       # label13:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -346,57 +326,52 @@ f4:                                     # @f4
 	i32.call	$push0=, strlen@FUNCTION, $4
 	i32.const	$push1=, 12
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label21
+	br_if   	0, $pop2        # 0: down to label17
 .LBB5_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label24:
-	i32.load8_u	$push15=, 0($4)
-	tee_local	$push14=, $5=, $pop15
+	loop                            # label19:
+	i32.load8_u	$push10=, 0($4)
+	tee_local	$push9=, $5=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label23
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label18
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB5_1 Depth=1
 	i32.load	$push3=, 12($10)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $6=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($10), $pop8
-	i32.load	$push17=, 0($6)
-	tee_local	$push16=, $6=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label22
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $6=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($10), $pop5
+	i32.load	$push13=, 0($6)
+	tee_local	$push12=, $6=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label17
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB5_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$4=, $4, $pop11
-	i32.load8_u	$push12=, .L.str($6)
-	i32.eq  	$push13=, $5, $pop12
-	br_if   	0, $pop13       # 0: up to label24
+	i32.const	$push19=, 1
+	i32.add 	$4=, $4, $pop19
+	i32.load8_u	$push7=, .L.str($6)
+	i32.eq  	$push8=, $5, $pop7
+	br_if   	0, $pop8        # 0: up to label19
 # BB#4:                                 # %if.then5
-	end_loop                        # label25:
+	end_loop                        # label20:
 	call    	abort@FUNCTION
 	unreachable
 .LBB5_5:                                # %while.end
-	end_block                       # label23:
+	end_block                       # label18:
 	i32.const	$9=, 16
 	i32.add 	$10=, $10, $9
 	i32.const	$9=, __stack_pointer
 	i32.store	$10=, 0($9), $10
 	return
 .LBB5_6:                                # %if.then.i
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB5_7:                                # %if.then
-	end_block                       # label21:
+	end_block                       # label17:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -422,57 +397,52 @@ f5:                                     # @f5
 	i32.call	$push0=, strlen@FUNCTION, $5
 	i32.const	$push1=, 11
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label26
+	br_if   	0, $pop2        # 0: down to label21
 .LBB6_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label29:
-	i32.load8_u	$push15=, 0($5)
-	tee_local	$push14=, $6=, $pop15
+	loop                            # label23:
+	i32.load8_u	$push10=, 0($5)
+	tee_local	$push9=, $6=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label28
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label22
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB6_1 Depth=1
 	i32.load	$push3=, 12($11)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $7=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($11), $pop8
-	i32.load	$push17=, 0($7)
-	tee_local	$push16=, $7=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label27
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $7=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($11), $pop5
+	i32.load	$push13=, 0($7)
+	tee_local	$push12=, $7=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label21
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB6_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$5=, $5, $pop11
-	i32.load8_u	$push12=, .L.str($7)
-	i32.eq  	$push13=, $6, $pop12
-	br_if   	0, $pop13       # 0: up to label29
+	i32.const	$push19=, 1
+	i32.add 	$5=, $5, $pop19
+	i32.load8_u	$push7=, .L.str($7)
+	i32.eq  	$push8=, $6, $pop7
+	br_if   	0, $pop8        # 0: up to label23
 # BB#4:                                 # %if.then5
-	end_loop                        # label30:
+	end_loop                        # label24:
 	call    	abort@FUNCTION
 	unreachable
 .LBB6_5:                                # %while.end
-	end_block                       # label28:
+	end_block                       # label22:
 	i32.const	$10=, 16
 	i32.add 	$11=, $11, $10
 	i32.const	$10=, __stack_pointer
 	i32.store	$11=, 0($10), $11
 	return
 .LBB6_6:                                # %if.then.i
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_7:                                # %if.then
-	end_block                       # label26:
+	end_block                       # label21:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -498,57 +468,52 @@ f6:                                     # @f6
 	i32.call	$push0=, strlen@FUNCTION, $6
 	i32.const	$push1=, 10
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label31
+	br_if   	0, $pop2        # 0: down to label25
 .LBB7_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label34:
-	i32.load8_u	$push15=, 0($6)
-	tee_local	$push14=, $7=, $pop15
+	loop                            # label27:
+	i32.load8_u	$push10=, 0($6)
+	tee_local	$push9=, $7=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label33
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label26
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB7_1 Depth=1
 	i32.load	$push3=, 12($12)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $8=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($12), $pop8
-	i32.load	$push17=, 0($8)
-	tee_local	$push16=, $8=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label32
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $8=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($12), $pop5
+	i32.load	$push13=, 0($8)
+	tee_local	$push12=, $8=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label25
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB7_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$6=, $6, $pop11
-	i32.load8_u	$push12=, .L.str($8)
-	i32.eq  	$push13=, $7, $pop12
-	br_if   	0, $pop13       # 0: up to label34
+	i32.const	$push19=, 1
+	i32.add 	$6=, $6, $pop19
+	i32.load8_u	$push7=, .L.str($8)
+	i32.eq  	$push8=, $7, $pop7
+	br_if   	0, $pop8        # 0: up to label27
 # BB#4:                                 # %if.then5
-	end_loop                        # label35:
+	end_loop                        # label28:
 	call    	abort@FUNCTION
 	unreachable
 .LBB7_5:                                # %while.end
-	end_block                       # label33:
+	end_block                       # label26:
 	i32.const	$11=, 16
 	i32.add 	$12=, $12, $11
 	i32.const	$11=, __stack_pointer
 	i32.store	$12=, 0($11), $12
 	return
 .LBB7_6:                                # %if.then.i
-	end_block                       # label32:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_7:                                # %if.then
-	end_block                       # label31:
+	end_block                       # label25:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -574,57 +539,52 @@ f7:                                     # @f7
 	i32.call	$push0=, strlen@FUNCTION, $7
 	i32.const	$push1=, 9
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label36
+	br_if   	0, $pop2        # 0: down to label29
 .LBB8_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label39:
-	i32.load8_u	$push15=, 0($7)
-	tee_local	$push14=, $8=, $pop15
+	loop                            # label31:
+	i32.load8_u	$push10=, 0($7)
+	tee_local	$push9=, $8=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label38
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label30
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB8_1 Depth=1
 	i32.load	$push3=, 12($13)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $9=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($13), $pop8
-	i32.load	$push17=, 0($9)
-	tee_local	$push16=, $9=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label37
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $9=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($13), $pop5
+	i32.load	$push13=, 0($9)
+	tee_local	$push12=, $9=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label29
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB8_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$7=, $7, $pop11
-	i32.load8_u	$push12=, .L.str($9)
-	i32.eq  	$push13=, $8, $pop12
-	br_if   	0, $pop13       # 0: up to label39
+	i32.const	$push19=, 1
+	i32.add 	$7=, $7, $pop19
+	i32.load8_u	$push7=, .L.str($9)
+	i32.eq  	$push8=, $8, $pop7
+	br_if   	0, $pop8        # 0: up to label31
 # BB#4:                                 # %if.then5
-	end_loop                        # label40:
+	end_loop                        # label32:
 	call    	abort@FUNCTION
 	unreachable
 .LBB8_5:                                # %while.end
-	end_block                       # label38:
+	end_block                       # label30:
 	i32.const	$12=, 16
 	i32.add 	$13=, $13, $12
 	i32.const	$12=, __stack_pointer
 	i32.store	$13=, 0($12), $13
 	return
 .LBB8_6:                                # %if.then.i
-	end_block                       # label37:
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_7:                                # %if.then
-	end_block                       # label36:
+	end_block                       # label29:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -650,57 +610,52 @@ f8:                                     # @f8
 	i32.call	$push0=, strlen@FUNCTION, $8
 	i32.const	$push1=, 8
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label41
+	br_if   	0, $pop2        # 0: down to label33
 .LBB9_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label44:
-	i32.load8_u	$push15=, 0($8)
-	tee_local	$push14=, $9=, $pop15
+	loop                            # label35:
+	i32.load8_u	$push10=, 0($8)
+	tee_local	$push9=, $9=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label43
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label34
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB9_1 Depth=1
 	i32.load	$push3=, 12($14)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $10=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($14), $pop8
-	i32.load	$push17=, 0($10)
-	tee_local	$push16=, $10=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label42
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $10=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($14), $pop5
+	i32.load	$push13=, 0($10)
+	tee_local	$push12=, $10=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label33
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB9_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$8=, $8, $pop11
-	i32.load8_u	$push12=, .L.str($10)
-	i32.eq  	$push13=, $9, $pop12
-	br_if   	0, $pop13       # 0: up to label44
+	i32.const	$push19=, 1
+	i32.add 	$8=, $8, $pop19
+	i32.load8_u	$push7=, .L.str($10)
+	i32.eq  	$push8=, $9, $pop7
+	br_if   	0, $pop8        # 0: up to label35
 # BB#4:                                 # %if.then5
-	end_loop                        # label45:
+	end_loop                        # label36:
 	call    	abort@FUNCTION
 	unreachable
 .LBB9_5:                                # %while.end
-	end_block                       # label43:
+	end_block                       # label34:
 	i32.const	$13=, 16
 	i32.add 	$14=, $14, $13
 	i32.const	$13=, __stack_pointer
 	i32.store	$14=, 0($13), $14
 	return
 .LBB9_6:                                # %if.then.i
-	end_block                       # label42:
-	call    	abort@FUNCTION
-	unreachable
-.LBB9_7:                                # %if.then
-	end_block                       # label41:
+	end_block                       # label33:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -726,57 +681,52 @@ f9:                                     # @f9
 	i32.call	$push0=, strlen@FUNCTION, $9
 	i32.const	$push1=, 7
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label46
+	br_if   	0, $pop2        # 0: down to label37
 .LBB10_1:                               # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label49:
-	i32.load8_u	$push15=, 0($9)
-	tee_local	$push14=, $10=, $pop15
+	loop                            # label39:
+	i32.load8_u	$push10=, 0($9)
+	tee_local	$push9=, $10=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label48
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label38
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB10_1 Depth=1
 	i32.load	$push3=, 12($15)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $11=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($15), $pop8
-	i32.load	$push17=, 0($11)
-	tee_local	$push16=, $11=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label47
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $11=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($15), $pop5
+	i32.load	$push13=, 0($11)
+	tee_local	$push12=, $11=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label37
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB10_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$9=, $9, $pop11
-	i32.load8_u	$push12=, .L.str($11)
-	i32.eq  	$push13=, $10, $pop12
-	br_if   	0, $pop13       # 0: up to label49
+	i32.const	$push19=, 1
+	i32.add 	$9=, $9, $pop19
+	i32.load8_u	$push7=, .L.str($11)
+	i32.eq  	$push8=, $10, $pop7
+	br_if   	0, $pop8        # 0: up to label39
 # BB#4:                                 # %if.then5
-	end_loop                        # label50:
+	end_loop                        # label40:
 	call    	abort@FUNCTION
 	unreachable
 .LBB10_5:                               # %while.end
-	end_block                       # label48:
+	end_block                       # label38:
 	i32.const	$14=, 16
 	i32.add 	$15=, $15, $14
 	i32.const	$14=, __stack_pointer
 	i32.store	$15=, 0($14), $15
 	return
 .LBB10_6:                               # %if.then.i
-	end_block                       # label47:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_7:                               # %if.then
-	end_block                       # label46:
+	end_block                       # label37:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -802,57 +752,52 @@ f10:                                    # @f10
 	i32.call	$push0=, strlen@FUNCTION, $10
 	i32.const	$push1=, 6
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label51
+	br_if   	0, $pop2        # 0: down to label41
 .LBB11_1:                               # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label54:
-	i32.load8_u	$push15=, 0($10)
-	tee_local	$push14=, $11=, $pop15
+	loop                            # label43:
+	i32.load8_u	$push10=, 0($10)
+	tee_local	$push9=, $11=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label53
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label42
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB11_1 Depth=1
 	i32.load	$push3=, 12($16)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $12=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($16), $pop8
-	i32.load	$push17=, 0($12)
-	tee_local	$push16=, $12=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label52
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $12=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($16), $pop5
+	i32.load	$push13=, 0($12)
+	tee_local	$push12=, $12=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label41
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB11_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$10=, $10, $pop11
-	i32.load8_u	$push12=, .L.str($12)
-	i32.eq  	$push13=, $11, $pop12
-	br_if   	0, $pop13       # 0: up to label54
+	i32.const	$push19=, 1
+	i32.add 	$10=, $10, $pop19
+	i32.load8_u	$push7=, .L.str($12)
+	i32.eq  	$push8=, $11, $pop7
+	br_if   	0, $pop8        # 0: up to label43
 # BB#4:                                 # %if.then5
-	end_loop                        # label55:
+	end_loop                        # label44:
 	call    	abort@FUNCTION
 	unreachable
 .LBB11_5:                               # %while.end
-	end_block                       # label53:
+	end_block                       # label42:
 	i32.const	$15=, 16
 	i32.add 	$16=, $16, $15
 	i32.const	$15=, __stack_pointer
 	i32.store	$16=, 0($15), $16
 	return
 .LBB11_6:                               # %if.then.i
-	end_block                       # label52:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_7:                               # %if.then
-	end_block                       # label51:
+	end_block                       # label41:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -878,57 +823,52 @@ f11:                                    # @f11
 	i32.call	$push0=, strlen@FUNCTION, $11
 	i32.const	$push1=, 5
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label56
+	br_if   	0, $pop2        # 0: down to label45
 .LBB12_1:                               # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label59:
-	i32.load8_u	$push15=, 0($11)
-	tee_local	$push14=, $12=, $pop15
+	loop                            # label47:
+	i32.load8_u	$push10=, 0($11)
+	tee_local	$push9=, $12=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label58
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label46
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB12_1 Depth=1
 	i32.load	$push3=, 12($17)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $13=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($17), $pop8
-	i32.load	$push17=, 0($13)
-	tee_local	$push16=, $13=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label57
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $13=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($17), $pop5
+	i32.load	$push13=, 0($13)
+	tee_local	$push12=, $13=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label45
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB12_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$11=, $11, $pop11
-	i32.load8_u	$push12=, .L.str($13)
-	i32.eq  	$push13=, $12, $pop12
-	br_if   	0, $pop13       # 0: up to label59
+	i32.const	$push19=, 1
+	i32.add 	$11=, $11, $pop19
+	i32.load8_u	$push7=, .L.str($13)
+	i32.eq  	$push8=, $12, $pop7
+	br_if   	0, $pop8        # 0: up to label47
 # BB#4:                                 # %if.then5
-	end_loop                        # label60:
+	end_loop                        # label48:
 	call    	abort@FUNCTION
 	unreachable
 .LBB12_5:                               # %while.end
-	end_block                       # label58:
+	end_block                       # label46:
 	i32.const	$16=, 16
 	i32.add 	$17=, $17, $16
 	i32.const	$16=, __stack_pointer
 	i32.store	$17=, 0($16), $17
 	return
 .LBB12_6:                               # %if.then.i
-	end_block                       # label57:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_7:                               # %if.then
-	end_block                       # label56:
+	end_block                       # label45:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -952,59 +892,54 @@ f12:                                    # @f12
 	i32.store	$discard=, 12($18), $13
 	block
 	i32.call	$push0=, strlen@FUNCTION, $12
-	i32.const	$push1=, 4
-	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label61
+	i32.const	$push8=, 4
+	i32.ne  	$push1=, $pop0, $pop8
+	br_if   	0, $pop1        # 0: down to label49
 .LBB13_1:                               # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label64:
-	i32.load8_u	$push15=, 0($12)
-	tee_local	$push14=, $13=, $pop15
+	loop                            # label51:
+	i32.load8_u	$push10=, 0($12)
+	tee_local	$push9=, $13=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label63
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label50
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB13_1 Depth=1
-	i32.load	$push3=, 12($18)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $14=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($18), $pop8
-	i32.load	$push17=, 0($14)
-	tee_local	$push16=, $14=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label62
+	i32.load	$push2=, 12($18)
+	i32.const	$push18=, 3
+	i32.add 	$push3=, $pop2, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop3, $pop17
+	tee_local	$push15=, $14=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push4=, $pop15, $pop14
+	i32.store	$discard=, 12($18), $pop4
+	i32.load	$push13=, 0($14)
+	tee_local	$push12=, $14=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push5=, $pop12, $pop11
+	br_if   	3, $pop5        # 3: down to label49
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB13_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$12=, $12, $pop11
-	i32.load8_u	$push12=, .L.str($14)
-	i32.eq  	$push13=, $13, $pop12
-	br_if   	0, $pop13       # 0: up to label64
+	i32.const	$push19=, 1
+	i32.add 	$12=, $12, $pop19
+	i32.load8_u	$push6=, .L.str($14)
+	i32.eq  	$push7=, $13, $pop6
+	br_if   	0, $pop7        # 0: up to label51
 # BB#4:                                 # %if.then5
-	end_loop                        # label65:
+	end_loop                        # label52:
 	call    	abort@FUNCTION
 	unreachable
 .LBB13_5:                               # %while.end
-	end_block                       # label63:
+	end_block                       # label50:
 	i32.const	$17=, 16
 	i32.add 	$18=, $18, $17
 	i32.const	$17=, __stack_pointer
 	i32.store	$18=, 0($17), $18
 	return
 .LBB13_6:                               # %if.then.i
-	end_block                       # label62:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_7:                               # %if.then
-	end_block                       # label61:
+	end_block                       # label49:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1028,59 +963,54 @@ f13:                                    # @f13
 	i32.store	$discard=, 12($19), $14
 	block
 	i32.call	$push0=, strlen@FUNCTION, $13
-	i32.const	$push1=, 3
-	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label66
+	i32.const	$push8=, 3
+	i32.ne  	$push1=, $pop0, $pop8
+	br_if   	0, $pop1        # 0: down to label53
 .LBB14_1:                               # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label69:
-	i32.load8_u	$push15=, 0($13)
-	tee_local	$push14=, $14=, $pop15
+	loop                            # label55:
+	i32.load8_u	$push10=, 0($13)
+	tee_local	$push9=, $14=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label68
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label54
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB14_1 Depth=1
-	i32.load	$push3=, 12($19)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $15=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($19), $pop8
-	i32.load	$push17=, 0($15)
-	tee_local	$push16=, $15=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label67
+	i32.load	$push2=, 12($19)
+	i32.const	$push18=, 3
+	i32.add 	$push3=, $pop2, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop3, $pop17
+	tee_local	$push15=, $15=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push4=, $pop15, $pop14
+	i32.store	$discard=, 12($19), $pop4
+	i32.load	$push13=, 0($15)
+	tee_local	$push12=, $15=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push5=, $pop12, $pop11
+	br_if   	3, $pop5        # 3: down to label53
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB14_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$13=, $13, $pop11
-	i32.load8_u	$push12=, .L.str($15)
-	i32.eq  	$push13=, $14, $pop12
-	br_if   	0, $pop13       # 0: up to label69
+	i32.const	$push19=, 1
+	i32.add 	$13=, $13, $pop19
+	i32.load8_u	$push6=, .L.str($15)
+	i32.eq  	$push7=, $14, $pop6
+	br_if   	0, $pop7        # 0: up to label55
 # BB#4:                                 # %if.then5
-	end_loop                        # label70:
+	end_loop                        # label56:
 	call    	abort@FUNCTION
 	unreachable
 .LBB14_5:                               # %while.end
-	end_block                       # label68:
+	end_block                       # label54:
 	i32.const	$18=, 16
 	i32.add 	$19=, $19, $18
 	i32.const	$18=, __stack_pointer
 	i32.store	$19=, 0($18), $19
 	return
 .LBB14_6:                               # %if.then.i
-	end_block                       # label67:
-	call    	abort@FUNCTION
-	unreachable
-.LBB14_7:                               # %if.then
-	end_block                       # label66:
+	end_block                       # label53:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1106,57 +1036,52 @@ f14:                                    # @f14
 	i32.call	$push0=, strlen@FUNCTION, $14
 	i32.const	$push1=, 2
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label71
+	br_if   	0, $pop2        # 0: down to label57
 .LBB15_1:                               # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label74:
-	i32.load8_u	$push15=, 0($14)
-	tee_local	$push14=, $15=, $pop15
+	loop                            # label59:
+	i32.load8_u	$push10=, 0($14)
+	tee_local	$push9=, $15=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label73
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label58
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB15_1 Depth=1
 	i32.load	$push3=, 12($20)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $16=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($20), $pop8
-	i32.load	$push17=, 0($16)
-	tee_local	$push16=, $16=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label72
+	i32.const	$push18=, 3
+	i32.add 	$push4=, $pop3, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop4, $pop17
+	tee_local	$push15=, $16=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push5=, $pop15, $pop14
+	i32.store	$discard=, 12($20), $pop5
+	i32.load	$push13=, 0($16)
+	tee_local	$push12=, $16=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push6=, $pop12, $pop11
+	br_if   	3, $pop6        # 3: down to label57
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB15_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$14=, $14, $pop11
-	i32.load8_u	$push12=, .L.str($16)
-	i32.eq  	$push13=, $15, $pop12
-	br_if   	0, $pop13       # 0: up to label74
+	i32.const	$push19=, 1
+	i32.add 	$14=, $14, $pop19
+	i32.load8_u	$push7=, .L.str($16)
+	i32.eq  	$push8=, $15, $pop7
+	br_if   	0, $pop8        # 0: up to label59
 # BB#4:                                 # %if.then5
-	end_loop                        # label75:
+	end_loop                        # label60:
 	call    	abort@FUNCTION
 	unreachable
 .LBB15_5:                               # %while.end
-	end_block                       # label73:
+	end_block                       # label58:
 	i32.const	$19=, 16
 	i32.add 	$20=, $20, $19
 	i32.const	$19=, __stack_pointer
 	i32.store	$20=, 0($19), $20
 	return
 .LBB15_6:                               # %if.then.i
-	end_block                       # label72:
-	call    	abort@FUNCTION
-	unreachable
-.LBB15_7:                               # %if.then
-	end_block                       # label71:
+	end_block                       # label57:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1180,59 +1105,54 @@ f15:                                    # @f15
 	i32.store	$discard=, 12($21), $16
 	block
 	i32.call	$push0=, strlen@FUNCTION, $15
-	i32.const	$push1=, 1
-	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label76
+	i32.const	$push8=, 1
+	i32.ne  	$push1=, $pop0, $pop8
+	br_if   	0, $pop1        # 0: down to label61
 .LBB16_1:                               # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label79:
-	i32.load8_u	$push15=, 0($15)
-	tee_local	$push14=, $16=, $pop15
+	loop                            # label63:
+	i32.load8_u	$push10=, 0($15)
+	tee_local	$push9=, $16=, $pop10
 	i32.const	$push20=, 0
-	i32.eq  	$push21=, $pop14, $pop20
-	br_if   	2, $pop21       # 2: down to label78
+	i32.eq  	$push21=, $pop9, $pop20
+	br_if   	2, $pop21       # 2: down to label62
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB16_1 Depth=1
-	i32.load	$push3=, 12($21)
-	i32.const	$push4=, 3
-	i32.add 	$push5=, $pop3, $pop4
-	i32.const	$push6=, -4
-	i32.and 	$push19=, $pop5, $pop6
-	tee_local	$push18=, $17=, $pop19
-	i32.const	$push7=, 4
-	i32.add 	$push8=, $pop18, $pop7
-	i32.store	$discard=, 12($21), $pop8
-	i32.load	$push17=, 0($17)
-	tee_local	$push16=, $17=, $pop17
-	i32.const	$push9=, 16
-	i32.ge_u	$push10=, $pop16, $pop9
-	br_if   	3, $pop10       # 3: down to label77
+	i32.load	$push2=, 12($21)
+	i32.const	$push18=, 3
+	i32.add 	$push3=, $pop2, $pop18
+	i32.const	$push17=, -4
+	i32.and 	$push16=, $pop3, $pop17
+	tee_local	$push15=, $17=, $pop16
+	i32.const	$push14=, 4
+	i32.add 	$push4=, $pop15, $pop14
+	i32.store	$discard=, 12($21), $pop4
+	i32.load	$push13=, 0($17)
+	tee_local	$push12=, $17=, $pop13
+	i32.const	$push11=, 16
+	i32.ge_u	$push5=, $pop12, $pop11
+	br_if   	3, $pop5        # 3: down to label61
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB16_1 Depth=1
-	i32.const	$push11=, 1
-	i32.add 	$15=, $15, $pop11
-	i32.load8_u	$push12=, .L.str($17)
-	i32.eq  	$push13=, $16, $pop12
-	br_if   	0, $pop13       # 0: up to label79
+	i32.const	$push19=, 1
+	i32.add 	$15=, $15, $pop19
+	i32.load8_u	$push6=, .L.str($17)
+	i32.eq  	$push7=, $16, $pop6
+	br_if   	0, $pop7        # 0: up to label63
 # BB#4:                                 # %if.then5
-	end_loop                        # label80:
+	end_loop                        # label64:
 	call    	abort@FUNCTION
 	unreachable
 .LBB16_5:                               # %while.end
-	end_block                       # label78:
+	end_block                       # label62:
 	i32.const	$20=, 16
 	i32.add 	$21=, $21, $20
 	i32.const	$20=, __stack_pointer
 	i32.store	$21=, 0($20), $21
 	return
 .LBB16_6:                               # %if.then.i
-	end_block                       # label77:
-	call    	abort@FUNCTION
-	unreachable
-.LBB16_7:                               # %if.then
-	end_block                       # label76:
+	end_block                       # label61:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/va-arg-4.c.s
+++ b/test/torture-s/va-arg-4.c.s
@@ -15,23 +15,20 @@ f:                                      # @f
 	i32.const	$4=, __stack_pointer
 	i32.store	$6=, 0($4), $6
 	block
-	block
-	block
-	block
 	i32.load8_u	$push0=, 0($0)
 	i32.const	$push1=, 97
 	i32.ne  	$push2=, $pop0, $pop1
-	br_if   	0, $pop2        # 0: down to label3
+	br_if   	0, $pop2        # 0: down to label0
 # BB#1:                                 # %lor.lhs.false
 	i32.load8_u	$push3=, 1($0)
 	i32.const	$push4=, 98
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label3
+	br_if   	0, $pop5        # 0: down to label0
 # BB#2:                                 # %lor.lhs.false7
 	i32.load8_u	$push6=, 2($0)
 	i32.const	$push7=, 99
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	0, $pop8        # 0: down to label3
+	br_if   	0, $pop8        # 0: down to label0
 # BB#3:                                 # %if.end
 	i32.store	$push9=, 12($6), $2
 	i32.const	$push32=, 3
@@ -45,7 +42,7 @@ f:                                      # @f
 	i32.load	$push12=, 0($0)
 	i32.const	$push13=, 42
 	i32.ne  	$push14=, $pop12, $pop13
-	br_if   	1, $pop14       # 1: down to label2
+	br_if   	0, $pop14       # 0: down to label0
 # BB#4:                                 # %if.end17
 	i32.load	$push15=, 12($6)
 	i32.const	$push37=, 3
@@ -59,7 +56,7 @@ f:                                      # @f
 	i32.load	$push18=, 0($0)
 	i32.const	$push19=, 120
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	2, $pop20       # 2: down to label1
+	br_if   	0, $pop20       # 0: down to label0
 # BB#5:                                 # %if.end21
 	i32.load	$push21=, 12($6)
 	i32.const	$push22=, 3
@@ -71,26 +68,14 @@ f:                                      # @f
 	i32.add 	$push26=, $pop38, $pop25
 	i32.store	$discard=, 12($6), $pop26
 	i32.load	$push27=, 0($0)
-	br_if   	3, $pop27       # 3: down to label0
+	br_if   	0, $pop27       # 0: down to label0
 # BB#6:                                 # %if.end25
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
-.LBB0_7:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then16
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_9:                                # %if.then20
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_10:                               # %if.then24
+.LBB0_7:                                # %if.then24
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-5.c.s
+++ b/test/torture-s/va-arg-5.c.s
@@ -25,13 +25,10 @@ va_double:                              # @va_double
 	i32.add 	$push2=, $pop25, $pop24
 	i32.store	$discard=, 12($5), $pop2
 	block
-	block
-	block
-	block
 	f64.load	$push3=, 0($1)
 	f64.const	$push4=, 0x1.921fafc8b007ap1
 	f64.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label3
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($5)
 	i32.const	$push33=, 7
@@ -45,7 +42,7 @@ va_double:                              # @va_double
 	f64.load	$push9=, 0($1)
 	f64.const	$push10=, 0x1.5bf04577d9557p1
 	f64.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label2
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($5)
 	i32.const	$push38=, 7
@@ -59,7 +56,7 @@ va_double:                              # @va_double
 	f64.load	$push15=, 0($1)
 	f64.const	$push16=, 0x1.1e3779131154cp1
 	f64.ne  	$push17=, $pop15, $pop16
-	br_if   	2, $pop17       # 2: down to label1
+	br_if   	0, $pop17       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.load	$push18=, 12($5)
 	i32.const	$push43=, 7
@@ -73,26 +70,14 @@ va_double:                              # @va_double
 	f64.load	$push21=, 0($1)
 	f64.const	$push22=, 0x1.12e0be1b5921ep1
 	f64.ne  	$push23=, $pop21, $pop22
-	br_if   	3, $pop23       # 3: down to label0
+	br_if   	0, $pop23       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return  	$1
-.LBB0_5:                                # %if.then
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then3
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_7:                                # %if.then6
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_8:                                # %if.then9
+.LBB0_5:                                # %if.then9
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -129,14 +114,11 @@ va_long_double:                         # @va_long_double
 	i32.add 	$push3=, $1, $pop32
 	i32.store	$discard=, 12($7), $pop3
 	block
-	block
-	block
-	block
 	i64.load	$push4=, 0($1)
 	i64.const	$push6=, -7338557514379428662
 	i64.const	$push5=, 4611846683218194439
 	i32.call	$push7=, __eqtf2@FUNCTION, $2, $pop4, $pop6, $pop5
-	br_if   	0, $pop7        # 0: down to label7
+	br_if   	0, $pop7        # 0: down to label1
 # BB#1:                                 # %if.end
 	i32.load	$push8=, 12($7)
 	i32.const	$push43=, 15
@@ -155,7 +137,7 @@ va_long_double:                         # @va_long_double
 	i64.const	$push14=, 8163791057260899163
 	i64.const	$push13=, 4611787105943148885
 	i32.call	$push15=, __eqtf2@FUNCTION, $2, $pop12, $pop14, $pop13
-	br_if   	1, $pop15       # 1: down to label6
+	br_if   	0, $pop15       # 0: down to label1
 # BB#2:                                 # %if.end4
 	i32.load	$push16=, 12($7)
 	i32.const	$push49=, 15
@@ -174,7 +156,7 @@ va_long_double:                         # @va_long_double
 	i64.const	$push22=, -4892607794577095924
 	i64.const	$push21=, 4611719242030715220
 	i32.call	$push23=, __eqtf2@FUNCTION, $2, $pop20, $pop22, $pop21
-	br_if   	2, $pop23       # 2: down to label5
+	br_if   	0, $pop23       # 0: down to label1
 # BB#3:                                 # %if.end7
 	i32.load	$push24=, 12($7)
 	i32.const	$push55=, 15
@@ -193,27 +175,15 @@ va_long_double:                         # @va_long_double
 	i64.const	$push30=, -2718666384188054750
 	i64.const	$push29=, 4611706774898825505
 	i32.call	$push31=, __eqtf2@FUNCTION, $2, $pop28, $pop30, $pop29
-	br_if   	3, $pop31       # 3: down to label4
+	br_if   	0, $pop31       # 0: down to label1
 # BB#4:                                 # %if.end10
 	i32.const	$6=, 16
 	i32.add 	$7=, $7, $6
 	i32.const	$6=, __stack_pointer
 	i32.store	$7=, 0($6), $7
 	return  	$1
-.LBB1_5:                                # %if.then
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_6:                                # %if.then3
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_7:                                # %if.then6
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_8:                                # %if.then9
-	end_block                       # label4:
+.LBB1_5:                                # %if.then9
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/va-arg-6.c.s
+++ b/test/torture-s/va-arg-6.c.s
@@ -25,18 +25,10 @@ f:                                      # @f
 	i32.add 	$push5=, $pop77, $pop4
 	i32.store	$discard=, 12($7), $pop5
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.load	$push6=, 0($1)
 	i32.const	$push7=, 10
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	0, $pop8        # 0: down to label8
+	br_if   	0, $pop8        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push9=, 12($7)
 	i32.const	$push10=, 7
@@ -50,7 +42,7 @@ f:                                      # @f
 	i64.load	$push15=, 0($1)
 	i64.const	$push16=, 10000000000
 	i64.ne  	$push17=, $pop15, $pop16
-	br_if   	1, $pop17       # 1: down to label7
+	br_if   	0, $pop17       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push18=, 12($7)
 	i32.const	$push19=, 3
@@ -64,7 +56,7 @@ f:                                      # @f
 	i32.load	$push24=, 0($1)
 	i32.const	$push25=, 11
 	i32.ne  	$push26=, $pop24, $pop25
-	br_if   	2, $pop26       # 2: down to label6
+	br_if   	0, $pop26       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.load	$push27=, 12($7)
 	i32.const	$push28=, 15
@@ -83,7 +75,7 @@ f:                                      # @f
 	i64.const	$push36=, -1475739525896764129
 	i64.const	$push35=, 4611846459164112977
 	i32.call	$push37=, __eqtf2@FUNCTION, $2, $pop34, $pop36, $pop35
-	br_if   	3, $pop37       # 3: down to label5
+	br_if   	0, $pop37       # 0: down to label0
 # BB#4:                                 # %if.end10
 	i32.load	$push38=, 12($7)
 	i32.const	$push90=, 3
@@ -97,7 +89,7 @@ f:                                      # @f
 	i32.load	$push41=, 0($1)
 	i32.const	$push42=, 12
 	i32.ne  	$push43=, $pop41, $pop42
-	br_if   	4, $pop43       # 4: down to label4
+	br_if   	0, $pop43       # 0: down to label0
 # BB#5:                                 # %if.end13
 	i32.load	$push44=, 12($7)
 	i32.const	$push95=, 3
@@ -111,7 +103,7 @@ f:                                      # @f
 	i32.load	$push47=, 0($1)
 	i32.const	$push48=, 13
 	i32.ne  	$push49=, $pop47, $pop48
-	br_if   	5, $pop49       # 5: down to label3
+	br_if   	0, $pop49       # 0: down to label0
 # BB#6:                                 # %if.end16
 	i32.load	$push50=, 12($7)
 	i32.const	$push51=, 7
@@ -125,7 +117,7 @@ f:                                      # @f
 	i64.load	$push56=, 0($1)
 	i64.const	$push57=, 20000000000
 	i64.ne  	$push58=, $pop56, $pop57
-	br_if   	6, $pop58       # 6: down to label2
+	br_if   	0, $pop58       # 0: down to label0
 # BB#7:                                 # %if.end19
 	i32.load	$push59=, 12($7)
 	i32.const	$push60=, 3
@@ -139,7 +131,7 @@ f:                                      # @f
 	i32.load	$push65=, 0($1)
 	i32.const	$push66=, 14
 	i32.ne  	$push67=, $pop65, $pop66
-	br_if   	7, $pop67       # 7: down to label1
+	br_if   	0, $pop67       # 0: down to label0
 # BB#8:                                 # %if.end22
 	i32.load	$push68=, 12($7)
 	i32.const	$push69=, 7
@@ -153,46 +145,14 @@ f:                                      # @f
 	f64.load	$push74=, 0($1)
 	f64.const	$push75=, 0x1.5c28f5c28f5c3p1
 	f64.ne  	$push76=, $pop74, $pop75
-	br_if   	8, $pop76       # 8: down to label0
+	br_if   	0, $pop76       # 0: down to label0
 # BB#9:                                 # %if.end25
 	i32.const	$6=, 16
 	i32.add 	$7=, $7, $6
 	i32.const	$6=, __stack_pointer
 	i32.store	$7=, 0($6), $7
 	return  	$1
-.LBB0_10:                               # %if.then
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_11:                               # %if.then3
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_12:                               # %if.then6
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_13:                               # %if.then9
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_14:                               # %if.then12
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_15:                               # %if.then15
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_16:                               # %if.then18
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_17:                               # %if.then21
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_18:                               # %if.then24
+.LBB0_10:                               # %if.then24
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-7.c.s
+++ b/test/torture-s/va-arg-7.c.s
@@ -24,12 +24,10 @@ debug:                                  # @debug
 	i32.add 	$push2=, $pop22, $pop21
 	i32.store	$discard=, 12($20), $pop2
 	block
-	block
-	block
 	i32.load	$push3=, 0($16)
 	i32.const	$push4=, 8
 	i32.ne  	$push5=, $pop3, $pop4
-	br_if   	0, $pop5        # 0: down to label2
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push6=, 12($20)
 	i32.const	$push30=, 3
@@ -43,7 +41,7 @@ debug:                                  # @debug
 	i32.load	$push9=, 0($16)
 	i32.const	$push10=, 9
 	i32.ne  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label1
+	br_if   	0, $pop11       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.load	$push12=, 12($20)
 	i32.const	$push13=, 3
@@ -57,22 +55,14 @@ debug:                                  # @debug
 	i32.load	$push18=, 0($16)
 	i32.const	$push19=, 10
 	i32.ne  	$push20=, $pop18, $pop19
-	br_if   	2, $pop20       # 2: down to label0
+	br_if   	0, $pop20       # 0: down to label0
 # BB#3:                                 # %if.end7
 	i32.const	$19=, 16
 	i32.add 	$20=, $20, $19
 	i32.const	$19=, __stack_pointer
 	i32.store	$20=, 0($19), $20
 	return
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then3
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then6
+.LBB0_4:                                # %if.then6
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-8.c.s
+++ b/test/torture-s/va-arg-8.c.s
@@ -24,11 +24,10 @@ debug:                                  # @debug
 	i32.add 	$push5=, $pop18, $pop4
 	i32.store	$discard=, 12($13), $pop5
 	block
-	block
 	i32.load	$push6=, 0($9)
 	i32.const	$push7=, 10
 	i32.ne  	$push8=, $pop6, $pop7
-	br_if   	0, $pop8        # 0: down to label1
+	br_if   	0, $pop8        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.load	$push9=, 12($13)
 	i32.const	$push10=, 7
@@ -42,18 +41,14 @@ debug:                                  # @debug
 	i64.load	$push15=, 0($9)
 	i64.const	$push16=, 20014547621496
 	i64.ne  	$push17=, $pop15, $pop16
-	br_if   	1, $pop17       # 1: down to label0
+	br_if   	0, $pop17       # 0: down to label0
 # BB#2:                                 # %if.end4
 	i32.const	$12=, 16
 	i32.add 	$13=, $13, $12
 	i32.const	$12=, __stack_pointer
 	i32.store	$13=, 0($12), $13
 	return
-.LBB0_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_4:                                # %if.then3
+.LBB0_3:                                # %if.then3
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/va-arg-9.c.s
+++ b/test/torture-s/va-arg-9.c.s
@@ -40,59 +40,54 @@ fap:                                    # @fap
 	i32.store	$discard=, 12($6), $2
 	block
 	i32.call	$push0=, strlen@FUNCTION, $1
-	i32.const	$push1=, 16
-	i32.sub 	$push2=, $pop1, $0
-	i32.ne  	$push3=, $pop0, $pop2
-	br_if   	0, $pop3        # 0: down to label1
+	i32.const	$push9=, 16
+	i32.sub 	$push1=, $pop9, $0
+	i32.ne  	$push2=, $pop0, $pop1
+	br_if   	0, $pop2        # 0: down to label1
 .LBB1_1:                                # %while.cond
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label4:
-	i32.load8_u	$push16=, 0($1)
-	tee_local	$push15=, $0=, $pop16
+	loop                            # label3:
+	i32.load8_u	$push11=, 0($1)
+	tee_local	$push10=, $0=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label3
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label2
 # BB#2:                                 # %while.body
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.load	$push4=, 12($6)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $2=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($6), $pop9
-	i32.load	$push18=, 0($2)
-	tee_local	$push17=, $2=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label2
+	i32.load	$push3=, 12($6)
+	i32.const	$push19=, 3
+	i32.add 	$push4=, $pop3, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop4, $pop18
+	tee_local	$push16=, $2=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push5=, $pop16, $pop15
+	i32.store	$discard=, 12($6), $pop5
+	i32.load	$push14=, 0($2)
+	tee_local	$push13=, $2=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push6=, $pop13, $pop12
+	br_if   	3, $pop6        # 3: down to label1
 # BB#3:                                 # %to_hex.exit
                                         #   in Loop: Header=BB1_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$1=, $1, $pop12
-	i32.load8_u	$push13=, .L.str($2)
-	i32.eq  	$push14=, $0, $pop13
-	br_if   	0, $pop14       # 0: up to label4
+	i32.const	$push20=, 1
+	i32.add 	$1=, $1, $pop20
+	i32.load8_u	$push7=, .L.str($2)
+	i32.eq  	$push8=, $0, $pop7
+	br_if   	0, $pop8        # 0: up to label3
 # BB#4:                                 # %if.then4
-	end_loop                        # label5:
+	end_loop                        # label4:
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_5:                                # %while.end
-	end_block                       # label3:
+	end_block                       # label2:
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
 .LBB1_6:                                # %if.then.i
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_7:                                # %if.then
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
@@ -118,59 +113,54 @@ f0:                                     # @f0
 	i32.store	$discard=, 12($6), $pop0
 	block
 	i32.call	$push1=, strlen@FUNCTION, $0
-	i32.const	$push2=, 16
-	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label6
+	i32.const	$push9=, 16
+	i32.ne  	$push2=, $pop1, $pop9
+	br_if   	0, $pop2        # 0: down to label5
 .LBB2_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label9:
-	i32.load8_u	$push16=, 0($0)
-	tee_local	$push15=, $1=, $pop16
+	loop                            # label7:
+	i32.load8_u	$push11=, 0($0)
+	tee_local	$push10=, $1=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label8
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label6
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.load	$push4=, 12($6)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $2=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($6), $pop9
-	i32.load	$push18=, 0($2)
-	tee_local	$push17=, $2=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label7
+	i32.load	$push3=, 12($6)
+	i32.const	$push19=, 3
+	i32.add 	$push4=, $pop3, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop4, $pop18
+	tee_local	$push16=, $2=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push5=, $pop16, $pop15
+	i32.store	$discard=, 12($6), $pop5
+	i32.load	$push14=, 0($2)
+	tee_local	$push13=, $2=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push6=, $pop13, $pop12
+	br_if   	3, $pop6        # 3: down to label5
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB2_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$0=, $0, $pop12
-	i32.load8_u	$push13=, .L.str($2)
-	i32.eq  	$push14=, $1, $pop13
-	br_if   	0, $pop14       # 0: up to label9
+	i32.const	$push20=, 1
+	i32.add 	$0=, $0, $pop20
+	i32.load8_u	$push7=, .L.str($2)
+	i32.eq  	$push8=, $1, $pop7
+	br_if   	0, $pop8        # 0: up to label7
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label10:
+	end_loop                        # label8:
 	call    	abort@FUNCTION
 	unreachable
 .LBB2_5:                                # %fap.exit
-	end_block                       # label8:
+	end_block                       # label6:
 	i32.const	$5=, 16
 	i32.add 	$6=, $6, $5
 	i32.const	$5=, __stack_pointer
 	i32.store	$6=, 0($5), $6
 	return
 .LBB2_6:                                # %if.then.i.i
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB2_7:                                # %if.then.i
-	end_block                       # label6:
+	end_block                       # label5:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -197,57 +187,52 @@ f1:                                     # @f1
 	i32.call	$push1=, strlen@FUNCTION, $1
 	i32.const	$push2=, 15
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label11
+	br_if   	0, $pop3        # 0: down to label9
 .LBB3_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label14:
-	i32.load8_u	$push16=, 0($1)
-	tee_local	$push15=, $2=, $pop16
+	loop                            # label11:
+	i32.load8_u	$push11=, 0($1)
+	tee_local	$push10=, $2=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label13
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label10
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB3_1 Depth=1
 	i32.load	$push4=, 12($7)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $3=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($7), $pop9
-	i32.load	$push18=, 0($3)
-	tee_local	$push17=, $3=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label12
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $3=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($7), $pop6
+	i32.load	$push14=, 0($3)
+	tee_local	$push13=, $3=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label9
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB3_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$1=, $1, $pop12
-	i32.load8_u	$push13=, .L.str($3)
-	i32.eq  	$push14=, $2, $pop13
-	br_if   	0, $pop14       # 0: up to label14
+	i32.const	$push20=, 1
+	i32.add 	$1=, $1, $pop20
+	i32.load8_u	$push8=, .L.str($3)
+	i32.eq  	$push9=, $2, $pop8
+	br_if   	0, $pop9        # 0: up to label11
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label15:
+	end_loop                        # label12:
 	call    	abort@FUNCTION
 	unreachable
 .LBB3_5:                                # %fap.exit
-	end_block                       # label13:
+	end_block                       # label10:
 	i32.const	$6=, 16
 	i32.add 	$7=, $7, $6
 	i32.const	$6=, __stack_pointer
 	i32.store	$7=, 0($6), $7
 	return
 .LBB3_6:                                # %if.then.i.i
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB3_7:                                # %if.then.i
-	end_block                       # label11:
+	end_block                       # label9:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -274,57 +259,52 @@ f2:                                     # @f2
 	i32.call	$push1=, strlen@FUNCTION, $2
 	i32.const	$push2=, 14
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label16
+	br_if   	0, $pop3        # 0: down to label13
 .LBB4_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label19:
-	i32.load8_u	$push16=, 0($2)
-	tee_local	$push15=, $3=, $pop16
+	loop                            # label15:
+	i32.load8_u	$push11=, 0($2)
+	tee_local	$push10=, $3=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label18
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label14
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB4_1 Depth=1
 	i32.load	$push4=, 12($8)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $4=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($8), $pop9
-	i32.load	$push18=, 0($4)
-	tee_local	$push17=, $4=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label17
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $4=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($8), $pop6
+	i32.load	$push14=, 0($4)
+	tee_local	$push13=, $4=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label13
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB4_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$2=, $2, $pop12
-	i32.load8_u	$push13=, .L.str($4)
-	i32.eq  	$push14=, $3, $pop13
-	br_if   	0, $pop14       # 0: up to label19
+	i32.const	$push20=, 1
+	i32.add 	$2=, $2, $pop20
+	i32.load8_u	$push8=, .L.str($4)
+	i32.eq  	$push9=, $3, $pop8
+	br_if   	0, $pop9        # 0: up to label15
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label20:
+	end_loop                        # label16:
 	call    	abort@FUNCTION
 	unreachable
 .LBB4_5:                                # %fap.exit
-	end_block                       # label18:
+	end_block                       # label14:
 	i32.const	$7=, 16
 	i32.add 	$8=, $8, $7
 	i32.const	$7=, __stack_pointer
 	i32.store	$8=, 0($7), $8
 	return
 .LBB4_6:                                # %if.then.i.i
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB4_7:                                # %if.then.i
-	end_block                       # label16:
+	end_block                       # label13:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -351,57 +331,52 @@ f3:                                     # @f3
 	i32.call	$push1=, strlen@FUNCTION, $3
 	i32.const	$push2=, 13
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label21
+	br_if   	0, $pop3        # 0: down to label17
 .LBB5_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label24:
-	i32.load8_u	$push16=, 0($3)
-	tee_local	$push15=, $4=, $pop16
+	loop                            # label19:
+	i32.load8_u	$push11=, 0($3)
+	tee_local	$push10=, $4=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label23
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label18
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB5_1 Depth=1
 	i32.load	$push4=, 12($9)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $5=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($9), $pop9
-	i32.load	$push18=, 0($5)
-	tee_local	$push17=, $5=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label22
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $5=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($9), $pop6
+	i32.load	$push14=, 0($5)
+	tee_local	$push13=, $5=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label17
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB5_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$3=, $3, $pop12
-	i32.load8_u	$push13=, .L.str($5)
-	i32.eq  	$push14=, $4, $pop13
-	br_if   	0, $pop14       # 0: up to label24
+	i32.const	$push20=, 1
+	i32.add 	$3=, $3, $pop20
+	i32.load8_u	$push8=, .L.str($5)
+	i32.eq  	$push9=, $4, $pop8
+	br_if   	0, $pop9        # 0: up to label19
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label25:
+	end_loop                        # label20:
 	call    	abort@FUNCTION
 	unreachable
 .LBB5_5:                                # %fap.exit
-	end_block                       # label23:
+	end_block                       # label18:
 	i32.const	$8=, 16
 	i32.add 	$9=, $9, $8
 	i32.const	$8=, __stack_pointer
 	i32.store	$9=, 0($8), $9
 	return
 .LBB5_6:                                # %if.then.i.i
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB5_7:                                # %if.then.i
-	end_block                       # label21:
+	end_block                       # label17:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -428,57 +403,52 @@ f4:                                     # @f4
 	i32.call	$push1=, strlen@FUNCTION, $4
 	i32.const	$push2=, 12
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label26
+	br_if   	0, $pop3        # 0: down to label21
 .LBB6_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label29:
-	i32.load8_u	$push16=, 0($4)
-	tee_local	$push15=, $5=, $pop16
+	loop                            # label23:
+	i32.load8_u	$push11=, 0($4)
+	tee_local	$push10=, $5=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label28
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label22
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB6_1 Depth=1
 	i32.load	$push4=, 12($10)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $6=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($10), $pop9
-	i32.load	$push18=, 0($6)
-	tee_local	$push17=, $6=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label27
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $6=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($10), $pop6
+	i32.load	$push14=, 0($6)
+	tee_local	$push13=, $6=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label21
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB6_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$4=, $4, $pop12
-	i32.load8_u	$push13=, .L.str($6)
-	i32.eq  	$push14=, $5, $pop13
-	br_if   	0, $pop14       # 0: up to label29
+	i32.const	$push20=, 1
+	i32.add 	$4=, $4, $pop20
+	i32.load8_u	$push8=, .L.str($6)
+	i32.eq  	$push9=, $5, $pop8
+	br_if   	0, $pop9        # 0: up to label23
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label30:
+	end_loop                        # label24:
 	call    	abort@FUNCTION
 	unreachable
 .LBB6_5:                                # %fap.exit
-	end_block                       # label28:
+	end_block                       # label22:
 	i32.const	$9=, 16
 	i32.add 	$10=, $10, $9
 	i32.const	$9=, __stack_pointer
 	i32.store	$10=, 0($9), $10
 	return
 .LBB6_6:                                # %if.then.i.i
-	end_block                       # label27:
-	call    	abort@FUNCTION
-	unreachable
-.LBB6_7:                                # %if.then.i
-	end_block                       # label26:
+	end_block                       # label21:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -505,57 +475,52 @@ f5:                                     # @f5
 	i32.call	$push1=, strlen@FUNCTION, $5
 	i32.const	$push2=, 11
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label31
+	br_if   	0, $pop3        # 0: down to label25
 .LBB7_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label34:
-	i32.load8_u	$push16=, 0($5)
-	tee_local	$push15=, $6=, $pop16
+	loop                            # label27:
+	i32.load8_u	$push11=, 0($5)
+	tee_local	$push10=, $6=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label33
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label26
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB7_1 Depth=1
 	i32.load	$push4=, 12($11)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $7=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($11), $pop9
-	i32.load	$push18=, 0($7)
-	tee_local	$push17=, $7=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label32
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $7=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($11), $pop6
+	i32.load	$push14=, 0($7)
+	tee_local	$push13=, $7=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label25
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB7_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$5=, $5, $pop12
-	i32.load8_u	$push13=, .L.str($7)
-	i32.eq  	$push14=, $6, $pop13
-	br_if   	0, $pop14       # 0: up to label34
+	i32.const	$push20=, 1
+	i32.add 	$5=, $5, $pop20
+	i32.load8_u	$push8=, .L.str($7)
+	i32.eq  	$push9=, $6, $pop8
+	br_if   	0, $pop9        # 0: up to label27
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label35:
+	end_loop                        # label28:
 	call    	abort@FUNCTION
 	unreachable
 .LBB7_5:                                # %fap.exit
-	end_block                       # label33:
+	end_block                       # label26:
 	i32.const	$10=, 16
 	i32.add 	$11=, $11, $10
 	i32.const	$10=, __stack_pointer
 	i32.store	$11=, 0($10), $11
 	return
 .LBB7_6:                                # %if.then.i.i
-	end_block                       # label32:
-	call    	abort@FUNCTION
-	unreachable
-.LBB7_7:                                # %if.then.i
-	end_block                       # label31:
+	end_block                       # label25:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -582,57 +547,52 @@ f6:                                     # @f6
 	i32.call	$push1=, strlen@FUNCTION, $6
 	i32.const	$push2=, 10
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label36
+	br_if   	0, $pop3        # 0: down to label29
 .LBB8_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label39:
-	i32.load8_u	$push16=, 0($6)
-	tee_local	$push15=, $7=, $pop16
+	loop                            # label31:
+	i32.load8_u	$push11=, 0($6)
+	tee_local	$push10=, $7=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label38
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label30
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB8_1 Depth=1
 	i32.load	$push4=, 12($12)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $8=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($12), $pop9
-	i32.load	$push18=, 0($8)
-	tee_local	$push17=, $8=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label37
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $8=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($12), $pop6
+	i32.load	$push14=, 0($8)
+	tee_local	$push13=, $8=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label29
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB8_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$6=, $6, $pop12
-	i32.load8_u	$push13=, .L.str($8)
-	i32.eq  	$push14=, $7, $pop13
-	br_if   	0, $pop14       # 0: up to label39
+	i32.const	$push20=, 1
+	i32.add 	$6=, $6, $pop20
+	i32.load8_u	$push8=, .L.str($8)
+	i32.eq  	$push9=, $7, $pop8
+	br_if   	0, $pop9        # 0: up to label31
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label40:
+	end_loop                        # label32:
 	call    	abort@FUNCTION
 	unreachable
 .LBB8_5:                                # %fap.exit
-	end_block                       # label38:
+	end_block                       # label30:
 	i32.const	$11=, 16
 	i32.add 	$12=, $12, $11
 	i32.const	$11=, __stack_pointer
 	i32.store	$12=, 0($11), $12
 	return
 .LBB8_6:                                # %if.then.i.i
-	end_block                       # label37:
-	call    	abort@FUNCTION
-	unreachable
-.LBB8_7:                                # %if.then.i
-	end_block                       # label36:
+	end_block                       # label29:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -659,57 +619,52 @@ f7:                                     # @f7
 	i32.call	$push1=, strlen@FUNCTION, $7
 	i32.const	$push2=, 9
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label41
+	br_if   	0, $pop3        # 0: down to label33
 .LBB9_1:                                # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label44:
-	i32.load8_u	$push16=, 0($7)
-	tee_local	$push15=, $8=, $pop16
+	loop                            # label35:
+	i32.load8_u	$push11=, 0($7)
+	tee_local	$push10=, $8=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label43
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label34
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB9_1 Depth=1
 	i32.load	$push4=, 12($13)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $9=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($13), $pop9
-	i32.load	$push18=, 0($9)
-	tee_local	$push17=, $9=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label42
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $9=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($13), $pop6
+	i32.load	$push14=, 0($9)
+	tee_local	$push13=, $9=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label33
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB9_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$7=, $7, $pop12
-	i32.load8_u	$push13=, .L.str($9)
-	i32.eq  	$push14=, $8, $pop13
-	br_if   	0, $pop14       # 0: up to label44
+	i32.const	$push20=, 1
+	i32.add 	$7=, $7, $pop20
+	i32.load8_u	$push8=, .L.str($9)
+	i32.eq  	$push9=, $8, $pop8
+	br_if   	0, $pop9        # 0: up to label35
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label45:
+	end_loop                        # label36:
 	call    	abort@FUNCTION
 	unreachable
 .LBB9_5:                                # %fap.exit
-	end_block                       # label43:
+	end_block                       # label34:
 	i32.const	$12=, 16
 	i32.add 	$13=, $13, $12
 	i32.const	$12=, __stack_pointer
 	i32.store	$13=, 0($12), $13
 	return
 .LBB9_6:                                # %if.then.i.i
-	end_block                       # label42:
-	call    	abort@FUNCTION
-	unreachable
-.LBB9_7:                                # %if.then.i
-	end_block                       # label41:
+	end_block                       # label33:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -736,57 +691,52 @@ f8:                                     # @f8
 	i32.call	$push1=, strlen@FUNCTION, $8
 	i32.const	$push2=, 8
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label46
+	br_if   	0, $pop3        # 0: down to label37
 .LBB10_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label49:
-	i32.load8_u	$push16=, 0($8)
-	tee_local	$push15=, $9=, $pop16
+	loop                            # label39:
+	i32.load8_u	$push11=, 0($8)
+	tee_local	$push10=, $9=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label48
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label38
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB10_1 Depth=1
 	i32.load	$push4=, 12($14)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $10=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($14), $pop9
-	i32.load	$push18=, 0($10)
-	tee_local	$push17=, $10=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label47
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $10=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($14), $pop6
+	i32.load	$push14=, 0($10)
+	tee_local	$push13=, $10=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label37
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB10_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$8=, $8, $pop12
-	i32.load8_u	$push13=, .L.str($10)
-	i32.eq  	$push14=, $9, $pop13
-	br_if   	0, $pop14       # 0: up to label49
+	i32.const	$push20=, 1
+	i32.add 	$8=, $8, $pop20
+	i32.load8_u	$push8=, .L.str($10)
+	i32.eq  	$push9=, $9, $pop8
+	br_if   	0, $pop9        # 0: up to label39
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label50:
+	end_loop                        # label40:
 	call    	abort@FUNCTION
 	unreachable
 .LBB10_5:                               # %fap.exit
-	end_block                       # label48:
+	end_block                       # label38:
 	i32.const	$13=, 16
 	i32.add 	$14=, $14, $13
 	i32.const	$13=, __stack_pointer
 	i32.store	$14=, 0($13), $14
 	return
 .LBB10_6:                               # %if.then.i.i
-	end_block                       # label47:
-	call    	abort@FUNCTION
-	unreachable
-.LBB10_7:                               # %if.then.i
-	end_block                       # label46:
+	end_block                       # label37:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -813,57 +763,52 @@ f9:                                     # @f9
 	i32.call	$push1=, strlen@FUNCTION, $9
 	i32.const	$push2=, 7
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label51
+	br_if   	0, $pop3        # 0: down to label41
 .LBB11_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label54:
-	i32.load8_u	$push16=, 0($9)
-	tee_local	$push15=, $10=, $pop16
+	loop                            # label43:
+	i32.load8_u	$push11=, 0($9)
+	tee_local	$push10=, $10=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label53
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label42
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB11_1 Depth=1
 	i32.load	$push4=, 12($15)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $11=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($15), $pop9
-	i32.load	$push18=, 0($11)
-	tee_local	$push17=, $11=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label52
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $11=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($15), $pop6
+	i32.load	$push14=, 0($11)
+	tee_local	$push13=, $11=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label41
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB11_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$9=, $9, $pop12
-	i32.load8_u	$push13=, .L.str($11)
-	i32.eq  	$push14=, $10, $pop13
-	br_if   	0, $pop14       # 0: up to label54
+	i32.const	$push20=, 1
+	i32.add 	$9=, $9, $pop20
+	i32.load8_u	$push8=, .L.str($11)
+	i32.eq  	$push9=, $10, $pop8
+	br_if   	0, $pop9        # 0: up to label43
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label55:
+	end_loop                        # label44:
 	call    	abort@FUNCTION
 	unreachable
 .LBB11_5:                               # %fap.exit
-	end_block                       # label53:
+	end_block                       # label42:
 	i32.const	$14=, 16
 	i32.add 	$15=, $15, $14
 	i32.const	$14=, __stack_pointer
 	i32.store	$15=, 0($14), $15
 	return
 .LBB11_6:                               # %if.then.i.i
-	end_block                       # label52:
-	call    	abort@FUNCTION
-	unreachable
-.LBB11_7:                               # %if.then.i
-	end_block                       # label51:
+	end_block                       # label41:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -890,57 +835,52 @@ f10:                                    # @f10
 	i32.call	$push1=, strlen@FUNCTION, $10
 	i32.const	$push2=, 6
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label56
+	br_if   	0, $pop3        # 0: down to label45
 .LBB12_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label59:
-	i32.load8_u	$push16=, 0($10)
-	tee_local	$push15=, $11=, $pop16
+	loop                            # label47:
+	i32.load8_u	$push11=, 0($10)
+	tee_local	$push10=, $11=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label58
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label46
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB12_1 Depth=1
 	i32.load	$push4=, 12($16)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $12=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($16), $pop9
-	i32.load	$push18=, 0($12)
-	tee_local	$push17=, $12=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label57
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $12=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($16), $pop6
+	i32.load	$push14=, 0($12)
+	tee_local	$push13=, $12=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label45
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB12_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$10=, $10, $pop12
-	i32.load8_u	$push13=, .L.str($12)
-	i32.eq  	$push14=, $11, $pop13
-	br_if   	0, $pop14       # 0: up to label59
+	i32.const	$push20=, 1
+	i32.add 	$10=, $10, $pop20
+	i32.load8_u	$push8=, .L.str($12)
+	i32.eq  	$push9=, $11, $pop8
+	br_if   	0, $pop9        # 0: up to label47
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label60:
+	end_loop                        # label48:
 	call    	abort@FUNCTION
 	unreachable
 .LBB12_5:                               # %fap.exit
-	end_block                       # label58:
+	end_block                       # label46:
 	i32.const	$15=, 16
 	i32.add 	$16=, $16, $15
 	i32.const	$15=, __stack_pointer
 	i32.store	$16=, 0($15), $16
 	return
 .LBB12_6:                               # %if.then.i.i
-	end_block                       # label57:
-	call    	abort@FUNCTION
-	unreachable
-.LBB12_7:                               # %if.then.i
-	end_block                       # label56:
+	end_block                       # label45:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -967,57 +907,52 @@ f11:                                    # @f11
 	i32.call	$push1=, strlen@FUNCTION, $11
 	i32.const	$push2=, 5
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label61
+	br_if   	0, $pop3        # 0: down to label49
 .LBB13_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label64:
-	i32.load8_u	$push16=, 0($11)
-	tee_local	$push15=, $12=, $pop16
+	loop                            # label51:
+	i32.load8_u	$push11=, 0($11)
+	tee_local	$push10=, $12=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label63
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label50
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB13_1 Depth=1
 	i32.load	$push4=, 12($17)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $13=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($17), $pop9
-	i32.load	$push18=, 0($13)
-	tee_local	$push17=, $13=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label62
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $13=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($17), $pop6
+	i32.load	$push14=, 0($13)
+	tee_local	$push13=, $13=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label49
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB13_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$11=, $11, $pop12
-	i32.load8_u	$push13=, .L.str($13)
-	i32.eq  	$push14=, $12, $pop13
-	br_if   	0, $pop14       # 0: up to label64
+	i32.const	$push20=, 1
+	i32.add 	$11=, $11, $pop20
+	i32.load8_u	$push8=, .L.str($13)
+	i32.eq  	$push9=, $12, $pop8
+	br_if   	0, $pop9        # 0: up to label51
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label65:
+	end_loop                        # label52:
 	call    	abort@FUNCTION
 	unreachable
 .LBB13_5:                               # %fap.exit
-	end_block                       # label63:
+	end_block                       # label50:
 	i32.const	$16=, 16
 	i32.add 	$17=, $17, $16
 	i32.const	$16=, __stack_pointer
 	i32.store	$17=, 0($16), $17
 	return
 .LBB13_6:                               # %if.then.i.i
-	end_block                       # label62:
-	call    	abort@FUNCTION
-	unreachable
-.LBB13_7:                               # %if.then.i
-	end_block                       # label61:
+	end_block                       # label49:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1042,59 +977,54 @@ f12:                                    # @f12
 	i32.store	$discard=, 12($18), $pop0
 	block
 	i32.call	$push1=, strlen@FUNCTION, $12
-	i32.const	$push2=, 4
-	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label66
+	i32.const	$push9=, 4
+	i32.ne  	$push2=, $pop1, $pop9
+	br_if   	0, $pop2        # 0: down to label53
 .LBB14_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label69:
-	i32.load8_u	$push16=, 0($12)
-	tee_local	$push15=, $13=, $pop16
+	loop                            # label55:
+	i32.load8_u	$push11=, 0($12)
+	tee_local	$push10=, $13=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label68
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label54
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB14_1 Depth=1
-	i32.load	$push4=, 12($18)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $14=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($18), $pop9
-	i32.load	$push18=, 0($14)
-	tee_local	$push17=, $14=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label67
+	i32.load	$push3=, 12($18)
+	i32.const	$push19=, 3
+	i32.add 	$push4=, $pop3, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop4, $pop18
+	tee_local	$push16=, $14=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push5=, $pop16, $pop15
+	i32.store	$discard=, 12($18), $pop5
+	i32.load	$push14=, 0($14)
+	tee_local	$push13=, $14=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push6=, $pop13, $pop12
+	br_if   	3, $pop6        # 3: down to label53
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB14_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$12=, $12, $pop12
-	i32.load8_u	$push13=, .L.str($14)
-	i32.eq  	$push14=, $13, $pop13
-	br_if   	0, $pop14       # 0: up to label69
+	i32.const	$push20=, 1
+	i32.add 	$12=, $12, $pop20
+	i32.load8_u	$push7=, .L.str($14)
+	i32.eq  	$push8=, $13, $pop7
+	br_if   	0, $pop8        # 0: up to label55
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label70:
+	end_loop                        # label56:
 	call    	abort@FUNCTION
 	unreachable
 .LBB14_5:                               # %fap.exit
-	end_block                       # label68:
+	end_block                       # label54:
 	i32.const	$17=, 16
 	i32.add 	$18=, $18, $17
 	i32.const	$17=, __stack_pointer
 	i32.store	$18=, 0($17), $18
 	return
 .LBB14_6:                               # %if.then.i.i
-	end_block                       # label67:
-	call    	abort@FUNCTION
-	unreachable
-.LBB14_7:                               # %if.then.i
-	end_block                       # label66:
+	end_block                       # label53:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1119,59 +1049,54 @@ f13:                                    # @f13
 	i32.store	$discard=, 12($19), $pop0
 	block
 	i32.call	$push1=, strlen@FUNCTION, $13
-	i32.const	$push2=, 3
-	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label71
+	i32.const	$push9=, 3
+	i32.ne  	$push2=, $pop1, $pop9
+	br_if   	0, $pop2        # 0: down to label57
 .LBB15_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label74:
-	i32.load8_u	$push16=, 0($13)
-	tee_local	$push15=, $14=, $pop16
+	loop                            # label59:
+	i32.load8_u	$push11=, 0($13)
+	tee_local	$push10=, $14=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label73
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label58
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB15_1 Depth=1
-	i32.load	$push4=, 12($19)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $15=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($19), $pop9
-	i32.load	$push18=, 0($15)
-	tee_local	$push17=, $15=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label72
+	i32.load	$push3=, 12($19)
+	i32.const	$push19=, 3
+	i32.add 	$push4=, $pop3, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop4, $pop18
+	tee_local	$push16=, $15=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push5=, $pop16, $pop15
+	i32.store	$discard=, 12($19), $pop5
+	i32.load	$push14=, 0($15)
+	tee_local	$push13=, $15=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push6=, $pop13, $pop12
+	br_if   	3, $pop6        # 3: down to label57
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB15_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$13=, $13, $pop12
-	i32.load8_u	$push13=, .L.str($15)
-	i32.eq  	$push14=, $14, $pop13
-	br_if   	0, $pop14       # 0: up to label74
+	i32.const	$push20=, 1
+	i32.add 	$13=, $13, $pop20
+	i32.load8_u	$push7=, .L.str($15)
+	i32.eq  	$push8=, $14, $pop7
+	br_if   	0, $pop8        # 0: up to label59
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label75:
+	end_loop                        # label60:
 	call    	abort@FUNCTION
 	unreachable
 .LBB15_5:                               # %fap.exit
-	end_block                       # label73:
+	end_block                       # label58:
 	i32.const	$18=, 16
 	i32.add 	$19=, $19, $18
 	i32.const	$18=, __stack_pointer
 	i32.store	$19=, 0($18), $19
 	return
 .LBB15_6:                               # %if.then.i.i
-	end_block                       # label72:
-	call    	abort@FUNCTION
-	unreachable
-.LBB15_7:                               # %if.then.i
-	end_block                       # label71:
+	end_block                       # label57:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1198,57 +1123,52 @@ f14:                                    # @f14
 	i32.call	$push1=, strlen@FUNCTION, $14
 	i32.const	$push2=, 2
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label76
+	br_if   	0, $pop3        # 0: down to label61
 .LBB16_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label79:
-	i32.load8_u	$push16=, 0($14)
-	tee_local	$push15=, $15=, $pop16
+	loop                            # label63:
+	i32.load8_u	$push11=, 0($14)
+	tee_local	$push10=, $15=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label78
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label62
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB16_1 Depth=1
 	i32.load	$push4=, 12($20)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $16=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($20), $pop9
-	i32.load	$push18=, 0($16)
-	tee_local	$push17=, $16=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label77
+	i32.const	$push19=, 3
+	i32.add 	$push5=, $pop4, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop5, $pop18
+	tee_local	$push16=, $16=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push6=, $pop16, $pop15
+	i32.store	$discard=, 12($20), $pop6
+	i32.load	$push14=, 0($16)
+	tee_local	$push13=, $16=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push7=, $pop13, $pop12
+	br_if   	3, $pop7        # 3: down to label61
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB16_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$14=, $14, $pop12
-	i32.load8_u	$push13=, .L.str($16)
-	i32.eq  	$push14=, $15, $pop13
-	br_if   	0, $pop14       # 0: up to label79
+	i32.const	$push20=, 1
+	i32.add 	$14=, $14, $pop20
+	i32.load8_u	$push8=, .L.str($16)
+	i32.eq  	$push9=, $15, $pop8
+	br_if   	0, $pop9        # 0: up to label63
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label80:
+	end_loop                        # label64:
 	call    	abort@FUNCTION
 	unreachable
 .LBB16_5:                               # %fap.exit
-	end_block                       # label78:
+	end_block                       # label62:
 	i32.const	$19=, 16
 	i32.add 	$20=, $20, $19
 	i32.const	$19=, __stack_pointer
 	i32.store	$20=, 0($19), $20
 	return
 .LBB16_6:                               # %if.then.i.i
-	end_block                       # label77:
-	call    	abort@FUNCTION
-	unreachable
-.LBB16_7:                               # %if.then.i
-	end_block                       # label76:
+	end_block                       # label61:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc
@@ -1273,59 +1193,54 @@ f15:                                    # @f15
 	i32.store	$discard=, 12($21), $pop0
 	block
 	i32.call	$push1=, strlen@FUNCTION, $15
-	i32.const	$push2=, 1
-	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label81
+	i32.const	$push9=, 1
+	i32.ne  	$push2=, $pop1, $pop9
+	br_if   	0, $pop2        # 0: down to label65
 .LBB17_1:                               # %while.cond.i
                                         # =>This Inner Loop Header: Depth=1
 	block
-	block
-	loop                            # label84:
-	i32.load8_u	$push16=, 0($15)
-	tee_local	$push15=, $16=, $pop16
+	loop                            # label67:
+	i32.load8_u	$push11=, 0($15)
+	tee_local	$push10=, $16=, $pop11
 	i32.const	$push21=, 0
-	i32.eq  	$push22=, $pop15, $pop21
-	br_if   	2, $pop22       # 2: down to label83
+	i32.eq  	$push22=, $pop10, $pop21
+	br_if   	2, $pop22       # 2: down to label66
 # BB#2:                                 # %while.body.i
                                         #   in Loop: Header=BB17_1 Depth=1
-	i32.load	$push4=, 12($21)
-	i32.const	$push5=, 3
-	i32.add 	$push6=, $pop4, $pop5
-	i32.const	$push7=, -4
-	i32.and 	$push20=, $pop6, $pop7
-	tee_local	$push19=, $17=, $pop20
-	i32.const	$push8=, 4
-	i32.add 	$push9=, $pop19, $pop8
-	i32.store	$discard=, 12($21), $pop9
-	i32.load	$push18=, 0($17)
-	tee_local	$push17=, $17=, $pop18
-	i32.const	$push10=, 16
-	i32.ge_u	$push11=, $pop17, $pop10
-	br_if   	3, $pop11       # 3: down to label82
+	i32.load	$push3=, 12($21)
+	i32.const	$push19=, 3
+	i32.add 	$push4=, $pop3, $pop19
+	i32.const	$push18=, -4
+	i32.and 	$push17=, $pop4, $pop18
+	tee_local	$push16=, $17=, $pop17
+	i32.const	$push15=, 4
+	i32.add 	$push5=, $pop16, $pop15
+	i32.store	$discard=, 12($21), $pop5
+	i32.load	$push14=, 0($17)
+	tee_local	$push13=, $17=, $pop14
+	i32.const	$push12=, 16
+	i32.ge_u	$push6=, $pop13, $pop12
+	br_if   	3, $pop6        # 3: down to label65
 # BB#3:                                 # %to_hex.exit.i
                                         #   in Loop: Header=BB17_1 Depth=1
-	i32.const	$push12=, 1
-	i32.add 	$15=, $15, $pop12
-	i32.load8_u	$push13=, .L.str($17)
-	i32.eq  	$push14=, $16, $pop13
-	br_if   	0, $pop14       # 0: up to label84
+	i32.const	$push20=, 1
+	i32.add 	$15=, $15, $pop20
+	i32.load8_u	$push7=, .L.str($17)
+	i32.eq  	$push8=, $16, $pop7
+	br_if   	0, $pop8        # 0: up to label67
 # BB#4:                                 # %if.then4.i
-	end_loop                        # label85:
+	end_loop                        # label68:
 	call    	abort@FUNCTION
 	unreachable
 .LBB17_5:                               # %fap.exit
-	end_block                       # label83:
+	end_block                       # label66:
 	i32.const	$20=, 16
 	i32.add 	$21=, $21, $20
 	i32.const	$20=, __stack_pointer
 	i32.store	$21=, 0($20), $21
 	return
 .LBB17_6:                               # %if.then.i.i
-	end_block                       # label82:
-	call    	abort@FUNCTION
-	unreachable
-.LBB17_7:                               # %if.then.i
-	end_block                       # label81:
+	end_block                       # label65:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/vfprintf-1.c.s
+++ b/test/torture-s/vfprintf-1.c.s
@@ -18,9 +18,11 @@ inner:                                  # @inner
 	i32.store	$discard=, 8($5), $pop0
 	block
 	block
+	block
+	block
 	i32.const	$push1=, 10
 	i32.gt_u	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	br_if   	0, $pop2        # 0: down to label3
 # BB#1:                                 # %entry
 	block
 	block
@@ -32,9 +34,7 @@ inner:                                  # @inner
 	block
 	block
 	block
-	block
-	block
-	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 10, 8, 9 # 0: down to label13
+	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 11, 8, 9 # 0: down to label13
                                         # 1: down to label12
                                         # 2: down to label11
                                         # 3: down to label10
@@ -42,7 +42,7 @@ inner:                                  # @inner
                                         # 5: down to label8
                                         # 6: down to label7
                                         # 7: down to label6
-                                        # 10: down to label3
+                                        # 11: down to label2
                                         # 8: down to label5
                                         # 9: down to label4
 .LBB0_2:                                # %sw.bb
@@ -59,7 +59,7 @@ inner:                                  # @inner
 	i32.call	$push95=, vfprintf@FUNCTION, $pop93, $pop98, $pop94
 	i32.const	$push96=, 5
 	i32.eq  	$push97=, $pop95, $pop96
-	br_if   	10, $pop97      # 10: down to label2
+	br_if   	11, $pop97      # 11: down to label1
 # BB#3:                                 # %if.then
 	call    	abort@FUNCTION
 	unreachable
@@ -77,7 +77,7 @@ inner:                                  # @inner
 	i32.call	$push86=, vfprintf@FUNCTION, $pop84, $pop100, $pop85
 	i32.const	$push87=, 6
 	i32.eq  	$push88=, $pop86, $pop87
-	br_if   	9, $pop88       # 9: down to label2
+	br_if   	10, $pop88      # 10: down to label1
 # BB#5:                                 # %if.then8
 	call    	abort@FUNCTION
 	unreachable
@@ -95,7 +95,7 @@ inner:                                  # @inner
 	i32.call	$push77=, vfprintf@FUNCTION, $pop75, $pop102, $pop76
 	i32.const	$push78=, 1
 	i32.eq  	$push79=, $pop77, $pop78
-	br_if   	8, $pop79       # 8: down to label2
+	br_if   	9, $pop79       # 9: down to label1
 # BB#7:                                 # %if.then14
 	call    	abort@FUNCTION
 	unreachable
@@ -113,7 +113,7 @@ inner:                                  # @inner
 	i32.call	$push70=, vfprintf@FUNCTION, $pop68, $pop104, $pop69
 	i32.const	$push120=, 0
 	i32.eq  	$push121=, $pop70, $pop120
-	br_if   	7, $pop121      # 7: down to label2
+	br_if   	8, $pop121      # 8: down to label1
 # BB#9:                                 # %if.then20
 	call    	abort@FUNCTION
 	unreachable
@@ -131,7 +131,7 @@ inner:                                  # @inner
 	i32.call	$push61=, vfprintf@FUNCTION, $pop59, $pop106, $pop60
 	i32.const	$push62=, 5
 	i32.eq  	$push63=, $pop61, $pop62
-	br_if   	6, $pop63       # 6: down to label2
+	br_if   	7, $pop63       # 7: down to label1
 # BB#11:                                # %if.then26
 	call    	abort@FUNCTION
 	unreachable
@@ -149,7 +149,7 @@ inner:                                  # @inner
 	i32.call	$push52=, vfprintf@FUNCTION, $pop50, $pop108, $pop51
 	i32.const	$push53=, 6
 	i32.eq  	$push54=, $pop52, $pop53
-	br_if   	5, $pop54       # 5: down to label2
+	br_if   	6, $pop54       # 6: down to label1
 # BB#13:                                # %if.then32
 	call    	abort@FUNCTION
 	unreachable
@@ -167,7 +167,7 @@ inner:                                  # @inner
 	i32.call	$push43=, vfprintf@FUNCTION, $pop41, $pop110, $pop42
 	i32.const	$push44=, 1
 	i32.eq  	$push45=, $pop43, $pop44
-	br_if   	4, $pop45       # 4: down to label2
+	br_if   	5, $pop45       # 5: down to label1
 # BB#15:                                # %if.then38
 	call    	abort@FUNCTION
 	unreachable
@@ -185,7 +185,7 @@ inner:                                  # @inner
 	i32.call	$push36=, vfprintf@FUNCTION, $pop34, $pop112, $pop35
 	i32.const	$push122=, 0
 	i32.eq  	$push123=, $pop36, $pop122
-	br_if   	3, $pop123      # 3: down to label2
+	br_if   	4, $pop123      # 4: down to label1
 # BB#17:                                # %if.then44
 	call    	abort@FUNCTION
 	unreachable
@@ -203,7 +203,7 @@ inner:                                  # @inner
 	i32.call	$push18=, vfprintf@FUNCTION, $pop16, $pop116, $pop17
 	i32.const	$push19=, 7
 	i32.eq  	$push20=, $pop18, $pop19
-	br_if   	2, $pop20       # 2: down to label2
+	br_if   	3, $pop20       # 3: down to label1
 # BB#19:                                # %if.then56
 	call    	abort@FUNCTION
 	unreachable
@@ -221,12 +221,13 @@ inner:                                  # @inner
 	i32.call	$push9=, vfprintf@FUNCTION, $pop7, $pop118, $pop8
 	i32.const	$push10=, 2
 	i32.eq  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label2
-# BB#21:                                # %if.then62
+	br_if   	2, $pop11       # 2: down to label1
+.LBB0_21:                               # %sw.default
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 .LBB0_22:                               # %sw.bb46
-	end_block                       # label3:
+	end_block                       # label2:
 	i32.const	$push21=, 0
 	i32.load	$push22=, stdout($pop21)
 	i32.const	$push24=, .L.str.5
@@ -239,19 +240,15 @@ inner:                                  # @inner
 	i32.call	$push27=, vfprintf@FUNCTION, $pop25, $pop114, $pop26
 	i32.const	$push28=, 1
 	i32.ne  	$push29=, $pop27, $pop28
-	br_if   	2, $pop29       # 2: down to label0
+	br_if   	1, $pop29       # 1: down to label0
 .LBB0_23:                               # %sw.epilog
-	end_block                       # label2:
+	end_block                       # label1:
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
-.LBB0_24:                               # %sw.default
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then50
+.LBB0_24:                               # %if.then50
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/vfprintf-chk-1.c.s
+++ b/test/torture-s/vfprintf-chk-1.c.s
@@ -43,32 +43,9 @@ inner:                                  # @inner
 	i32.store	$push0=, 12($5), $1
 	i32.store	$discard=, 8($5), $pop0
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push1=, 10
 	i32.gt_u	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label24
+	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %entry
 	block
 	block
@@ -82,19 +59,19 @@ inner:                                  # @inner
 	block
 	block
 	block
-	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 # 0: down to label36
-                                        # 1: down to label35
-                                        # 2: down to label34
-                                        # 3: down to label33
-                                        # 4: down to label32
-                                        # 5: down to label31
-                                        # 6: down to label30
-                                        # 7: down to label29
-                                        # 8: down to label28
-                                        # 9: down to label27
-                                        # 10: down to label26
+	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 # 0: down to label13
+                                        # 1: down to label12
+                                        # 2: down to label11
+                                        # 3: down to label10
+                                        # 4: down to label9
+                                        # 5: down to label8
+                                        # 6: down to label7
+                                        # 7: down to label6
+                                        # 8: down to label5
+                                        # 9: down to label4
+                                        # 10: down to label3
 .LBB1_2:                                # %sw.bb
-	end_block                       # label36:
+	end_block                       # label13:
 	i32.const	$push133=, 0
 	i32.const	$push118=, 1
 	i32.store	$discard=, should_optimize($pop133), $pop118
@@ -107,7 +84,7 @@ inner:                                  # @inner
 	i32.load	$push121=, should_optimize($pop130)
 	i32.const	$push193=, 0
 	i32.eq  	$push194=, $pop121, $pop193
-	br_if   	12, $pop194     # 12: down to label23
+	br_if   	11, $pop194     # 11: down to label1
 # BB#3:                                 # %if.end
 	i32.const	$push136=, 0
 	i32.const	$push135=, 0
@@ -118,16 +95,16 @@ inner:                                  # @inner
 	i32.call	$push125=, __vfprintf_chk@FUNCTION, $pop123, $0, $pop134, $pop124
 	i32.const	$push126=, 5
 	i32.ne  	$push127=, $pop125, $pop126
-	br_if   	13, $pop127     # 13: down to label22
+	br_if   	11, $pop127     # 11: down to label1
 # BB#4:                                 # %if.end5
 	i32.const	$push128=, 0
 	i32.load	$push129=, should_optimize($pop128)
-	br_if   	10, $pop129     # 10: down to label25
+	br_if   	10, $pop129     # 10: down to label2
 # BB#5:                                 # %if.then7
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_6:                                # %sw.bb9
-	end_block                       # label35:
+	end_block                       # label12:
 	i32.const	$push140=, 0
 	i32.const	$push106=, 1
 	i32.store	$discard=, should_optimize($pop140), $pop106
@@ -140,7 +117,7 @@ inner:                                  # @inner
 	i32.load	$push109=, should_optimize($pop137)
 	i32.const	$push195=, 0
 	i32.eq  	$push196=, $pop109, $pop195
-	br_if   	13, $pop196     # 13: down to label21
+	br_if   	10, $pop196     # 10: down to label1
 # BB#7:                                 # %if.end13
 	i32.const	$push143=, 0
 	i32.const	$push142=, 0
@@ -151,16 +128,16 @@ inner:                                  # @inner
 	i32.call	$push113=, __vfprintf_chk@FUNCTION, $pop111, $0, $pop141, $pop112
 	i32.const	$push114=, 6
 	i32.ne  	$push115=, $pop113, $pop114
-	br_if   	14, $pop115     # 14: down to label20
+	br_if   	10, $pop115     # 10: down to label1
 # BB#8:                                 # %if.end17
 	i32.const	$push116=, 0
 	i32.load	$push117=, should_optimize($pop116)
-	br_if   	9, $pop117      # 9: down to label25
+	br_if   	9, $pop117      # 9: down to label2
 # BB#9:                                 # %if.then19
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_10:                               # %sw.bb21
-	end_block                       # label34:
+	end_block                       # label11:
 	i32.const	$push147=, 0
 	i32.const	$push95=, 1
 	i32.store	$0=, should_optimize($pop147), $pop95
@@ -173,7 +150,7 @@ inner:                                  # @inner
 	i32.load	$push98=, should_optimize($pop144)
 	i32.const	$push197=, 0
 	i32.eq  	$push198=, $pop98, $pop197
-	br_if   	14, $pop198     # 14: down to label19
+	br_if   	9, $pop198      # 9: down to label1
 # BB#11:                                # %if.end25
 	i32.const	$push150=, 0
 	i32.const	$push149=, 0
@@ -183,16 +160,16 @@ inner:                                  # @inner
 	i32.load	$push101=, 8($5)
 	i32.call	$push102=, __vfprintf_chk@FUNCTION, $pop100, $0, $pop148, $pop101
 	i32.ne  	$push103=, $pop102, $0
-	br_if   	15, $pop103     # 15: down to label18
+	br_if   	9, $pop103      # 9: down to label1
 # BB#12:                                # %if.end29
 	i32.const	$push104=, 0
 	i32.load	$push105=, should_optimize($pop104)
-	br_if   	8, $pop105      # 8: down to label25
+	br_if   	8, $pop105      # 8: down to label2
 # BB#13:                                # %if.then31
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_14:                               # %sw.bb33
-	end_block                       # label33:
+	end_block                       # label10:
 	i32.const	$push154=, 0
 	i32.const	$push85=, 1
 	i32.store	$discard=, should_optimize($pop154), $pop85
@@ -205,7 +182,7 @@ inner:                                  # @inner
 	i32.load	$push88=, should_optimize($pop151)
 	i32.const	$push199=, 0
 	i32.eq  	$push200=, $pop88, $pop199
-	br_if   	15, $pop200     # 15: down to label17
+	br_if   	8, $pop200      # 8: down to label1
 # BB#15:                                # %if.end37
 	i32.const	$push157=, 0
 	i32.const	$push156=, 0
@@ -214,16 +191,16 @@ inner:                                  # @inner
 	i32.const	$push155=, .L.str.3
 	i32.load	$push91=, 8($5)
 	i32.call	$push92=, __vfprintf_chk@FUNCTION, $pop90, $0, $pop155, $pop91
-	br_if   	16, $pop92      # 16: down to label16
+	br_if   	8, $pop92       # 8: down to label1
 # BB#16:                                # %if.end41
 	i32.const	$push93=, 0
 	i32.load	$push94=, should_optimize($pop93)
-	br_if   	7, $pop94       # 7: down to label25
+	br_if   	7, $pop94       # 7: down to label2
 # BB#17:                                # %if.then43
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_18:                               # %sw.bb45
-	end_block                       # label32:
+	end_block                       # label9:
 	i32.const	$push73=, 0
 	i32.const	$push161=, 0
 	i32.store	$push160=, should_optimize($pop73), $pop161
@@ -235,7 +212,7 @@ inner:                                  # @inner
 	i32.load	$push76=, should_optimize($0)
 	i32.const	$push201=, 0
 	i32.eq  	$push202=, $pop76, $pop201
-	br_if   	16, $pop202     # 16: down to label15
+	br_if   	7, $pop202      # 7: down to label1
 # BB#19:                                # %if.end49
 	i32.store	$push77=, should_optimize($0), $0
 	i32.load	$push78=, stdout($pop77)
@@ -244,16 +221,16 @@ inner:                                  # @inner
 	i32.call	$push80=, __vfprintf_chk@FUNCTION, $pop78, $0, $pop162, $pop79
 	i32.const	$push81=, 5
 	i32.ne  	$push82=, $pop80, $pop81
-	br_if   	17, $pop82      # 17: down to label14
+	br_if   	7, $pop82       # 7: down to label1
 # BB#20:                                # %if.end53
 	i32.const	$push83=, 0
 	i32.load	$push84=, should_optimize($pop83)
-	br_if   	6, $pop84       # 6: down to label25
+	br_if   	6, $pop84       # 6: down to label2
 # BB#21:                                # %if.then55
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_22:                               # %sw.bb57
-	end_block                       # label31:
+	end_block                       # label8:
 	i32.const	$push61=, 0
 	i32.const	$push166=, 0
 	i32.store	$push165=, should_optimize($pop61), $pop166
@@ -265,7 +242,7 @@ inner:                                  # @inner
 	i32.load	$push64=, should_optimize($0)
 	i32.const	$push203=, 0
 	i32.eq  	$push204=, $pop64, $pop203
-	br_if   	17, $pop204     # 17: down to label13
+	br_if   	6, $pop204      # 6: down to label1
 # BB#23:                                # %if.end61
 	i32.store	$push65=, should_optimize($0), $0
 	i32.load	$push66=, stdout($pop65)
@@ -274,16 +251,16 @@ inner:                                  # @inner
 	i32.call	$push68=, __vfprintf_chk@FUNCTION, $pop66, $0, $pop167, $pop67
 	i32.const	$push69=, 6
 	i32.ne  	$push70=, $pop68, $pop69
-	br_if   	18, $pop70      # 18: down to label12
+	br_if   	6, $pop70       # 6: down to label1
 # BB#24:                                # %if.end65
 	i32.const	$push71=, 0
 	i32.load	$push72=, should_optimize($pop71)
-	br_if   	5, $pop72       # 5: down to label25
+	br_if   	5, $pop72       # 5: down to label2
 # BB#25:                                # %if.then67
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_26:                               # %sw.bb69
-	end_block                       # label30:
+	end_block                       # label7:
 	i32.const	$push49=, 0
 	i32.const	$push171=, 0
 	i32.store	$push170=, should_optimize($pop49), $pop171
@@ -295,7 +272,7 @@ inner:                                  # @inner
 	i32.load	$push52=, should_optimize($0)
 	i32.const	$push205=, 0
 	i32.eq  	$push206=, $pop52, $pop205
-	br_if   	18, $pop206     # 18: down to label11
+	br_if   	5, $pop206      # 5: down to label1
 # BB#27:                                # %if.end73
 	i32.store	$push53=, should_optimize($0), $0
 	i32.load	$push54=, stdout($pop53)
@@ -304,16 +281,16 @@ inner:                                  # @inner
 	i32.call	$push56=, __vfprintf_chk@FUNCTION, $pop54, $0, $pop172, $pop55
 	i32.const	$push57=, 1
 	i32.ne  	$push58=, $pop56, $pop57
-	br_if   	19, $pop58      # 19: down to label10
+	br_if   	5, $pop58       # 5: down to label1
 # BB#28:                                # %if.end77
 	i32.const	$push59=, 0
 	i32.load	$push60=, should_optimize($pop59)
-	br_if   	4, $pop60       # 4: down to label25
+	br_if   	4, $pop60       # 4: down to label2
 # BB#29:                                # %if.then79
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_30:                               # %sw.bb81
-	end_block                       # label29:
+	end_block                       # label6:
 	i32.const	$push39=, 0
 	i32.const	$push176=, 0
 	i32.store	$push175=, should_optimize($pop39), $pop176
@@ -325,23 +302,23 @@ inner:                                  # @inner
 	i32.load	$push42=, should_optimize($0)
 	i32.const	$push207=, 0
 	i32.eq  	$push208=, $pop42, $pop207
-	br_if   	19, $pop208     # 19: down to label9
+	br_if   	4, $pop208      # 4: down to label1
 # BB#31:                                # %if.end85
 	i32.store	$push43=, should_optimize($0), $0
 	i32.load	$push44=, stdout($pop43)
 	i32.const	$push177=, .L.str.4
 	i32.load	$push45=, 8($5)
 	i32.call	$push46=, __vfprintf_chk@FUNCTION, $pop44, $0, $pop177, $pop45
-	br_if   	20, $pop46      # 20: down to label8
+	br_if   	4, $pop46       # 4: down to label1
 # BB#32:                                # %if.end89
 	i32.const	$push47=, 0
 	i32.load	$push48=, should_optimize($pop47)
-	br_if   	3, $pop48       # 3: down to label25
+	br_if   	3, $pop48       # 3: down to label2
 # BB#33:                                # %if.then91
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_34:                               # %sw.bb93
-	end_block                       # label28:
+	end_block                       # label5:
 	i32.const	$push27=, 0
 	i32.const	$push181=, 0
 	i32.store	$push180=, should_optimize($pop27), $pop181
@@ -353,7 +330,7 @@ inner:                                  # @inner
 	i32.load	$push30=, should_optimize($0)
 	i32.const	$push209=, 0
 	i32.eq  	$push210=, $pop30, $pop209
-	br_if   	20, $pop210     # 20: down to label7
+	br_if   	3, $pop210      # 3: down to label1
 # BB#35:                                # %if.end97
 	i32.store	$push31=, should_optimize($0), $0
 	i32.load	$push32=, stdout($pop31)
@@ -362,16 +339,16 @@ inner:                                  # @inner
 	i32.call	$push34=, __vfprintf_chk@FUNCTION, $pop32, $0, $pop182, $pop33
 	i32.const	$push35=, 1
 	i32.ne  	$push36=, $pop34, $pop35
-	br_if   	21, $pop36      # 21: down to label6
+	br_if   	3, $pop36       # 3: down to label1
 # BB#36:                                # %if.end101
 	i32.const	$push37=, 0
 	i32.load	$push38=, should_optimize($pop37)
-	br_if   	2, $pop38       # 2: down to label25
+	br_if   	2, $pop38       # 2: down to label2
 # BB#37:                                # %if.then103
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_38:                               # %sw.bb105
-	end_block                       # label27:
+	end_block                       # label4:
 	i32.const	$push15=, 0
 	i32.const	$push186=, 0
 	i32.store	$push185=, should_optimize($pop15), $pop186
@@ -383,7 +360,7 @@ inner:                                  # @inner
 	i32.load	$push18=, should_optimize($0)
 	i32.const	$push211=, 0
 	i32.eq  	$push212=, $pop18, $pop211
-	br_if   	21, $pop212     # 21: down to label5
+	br_if   	2, $pop212      # 2: down to label1
 # BB#39:                                # %if.end109
 	i32.store	$push19=, should_optimize($0), $0
 	i32.load	$push20=, stdout($pop19)
@@ -392,16 +369,16 @@ inner:                                  # @inner
 	i32.call	$push22=, __vfprintf_chk@FUNCTION, $pop20, $0, $pop187, $pop21
 	i32.const	$push23=, 7
 	i32.ne  	$push24=, $pop22, $pop23
-	br_if   	22, $pop24      # 22: down to label4
+	br_if   	2, $pop24       # 2: down to label1
 # BB#40:                                # %if.end113
 	i32.const	$push25=, 0
 	i32.load	$push26=, should_optimize($pop25)
-	br_if   	1, $pop26       # 1: down to label25
+	br_if   	1, $pop26       # 1: down to label2
 # BB#41:                                # %if.then115
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_42:                               # %sw.bb117
-	end_block                       # label26:
+	end_block                       # label3:
 	i32.const	$push3=, 0
 	i32.const	$push191=, 0
 	i32.store	$push190=, should_optimize($pop3), $pop191
@@ -413,7 +390,7 @@ inner:                                  # @inner
 	i32.load	$push6=, should_optimize($0)
 	i32.const	$push213=, 0
 	i32.eq  	$push214=, $pop6, $pop213
-	br_if   	22, $pop214     # 22: down to label3
+	br_if   	1, $pop214      # 1: down to label1
 # BB#43:                                # %if.end121
 	i32.store	$push7=, should_optimize($0), $0
 	i32.load	$push8=, stdout($pop7)
@@ -422,113 +399,21 @@ inner:                                  # @inner
 	i32.call	$push10=, __vfprintf_chk@FUNCTION, $pop8, $0, $pop192, $pop9
 	i32.const	$push11=, 2
 	i32.ne  	$push12=, $pop10, $pop11
-	br_if   	23, $pop12      # 23: down to label2
+	br_if   	1, $pop12       # 1: down to label1
 # BB#44:                                # %if.end125
 	i32.const	$push13=, 0
 	i32.load	$push14=, should_optimize($pop13)
 	i32.const	$push215=, 0
 	i32.eq  	$push216=, $pop14, $pop215
-	br_if   	24, $pop216     # 24: down to label1
+	br_if   	1, $pop216      # 1: down to label1
 .LBB1_45:                               # %sw.epilog
-	end_block                       # label25:
+	end_block                       # label2:
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
 .LBB1_46:                               # %sw.default
-	end_block                       # label24:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_47:                               # %if.then
-	end_block                       # label23:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_48:                               # %if.then4
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_49:                               # %if.then12
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_50:                               # %if.then16
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_51:                               # %if.then24
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_52:                               # %if.then28
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_53:                               # %if.then36
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_54:                               # %if.then40
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_55:                               # %if.then48
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_56:                               # %if.then52
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_57:                               # %if.then60
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_58:                               # %if.then64
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_59:                               # %if.then72
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_60:                               # %if.then76
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_61:                               # %if.then84
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_62:                               # %if.then88
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_63:                               # %if.then96
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_64:                               # %if.then100
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_65:                               # %if.then108
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_66:                               # %if.then112
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_67:                               # %if.then120
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_68:                               # %if.then124
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_69:                               # %if.then127
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/vprintf-1.c.s
+++ b/test/torture-s/vprintf-1.c.s
@@ -18,9 +18,11 @@ inner:                                  # @inner
 	i32.store	$discard=, 8($5), $pop0
 	block
 	block
+	block
+	block
 	i32.const	$push1=, 10
 	i32.gt_u	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label1
+	br_if   	0, $pop2        # 0: down to label3
 # BB#1:                                 # %entry
 	block
 	block
@@ -32,9 +34,7 @@ inner:                                  # @inner
 	block
 	block
 	block
-	block
-	block
-	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 10, 8, 9 # 0: down to label13
+	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 11, 8, 9 # 0: down to label13
                                         # 1: down to label12
                                         # 2: down to label11
                                         # 3: down to label10
@@ -42,7 +42,7 @@ inner:                                  # @inner
                                         # 5: down to label8
                                         # 6: down to label7
                                         # 7: down to label6
-                                        # 10: down to label3
+                                        # 11: down to label2
                                         # 8: down to label5
                                         # 9: down to label4
 .LBB0_2:                                # %sw.bb
@@ -59,7 +59,7 @@ inner:                                  # @inner
 	i32.call	$push95=, vfprintf@FUNCTION, $pop94, $pop98, $pop93
 	i32.const	$push96=, 5
 	i32.eq  	$push97=, $pop95, $pop96
-	br_if   	10, $pop97      # 10: down to label2
+	br_if   	11, $pop97      # 11: down to label1
 # BB#3:                                 # %if.then
 	call    	abort@FUNCTION
 	unreachable
@@ -77,7 +77,7 @@ inner:                                  # @inner
 	i32.call	$push86=, vfprintf@FUNCTION, $pop85, $pop100, $pop84
 	i32.const	$push87=, 6
 	i32.eq  	$push88=, $pop86, $pop87
-	br_if   	9, $pop88       # 9: down to label2
+	br_if   	10, $pop88      # 10: down to label1
 # BB#5:                                 # %if.then8
 	call    	abort@FUNCTION
 	unreachable
@@ -95,7 +95,7 @@ inner:                                  # @inner
 	i32.call	$push77=, vfprintf@FUNCTION, $pop76, $pop102, $pop75
 	i32.const	$push78=, 1
 	i32.eq  	$push79=, $pop77, $pop78
-	br_if   	8, $pop79       # 8: down to label2
+	br_if   	9, $pop79       # 9: down to label1
 # BB#7:                                 # %if.then14
 	call    	abort@FUNCTION
 	unreachable
@@ -113,7 +113,7 @@ inner:                                  # @inner
 	i32.call	$push70=, vfprintf@FUNCTION, $pop69, $pop104, $pop68
 	i32.const	$push120=, 0
 	i32.eq  	$push121=, $pop70, $pop120
-	br_if   	7, $pop121      # 7: down to label2
+	br_if   	8, $pop121      # 8: down to label1
 # BB#9:                                 # %if.then20
 	call    	abort@FUNCTION
 	unreachable
@@ -131,7 +131,7 @@ inner:                                  # @inner
 	i32.call	$push61=, vfprintf@FUNCTION, $pop60, $pop106, $pop59
 	i32.const	$push62=, 5
 	i32.eq  	$push63=, $pop61, $pop62
-	br_if   	6, $pop63       # 6: down to label2
+	br_if   	7, $pop63       # 7: down to label1
 # BB#11:                                # %if.then26
 	call    	abort@FUNCTION
 	unreachable
@@ -149,7 +149,7 @@ inner:                                  # @inner
 	i32.call	$push52=, vfprintf@FUNCTION, $pop51, $pop108, $pop50
 	i32.const	$push53=, 6
 	i32.eq  	$push54=, $pop52, $pop53
-	br_if   	5, $pop54       # 5: down to label2
+	br_if   	6, $pop54       # 6: down to label1
 # BB#13:                                # %if.then32
 	call    	abort@FUNCTION
 	unreachable
@@ -167,7 +167,7 @@ inner:                                  # @inner
 	i32.call	$push43=, vfprintf@FUNCTION, $pop42, $pop110, $pop41
 	i32.const	$push44=, 1
 	i32.eq  	$push45=, $pop43, $pop44
-	br_if   	4, $pop45       # 4: down to label2
+	br_if   	5, $pop45       # 5: down to label1
 # BB#15:                                # %if.then38
 	call    	abort@FUNCTION
 	unreachable
@@ -185,7 +185,7 @@ inner:                                  # @inner
 	i32.call	$push36=, vfprintf@FUNCTION, $pop35, $pop112, $pop34
 	i32.const	$push122=, 0
 	i32.eq  	$push123=, $pop36, $pop122
-	br_if   	3, $pop123      # 3: down to label2
+	br_if   	4, $pop123      # 4: down to label1
 # BB#17:                                # %if.then44
 	call    	abort@FUNCTION
 	unreachable
@@ -203,7 +203,7 @@ inner:                                  # @inner
 	i32.call	$push18=, vfprintf@FUNCTION, $pop17, $pop116, $pop16
 	i32.const	$push19=, 7
 	i32.eq  	$push20=, $pop18, $pop19
-	br_if   	2, $pop20       # 2: down to label2
+	br_if   	3, $pop20       # 3: down to label1
 # BB#19:                                # %if.then56
 	call    	abort@FUNCTION
 	unreachable
@@ -221,12 +221,13 @@ inner:                                  # @inner
 	i32.call	$push9=, vfprintf@FUNCTION, $pop8, $pop118, $pop7
 	i32.const	$push10=, 2
 	i32.eq  	$push11=, $pop9, $pop10
-	br_if   	1, $pop11       # 1: down to label2
-# BB#21:                                # %if.then62
+	br_if   	2, $pop11       # 2: down to label1
+.LBB0_21:                               # %sw.default
+	end_block                       # label3:
 	call    	abort@FUNCTION
 	unreachable
 .LBB0_22:                               # %sw.bb46
-	end_block                       # label3:
+	end_block                       # label2:
 	i32.const	$push22=, 0
 	i32.load	$push23=, stdout($pop22)
 	i32.const	$push24=, .L.str.5
@@ -239,19 +240,15 @@ inner:                                  # @inner
 	i32.call	$push27=, vfprintf@FUNCTION, $pop26, $pop114, $pop25
 	i32.const	$push28=, 1
 	i32.ne  	$push29=, $pop27, $pop28
-	br_if   	2, $pop29       # 2: down to label0
+	br_if   	1, $pop29       # 1: down to label0
 .LBB0_23:                               # %sw.epilog
-	end_block                       # label2:
+	end_block                       # label1:
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
-.LBB0_24:                               # %sw.default
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_25:                               # %if.then50
+.LBB0_24:                               # %if.then50
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/vprintf-chk-1.c.s
+++ b/test/torture-s/vprintf-chk-1.c.s
@@ -45,32 +45,9 @@ inner:                                  # @inner
 	i32.store	$push0=, 12($5), $1
 	i32.store	$discard=, 8($5), $pop0
 	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
-	block
 	i32.const	$push1=, 10
 	i32.gt_u	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label24
+	br_if   	0, $pop2        # 0: down to label1
 # BB#1:                                 # %entry
 	block
 	block
@@ -84,19 +61,19 @@ inner:                                  # @inner
 	block
 	block
 	block
-	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 # 0: down to label36
-                                        # 1: down to label35
-                                        # 2: down to label34
-                                        # 3: down to label33
-                                        # 4: down to label32
-                                        # 5: down to label31
-                                        # 6: down to label30
-                                        # 7: down to label29
-                                        # 8: down to label28
-                                        # 9: down to label27
-                                        # 10: down to label26
+	tableswitch	$0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 # 0: down to label13
+                                        # 1: down to label12
+                                        # 2: down to label11
+                                        # 3: down to label10
+                                        # 4: down to label9
+                                        # 5: down to label8
+                                        # 6: down to label7
+                                        # 7: down to label6
+                                        # 8: down to label5
+                                        # 9: down to label4
+                                        # 10: down to label3
 .LBB1_2:                                # %sw.bb
-	end_block                       # label36:
+	end_block                       # label13:
 	i32.const	$push88=, 0
 	i32.const	$push98=, 0
 	i32.store	$0=, should_optimize($pop88), $pop98
@@ -106,7 +83,7 @@ inner:                                  # @inner
 	i32.load	$push90=, should_optimize($0)
 	i32.const	$push139=, 0
 	i32.eq  	$push140=, $pop90, $pop139
-	br_if   	12, $pop140     # 12: down to label23
+	br_if   	11, $pop140     # 11: down to label1
 # BB#3:                                 # %if.end
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push99=, .L.str
@@ -114,16 +91,16 @@ inner:                                  # @inner
 	i32.call	$push92=, __vprintf_chk@FUNCTION, $0, $pop99, $pop91
 	i32.const	$push93=, 5
 	i32.ne  	$push94=, $pop92, $pop93
-	br_if   	13, $pop94      # 13: down to label22
+	br_if   	11, $pop94      # 11: down to label1
 # BB#4:                                 # %if.end5
 	i32.const	$push95=, 0
 	i32.load	$push96=, should_optimize($pop95)
-	br_if   	10, $pop96      # 10: down to label25
+	br_if   	10, $pop96      # 10: down to label2
 # BB#5:                                 # %if.then7
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_6:                                # %sw.bb9
-	end_block                       # label35:
+	end_block                       # label12:
 	i32.const	$push102=, 0
 	i32.const	$push79=, 1
 	i32.store	$discard=, should_optimize($pop102), $pop79
@@ -134,7 +111,7 @@ inner:                                  # @inner
 	i32.load	$push81=, should_optimize($pop100)
 	i32.const	$push141=, 0
 	i32.eq  	$push142=, $pop81, $pop141
-	br_if   	13, $pop142     # 13: down to label21
+	br_if   	10, $pop142     # 10: down to label1
 # BB#7:                                 # %if.end13
 	i32.const	$push105=, 0
 	i32.const	$push104=, 0
@@ -144,16 +121,16 @@ inner:                                  # @inner
 	i32.call	$push83=, __vprintf_chk@FUNCTION, $0, $pop103, $pop82
 	i32.const	$push84=, 6
 	i32.ne  	$push85=, $pop83, $pop84
-	br_if   	14, $pop85      # 14: down to label20
+	br_if   	10, $pop85      # 10: down to label1
 # BB#8:                                 # %if.end17
 	i32.const	$push86=, 0
 	i32.load	$push87=, should_optimize($pop86)
-	br_if   	9, $pop87       # 9: down to label25
+	br_if   	9, $pop87       # 9: down to label2
 # BB#9:                                 # %if.then19
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_10:                               # %sw.bb21
-	end_block                       # label34:
+	end_block                       # label11:
 	i32.const	$push108=, 0
 	i32.const	$push71=, 1
 	i32.store	$0=, should_optimize($pop108), $pop71
@@ -164,7 +141,7 @@ inner:                                  # @inner
 	i32.load	$push73=, should_optimize($pop106)
 	i32.const	$push143=, 0
 	i32.eq  	$push144=, $pop73, $pop143
-	br_if   	14, $pop144     # 14: down to label19
+	br_if   	9, $pop144      # 9: down to label1
 # BB#11:                                # %if.end25
 	i32.const	$push111=, 0
 	i32.const	$push110=, 0
@@ -173,16 +150,16 @@ inner:                                  # @inner
 	i32.load	$push74=, 8($5)
 	i32.call	$push75=, __vprintf_chk@FUNCTION, $0, $pop109, $pop74
 	i32.ne  	$push76=, $pop75, $0
-	br_if   	15, $pop76      # 15: down to label18
+	br_if   	9, $pop76       # 9: down to label1
 # BB#12:                                # %if.end29
 	i32.const	$push77=, 0
 	i32.load	$push78=, should_optimize($pop77)
-	br_if   	8, $pop78       # 8: down to label25
+	br_if   	8, $pop78       # 8: down to label2
 # BB#13:                                # %if.then31
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_14:                               # %sw.bb33
-	end_block                       # label33:
+	end_block                       # label10:
 	i32.const	$push114=, 0
 	i32.const	$push64=, 1
 	i32.store	$discard=, should_optimize($pop114), $pop64
@@ -193,7 +170,7 @@ inner:                                  # @inner
 	i32.load	$push66=, should_optimize($pop112)
 	i32.const	$push145=, 0
 	i32.eq  	$push146=, $pop66, $pop145
-	br_if   	15, $pop146     # 15: down to label17
+	br_if   	8, $pop146      # 8: down to label1
 # BB#15:                                # %if.end37
 	i32.const	$push117=, 0
 	i32.const	$push116=, 0
@@ -201,16 +178,16 @@ inner:                                  # @inner
 	i32.const	$push115=, .L.str.3
 	i32.load	$push67=, 8($5)
 	i32.call	$push68=, __vprintf_chk@FUNCTION, $0, $pop115, $pop67
-	br_if   	16, $pop68      # 16: down to label16
+	br_if   	8, $pop68       # 8: down to label1
 # BB#16:                                # %if.end41
 	i32.const	$push69=, 0
 	i32.load	$push70=, should_optimize($pop69)
-	br_if   	7, $pop70       # 7: down to label25
+	br_if   	7, $pop70       # 7: down to label2
 # BB#17:                                # %if.then43
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_18:                               # %sw.bb45
-	end_block                       # label32:
+	end_block                       # label9:
 	i32.const	$push55=, 0
 	i32.const	$push119=, 0
 	i32.store	$0=, should_optimize($pop55), $pop119
@@ -220,7 +197,7 @@ inner:                                  # @inner
 	i32.load	$push57=, should_optimize($0)
 	i32.const	$push147=, 0
 	i32.eq  	$push148=, $pop57, $pop147
-	br_if   	16, $pop148     # 16: down to label15
+	br_if   	7, $pop148      # 7: down to label1
 # BB#19:                                # %if.end49
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push120=, .L.str.4
@@ -228,16 +205,16 @@ inner:                                  # @inner
 	i32.call	$push59=, __vprintf_chk@FUNCTION, $0, $pop120, $pop58
 	i32.const	$push60=, 5
 	i32.ne  	$push61=, $pop59, $pop60
-	br_if   	17, $pop61      # 17: down to label14
+	br_if   	7, $pop61       # 7: down to label1
 # BB#20:                                # %if.end53
 	i32.const	$push62=, 0
 	i32.load	$push63=, should_optimize($pop62)
-	br_if   	6, $pop63       # 6: down to label25
+	br_if   	6, $pop63       # 6: down to label2
 # BB#21:                                # %if.then55
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_22:                               # %sw.bb57
-	end_block                       # label31:
+	end_block                       # label8:
 	i32.const	$push46=, 0
 	i32.const	$push122=, 0
 	i32.store	$0=, should_optimize($pop46), $pop122
@@ -247,7 +224,7 @@ inner:                                  # @inner
 	i32.load	$push48=, should_optimize($0)
 	i32.const	$push149=, 0
 	i32.eq  	$push150=, $pop48, $pop149
-	br_if   	17, $pop150     # 17: down to label13
+	br_if   	6, $pop150      # 6: down to label1
 # BB#23:                                # %if.end61
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push123=, .L.str.4
@@ -255,16 +232,16 @@ inner:                                  # @inner
 	i32.call	$push50=, __vprintf_chk@FUNCTION, $0, $pop123, $pop49
 	i32.const	$push51=, 6
 	i32.ne  	$push52=, $pop50, $pop51
-	br_if   	18, $pop52      # 18: down to label12
+	br_if   	6, $pop52       # 6: down to label1
 # BB#24:                                # %if.end65
 	i32.const	$push53=, 0
 	i32.load	$push54=, should_optimize($pop53)
-	br_if   	5, $pop54       # 5: down to label25
+	br_if   	5, $pop54       # 5: down to label2
 # BB#25:                                # %if.then67
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_26:                               # %sw.bb69
-	end_block                       # label30:
+	end_block                       # label7:
 	i32.const	$push37=, 0
 	i32.const	$push125=, 0
 	i32.store	$0=, should_optimize($pop37), $pop125
@@ -274,7 +251,7 @@ inner:                                  # @inner
 	i32.load	$push39=, should_optimize($0)
 	i32.const	$push151=, 0
 	i32.eq  	$push152=, $pop39, $pop151
-	br_if   	18, $pop152     # 18: down to label11
+	br_if   	5, $pop152      # 5: down to label1
 # BB#27:                                # %if.end73
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push126=, .L.str.4
@@ -282,16 +259,16 @@ inner:                                  # @inner
 	i32.call	$push41=, __vprintf_chk@FUNCTION, $0, $pop126, $pop40
 	i32.const	$push42=, 1
 	i32.ne  	$push43=, $pop41, $pop42
-	br_if   	19, $pop43      # 19: down to label10
+	br_if   	5, $pop43       # 5: down to label1
 # BB#28:                                # %if.end77
 	i32.const	$push44=, 0
 	i32.load	$push45=, should_optimize($pop44)
-	br_if   	4, $pop45       # 4: down to label25
+	br_if   	4, $pop45       # 4: down to label2
 # BB#29:                                # %if.then79
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_30:                               # %sw.bb81
-	end_block                       # label29:
+	end_block                       # label6:
 	i32.const	$push30=, 0
 	i32.const	$push128=, 0
 	i32.store	$0=, should_optimize($pop30), $pop128
@@ -301,22 +278,22 @@ inner:                                  # @inner
 	i32.load	$push32=, should_optimize($0)
 	i32.const	$push153=, 0
 	i32.eq  	$push154=, $pop32, $pop153
-	br_if   	19, $pop154     # 19: down to label9
+	br_if   	4, $pop154      # 4: down to label1
 # BB#31:                                # %if.end85
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push129=, .L.str.4
 	i32.load	$push33=, 8($5)
 	i32.call	$push34=, __vprintf_chk@FUNCTION, $0, $pop129, $pop33
-	br_if   	20, $pop34      # 20: down to label8
+	br_if   	4, $pop34       # 4: down to label1
 # BB#32:                                # %if.end89
 	i32.const	$push35=, 0
 	i32.load	$push36=, should_optimize($pop35)
-	br_if   	3, $pop36       # 3: down to label25
+	br_if   	3, $pop36       # 3: down to label2
 # BB#33:                                # %if.then91
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_34:                               # %sw.bb93
-	end_block                       # label28:
+	end_block                       # label5:
 	i32.const	$push21=, 0
 	i32.const	$push131=, 0
 	i32.store	$0=, should_optimize($pop21), $pop131
@@ -326,7 +303,7 @@ inner:                                  # @inner
 	i32.load	$push23=, should_optimize($0)
 	i32.const	$push155=, 0
 	i32.eq  	$push156=, $pop23, $pop155
-	br_if   	20, $pop156     # 20: down to label7
+	br_if   	3, $pop156      # 3: down to label1
 # BB#35:                                # %if.end97
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push132=, .L.str.5
@@ -334,16 +311,16 @@ inner:                                  # @inner
 	i32.call	$push25=, __vprintf_chk@FUNCTION, $0, $pop132, $pop24
 	i32.const	$push26=, 1
 	i32.ne  	$push27=, $pop25, $pop26
-	br_if   	21, $pop27      # 21: down to label6
+	br_if   	3, $pop27       # 3: down to label1
 # BB#36:                                # %if.end101
 	i32.const	$push28=, 0
 	i32.load	$push29=, should_optimize($pop28)
-	br_if   	2, $pop29       # 2: down to label25
+	br_if   	2, $pop29       # 2: down to label2
 # BB#37:                                # %if.then103
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_38:                               # %sw.bb105
-	end_block                       # label27:
+	end_block                       # label4:
 	i32.const	$push12=, 0
 	i32.const	$push134=, 0
 	i32.store	$0=, should_optimize($pop12), $pop134
@@ -353,7 +330,7 @@ inner:                                  # @inner
 	i32.load	$push14=, should_optimize($0)
 	i32.const	$push157=, 0
 	i32.eq  	$push158=, $pop14, $pop157
-	br_if   	21, $pop158     # 21: down to label5
+	br_if   	2, $pop158      # 2: down to label1
 # BB#39:                                # %if.end109
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push135=, .L.str.6
@@ -361,16 +338,16 @@ inner:                                  # @inner
 	i32.call	$push16=, __vprintf_chk@FUNCTION, $0, $pop135, $pop15
 	i32.const	$push17=, 7
 	i32.ne  	$push18=, $pop16, $pop17
-	br_if   	22, $pop18      # 22: down to label4
+	br_if   	2, $pop18       # 2: down to label1
 # BB#40:                                # %if.end113
 	i32.const	$push19=, 0
 	i32.load	$push20=, should_optimize($pop19)
-	br_if   	1, $pop20       # 1: down to label25
+	br_if   	1, $pop20       # 1: down to label2
 # BB#41:                                # %if.then115
 	call    	abort@FUNCTION
 	unreachable
 .LBB1_42:                               # %sw.bb117
-	end_block                       # label26:
+	end_block                       # label3:
 	i32.const	$push3=, 0
 	i32.const	$push137=, 0
 	i32.store	$0=, should_optimize($pop3), $pop137
@@ -380,7 +357,7 @@ inner:                                  # @inner
 	i32.load	$push5=, should_optimize($0)
 	i32.const	$push159=, 0
 	i32.eq  	$push160=, $pop5, $pop159
-	br_if   	22, $pop160     # 22: down to label3
+	br_if   	1, $pop160      # 1: down to label1
 # BB#43:                                # %if.end121
 	i32.store	$discard=, should_optimize($0), $0
 	i32.const	$push138=, .L.str.7
@@ -388,113 +365,21 @@ inner:                                  # @inner
 	i32.call	$push7=, __vprintf_chk@FUNCTION, $0, $pop138, $pop6
 	i32.const	$push8=, 2
 	i32.ne  	$push9=, $pop7, $pop8
-	br_if   	23, $pop9       # 23: down to label2
+	br_if   	1, $pop9        # 1: down to label1
 # BB#44:                                # %if.end125
 	i32.const	$push10=, 0
 	i32.load	$push11=, should_optimize($pop10)
 	i32.const	$push161=, 0
 	i32.eq  	$push162=, $pop11, $pop161
-	br_if   	24, $pop162     # 24: down to label1
+	br_if   	1, $pop162      # 1: down to label1
 .LBB1_45:                               # %sw.epilog
-	end_block                       # label25:
+	end_block                       # label2:
 	i32.const	$4=, 16
 	i32.add 	$5=, $5, $4
 	i32.const	$4=, __stack_pointer
 	i32.store	$5=, 0($4), $5
 	return
 .LBB1_46:                               # %sw.default
-	end_block                       # label24:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_47:                               # %if.then
-	end_block                       # label23:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_48:                               # %if.then4
-	end_block                       # label22:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_49:                               # %if.then12
-	end_block                       # label21:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_50:                               # %if.then16
-	end_block                       # label20:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_51:                               # %if.then24
-	end_block                       # label19:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_52:                               # %if.then28
-	end_block                       # label18:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_53:                               # %if.then36
-	end_block                       # label17:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_54:                               # %if.then40
-	end_block                       # label16:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_55:                               # %if.then48
-	end_block                       # label15:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_56:                               # %if.then52
-	end_block                       # label14:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_57:                               # %if.then60
-	end_block                       # label13:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_58:                               # %if.then64
-	end_block                       # label12:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_59:                               # %if.then72
-	end_block                       # label11:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_60:                               # %if.then76
-	end_block                       # label10:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_61:                               # %if.then84
-	end_block                       # label9:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_62:                               # %if.then88
-	end_block                       # label8:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_63:                               # %if.then96
-	end_block                       # label7:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_64:                               # %if.then100
-	end_block                       # label6:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_65:                               # %if.then108
-	end_block                       # label5:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_66:                               # %if.then112
-	end_block                       # label4:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_67:                               # %if.then120
-	end_block                       # label3:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_68:                               # %if.then124
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_69:                               # %if.then127
 	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/vrp-4.c.s
+++ b/test/torture-s/vrp-4.c.s
@@ -8,31 +8,21 @@ test:                                   # @test
 	.param  	i32, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	i32.const	$push5=, 1
 	i32.eq  	$push0=, $0, $pop5
-	br_if   	0, $pop0        # 0: down to label2
+	br_if   	0, $pop0        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 1
 	i32.eq  	$push1=, $1, $pop6
-	br_if   	1, $pop1        # 1: down to label1
+	br_if   	0, $pop1        # 0: down to label0
 # BB#2:                                 # %if.end3
 	i32.div_s	$push2=, $0, $1
 	i32.const	$push3=, 1
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	2, $pop4        # 2: down to label0
+	br_if   	0, $pop4        # 0: down to label0
 # BB#3:                                 # %if.end6
 	return
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then2
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then5
+.LBB0_4:                                # %if.then5
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/vrp-5.c.s
+++ b/test/torture-s/vrp-5.c.s
@@ -8,31 +8,21 @@ test:                                   # @test
 	.param  	i32, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	i32.const	$push5=, 4
 	i32.le_u	$push0=, $0, $pop5
-	br_if   	0, $pop0        # 0: down to label2
+	br_if   	0, $pop0        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 4
 	i32.le_u	$push1=, $1, $pop6
-	br_if   	1, $pop1        # 1: down to label1
+	br_if   	0, $pop1        # 0: down to label0
 # BB#2:                                 # %if.end3
 	i32.const	$push2=, 0
 	i32.sub 	$push3=, $pop2, $1
 	i32.ne  	$push4=, $0, $pop3
-	br_if   	2, $pop4        # 2: down to label0
+	br_if   	0, $pop4        # 0: down to label0
 # BB#3:                                 # %if.end6
 	return
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then2
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then5
+.LBB0_4:                                # %if.then5
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/vrp-6.c.s
+++ b/test/torture-s/vrp-6.c.s
@@ -8,31 +8,21 @@ test01:                                 # @test01
 	.param  	i32, i32
 # BB#0:                                 # %entry
 	block
-	block
-	block
 	i32.const	$push5=, 4
 	i32.le_u	$push0=, $0, $pop5
-	br_if   	0, $pop0        # 0: down to label2
+	br_if   	0, $pop0        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push6=, 4
 	i32.le_u	$push1=, $1, $pop6
-	br_if   	1, $pop1        # 1: down to label1
+	br_if   	0, $pop1        # 0: down to label0
 # BB#2:                                 # %if.end3
 	i32.sub 	$push2=, $0, $1
 	i32.const	$push3=, 5
 	i32.ne  	$push4=, $pop2, $pop3
-	br_if   	2, $pop4        # 2: down to label0
+	br_if   	0, $pop4        # 0: down to label0
 # BB#3:                                 # %if.end6
 	return
-.LBB0_4:                                # %if.then
-	end_block                       # label2:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then2
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_6:                                # %if.then5
+.LBB0_4:                                # %if.then5
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable
@@ -51,21 +41,21 @@ test02:                                 # @test02
 	block
 	i32.const	$push1=, 12
 	i32.lt_u	$push2=, $0, $pop1
-	br_if   	0, $pop2        # 0: down to label4
+	br_if   	0, $pop2        # 0: down to label2
 # BB#1:                                 # %entry
 	i32.const	$push3=, 16
 	i32.lt_u	$push4=, $1, $pop3
-	br_if   	0, $pop4        # 0: down to label4
+	br_if   	0, $pop4        # 0: down to label2
 # BB#2:                                 # %entry
 	i32.sub 	$push0=, $0, $1
 	i32.const	$push5=, -17
 	i32.le_u	$push6=, $pop0, $pop5
-	br_if   	1, $pop6        # 1: down to label3
+	br_if   	1, $pop6        # 1: down to label1
 .LBB1_3:                                # %if.end6
-	end_block                       # label4:
+	end_block                       # label2:
 	return
 .LBB1_4:                                # %if.then4
-	end_block                       # label3:
+	end_block                       # label1:
 	call    	abort@FUNCTION
 	unreachable
 	.endfunc

--- a/test/torture-s/wchar_t-1.c.s
+++ b/test/torture-s/wchar_t-1.c.s
@@ -8,31 +8,26 @@ main:                                   # @main
 	.result 	i32
 # BB#0:                                 # %entry
 	block
-	block
 	i32.const	$push7=, 0
 	i32.load	$push1=, x($pop7)
 	i32.const	$push2=, 196
 	i32.ne  	$push3=, $pop1, $pop2
-	br_if   	0, $pop3        # 0: down to label1
+	br_if   	0, $pop3        # 0: down to label0
 # BB#1:                                 # %entry
 	i32.const	$push8=, 0
 	i32.load	$push0=, x+4($pop8)
-	br_if   	0, $pop0        # 0: down to label1
+	br_if   	0, $pop0        # 0: down to label0
 # BB#2:                                 # %if.end
 	i32.const	$push9=, 0
 	i32.load	$push4=, y($pop9)
 	i32.const	$push5=, 196
 	i32.ne  	$push6=, $pop4, $pop5
-	br_if   	1, $pop6        # 1: down to label0
+	br_if   	0, $pop6        # 0: down to label0
 # BB#3:                                 # %if.end4
 	i32.const	$push10=, 0
 	call    	exit@FUNCTION, $pop10
 	unreachable
-.LBB0_4:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB0_5:                                # %if.then3
+.LBB0_4:                                # %if.then3
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable

--- a/test/torture-s/zero-struct-1.c.s
+++ b/test/torture-s/zero-struct-1.c.s
@@ -45,22 +45,17 @@ main:                                   # @main
 	i32.add 	$push0=, $0, $pop9
 	i32.store	$0=, ff($pop10), $pop0
 	block
-	block
 	i32.const	$push8=, y+2
 	i32.ne  	$push5=, $1, $pop8
-	br_if   	0, $pop5        # 0: down to label1
+	br_if   	0, $pop5        # 0: down to label0
 # BB#1:                                 # %if.end
 	i32.const	$push13=, y+2
 	i32.ne  	$push6=, $0, $pop13
-	br_if   	1, $pop6        # 1: down to label0
+	br_if   	0, $pop6        # 0: down to label0
 # BB#2:                                 # %if.end3
 	i32.const	$push7=, 0
 	return  	$pop7
-.LBB1_3:                                # %if.then
-	end_block                       # label1:
-	call    	abort@FUNCTION
-	unreachable
-.LBB1_4:                                # %if.then2
+.LBB1_3:                                # %if.then2
 	end_block                       # label0:
 	call    	abort@FUNCTION
 	unreachable


### PR DESCRIPTION
Two new tests fail because of imports, on that used to pass now uses memset because LLVM is smarter.