### PR TITLE
Don't print the default alignment

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -179,7 +179,7 @@ struct PrintSExpression : public WasmVisitor<PrintSExpression, void> {
     if (curr->offset) {
       o << " offset=" << curr->offset;
     }
-    if (curr->align) {
+    if (curr->align != curr->bytes) {
       o << " align=" << curr->align;
     }
     incIndent(o, indent);
@@ -204,7 +204,7 @@ struct PrintSExpression : public WasmVisitor<PrintSExpression, void> {
     if (curr->offset) {
       o << " offset=" << curr->offset;
     }
-    if (curr->align) {
+    if (curr->align != curr->bytes) {
       o << " align=" << curr->align;
     }
     incIndent(o, indent);

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -726,7 +726,7 @@ private:
     ret->signed_ = extra[0] && extra[1] == 's';
     size_t i = 1;
     ret->offset = 0;
-    ret->align = 0;
+    ret->align = ret->bytes;
     while (!s[i]->isList()) {
       const char *str = s[i]->c_str();
       const char *eq = strchr(str, '=');
@@ -764,7 +764,7 @@ private:
     }
     size_t i = 1;
     ret->offset = 0;
-    ret->align = 0;
+    ret->align = ret->bytes;
     while (!s[i]->isList()) {
       const char *str = s[i]->c_str();
       const char *eq = strchr(str, '=');

--- a/test/dot_s/bcp-1.wast
+++ b/test/dot_s/bcp-1.wast
@@ -128,48 +128,48 @@
     (block $label$0
       (br_if $label$0
         (call_indirect $FUNCSIG_i
-          (i32.load offset=16 align=4
+          (i32.load offset=16
             (get_local $$0)
           )
         )
       )
       (br_if $label$0
         (call_indirect $FUNCSIG_i
-          (i32.load offset=20 align=4
+          (i32.load offset=20
             (get_local $$0)
           )
         )
       )
       (br_if $label$0
         (call_indirect $FUNCSIG_i
-          (i32.load offset=24 align=4
+          (i32.load offset=24
             (get_local $$0)
           )
         )
       )
       (br_if $label$0
         (call_indirect $FUNCSIG_i
-          (i32.load offset=28 align=4
+          (i32.load offset=28
             (get_local $$0)
           )
         )
       )
       (br_if $label$0
         (call_indirect $FUNCSIG_i
-          (i32.load offset=32 align=4
+          (i32.load offset=32
             (get_local $$0)
           )
         )
       )
       (br_if $label$0
         (call_indirect $FUNCSIG_i
-          (i32.load offset=36 align=4
+          (i32.load offset=36
             (get_local $$0)
           )
         )
       )
       (set_local $$1
-        (i32.load offset=40 align=4
+        (i32.load offset=40
           (get_local $$0)
         )
       )
@@ -185,7 +185,7 @@
         )
         (br_if $label$1
           (call_indirect $FUNCSIG_ii
-            (i32.load offset=44 align=4
+            (i32.load offset=44
               (get_local $$0)
             )
             (get_local $$2)
@@ -193,14 +193,14 @@
         )
         (br_if $label$1
           (call_indirect $FUNCSIG_ii
-            (i32.load offset=48 align=4
+            (i32.load offset=48
               (get_local $$0)
             )
             (get_local $$2)
           )
         )
         (set_local $$1
-          (i32.load offset=52 align=4
+          (i32.load offset=52
             (get_local $$0)
           )
         )
@@ -216,7 +216,7 @@
           )
           (br_if $label$2
             (call_indirect $FUNCSIG_ii
-              (i32.load offset=56 align=4
+              (i32.load offset=56
                 (get_local $$0)
               )
               (get_local $$2)
@@ -226,7 +226,7 @@
             (br_if $label$3
               (i32.eq
                 (call_indirect $FUNCSIG_i
-                  (i32.load offset=60 align=4
+                  (i32.load offset=60
                     (get_local $$0)
                   )
                 )
@@ -236,7 +236,7 @@
             (br_if $label$3
               (i32.eq
                 (call_indirect $FUNCSIG_i
-                  (i32.load offset=64 align=4
+                  (i32.load offset=64
                     (get_local $$0)
                   )
                 )
@@ -246,7 +246,7 @@
             (br_if $label$3
               (i32.eq
                 (call_indirect $FUNCSIG_i
-                  (i32.load offset=68 align=4
+                  (i32.load offset=68
                     (get_local $$0)
                   )
                 )
@@ -257,7 +257,7 @@
               (br_if $label$4
                 (i32.eq
                   (call_indirect $FUNCSIG_i
-                    (i32.load offset=72 align=4
+                    (i32.load offset=72
                       (get_local $$0)
                     )
                   )
@@ -267,7 +267,7 @@
               (br_if $label$4
                 (i32.eq
                   (call_indirect $FUNCSIG_i
-                    (i32.load offset=76 align=4
+                    (i32.load offset=76
                       (get_local $$0)
                     )
                   )
@@ -277,7 +277,7 @@
               (br_if $label$4
                 (i32.eq
                   (call_indirect $FUNCSIG_i
-                    (i32.load offset=80 align=4
+                    (i32.load offset=80
                       (get_local $$0)
                     )
                   )

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -7,7 +7,7 @@
   (export "_Z6reporti" $_Z6reporti)
   (export "main" $main)
   (func $_Z6reporti (param $$0 i32)
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $$0)
     )
@@ -34,7 +34,7 @@
       (i32.const 0)
     )
     (set_local $$7
-      (i32.load align=4
+      (i32.load
         (get_local $$7)
       )
     )
@@ -51,7 +51,7 @@
       (i32.const 0)
     )
     (set_local $$12
-      (i32.store align=4
+      (i32.store
         (get_local $$8)
         (get_local $$12)
       )
@@ -79,7 +79,7 @@
             (get_local $$10)
           )
         )
-        (i32.store8 align=1
+        (i32.store8
           (i32.add
             (get_local $$10)
             (get_local $$4)
@@ -124,7 +124,7 @@
         (set_local $$6
           (i32.add
             (i32.and
-              (i32.load8_u align=1
+              (i32.load8_u
                 (i32.add
                   (get_local $$11)
                   (get_local $$5)
@@ -195,7 +195,7 @@
       (i32.const 0)
     )
     (set_local $$12
-      (i32.store align=4
+      (i32.store
         (get_local $$9)
         (get_local $$12)
       )

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -7,7 +7,7 @@
   (func $main (result i32)
     (local $$0 i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.const 12)
       )
     )

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -4,7 +4,7 @@
   )
   (export "f" $f)
   (func $f (param $$0 i32) (param $$1 i32)
-    (i32.store offset=12 align=4
+    (i32.store offset=12
       (get_local $$0)
       (get_local $$1)
     )

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -163,7 +163,7 @@
             )
           )
           (set_local $i4
-            (i32.load align=4
+            (i32.load
               (i32.const 176)
             )
           )
@@ -210,7 +210,7 @@
                 )
               )
               (set_local $i9
-                (i32.load align=4
+                (i32.load
                   (get_local $i8)
                 )
               )
@@ -221,7 +221,7 @@
                 )
               )
               (set_local $i11
-                (i32.load align=4
+                (i32.load
                   (get_local $i10)
                 )
               )
@@ -235,7 +235,7 @@
                     (if
                       (i32.lt_u
                         (get_local $i11)
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
@@ -249,17 +249,17 @@
                     )
                     (if_else
                       (i32.eq
-                        (i32.load align=4
+                        (i32.load
                           (get_local $i12)
                         )
                         (get_local $i9)
                       )
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (get_local $i12)
                           (get_local $i7)
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $i8)
                           (get_local $i11)
                         )
@@ -268,7 +268,7 @@
                       (call_import $_abort)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 176)
                     (i32.and
                       (get_local $i4)
@@ -289,7 +289,7 @@
                   (i32.const 3)
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $i9)
                 (i32.or
                   (get_local $i11)
@@ -305,10 +305,10 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $i8)
                 (i32.or
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i8)
                   )
                   (i32.const 1)
@@ -323,7 +323,7 @@
             )
           )
           (set_local $i8
-            (i32.load align=4
+            (i32.load
               (i32.const 184)
             )
           )
@@ -478,7 +478,7 @@
                     )
                   )
                   (set_local $i14
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i16)
                     )
                   )
@@ -489,7 +489,7 @@
                     )
                   )
                   (set_local $i7
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i12)
                     )
                   )
@@ -503,7 +503,7 @@
                         (if
                           (i32.lt_u
                             (get_local $i7)
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 192)
                             )
                           )
@@ -517,22 +517,22 @@
                         )
                         (if_else
                           (i32.eq
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i11)
                             )
                             (get_local $i14)
                           )
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $i11)
                               (get_local $i15)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $i16)
                               (get_local $i7)
                             )
                             (set_local $i18
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 184)
                               )
                             )
@@ -542,7 +542,7 @@
                         )
                       )
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (i32.const 176)
                           (i32.and
                             (get_local $i4)
@@ -570,7 +570,7 @@
                       (get_local $i2)
                     )
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (get_local $i14)
                     (i32.or
                       (get_local $i2)
@@ -583,14 +583,14 @@
                       (get_local $i2)
                     )
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (get_local $i4)
                     (i32.or
                       (get_local $i8)
                       (i32.const 1)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.add
                       (get_local $i4)
                       (get_local $i8)
@@ -601,7 +601,7 @@
                     (get_local $i18)
                     (block
                       (set_local $i7
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 196)
                         )
                       )
@@ -624,7 +624,7 @@
                         )
                       )
                       (set_local $i3
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 176)
                         )
                       )
@@ -647,14 +647,14 @@
                             )
                           )
                           (set_local $i10
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i16)
                             )
                           )
                           (if_else
                             (i32.lt_u
                               (get_local $i10)
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 192)
                               )
                             )
@@ -670,7 +670,7 @@
                           )
                         )
                         (block
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 176)
                             (i32.or
                               (get_local $i3)
@@ -688,29 +688,29 @@
                           )
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $i19)
                         (get_local $i7)
                       )
-                      (i32.store offset=12 align=4
+                      (i32.store offset=12
                         (get_local $i20)
                         (get_local $i7)
                       )
-                      (i32.store offset=8 align=4
+                      (i32.store offset=8
                         (get_local $i7)
                         (get_local $i20)
                       )
-                      (i32.store offset=12 align=4
+                      (i32.store offset=12
                         (get_local $i7)
                         (get_local $i15)
                       )
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 184)
                     (get_local $i8)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 196)
                     (get_local $i4)
                   )
@@ -723,7 +723,7 @@
                 )
               )
               (set_local $i4
-                (i32.load align=4
+                (i32.load
                   (i32.const 180)
                 )
               )
@@ -812,7 +812,7 @@
                     )
                   )
                   (set_local $i10
-                    (i32.load offset=480 align=4
+                    (i32.load offset=480
                       (i32.shl
                         (i32.add
                           (i32.or
@@ -840,7 +840,7 @@
                   (set_local $i5
                     (i32.sub
                       (i32.and
-                        (i32.load offset=4 align=4
+                        (i32.load offset=4
                           (get_local $i10)
                         )
                         (i32.const -8)
@@ -856,7 +856,7 @@
                   )
                   (loop $while-out$3 $while-in$4
                     (set_local $i10
-                      (i32.load offset=16 align=4
+                      (i32.load offset=16
                         (get_local $i3)
                       )
                     )
@@ -867,7 +867,7 @@
                       )
                       (block
                         (set_local $i15
-                          (i32.load offset=20 align=4
+                          (i32.load offset=20
                             (get_local $i3)
                           )
                         )
@@ -897,7 +897,7 @@
                     (set_local $i10
                       (i32.sub
                         (i32.and
-                          (i32.load offset=4 align=4
+                          (i32.load offset=4
                             (get_local $i23)
                           )
                           (i32.const -8)
@@ -931,7 +931,7 @@
                     (br $while-in$4)
                   )
                   (set_local $i7
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -956,12 +956,12 @@
                     (call_import $_abort)
                   )
                   (set_local $i5
-                    (i32.load offset=24 align=4
+                    (i32.load offset=24
                       (get_local $i22)
                     )
                   )
                   (set_local $i12
-                    (i32.load offset=12 align=4
+                    (i32.load offset=12
                       (get_local $i22)
                     )
                   )
@@ -979,7 +979,7 @@
                           )
                         )
                         (set_local $i17
-                          (i32.load align=4
+                          (i32.load
                             (get_local $i14)
                           )
                         )
@@ -996,7 +996,7 @@
                               )
                             )
                             (set_local $i10
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i15)
                               )
                             )
@@ -1038,7 +1038,7 @@
                             )
                           )
                           (set_local $i17
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i14)
                             )
                           )
@@ -1061,7 +1061,7 @@
                             )
                           )
                           (set_local $i17
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i14)
                             )
                           )
@@ -1097,7 +1097,7 @@
                           )
                           (call_import $_abort)
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $i28)
                               (i32.const 0)
                             )
@@ -1110,7 +1110,7 @@
                       )
                       (block
                         (set_local $i14
-                          (i32.load offset=8 align=4
+                          (i32.load offset=8
                             (get_local $i22)
                           )
                         )
@@ -1129,7 +1129,7 @@
                         )
                         (if
                           (i32.ne
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i17)
                             )
                             (get_local $i22)
@@ -1144,17 +1144,17 @@
                         )
                         (if_else
                           (i32.eq
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i15)
                             )
                             (get_local $i22)
                           )
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $i17)
                               (get_local $i12)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $i15)
                               (get_local $i14)
                             )
@@ -1173,7 +1173,7 @@
                       (get_local $i5)
                       (block
                         (set_local $i12
-                          (i32.load offset=28 align=4
+                          (i32.load offset=28
                             (get_local $i22)
                           )
                         )
@@ -1189,12 +1189,12 @@
                         (if_else
                           (i32.eq
                             (get_local $i22)
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i7)
                             )
                           )
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $i7)
                               (get_local $i24)
                             )
@@ -1204,10 +1204,10 @@
                                 (i32.const 0)
                               )
                               (block
-                                (i32.store align=4
+                                (i32.store
                                   (i32.const 180)
                                   (i32.and
-                                    (i32.load align=4
+                                    (i32.load
                                       (i32.const 180)
                                     )
                                     (i32.xor
@@ -1227,7 +1227,7 @@
                             (if
                               (i32.lt_u
                                 (get_local $i5)
-                                (i32.load align=4
+                                (i32.load
                                   (i32.const 192)
                                 )
                               )
@@ -1241,16 +1241,16 @@
                             )
                             (if_else
                               (i32.eq
-                                (i32.load align=4
+                                (i32.load
                                   (get_local $i12)
                                 )
                                 (get_local $i22)
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i12)
                                 (get_local $i24)
                               )
-                              (i32.store offset=20 align=4
+                              (i32.store offset=20
                                 (get_local $i5)
                                 (get_local $i24)
                               )
@@ -1264,7 +1264,7 @@
                           )
                         )
                         (set_local $i12
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 192)
                           )
                         )
@@ -1275,12 +1275,12 @@
                           )
                           (call_import $_abort)
                         )
-                        (i32.store offset=24 align=4
+                        (i32.store offset=24
                           (get_local $i24)
                           (get_local $i5)
                         )
                         (set_local $i7
-                          (i32.load offset=16 align=4
+                          (i32.load offset=16
                             (get_local $i22)
                           )
                         )
@@ -1294,11 +1294,11 @@
                               )
                               (call_import $_abort)
                               (block
-                                (i32.store offset=16 align=4
+                                (i32.store offset=16
                                   (get_local $i24)
                                   (get_local $i7)
                                 )
-                                (i32.store offset=24 align=4
+                                (i32.store offset=24
                                   (get_local $i7)
                                   (get_local $i24)
                                 )
@@ -1308,7 +1308,7 @@
                           )
                         )
                         (set_local $i7
-                          (i32.load offset=20 align=4
+                          (i32.load offset=20
                             (get_local $i22)
                           )
                         )
@@ -1317,17 +1317,17 @@
                           (if_else
                             (i32.lt_u
                               (get_local $i7)
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 192)
                               )
                             )
                             (call_import $_abort)
                             (block
-                              (i32.store offset=20 align=4
+                              (i32.store offset=20
                                 (get_local $i24)
                                 (get_local $i7)
                               )
-                              (i32.store offset=24 align=4
+                              (i32.store offset=24
                                 (get_local $i7)
                                 (get_local $i24)
                               )
@@ -1350,7 +1350,7 @@
                           (get_local $i2)
                         )
                       )
-                      (i32.store offset=4 align=4
+                      (i32.store offset=4
                         (get_local $i22)
                         (i32.or
                           (get_local $i5)
@@ -1366,10 +1366,10 @@
                           (i32.const 4)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $i7)
                         (i32.or
-                          (i32.load align=4
+                          (i32.load
                             (get_local $i7)
                           )
                           (i32.const 1)
@@ -1377,21 +1377,21 @@
                       )
                     )
                     (block
-                      (i32.store offset=4 align=4
+                      (i32.store offset=4
                         (get_local $i22)
                         (i32.or
                           (get_local $i2)
                           (i32.const 3)
                         )
                       )
-                      (i32.store offset=4 align=4
+                      (i32.store offset=4
                         (get_local $i3)
                         (i32.or
                           (get_local $i21)
                           (i32.const 1)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (i32.add
                           (get_local $i3)
                           (get_local $i21)
@@ -1399,7 +1399,7 @@
                         (get_local $i21)
                       )
                       (set_local $i7
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 184)
                         )
                       )
@@ -1407,7 +1407,7 @@
                         (get_local $i7)
                         (block
                           (set_local $i5
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 196)
                             )
                           )
@@ -1430,7 +1430,7 @@
                             )
                           )
                           (set_local $i14
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 176)
                             )
                           )
@@ -1453,14 +1453,14 @@
                                 )
                               )
                               (set_local $i17
-                                (i32.load align=4
+                                (i32.load
                                   (get_local $i12)
                                 )
                               )
                               (if_else
                                 (i32.lt_u
                                   (get_local $i17)
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 192)
                                   )
                                 )
@@ -1476,7 +1476,7 @@
                               )
                             )
                             (block
-                              (i32.store align=4
+                              (i32.store
                                 (i32.const 176)
                                 (i32.or
                                   (get_local $i14)
@@ -1494,29 +1494,29 @@
                               )
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $i29)
                             (get_local $i5)
                           )
-                          (i32.store offset=12 align=4
+                          (i32.store offset=12
                             (get_local $i30)
                             (get_local $i5)
                           )
-                          (i32.store offset=8 align=4
+                          (i32.store offset=8
                             (get_local $i5)
                             (get_local $i30)
                           )
-                          (i32.store offset=12 align=4
+                          (i32.store offset=12
                             (get_local $i5)
                             (get_local $i7)
                           )
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 184)
                         (get_local $i21)
                       )
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 196)
                         (get_local $i3)
                       )
@@ -1561,7 +1561,7 @@
               )
             )
             (set_local $i15
-              (i32.load align=4
+              (i32.load
                 (i32.const 180)
               )
             )
@@ -1685,7 +1685,7 @@
                   )
                 )
                 (set_local $i4
-                  (i32.load offset=480 align=4
+                  (i32.load offset=480
                     (i32.shl
                       (get_local $i32)
                       (i32.const 2)
@@ -1747,7 +1747,7 @@
                       (loop $while-out$10 $while-in$11
                         (set_local $i16
                           (i32.and
-                            (i32.load offset=4 align=4
+                            (i32.load offset=4
                               (get_local $i17)
                             )
                             (i32.const -8)
@@ -1803,12 +1803,12 @@
                           )
                         )
                         (set_local $i9
-                          (i32.load offset=20 align=4
+                          (i32.load offset=20
                             (get_local $i17)
                           )
                         )
                         (set_local $i17
-                          (i32.load align=4
+                          (i32.load
                             (i32.add
                               (i32.add
                                 (get_local $i17)
@@ -2022,7 +2022,7 @@
                           )
                         )
                         (set_local $i42
-                          (i32.load offset=480 align=4
+                          (i32.load offset=480
                             (i32.shl
                               (i32.add
                                 (i32.or
@@ -2094,7 +2094,7 @@
                     (set_local $i8
                       (i32.sub
                         (i32.and
-                          (i32.load offset=4 align=4
+                          (i32.load offset=4
                             (get_local $i38)
                           )
                           (i32.const -8)
@@ -2123,7 +2123,7 @@
                       )
                     )
                     (set_local $i7
-                      (i32.load offset=16 align=4
+                      (i32.load offset=16
                         (get_local $i38)
                       )
                     )
@@ -2146,7 +2146,7 @@
                       )
                     )
                     (set_local $i38
-                      (i32.load offset=20 align=4
+                      (i32.load offset=20
                         (get_local $i38)
                       )
                     )
@@ -2188,7 +2188,7 @@
                     (i32.lt_u
                       (get_local $i43)
                       (i32.sub
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 184)
                         )
                         (get_local $i5)
@@ -2198,7 +2198,7 @@
                   )
                   (block
                     (set_local $i15
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 192)
                       )
                     )
@@ -2223,12 +2223,12 @@
                       (call_import $_abort)
                     )
                     (set_local $i3
-                      (i32.load offset=24 align=4
+                      (i32.load offset=24
                         (get_local $i44)
                       )
                     )
                     (set_local $i7
-                      (i32.load offset=12 align=4
+                      (i32.load offset=12
                         (get_local $i44)
                       )
                     )
@@ -2246,7 +2246,7 @@
                             )
                           )
                           (set_local $i14
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i2)
                             )
                           )
@@ -2263,7 +2263,7 @@
                                 )
                               )
                               (set_local $i10
-                                (i32.load align=4
+                                (i32.load
                                   (get_local $i4)
                                 )
                               )
@@ -2305,7 +2305,7 @@
                               )
                             )
                             (set_local $i14
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i2)
                               )
                             )
@@ -2328,7 +2328,7 @@
                               )
                             )
                             (set_local $i14
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i2)
                               )
                             )
@@ -2364,7 +2364,7 @@
                             )
                             (call_import $_abort)
                             (block
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i49)
                                 (i32.const 0)
                               )
@@ -2377,7 +2377,7 @@
                         )
                         (block
                           (set_local $i2
-                            (i32.load offset=8 align=4
+                            (i32.load offset=8
                               (get_local $i44)
                             )
                           )
@@ -2396,7 +2396,7 @@
                           )
                           (if
                             (i32.ne
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i14)
                               )
                               (get_local $i44)
@@ -2411,17 +2411,17 @@
                           )
                           (if_else
                             (i32.eq
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i4)
                               )
                               (get_local $i44)
                             )
                             (block
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i14)
                                 (get_local $i7)
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i4)
                                 (get_local $i2)
                               )
@@ -2440,7 +2440,7 @@
                         (get_local $i3)
                         (block
                           (set_local $i7
-                            (i32.load offset=28 align=4
+                            (i32.load offset=28
                               (get_local $i44)
                             )
                           )
@@ -2456,12 +2456,12 @@
                           (if_else
                             (i32.eq
                               (get_local $i44)
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i15)
                               )
                             )
                             (block
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i15)
                                 (get_local $i45)
                               )
@@ -2471,10 +2471,10 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (i32.store align=4
+                                  (i32.store
                                     (i32.const 180)
                                     (i32.and
-                                      (i32.load align=4
+                                      (i32.load
                                         (i32.const 180)
                                       )
                                       (i32.xor
@@ -2494,7 +2494,7 @@
                               (if
                                 (i32.lt_u
                                   (get_local $i3)
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 192)
                                   )
                                 )
@@ -2508,16 +2508,16 @@
                               )
                               (if_else
                                 (i32.eq
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $i7)
                                   )
                                   (get_local $i44)
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $i7)
                                   (get_local $i45)
                                 )
-                                (i32.store offset=20 align=4
+                                (i32.store offset=20
                                   (get_local $i3)
                                   (get_local $i45)
                                 )
@@ -2531,7 +2531,7 @@
                             )
                           )
                           (set_local $i7
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 192)
                             )
                           )
@@ -2542,12 +2542,12 @@
                             )
                             (call_import $_abort)
                           )
-                          (i32.store offset=24 align=4
+                          (i32.store offset=24
                             (get_local $i45)
                             (get_local $i3)
                           )
                           (set_local $i15
-                            (i32.load offset=16 align=4
+                            (i32.load offset=16
                               (get_local $i44)
                             )
                           )
@@ -2561,11 +2561,11 @@
                                 )
                                 (call_import $_abort)
                                 (block
-                                  (i32.store offset=16 align=4
+                                  (i32.store offset=16
                                     (get_local $i45)
                                     (get_local $i15)
                                   )
-                                  (i32.store offset=24 align=4
+                                  (i32.store offset=24
                                     (get_local $i15)
                                     (get_local $i45)
                                   )
@@ -2575,7 +2575,7 @@
                             )
                           )
                           (set_local $i15
-                            (i32.load offset=20 align=4
+                            (i32.load offset=20
                               (get_local $i44)
                             )
                           )
@@ -2584,17 +2584,17 @@
                             (if_else
                               (i32.lt_u
                                 (get_local $i15)
-                                (i32.load align=4
+                                (i32.load
                                   (i32.const 192)
                                 )
                               )
                               (call_import $_abort)
                               (block
-                                (i32.store offset=20 align=4
+                                (i32.store offset=20
                                   (get_local $i45)
                                   (get_local $i15)
                                 )
-                                (i32.store offset=24 align=4
+                                (i32.store offset=24
                                   (get_local $i15)
                                   (get_local $i45)
                                 )
@@ -2612,21 +2612,21 @@
                           (i32.const 16)
                         )
                         (block
-                          (i32.store offset=4 align=4
+                          (i32.store offset=4
                             (get_local $i44)
                             (i32.or
                               (get_local $i5)
                               (i32.const 3)
                             )
                           )
-                          (i32.store offset=4 align=4
+                          (i32.store offset=4
                             (get_local $i8)
                             (i32.or
                               (get_local $i43)
                               (i32.const 1)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.add
                               (get_local $i8)
                               (get_local $i43)
@@ -2658,7 +2658,7 @@
                                 )
                               )
                               (set_local $i7
-                                (i32.load align=4
+                                (i32.load
                                   (i32.const 176)
                                 )
                               )
@@ -2681,14 +2681,14 @@
                                     )
                                   )
                                   (set_local $i4
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $i3)
                                     )
                                   )
                                   (if_else
                                     (i32.lt_u
                                       (get_local $i4)
-                                      (i32.load align=4
+                                      (i32.load
                                         (i32.const 192)
                                       )
                                     )
@@ -2704,7 +2704,7 @@
                                   )
                                 )
                                 (block
-                                  (i32.store align=4
+                                  (i32.store
                                     (i32.const 176)
                                     (i32.or
                                       (get_local $i7)
@@ -2722,19 +2722,19 @@
                                   )
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i50)
                                 (get_local $i8)
                               )
-                              (i32.store offset=12 align=4
+                              (i32.store offset=12
                                 (get_local $i51)
                                 (get_local $i8)
                               )
-                              (i32.store offset=8 align=4
+                              (i32.store offset=8
                                 (get_local $i8)
                                 (get_local $i51)
                               )
-                              (i32.store offset=12 align=4
+                              (i32.store offset=12
                                 (get_local $i8)
                                 (get_local $i15)
                               )
@@ -2860,7 +2860,7 @@
                               )
                             )
                           )
-                          (i32.store offset=28 align=4
+                          (i32.store offset=28
                             (get_local $i8)
                             (get_local $i52)
                           )
@@ -2870,16 +2870,16 @@
                               (i32.const 16)
                             )
                           )
-                          (i32.store offset=4 align=4
+                          (i32.store offset=4
                             (get_local $i7)
                             (i32.const 0)
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $i7)
                             (i32.const 0)
                           )
                           (set_local $i7
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 180)
                             )
                           )
@@ -2898,26 +2898,26 @@
                               (i32.const 0)
                             )
                             (block
-                              (i32.store align=4
+                              (i32.store
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $i7)
                                   (get_local $i4)
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i3)
                                 (get_local $i8)
                               )
-                              (i32.store offset=24 align=4
+                              (i32.store offset=24
                                 (get_local $i8)
                                 (get_local $i3)
                               )
-                              (i32.store offset=12 align=4
+                              (i32.store offset=12
                                 (get_local $i8)
                                 (get_local $i8)
                               )
-                              (i32.store offset=8 align=4
+                              (i32.store offset=8
                                 (get_local $i8)
                                 (get_local $i8)
                               )
@@ -2944,7 +2944,7 @@
                             )
                           )
                           (set_local $i7
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i3)
                             )
                           )
@@ -2952,7 +2952,7 @@
                             (if
                               (i32.eq
                                 (i32.and
-                                  (i32.load offset=4 align=4
+                                  (i32.load offset=4
                                     (get_local $i7)
                                   )
                                   (i32.const -8)
@@ -2985,7 +2985,7 @@
                               )
                             )
                             (set_local $i2
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i3)
                               )
                             )
@@ -3028,25 +3028,25 @@
                             (if_else
                               (i32.lt_u
                                 (get_local $i54)
-                                (i32.load align=4
+                                (i32.load
                                   (i32.const 192)
                                 )
                               )
                               (call_import $_abort)
                               (block
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $i54)
                                   (get_local $i8)
                                 )
-                                (i32.store offset=24 align=4
+                                (i32.store offset=24
                                   (get_local $i8)
                                   (get_local $i55)
                                 )
-                                (i32.store offset=12 align=4
+                                (i32.store offset=12
                                   (get_local $i8)
                                   (get_local $i8)
                                 )
-                                (i32.store offset=8 align=4
+                                (i32.store offset=8
                                   (get_local $i8)
                                   (get_local $i8)
                                 )
@@ -3066,12 +3066,12 @@
                                   )
                                 )
                                 (set_local $i4
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $i7)
                                   )
                                 )
                                 (set_local $i2
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 192)
                                   )
                                 )
@@ -3087,23 +3087,23 @@
                                     )
                                   )
                                   (block
-                                    (i32.store offset=12 align=4
+                                    (i32.store offset=12
                                       (get_local $i4)
                                       (get_local $i8)
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $i7)
                                       (get_local $i8)
                                     )
-                                    (i32.store offset=8 align=4
+                                    (i32.store offset=8
                                       (get_local $i8)
                                       (get_local $i4)
                                     )
-                                    (i32.store offset=12 align=4
+                                    (i32.store offset=12
                                       (get_local $i8)
                                       (get_local $i53)
                                     )
-                                    (i32.store offset=24 align=4
+                                    (i32.store offset=24
                                       (get_local $i8)
                                       (i32.const 0)
                                     )
@@ -3122,7 +3122,7 @@
                               (get_local $i5)
                             )
                           )
-                          (i32.store offset=4 align=4
+                          (i32.store offset=4
                             (get_local $i44)
                             (i32.or
                               (get_local $i4)
@@ -3138,10 +3138,10 @@
                               (i32.const 4)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $i7)
                             (i32.or
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i7)
                               )
                               (i32.const 1)
@@ -3177,7 +3177,7 @@
       )
     )
     (set_local $i44
-      (i32.load align=4
+      (i32.load
         (i32.const 184)
       )
     )
@@ -3194,7 +3194,7 @@
           )
         )
         (set_local $i53
-          (i32.load align=4
+          (i32.load
             (i32.const 196)
           )
         )
@@ -3210,29 +3210,29 @@
                 (get_local $i31)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (get_local $i55)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (get_local $i43)
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $i55)
               (i32.or
                 (get_local $i43)
                 (i32.const 1)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.add
                 (get_local $i55)
                 (get_local $i43)
               )
               (get_local $i43)
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $i53)
               (i32.or
                 (get_local $i31)
@@ -3241,15 +3241,15 @@
             )
           )
           (block
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (i32.const 0)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (i32.const 0)
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $i53)
               (i32.or
                 (get_local $i44)
@@ -3265,10 +3265,10 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $i43)
               (i32.or
-                (i32.load align=4
+                (i32.load
                   (get_local $i43)
                 )
                 (i32.const 1)
@@ -3288,7 +3288,7 @@
       )
     )
     (set_local $i53
-      (i32.load align=4
+      (i32.load
         (i32.const 188)
       )
     )
@@ -3304,12 +3304,12 @@
             (get_local $i31)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 188)
           (get_local $i43)
         )
         (set_local $i53
-          (i32.load align=4
+          (i32.load
             (i32.const 200)
           )
         )
@@ -3319,18 +3319,18 @@
             (get_local $i31)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 200)
           (get_local $i44)
         )
-        (i32.store offset=4 align=4
+        (i32.store offset=4
           (get_local $i44)
           (i32.or
             (get_local $i43)
             (i32.const 1)
           )
         )
-        (i32.store offset=4 align=4
+        (i32.store offset=4
           (get_local $i53)
           (i32.or
             (get_local $i31)
@@ -3351,7 +3351,7 @@
     (block $do-once$22
       (if
         (i32.eq
-          (i32.load align=4
+          (i32.load
             (i32.const 648)
           )
           (i32.const 0)
@@ -3374,31 +3374,31 @@
               (i32.const 0)
             )
             (block
-              (i32.store align=4
+              (i32.store
                 (i32.const 656)
                 (get_local $i53)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 652)
                 (get_local $i53)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 660)
                 (i32.const -1)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 664)
                 (i32.const -1)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 668)
                 (i32.const 0)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 620)
                 (i32.const 0)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 648)
                 (i32.xor
                   (i32.and
@@ -3424,7 +3424,7 @@
       )
     )
     (set_local $i43
-      (i32.load align=4
+      (i32.load
         (i32.const 656)
       )
     )
@@ -3467,7 +3467,7 @@
       )
     )
     (set_local $i52
-      (i32.load align=4
+      (i32.load
         (i32.const 616)
       )
     )
@@ -3479,7 +3479,7 @@
         )
         (block
           (set_local $i51
-            (i32.load align=4
+            (i32.load
               (i32.const 608)
             )
           )
@@ -3515,7 +3515,7 @@
       (if_else
         (i32.eq
           (i32.and
-            (i32.load align=4
+            (i32.load
               (i32.const 620)
             )
             (i32.const 4)
@@ -3524,7 +3524,7 @@
         )
         (block
           (set_local $i52
-            (i32.load align=4
+            (i32.load
               (i32.const 200)
             )
           )
@@ -3537,7 +3537,7 @@
                 )
                 (loop $while-out$23 $while-in$24
                   (set_local $i51
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i50)
                     )
                   )
@@ -3557,7 +3557,7 @@
                         (i32.gt_u
                           (i32.add
                             (get_local $i51)
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i45)
                             )
                           )
@@ -3577,7 +3577,7 @@
                     )
                   )
                   (set_local $i50
-                    (i32.load offset=8 align=4
+                    (i32.load offset=8
                       (get_local $i50)
                     )
                   )
@@ -3599,7 +3599,7 @@
                   (i32.and
                     (i32.sub
                       (get_local $i55)
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 188)
                       )
                     )
@@ -3621,10 +3621,10 @@
                       (i32.eq
                         (get_local $i45)
                         (i32.add
-                          (i32.load align=4
+                          (i32.load
                             (get_local $i56)
                           )
-                          (i32.load align=4
+                          (i32.load
                             (get_local $i57)
                           )
                         )
@@ -3692,7 +3692,7 @@
                   (get_local $i52)
                 )
                 (set_local $i50
-                  (i32.load align=4
+                  (i32.load
                     (i32.const 652)
                   )
                 )
@@ -3733,7 +3733,7 @@
                   )
                 )
                 (set_local $i50
-                  (i32.load align=4
+                  (i32.load
                     (i32.const 608)
                   )
                 )
@@ -3756,7 +3756,7 @@
                   )
                   (block
                     (set_local $i45
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 616)
                       )
                     )
@@ -3852,7 +3852,7 @@
                       )
                       (block
                         (set_local $i52
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 656)
                           )
                         )
@@ -3927,10 +3927,10 @@
               )
             )
           )
-          (i32.store align=4
+          (i32.store
             (i32.const 620)
             (i32.or
-              (i32.load align=4
+              (i32.load
                 (i32.const 620)
               )
               (i32.const 4)
@@ -4026,30 +4026,30 @@
       (block
         (set_local $i60
           (i32.add
-            (i32.load align=4
+            (i32.load
               (i32.const 608)
             )
             (get_local $i59)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 608)
           (get_local $i60)
         )
         (if
           (i32.gt_u
             (get_local $i60)
-            (i32.load align=4
+            (i32.load
               (i32.const 612)
             )
           )
-          (i32.store align=4
+          (i32.store
             (i32.const 612)
             (get_local $i60)
           )
         )
         (set_local $i60
-          (i32.load align=4
+          (i32.load
             (i32.const 200)
           )
         )
@@ -4062,7 +4062,7 @@
               )
               (loop $do-out$28 $do-in$29
                 (set_local $i43
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i63)
                   )
                 )
@@ -4073,7 +4073,7 @@
                   )
                 )
                 (set_local $i44
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i61)
                   )
                 )
@@ -4105,7 +4105,7 @@
                   )
                 )
                 (set_local $i63
-                  (i32.load offset=8 align=4
+                  (i32.load offset=8
                     (get_local $i63)
                   )
                 )
@@ -4125,7 +4125,7 @@
                     )
                     (i32.eq
                       (i32.and
-                        (i32.load offset=12 align=4
+                        (i32.load offset=12
                           (get_local $i67)
                         )
                         (i32.const 8)
@@ -4147,7 +4147,7 @@
                   (i32.const 0)
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (get_local $i65)
                     (i32.add
                       (get_local $i66)
@@ -4191,36 +4191,36 @@
                         (get_local $i59)
                         (get_local $i44)
                       )
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 188)
                       )
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 200)
                     (get_local $i63)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 188)
                     (get_local $i61)
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (get_local $i63)
                     (i32.or
                       (get_local $i61)
                       (i32.const 1)
                     )
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (i32.add
                       (get_local $i63)
                       (get_local $i61)
                     )
                     (i32.const 40)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 204)
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 664)
                     )
                   )
@@ -4228,7 +4228,7 @@
                 )
               )
               (set_local $i61
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -4238,7 +4238,7 @@
                   (get_local $i61)
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 192)
                     (get_local $i58)
                   )
@@ -4262,7 +4262,7 @@
               (loop $while-out$30 $while-in$31
                 (if
                   (i32.eq
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i63)
                     )
                     (get_local $i61)
@@ -4281,7 +4281,7 @@
                   )
                 )
                 (set_local $i63
-                  (i32.load offset=8 align=4
+                  (i32.load offset=8
                     (get_local $i63)
                   )
                 )
@@ -4307,7 +4307,7 @@
                 (if_else
                   (i32.eq
                     (i32.and
-                      (i32.load offset=12 align=4
+                      (i32.load offset=12
                         (get_local $i70)
                       )
                       (i32.const 8)
@@ -4315,7 +4315,7 @@
                     (i32.const 0)
                   )
                   (block
-                    (i32.store align=4
+                    (i32.store
                       (get_local $i69)
                       (get_local $i58)
                     )
@@ -4325,10 +4325,10 @@
                         (i32.const 4)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $i63)
                       (i32.add
-                        (i32.load align=4
+                        (i32.load
                           (get_local $i63)
                         )
                         (get_local $i59)
@@ -4405,7 +4405,7 @@
                         (get_local $i31)
                       )
                     )
-                    (i32.store offset=4 align=4
+                    (i32.store offset=4
                       (get_local $i44)
                       (i32.or
                         (get_local $i31)
@@ -4422,35 +4422,35 @@
                           (if
                             (i32.eq
                               (get_local $i43)
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 196)
                               )
                             )
                             (block
                               (set_local $i62
                                 (i32.add
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 184)
                                   )
                                   (get_local $i53)
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (i32.const 184)
                                 (get_local $i62)
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (i32.const 196)
                                 (get_local $i63)
                               )
-                              (i32.store offset=4 align=4
+                              (i32.store offset=4
                                 (get_local $i63)
                                 (i32.or
                                   (get_local $i62)
                                   (i32.const 1)
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (i32.add
                                   (get_local $i63)
                                   (get_local $i62)
@@ -4461,7 +4461,7 @@
                             )
                           )
                           (set_local $i62
-                            (i32.load offset=4 align=4
+                            (i32.load offset=4
                               (get_local $i43)
                             )
                           )
@@ -4494,12 +4494,12 @@
                                   )
                                   (block
                                     (set_local $i54
-                                      (i32.load offset=24 align=4
+                                      (i32.load offset=24
                                         (get_local $i43)
                                       )
                                     )
                                     (set_local $i55
-                                      (i32.load offset=12 align=4
+                                      (i32.load offset=12
                                         (get_local $i43)
                                       )
                                     )
@@ -4523,7 +4523,7 @@
                                             )
                                           )
                                           (set_local $i52
-                                            (i32.load align=4
+                                            (i32.load
                                               (get_local $i5)
                                             )
                                           )
@@ -4534,7 +4534,7 @@
                                             )
                                             (block
                                               (set_local $i50
-                                                (i32.load align=4
+                                                (i32.load
                                                   (get_local $i45)
                                                 )
                                               )
@@ -4576,7 +4576,7 @@
                                               )
                                             )
                                             (set_local $i52
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $i5)
                                               )
                                             )
@@ -4599,7 +4599,7 @@
                                               )
                                             )
                                             (set_local $i52
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $i5)
                                               )
                                             )
@@ -4635,7 +4635,7 @@
                                             )
                                             (call_import $_abort)
                                             (block
-                                              (i32.store align=4
+                                              (i32.store
                                                 (get_local $i76)
                                                 (i32.const 0)
                                               )
@@ -4648,7 +4648,7 @@
                                         )
                                         (block
                                           (set_local $i5
-                                            (i32.load offset=8 align=4
+                                            (i32.load offset=8
                                               (get_local $i43)
                                             )
                                           )
@@ -4667,7 +4667,7 @@
                                           )
                                           (if
                                             (i32.ne
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $i52)
                                               )
                                               (get_local $i43)
@@ -4682,17 +4682,17 @@
                                           )
                                           (if_else
                                             (i32.eq
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $i45)
                                               )
                                               (get_local $i43)
                                             )
                                             (block
-                                              (i32.store align=4
+                                              (i32.store
                                                 (get_local $i52)
                                                 (get_local $i55)
                                               )
-                                              (i32.store align=4
+                                              (i32.store
                                                 (get_local $i45)
                                                 (get_local $i5)
                                               )
@@ -4713,7 +4713,7 @@
                                       )
                                     )
                                     (set_local $i55
-                                      (i32.load offset=28 align=4
+                                      (i32.load offset=28
                                         (get_local $i43)
                                       )
                                     )
@@ -4730,7 +4730,7 @@
                                       (if_else
                                         (i32.ne
                                           (get_local $i43)
-                                          (i32.load align=4
+                                          (i32.load
                                             (get_local $i5)
                                           )
                                         )
@@ -4738,7 +4738,7 @@
                                           (if
                                             (i32.lt_u
                                               (get_local $i54)
-                                              (i32.load align=4
+                                              (i32.load
                                                 (i32.const 192)
                                               )
                                             )
@@ -4752,16 +4752,16 @@
                                           )
                                           (if_else
                                             (i32.eq
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $i45)
                                               )
                                               (get_local $i43)
                                             )
-                                            (i32.store align=4
+                                            (i32.store
                                               (get_local $i45)
                                               (get_local $i72)
                                             )
-                                            (i32.store offset=20 align=4
+                                            (i32.store offset=20
                                               (get_local $i54)
                                               (get_local $i72)
                                             )
@@ -4774,17 +4774,17 @@
                                           )
                                         )
                                         (block
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $i5)
                                             (get_local $i72)
                                           )
                                           (br_if $do-once$36
                                             (get_local $i72)
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (i32.const 180)
                                             (i32.and
-                                              (i32.load align=4
+                                              (i32.load
                                                 (i32.const 180)
                                               )
                                               (i32.xor
@@ -4801,7 +4801,7 @@
                                       )
                                     )
                                     (set_local $i55
-                                      (i32.load align=4
+                                      (i32.load
                                         (i32.const 192)
                                       )
                                     )
@@ -4812,7 +4812,7 @@
                                       )
                                       (call_import $_abort)
                                     )
-                                    (i32.store offset=24 align=4
+                                    (i32.store offset=24
                                       (get_local $i72)
                                       (get_local $i54)
                                     )
@@ -4823,7 +4823,7 @@
                                       )
                                     )
                                     (set_local $i45
-                                      (i32.load align=4
+                                      (i32.load
                                         (get_local $i5)
                                       )
                                     )
@@ -4837,11 +4837,11 @@
                                           )
                                           (call_import $_abort)
                                           (block
-                                            (i32.store offset=16 align=4
+                                            (i32.store offset=16
                                               (get_local $i72)
                                               (get_local $i45)
                                             )
-                                            (i32.store offset=24 align=4
+                                            (i32.store offset=24
                                               (get_local $i45)
                                               (get_local $i72)
                                             )
@@ -4851,7 +4851,7 @@
                                       )
                                     )
                                     (set_local $i45
-                                      (i32.load offset=4 align=4
+                                      (i32.load offset=4
                                         (get_local $i5)
                                       )
                                     )
@@ -4864,17 +4864,17 @@
                                     (if_else
                                       (i32.lt_u
                                         (get_local $i45)
-                                        (i32.load align=4
+                                        (i32.load
                                           (i32.const 192)
                                         )
                                       )
                                       (call_import $_abort)
                                       (block
-                                        (i32.store offset=20 align=4
+                                        (i32.store offset=20
                                           (get_local $i72)
                                           (get_local $i45)
                                         )
-                                        (i32.store offset=24 align=4
+                                        (i32.store offset=24
                                           (get_local $i45)
                                           (get_local $i72)
                                         )
@@ -4884,12 +4884,12 @@
                                   )
                                   (block
                                     (set_local $i45
-                                      (i32.load offset=8 align=4
+                                      (i32.load offset=8
                                         (get_local $i43)
                                       )
                                     )
                                     (set_local $i55
-                                      (i32.load offset=12 align=4
+                                      (i32.load offset=12
                                         (get_local $i43)
                                       )
                                     )
@@ -4921,7 +4921,7 @@
                                           )
                                           (br_if $do-once$38
                                             (i32.eq
-                                              (i32.load offset=12 align=4
+                                              (i32.load offset=12
                                                 (get_local $i45)
                                               )
                                               (get_local $i43)
@@ -4937,10 +4937,10 @@
                                         (get_local $i45)
                                       )
                                       (block
-                                        (i32.store align=4
+                                        (i32.store
                                           (i32.const 176)
                                           (i32.and
-                                            (i32.load align=4
+                                            (i32.load
                                               (i32.const 176)
                                             )
                                             (i32.xor
@@ -4983,7 +4983,7 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $i5)
                                               )
                                               (get_local $i43)
@@ -4999,11 +4999,11 @@
                                         )
                                       )
                                     )
-                                    (i32.store offset=12 align=4
+                                    (i32.store offset=12
                                       (get_local $i45)
                                       (get_local $i55)
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $i77)
                                       (get_local $i45)
                                     )
@@ -5038,23 +5038,23 @@
                               (i32.const 4)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $i56)
                             (i32.and
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i56)
                               )
                               (i32.const -2)
                             )
                           )
-                          (i32.store offset=4 align=4
+                          (i32.store offset=4
                             (get_local $i63)
                             (i32.or
                               (get_local $i79)
                               (i32.const 1)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.add
                               (get_local $i63)
                               (get_local $i79)
@@ -5086,7 +5086,7 @@
                                 )
                               )
                               (set_local $i54
-                                (i32.load align=4
+                                (i32.load
                                   (i32.const 176)
                                 )
                               )
@@ -5106,7 +5106,7 @@
                                     (i32.const 0)
                                   )
                                   (block
-                                    (i32.store align=4
+                                    (i32.store
                                       (i32.const 176)
                                       (i32.or
                                         (get_local $i54)
@@ -5131,14 +5131,14 @@
                                       )
                                     )
                                     (set_local $i52
-                                      (i32.load align=4
+                                      (i32.load
                                         (get_local $i56)
                                       )
                                     )
                                     (if
                                       (i32.ge_u
                                         (get_local $i52)
-                                        (i32.load align=4
+                                        (i32.load
                                           (i32.const 192)
                                         )
                                       )
@@ -5156,19 +5156,19 @@
                                   )
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i80)
                                 (get_local $i63)
                               )
-                              (i32.store offset=12 align=4
+                              (i32.store offset=12
                                 (get_local $i81)
                                 (get_local $i63)
                               )
-                              (i32.store offset=8 align=4
+                              (i32.store offset=8
                                 (get_local $i63)
                                 (get_local $i81)
                               )
-                              (i32.store offset=12 align=4
+                              (i32.store offset=12
                                 (get_local $i63)
                                 (get_local $i62)
                               )
@@ -5302,7 +5302,7 @@
                               )
                             )
                           )
-                          (i32.store offset=28 align=4
+                          (i32.store offset=28
                             (get_local $i63)
                             (get_local $i82)
                           )
@@ -5312,16 +5312,16 @@
                               (i32.const 16)
                             )
                           )
-                          (i32.store offset=4 align=4
+                          (i32.store offset=4
                             (get_local $i62)
                             (i32.const 0)
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $i62)
                             (i32.const 0)
                           )
                           (set_local $i62
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 180)
                             )
                           )
@@ -5340,26 +5340,26 @@
                               (i32.const 0)
                             )
                             (block
-                              (i32.store align=4
+                              (i32.store
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $i62)
                                   (get_local $i50)
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $i5)
                                 (get_local $i63)
                               )
-                              (i32.store offset=24 align=4
+                              (i32.store offset=24
                                 (get_local $i63)
                                 (get_local $i5)
                               )
-                              (i32.store offset=12 align=4
+                              (i32.store offset=12
                                 (get_local $i63)
                                 (get_local $i63)
                               )
-                              (i32.store offset=8 align=4
+                              (i32.store offset=8
                                 (get_local $i63)
                                 (get_local $i63)
                               )
@@ -5386,7 +5386,7 @@
                             )
                           )
                           (set_local $i62
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i5)
                             )
                           )
@@ -5394,7 +5394,7 @@
                             (if
                               (i32.eq
                                 (i32.and
-                                  (i32.load offset=4 align=4
+                                  (i32.load offset=4
                                     (get_local $i62)
                                   )
                                   (i32.const -8)
@@ -5427,7 +5427,7 @@
                               )
                             )
                             (set_local $i57
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $i5)
                               )
                             )
@@ -5470,25 +5470,25 @@
                             (if_else
                               (i32.lt_u
                                 (get_local $i84)
-                                (i32.load align=4
+                                (i32.load
                                   (i32.const 192)
                                 )
                               )
                               (call_import $_abort)
                               (block
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $i84)
                                   (get_local $i63)
                                 )
-                                (i32.store offset=24 align=4
+                                (i32.store offset=24
                                   (get_local $i63)
                                   (get_local $i85)
                                 )
-                                (i32.store offset=12 align=4
+                                (i32.store offset=12
                                   (get_local $i63)
                                   (get_local $i63)
                                 )
-                                (i32.store offset=8 align=4
+                                (i32.store offset=8
                                   (get_local $i63)
                                   (get_local $i63)
                                 )
@@ -5508,12 +5508,12 @@
                                   )
                                 )
                                 (set_local $i50
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $i62)
                                   )
                                 )
                                 (set_local $i57
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 192)
                                   )
                                 )
@@ -5529,23 +5529,23 @@
                                     )
                                   )
                                   (block
-                                    (i32.store offset=12 align=4
+                                    (i32.store offset=12
                                       (get_local $i50)
                                       (get_local $i63)
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $i62)
                                       (get_local $i63)
                                     )
-                                    (i32.store offset=8 align=4
+                                    (i32.store offset=8
                                       (get_local $i63)
                                       (get_local $i50)
                                     )
-                                    (i32.store offset=12 align=4
+                                    (i32.store offset=12
                                       (get_local $i63)
                                       (get_local $i83)
                                     )
-                                    (i32.store offset=24 align=4
+                                    (i32.store offset=24
                                       (get_local $i63)
                                       (i32.const 0)
                                     )
@@ -5560,21 +5560,21 @@
                         (block
                           (set_local $i50
                             (i32.add
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 188)
                               )
                               (get_local $i53)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 188)
                             (get_local $i50)
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 200)
                             (get_local $i63)
                           )
-                          (i32.store offset=4 align=4
+                          (i32.store offset=4
                             (get_local $i63)
                             (i32.or
                               (get_local $i50)
@@ -5601,7 +5601,7 @@
               )
               (loop $while-out$44 $while-in$45
                 (set_local $i63
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i71)
                   )
                 )
@@ -5615,7 +5615,7 @@
                       (set_local $i53
                         (i32.add
                           (get_local $i63)
-                          (i32.load offset=4 align=4
+                          (i32.load offset=4
                             (get_local $i71)
                           )
                         )
@@ -5635,7 +5635,7 @@
                   )
                 )
                 (set_local $i71
-                  (i32.load offset=8 align=4
+                  (i32.load offset=8
                     (get_local $i71)
                   )
                 )
@@ -5737,31 +5737,31 @@
                   (get_local $i61)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 200)
                 (get_local $i43)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 188)
                 (get_local $i50)
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $i43)
                 (i32.or
                   (get_local $i50)
                   (i32.const 1)
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (i32.add
                   (get_local $i43)
                   (get_local $i50)
                 )
                 (i32.const 40)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 204)
-                (i32.load align=4
+                (i32.load
                   (i32.const 664)
                 )
               )
@@ -5771,47 +5771,47 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $i50)
                 (i32.const 27)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $i63)
-                (i32.load align=4
+                (i32.load
                   (i32.const 624)
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $i63)
-                (i32.load align=4
+                (i32.load
                   (i32.const 628)
                 )
               )
-              (i32.store offset=8 align=4
+              (i32.store offset=8
                 (get_local $i63)
-                (i32.load align=4
+                (i32.load
                   (i32.const 632)
                 )
               )
-              (i32.store offset=12 align=4
+              (i32.store offset=12
                 (get_local $i63)
-                (i32.load align=4
+                (i32.load
                   (i32.const 636)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 624)
                 (get_local $i58)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 628)
                 (get_local $i59)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 636)
                 (i32.const 0)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 632)
                 (get_local $i63)
               )
@@ -5828,7 +5828,7 @@
                     (i32.const 4)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $i63)
                   (i32.const 7)
                 )
@@ -5854,23 +5854,23 @@
                       (get_local $i60)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $i50)
                     (i32.and
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i50)
                       )
                       (i32.const -2)
                     )
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (get_local $i60)
                     (i32.or
                       (get_local $i63)
                       (i32.const 1)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $i44)
                     (get_local $i63)
                   )
@@ -5899,7 +5899,7 @@
                         )
                       )
                       (set_local $i62
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 176)
                         )
                       )
@@ -5922,14 +5922,14 @@
                             )
                           )
                           (set_local $i5
-                            (i32.load align=4
+                            (i32.load
                               (get_local $i43)
                             )
                           )
                           (if_else
                             (i32.lt_u
                               (get_local $i5)
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 192)
                               )
                             )
@@ -5945,7 +5945,7 @@
                           )
                         )
                         (block
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 176)
                             (i32.or
                               (get_local $i62)
@@ -5963,19 +5963,19 @@
                           )
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $i87)
                         (get_local $i60)
                       )
-                      (i32.store offset=12 align=4
+                      (i32.store offset=12
                         (get_local $i88)
                         (get_local $i60)
                       )
-                      (i32.store offset=8 align=4
+                      (i32.store offset=8
                         (get_local $i60)
                         (get_local $i88)
                       )
-                      (i32.store offset=12 align=4
+                      (i32.store offset=12
                         (get_local $i60)
                         (get_local $i61)
                       )
@@ -6101,20 +6101,20 @@
                       )
                     )
                   )
-                  (i32.store offset=28 align=4
+                  (i32.store offset=28
                     (get_local $i60)
                     (get_local $i89)
                   )
-                  (i32.store offset=20 align=4
+                  (i32.store offset=20
                     (get_local $i60)
                     (i32.const 0)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $i53)
                     (i32.const 0)
                   )
                   (set_local $i62
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 180)
                     )
                   )
@@ -6133,26 +6133,26 @@
                       (i32.const 0)
                     )
                     (block
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 180)
                         (i32.or
                           (get_local $i62)
                           (get_local $i5)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $i43)
                         (get_local $i60)
                       )
-                      (i32.store offset=24 align=4
+                      (i32.store offset=24
                         (get_local $i60)
                         (get_local $i43)
                       )
-                      (i32.store offset=12 align=4
+                      (i32.store offset=12
                         (get_local $i60)
                         (get_local $i60)
                       )
-                      (i32.store offset=8 align=4
+                      (i32.store offset=8
                         (get_local $i60)
                         (get_local $i60)
                       )
@@ -6179,7 +6179,7 @@
                     )
                   )
                   (set_local $i62
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i43)
                     )
                   )
@@ -6187,7 +6187,7 @@
                     (if
                       (i32.eq
                         (i32.and
-                          (i32.load offset=4 align=4
+                          (i32.load offset=4
                             (get_local $i62)
                           )
                           (i32.const -8)
@@ -6220,7 +6220,7 @@
                       )
                     )
                     (set_local $i57
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i43)
                       )
                     )
@@ -6263,25 +6263,25 @@
                     (if_else
                       (i32.lt_u
                         (get_local $i91)
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
                       (call_import $_abort)
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (get_local $i91)
                           (get_local $i60)
                         )
-                        (i32.store offset=24 align=4
+                        (i32.store offset=24
                           (get_local $i60)
                           (get_local $i92)
                         )
-                        (i32.store offset=12 align=4
+                        (i32.store offset=12
                           (get_local $i60)
                           (get_local $i60)
                         )
-                        (i32.store offset=8 align=4
+                        (i32.store offset=8
                           (get_local $i60)
                           (get_local $i60)
                         )
@@ -6301,12 +6301,12 @@
                           )
                         )
                         (set_local $i5
-                          (i32.load align=4
+                          (i32.load
                             (get_local $i62)
                           )
                         )
                         (set_local $i63
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 192)
                           )
                         )
@@ -6322,23 +6322,23 @@
                             )
                           )
                           (block
-                            (i32.store offset=12 align=4
+                            (i32.store offset=12
                               (get_local $i5)
                               (get_local $i60)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $i62)
                               (get_local $i60)
                             )
-                            (i32.store offset=8 align=4
+                            (i32.store offset=8
                               (get_local $i60)
                               (get_local $i5)
                             )
-                            (i32.store offset=12 align=4
+                            (i32.store offset=12
                               (get_local $i60)
                               (get_local $i90)
                             )
-                            (i32.store offset=24 align=4
+                            (i32.store offset=24
                               (get_local $i60)
                               (i32.const 0)
                             )
@@ -6354,7 +6354,7 @@
             )
             (block
               (set_local $i5
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -6369,30 +6369,30 @@
                     (get_local $i5)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (i32.const 192)
                   (get_local $i58)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 624)
                 (get_local $i58)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 628)
                 (get_local $i59)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 636)
                 (i32.const 0)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 212)
-                (i32.load align=4
+                (i32.load
                   (i32.const 648)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 208)
                 (i32.const -1)
               )
@@ -6412,11 +6412,11 @@
                     )
                   )
                 )
-                (i32.store offset=12 align=4
+                (i32.store offset=12
                   (get_local $i62)
                   (get_local $i62)
                 )
-                (i32.store offset=8 align=4
+                (i32.store offset=8
                   (get_local $i62)
                   (get_local $i62)
                 )
@@ -6473,31 +6473,31 @@
                   (get_local $i62)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 200)
                 (get_local $i5)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 188)
                 (get_local $i63)
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $i5)
                 (i32.or
                   (get_local $i63)
                   (i32.const 1)
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (i32.add
                   (get_local $i5)
                   (get_local $i63)
                 )
                 (i32.const 40)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 204)
-                (i32.load align=4
+                (i32.load
                   (i32.const 664)
                 )
               )
@@ -6505,7 +6505,7 @@
           )
         )
         (set_local $i59
-          (i32.load align=4
+          (i32.load
             (i32.const 188)
           )
         )
@@ -6521,12 +6521,12 @@
                 (get_local $i31)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 188)
               (get_local $i58)
             )
             (set_local $i59
-              (i32.load align=4
+              (i32.load
                 (i32.const 200)
               )
             )
@@ -6536,18 +6536,18 @@
                 (get_local $i31)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 200)
               (get_local $i60)
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $i60)
               (i32.or
                 (get_local $i58)
                 (i32.const 1)
               )
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $i59)
               (i32.or
                 (get_local $i31)
@@ -6567,7 +6567,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (call $___errno_location)
       (i32.const 12)
     )
@@ -6629,7 +6629,7 @@
       )
     )
     (set_local $i3
-      (i32.load align=4
+      (i32.load
         (i32.const 192)
       )
     )
@@ -6641,7 +6641,7 @@
       (call_import $_abort)
     )
     (set_local $i4
-      (i32.load align=4
+      (i32.load
         (i32.add
           (get_local $i1)
           (i32.const -4)
@@ -6684,7 +6684,7 @@
         )
         (block
           (set_local $i7
-            (i32.load align=4
+            (i32.load
               (get_local $i2)
             )
           )
@@ -6720,7 +6720,7 @@
           (if
             (i32.eq
               (get_local $i8)
-              (i32.load align=4
+              (i32.load
                 (i32.const 196)
               )
             )
@@ -6732,7 +6732,7 @@
                 )
               )
               (set_local $i11
-                (i32.load align=4
+                (i32.load
                   (get_local $i10)
                 )
               )
@@ -6754,25 +6754,25 @@
                   (br $do-once$0)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 184)
                 (get_local $i9)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $i10)
                 (i32.and
                   (get_local $i11)
                   (i32.const -2)
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $i8)
                 (i32.or
                   (get_local $i9)
                   (i32.const 1)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.add
                   (get_local $i8)
                   (get_local $i9)
@@ -6795,12 +6795,12 @@
             )
             (block
               (set_local $i7
-                (i32.load offset=8 align=4
+                (i32.load offset=8
                   (get_local $i8)
                 )
               )
               (set_local $i10
-                (i32.load offset=12 align=4
+                (i32.load offset=12
                   (get_local $i8)
                 )
               )
@@ -6831,7 +6831,7 @@
                   )
                   (if
                     (i32.ne
-                      (i32.load offset=12 align=4
+                      (i32.load offset=12
                         (get_local $i7)
                       )
                       (get_local $i8)
@@ -6846,10 +6846,10 @@
                   (get_local $i7)
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 176)
                     (i32.and
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 176)
                       )
                       (i32.xor
@@ -6891,7 +6891,7 @@
                   )
                   (if_else
                     (i32.eq
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i14)
                       )
                       (get_local $i8)
@@ -6909,11 +6909,11 @@
                   )
                 )
               )
-              (i32.store offset=12 align=4
+              (i32.store offset=12
                 (get_local $i7)
                 (get_local $i10)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $i15)
                 (get_local $i7)
               )
@@ -6927,12 +6927,12 @@
             )
           )
           (set_local $i7
-            (i32.load offset=24 align=4
+            (i32.load offset=24
               (get_local $i8)
             )
           )
           (set_local $i10
-            (i32.load offset=12 align=4
+            (i32.load offset=12
               (get_local $i8)
             )
           )
@@ -6956,7 +6956,7 @@
                   )
                 )
                 (set_local $i16
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i11)
                   )
                 )
@@ -6967,7 +6967,7 @@
                   )
                   (block
                     (set_local $i17
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i14)
                       )
                     )
@@ -7009,7 +7009,7 @@
                     )
                   )
                   (set_local $i16
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i11)
                     )
                   )
@@ -7032,7 +7032,7 @@
                     )
                   )
                   (set_local $i16
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i11)
                     )
                   )
@@ -7068,7 +7068,7 @@
                   )
                   (call_import $_abort)
                   (block
-                    (i32.store align=4
+                    (i32.store
                       (get_local $i22)
                       (i32.const 0)
                     )
@@ -7081,7 +7081,7 @@
               )
               (block
                 (set_local $i11
-                  (i32.load offset=8 align=4
+                  (i32.load offset=8
                     (get_local $i8)
                   )
                 )
@@ -7100,7 +7100,7 @@
                 )
                 (if
                   (i32.ne
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i16)
                     )
                     (get_local $i8)
@@ -7115,17 +7115,17 @@
                 )
                 (if_else
                   (i32.eq
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i14)
                     )
                     (get_local $i8)
                   )
                   (block
-                    (i32.store align=4
+                    (i32.store
                       (get_local $i16)
                       (get_local $i10)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $i14)
                       (get_local $i11)
                     )
@@ -7143,7 +7143,7 @@
             (get_local $i7)
             (block
               (set_local $i10
-                (i32.load offset=28 align=4
+                (i32.load offset=28
                   (get_local $i8)
                 )
               )
@@ -7159,12 +7159,12 @@
               (if_else
                 (i32.eq
                   (get_local $i8)
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i11)
                   )
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (get_local $i11)
                     (get_local $i18)
                   )
@@ -7174,10 +7174,10 @@
                       (i32.const 0)
                     )
                     (block
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 180)
                         (i32.and
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 180)
                           )
                           (i32.xor
@@ -7203,7 +7203,7 @@
                   (if
                     (i32.lt_u
                       (get_local $i7)
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 192)
                       )
                     )
@@ -7217,16 +7217,16 @@
                   )
                   (if_else
                     (i32.eq
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i10)
                       )
                       (get_local $i8)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $i10)
                       (get_local $i18)
                     )
-                    (i32.store offset=20 align=4
+                    (i32.store offset=20
                       (get_local $i7)
                       (get_local $i18)
                     )
@@ -7249,7 +7249,7 @@
                 )
               )
               (set_local $i10
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -7260,7 +7260,7 @@
                 )
                 (call_import $_abort)
               )
-              (i32.store offset=24 align=4
+              (i32.store offset=24
                 (get_local $i18)
                 (get_local $i7)
               )
@@ -7271,7 +7271,7 @@
                 )
               )
               (set_local $i14
-                (i32.load align=4
+                (i32.load
                   (get_local $i11)
                 )
               )
@@ -7285,11 +7285,11 @@
                     )
                     (call_import $_abort)
                     (block
-                      (i32.store offset=16 align=4
+                      (i32.store offset=16
                         (get_local $i18)
                         (get_local $i14)
                       )
-                      (i32.store offset=24 align=4
+                      (i32.store offset=24
                         (get_local $i14)
                         (get_local $i18)
                       )
@@ -7299,7 +7299,7 @@
                 )
               )
               (set_local $i14
-                (i32.load offset=4 align=4
+                (i32.load offset=4
                   (get_local $i11)
                 )
               )
@@ -7308,17 +7308,17 @@
                 (if_else
                   (i32.lt_u
                     (get_local $i14)
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
                   (call_import $_abort)
                   (block
-                    (i32.store offset=20 align=4
+                    (i32.store offset=20
                       (get_local $i18)
                       (get_local $i14)
                     )
-                    (i32.store offset=24 align=4
+                    (i32.store offset=24
                       (get_local $i14)
                       (get_local $i18)
                     )
@@ -7375,7 +7375,7 @@
       )
     )
     (set_local $i2
-      (i32.load align=4
+      (i32.load
         (get_local $i5)
       )
     )
@@ -7401,28 +7401,28 @@
         (if
           (i32.eq
             (get_local $i6)
-            (i32.load align=4
+            (i32.load
               (i32.const 200)
             )
           )
           (block
             (set_local $i18
               (i32.add
-                (i32.load align=4
+                (i32.load
                   (i32.const 188)
                 )
                 (get_local $i13)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 188)
               (get_local $i18)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 200)
               (get_local $i12)
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $i12)
               (i32.or
                 (get_local $i18)
@@ -7432,17 +7432,17 @@
             (if
               (i32.ne
                 (get_local $i12)
-                (i32.load align=4
+                (i32.load
                   (i32.const 196)
                 )
               )
               (return)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (i32.const 0)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (i32.const 0)
             )
@@ -7452,35 +7452,35 @@
         (if
           (i32.eq
             (get_local $i6)
-            (i32.load align=4
+            (i32.load
               (i32.const 196)
             )
           )
           (block
             (set_local $i18
               (i32.add
-                (i32.load align=4
+                (i32.load
                   (i32.const 184)
                 )
                 (get_local $i13)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (get_local $i18)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (get_local $i12)
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $i12)
               (i32.or
                 (get_local $i18)
                 (i32.const 1)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.add
                 (get_local $i12)
                 (get_local $i18)
@@ -7513,12 +7513,12 @@
             )
             (block
               (set_local $i21
-                (i32.load offset=24 align=4
+                (i32.load offset=24
                   (get_local $i6)
                 )
               )
               (set_local $i22
-                (i32.load offset=12 align=4
+                (i32.load offset=12
                   (get_local $i6)
                 )
               )
@@ -7542,7 +7542,7 @@
                       )
                     )
                     (set_local $i15
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i19)
                       )
                     )
@@ -7553,7 +7553,7 @@
                       )
                       (block
                         (set_local $i1
-                          (i32.load align=4
+                          (i32.load
                             (get_local $i20)
                           )
                         )
@@ -7595,7 +7595,7 @@
                         )
                       )
                       (set_local $i15
-                        (i32.load align=4
+                        (i32.load
                           (get_local $i19)
                         )
                       )
@@ -7618,7 +7618,7 @@
                         )
                       )
                       (set_local $i15
-                        (i32.load align=4
+                        (i32.load
                           (get_local $i19)
                         )
                       )
@@ -7650,13 +7650,13 @@
                     (if_else
                       (i32.lt_u
                         (get_local $i27)
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
                       (call_import $_abort)
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (get_local $i27)
                           (i32.const 0)
                         )
@@ -7669,14 +7669,14 @@
                   )
                   (block
                     (set_local $i19
-                      (i32.load offset=8 align=4
+                      (i32.load offset=8
                         (get_local $i6)
                       )
                     )
                     (if
                       (i32.lt_u
                         (get_local $i19)
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
@@ -7690,7 +7690,7 @@
                     )
                     (if
                       (i32.ne
-                        (i32.load align=4
+                        (i32.load
                           (get_local $i15)
                         )
                         (get_local $i6)
@@ -7705,17 +7705,17 @@
                     )
                     (if_else
                       (i32.eq
-                        (i32.load align=4
+                        (i32.load
                           (get_local $i20)
                         )
                         (get_local $i6)
                       )
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (get_local $i15)
                           (get_local $i22)
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $i20)
                           (get_local $i19)
                         )
@@ -7733,7 +7733,7 @@
                 (get_local $i21)
                 (block
                   (set_local $i22
-                    (i32.load offset=28 align=4
+                    (i32.load offset=28
                       (get_local $i6)
                     )
                   )
@@ -7749,12 +7749,12 @@
                   (if_else
                     (i32.eq
                       (get_local $i6)
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i9)
                       )
                     )
                     (block
-                      (i32.store align=4
+                      (i32.store
                         (get_local $i9)
                         (get_local $i23)
                       )
@@ -7764,10 +7764,10 @@
                           (i32.const 0)
                         )
                         (block
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 180)
                             (i32.and
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 180)
                               )
                               (i32.xor
@@ -7787,7 +7787,7 @@
                       (if
                         (i32.lt_u
                           (get_local $i21)
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 192)
                           )
                         )
@@ -7801,16 +7801,16 @@
                       )
                       (if_else
                         (i32.eq
-                          (i32.load align=4
+                          (i32.load
                             (get_local $i22)
                           )
                           (get_local $i6)
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $i22)
                           (get_local $i23)
                         )
-                        (i32.store offset=20 align=4
+                        (i32.store offset=20
                           (get_local $i21)
                           (get_local $i23)
                         )
@@ -7824,7 +7824,7 @@
                     )
                   )
                   (set_local $i22
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -7835,7 +7835,7 @@
                     )
                     (call_import $_abort)
                   )
-                  (i32.store offset=24 align=4
+                  (i32.store offset=24
                     (get_local $i23)
                     (get_local $i21)
                   )
@@ -7846,7 +7846,7 @@
                     )
                   )
                   (set_local $i8
-                    (i32.load align=4
+                    (i32.load
                       (get_local $i9)
                     )
                   )
@@ -7860,11 +7860,11 @@
                         )
                         (call_import $_abort)
                         (block
-                          (i32.store offset=16 align=4
+                          (i32.store offset=16
                             (get_local $i23)
                             (get_local $i8)
                           )
-                          (i32.store offset=24 align=4
+                          (i32.store offset=24
                             (get_local $i8)
                             (get_local $i23)
                           )
@@ -7874,7 +7874,7 @@
                     )
                   )
                   (set_local $i8
-                    (i32.load offset=4 align=4
+                    (i32.load offset=4
                       (get_local $i9)
                     )
                   )
@@ -7883,17 +7883,17 @@
                     (if_else
                       (i32.lt_u
                         (get_local $i8)
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
                       (call_import $_abort)
                       (block
-                        (i32.store offset=20 align=4
+                        (i32.store offset=20
                           (get_local $i23)
                           (get_local $i8)
                         )
-                        (i32.store offset=24 align=4
+                        (i32.store offset=24
                           (get_local $i8)
                           (get_local $i23)
                         )
@@ -7906,12 +7906,12 @@
             )
             (block
               (set_local $i8
-                (i32.load offset=8 align=4
+                (i32.load offset=8
                   (get_local $i6)
                 )
               )
               (set_local $i22
-                (i32.load offset=12 align=4
+                (i32.load offset=12
                   (get_local $i6)
                 )
               )
@@ -7936,7 +7936,7 @@
                   (if
                     (i32.lt_u
                       (get_local $i8)
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 192)
                       )
                     )
@@ -7944,7 +7944,7 @@
                   )
                   (if
                     (i32.ne
-                      (i32.load offset=12 align=4
+                      (i32.load offset=12
                         (get_local $i8)
                       )
                       (get_local $i6)
@@ -7959,10 +7959,10 @@
                   (get_local $i8)
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 176)
                     (i32.and
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 176)
                       )
                       (i32.xor
@@ -7986,7 +7986,7 @@
                   (if
                     (i32.lt_u
                       (get_local $i22)
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 192)
                       )
                     )
@@ -8000,7 +8000,7 @@
                   )
                   (if_else
                     (i32.eq
-                      (i32.load align=4
+                      (i32.load
                         (get_local $i21)
                       )
                       (get_local $i6)
@@ -8018,25 +8018,25 @@
                   )
                 )
               )
-              (i32.store offset=12 align=4
+              (i32.store offset=12
                 (get_local $i8)
                 (get_local $i22)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $i28)
                 (get_local $i8)
               )
             )
           )
         )
-        (i32.store offset=4 align=4
+        (i32.store offset=4
           (get_local $i12)
           (i32.or
             (get_local $i18)
             (i32.const 1)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.add
             (get_local $i12)
             (get_local $i18)
@@ -8046,12 +8046,12 @@
         (if_else
           (i32.eq
             (get_local $i12)
-            (i32.load align=4
+            (i32.load
               (i32.const 196)
             )
           )
           (block
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (get_local $i18)
             )
@@ -8063,21 +8063,21 @@
         )
       )
       (block
-        (i32.store align=4
+        (i32.store
           (get_local $i5)
           (i32.and
             (get_local $i2)
             (i32.const -2)
           )
         )
-        (i32.store offset=4 align=4
+        (i32.store offset=4
           (get_local $i12)
           (i32.or
             (get_local $i13)
             (i32.const 1)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.add
             (get_local $i12)
             (get_local $i13)
@@ -8114,7 +8114,7 @@
           )
         )
         (set_local $i5
-          (i32.load align=4
+          (i32.load
             (i32.const 176)
           )
         )
@@ -8137,14 +8137,14 @@
               )
             )
             (set_local $i28
-              (i32.load align=4
+              (i32.load
                 (get_local $i13)
               )
             )
             (if_else
               (i32.lt_u
                 (get_local $i28)
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -8160,7 +8160,7 @@
             )
           )
           (block
-            (i32.store align=4
+            (i32.store
               (i32.const 176)
               (i32.or
                 (get_local $i5)
@@ -8178,19 +8178,19 @@
             )
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $i30)
           (get_local $i12)
         )
-        (i32.store offset=12 align=4
+        (i32.store offset=12
           (get_local $i31)
           (get_local $i12)
         )
-        (i32.store offset=8 align=4
+        (i32.store offset=8
           (get_local $i12)
           (get_local $i31)
         )
-        (i32.store offset=12 align=4
+        (i32.store offset=12
           (get_local $i12)
           (get_local $i2)
         )
@@ -8316,20 +8316,20 @@
         )
       )
     )
-    (i32.store offset=28 align=4
+    (i32.store offset=28
       (get_local $i12)
       (get_local $i32)
     )
-    (i32.store offset=20 align=4
+    (i32.store offset=20
       (get_local $i12)
       (i32.const 0)
     )
-    (i32.store offset=16 align=4
+    (i32.store offset=16
       (get_local $i12)
       (i32.const 0)
     )
     (set_local $i30
-      (i32.load align=4
+      (i32.load
         (i32.const 180)
       )
     )
@@ -8366,7 +8366,7 @@
             )
           )
           (set_local $i2
-            (i32.load align=4
+            (i32.load
               (get_local $i5)
             )
           )
@@ -8374,7 +8374,7 @@
             (if
               (i32.eq
                 (i32.and
-                  (i32.load offset=4 align=4
+                  (i32.load offset=4
                     (get_local $i2)
                   )
                   (i32.const -8)
@@ -8407,7 +8407,7 @@
               )
             )
             (set_local $i13
-              (i32.load align=4
+              (i32.load
                 (get_local $i28)
               )
             )
@@ -8450,25 +8450,25 @@
             (if_else
               (i32.lt_u
                 (get_local $i35)
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
               (call_import $_abort)
               (block
-                (i32.store align=4
+                (i32.store
                   (get_local $i35)
                   (get_local $i12)
                 )
-                (i32.store offset=24 align=4
+                (i32.store offset=24
                   (get_local $i12)
                   (get_local $i36)
                 )
-                (i32.store offset=12 align=4
+                (i32.store offset=12
                   (get_local $i12)
                   (get_local $i12)
                 )
-                (i32.store offset=8 align=4
+                (i32.store offset=8
                   (get_local $i12)
                   (get_local $i12)
                 )
@@ -8488,12 +8488,12 @@
                   )
                 )
                 (set_local $i31
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i2)
                   )
                 )
                 (set_local $i9
-                  (i32.load align=4
+                  (i32.load
                     (i32.const 192)
                   )
                 )
@@ -8509,23 +8509,23 @@
                     )
                   )
                   (block
-                    (i32.store offset=12 align=4
+                    (i32.store offset=12
                       (get_local $i31)
                       (get_local $i12)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $i2)
                       (get_local $i12)
                     )
-                    (i32.store offset=8 align=4
+                    (i32.store offset=8
                       (get_local $i12)
                       (get_local $i31)
                     )
-                    (i32.store offset=12 align=4
+                    (i32.store offset=12
                       (get_local $i12)
                       (get_local $i33)
                     )
-                    (i32.store offset=24 align=4
+                    (i32.store offset=24
                       (get_local $i12)
                       (i32.const 0)
                     )
@@ -8538,26 +8538,26 @@
           )
         )
         (block
-          (i32.store align=4
+          (i32.store
             (i32.const 180)
             (i32.or
               (get_local $i30)
               (get_local $i18)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i5)
             (get_local $i12)
           )
-          (i32.store offset=24 align=4
+          (i32.store offset=24
             (get_local $i12)
             (get_local $i5)
           )
-          (i32.store offset=12 align=4
+          (i32.store offset=12
             (get_local $i12)
             (get_local $i12)
           )
-          (i32.store offset=8 align=4
+          (i32.store offset=8
             (get_local $i12)
             (get_local $i12)
           )
@@ -8566,13 +8566,13 @@
     )
     (set_local $i12
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 208)
         )
         (i32.const -1)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 208)
       (get_local $i12)
     )
@@ -8588,7 +8588,7 @@
     )
     (loop $while-out$13 $while-in$14
       (set_local $i12
-        (i32.load align=4
+        (i32.load
           (get_local $i37)
         )
       )
@@ -8607,7 +8607,7 @@
       )
       (br $while-in$14)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 208)
       (i32.const -1)
     )
@@ -8636,14 +8636,14 @@
     (local $i17 i32)
     (local $i16 i32)
     (set_local $i4
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 48)
@@ -8671,11 +8671,11 @@
       )
     )
     (set_local $i9
-      (i32.load align=4
+      (i32.load
         (get_local $i8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $i7)
       (get_local $i9)
     )
@@ -8687,21 +8687,21 @@
     )
     (set_local $i11
       (i32.sub
-        (i32.load align=4
+        (i32.load
           (get_local $i10)
         )
         (get_local $i9)
       )
     )
-    (i32.store offset=4 align=4
+    (i32.store offset=4
       (get_local $i7)
       (get_local $i11)
     )
-    (i32.store offset=8 align=4
+    (i32.store offset=8
       (get_local $i7)
       (get_local $i2)
     )
-    (i32.store offset=12 align=4
+    (i32.store offset=12
       (get_local $i7)
       (get_local $i3)
     )
@@ -8732,23 +8732,23 @@
     (loop $while-out$0 $while-in$1
       (if_else
         (i32.eq
-          (i32.load align=4
+          (i32.load
             (i32.const 8)
           )
           (i32.const 0)
         )
         (block
-          (i32.store align=4
+          (i32.store
             (get_local $i5)
-            (i32.load align=4
+            (i32.load
               (get_local $i2)
             )
           )
-          (i32.store offset=4 align=4
+          (i32.store offset=4
             (get_local $i5)
             (get_local $i12)
           )
-          (i32.store offset=8 align=4
+          (i32.store offset=8
             (get_local $i5)
             (get_local $i7)
           )
@@ -8766,17 +8766,17 @@
             (i32.const 4)
             (get_local $i1)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i6)
-            (i32.load align=4
+            (i32.load
               (get_local $i2)
             )
           )
-          (i32.store offset=4 align=4
+          (i32.store offset=4
             (get_local $i6)
             (get_local $i12)
           )
-          (i32.store offset=8 align=4
+          (i32.store offset=8
             (get_local $i6)
             (get_local $i7)
           )
@@ -8833,7 +8833,7 @@
         )
       )
       (set_local $i18
-        (i32.load offset=4 align=4
+        (i32.load offset=4
           (get_local $i12)
         )
       )
@@ -8848,10 +8848,10 @@
             (i32.const 2)
           )
           (block
-            (i32.store align=4
+            (i32.store
               (get_local $i8)
               (i32.add
-                (i32.load align=4
+                (i32.load
                   (get_local $i8)
                 )
                 (get_local $i14)
@@ -8887,20 +8887,20 @@
         )
         (block
           (set_local $i23
-            (i32.load align=4
+            (i32.load
               (get_local $i9)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i8)
             (get_local $i23)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i10)
             (get_local $i23)
           )
           (set_local $i19
-            (i32.load offset=12 align=4
+            (i32.load offset=12
               (get_local $i12)
             )
           )
@@ -8924,16 +8924,16 @@
           )
         )
       )
-      (i32.store align=4
+      (i32.store
         (get_local $i21)
         (i32.add
-          (i32.load align=4
+          (i32.load
             (get_local $i21)
           )
           (get_local $i20)
         )
       )
-      (i32.store offset=4 align=4
+      (i32.store offset=4
         (get_local $i21)
         (i32.sub
           (get_local $i19)
@@ -8958,15 +8958,15 @@
       )
       (block
         (set_local $i13
-          (i32.load align=4
+          (i32.load
             (get_local $i9)
           )
         )
-        (i32.store offset=16 align=4
+        (i32.store offset=16
           (get_local $i1)
           (i32.add
             (get_local $i13)
-            (i32.load offset=48 align=4
+            (i32.load offset=48
               (get_local $i1)
             )
           )
@@ -8974,11 +8974,11 @@
         (set_local $i9
           (get_local $i13)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $i8)
           (get_local $i9)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $i10)
           (get_local $i9)
         )
@@ -8992,22 +8992,22 @@
           (i32.const 8)
         )
         (block
-          (i32.store offset=16 align=4
+          (i32.store offset=16
             (get_local $i1)
             (i32.const 0)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i8)
             (i32.const 0)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i10)
             (i32.const 0)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i1)
             (i32.or
-              (i32.load align=4
+              (i32.load
                 (get_local $i1)
               )
               (i32.const 32)
@@ -9024,7 +9024,7 @@
             (set_local $i24
               (i32.sub
                 (get_local $i3)
-                (i32.load offset=4 align=4
+                (i32.load offset=4
                   (get_local $i16)
                 )
               )
@@ -9033,7 +9033,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $i4)
     )
@@ -9061,7 +9061,7 @@
       )
     )
     (set_local $i5
-      (i32.load align=4
+      (i32.load
         (get_local $i4)
       )
     )
@@ -9079,7 +9079,7 @@
         )
         (block
           (set_local $i6
-            (i32.load align=4
+            (i32.load
               (get_local $i4)
             )
           )
@@ -9114,7 +9114,7 @@
             )
           )
           (set_local $i4
-            (i32.load align=4
+            (i32.load
               (get_local $i5)
             )
           )
@@ -9134,7 +9134,7 @@
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
-                      (i32.load offset=36 align=4
+                      (i32.load offset=36
                         (get_local $i3)
                       )
                       (i32.const 7)
@@ -9152,7 +9152,7 @@
           (block $label$break$L10
             (if_else
               (i32.gt_s
-                (i32.load8_s offset=75 align=1
+                (i32.load8_s offset=75
                   (get_local $i3)
                 )
                 (i32.const -1)
@@ -9191,7 +9191,7 @@
                   )
                   (if_else
                     (i32.eq
-                      (i32.load8_s align=1
+                      (i32.load8_s
                         (i32.add
                           (get_local $i1)
                           (get_local $i14)
@@ -9216,7 +9216,7 @@
                     (call_indirect $FUNCSIG$iiii
                       (i32.add
                         (i32.and
-                          (i32.load offset=36 align=4
+                          (i32.load offset=36
                             (get_local $i3)
                           )
                           (i32.const 7)
@@ -9249,7 +9249,7 @@
                   )
                 )
                 (set_local $i12
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i5)
                   )
                 )
@@ -9278,10 +9278,10 @@
             (get_local $i11)
             (get_local $i10)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i5)
             (i32.add
-              (i32.load align=4
+              (i32.load
                 (get_local $i5)
               )
               (get_local $i10)
@@ -9314,7 +9314,7 @@
         (block
           (if
             (i32.le_s
-              (i32.load offset=76 align=4
+              (i32.load offset=76
                 (get_local $i1)
               )
               (i32.const -1)
@@ -9359,7 +9359,7 @@
         (block
           (if_else
             (i32.eq
-              (i32.load align=4
+              (i32.load
                 (i32.const 56)
               )
               (i32.const 0)
@@ -9369,7 +9369,7 @@
             )
             (set_local $i5
               (call $_fflush
-                (i32.load align=4
+                (i32.load
                   (i32.const 56)
                 )
               )
@@ -9379,7 +9379,7 @@
             (i32.const 36)
           )
           (set_local $i4
-            (i32.load align=4
+            (i32.load
               (i32.const 32)
             )
           )
@@ -9401,7 +9401,7 @@
               (loop $while-out$1 $while-in$2
                 (if_else
                   (i32.gt_s
-                    (i32.load offset=76 align=4
+                    (i32.load offset=76
                       (get_local $i3)
                     )
                     (i32.const -1)
@@ -9417,10 +9417,10 @@
                 )
                 (if_else
                   (i32.gt_u
-                    (i32.load offset=20 align=4
+                    (i32.load offset=20
                       (get_local $i3)
                     )
-                    (i32.load offset=28 align=4
+                    (i32.load offset=28
                       (get_local $i3)
                     )
                   )
@@ -9443,7 +9443,7 @@
                   )
                 )
                 (set_local $i3
-                  (i32.load offset=56 align=4
+                  (i32.load offset=56
                     (get_local $i3)
                   )
                 )
@@ -9520,7 +9520,7 @@
           (loop $while-out$0 $while-in$1
             (if
               (i32.eq
-                (i32.load8_s align=1
+                (i32.load8_s
                   (get_local $i5)
                 )
                 (i32.const 0)
@@ -9578,7 +9578,7 @@
         )
         (loop $while-out$2 $while-in$3
           (set_local $i3
-            (i32.load align=4
+            (i32.load
               (get_local $i4)
             )
           )
@@ -9647,7 +9647,7 @@
               )
               (if_else
                 (i32.eq
-                  (i32.load8_s align=1
+                  (i32.load8_s
                     (get_local $i10)
                   )
                   (i32.const 0)
@@ -9689,14 +9689,14 @@
     (local $i3 i32)
     (local $i11 i32)
     (set_local $i3
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 16)
@@ -9711,7 +9711,7 @@
         (i32.const 255)
       )
     )
-    (i32.store8 align=1
+    (i32.store8
       (get_local $i4)
       (get_local $i5)
     )
@@ -9722,7 +9722,7 @@
       )
     )
     (set_local $i7
-      (i32.load align=4
+      (i32.load
         (get_local $i6)
       )
     )
@@ -9740,7 +9740,7 @@
         )
         (block
           (set_local $i8
-            (i32.load align=4
+            (i32.load
               (get_local $i6)
             )
           )
@@ -9775,7 +9775,7 @@
             )
           )
           (set_local $i6
-            (i32.load align=4
+            (i32.load
               (get_local $i7)
             )
           )
@@ -9794,7 +9794,7 @@
                 )
                 (i32.ne
                   (get_local $i11)
-                  (i32.load8_s offset=75 align=1
+                  (i32.load8_s offset=75
                     (get_local $i1)
                   )
                 )
@@ -9802,14 +9802,14 @@
               (i32.const 0)
             )
             (block
-              (i32.store align=4
+              (i32.store
                 (get_local $i7)
                 (i32.add
                   (get_local $i6)
                   (i32.const 1)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $i6)
                 (get_local $i5)
               )
@@ -9824,7 +9824,7 @@
               (call_indirect $FUNCSIG$iiii
                 (i32.add
                   (i32.and
-                    (i32.load offset=36 align=4
+                    (i32.load offset=36
                       (get_local $i1)
                     )
                     (i32.const 7)
@@ -9838,7 +9838,7 @@
               (i32.const 1)
             )
             (set_local $i10
-              (i32.load8_u align=1
+              (i32.load8_u
                 (get_local $i4)
               )
             )
@@ -9849,7 +9849,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $i3)
     )
@@ -9880,10 +9880,10 @@
     (if_else
       (if_else
         (i32.gt_u
-          (i32.load align=4
+          (i32.load
             (get_local $i2)
           )
-          (i32.load align=4
+          (i32.load
             (get_local $i3)
           )
         )
@@ -9891,7 +9891,7 @@
           (call_indirect $FUNCSIG$iiii
             (i32.add
               (i32.and
-                (i32.load offset=36 align=4
+                (i32.load offset=36
                   (get_local $i1)
                 )
                 (i32.const 7)
@@ -9903,7 +9903,7 @@
             (i32.const 0)
           )
           (i32.eq
-            (i32.load align=4
+            (i32.load
               (get_local $i2)
             )
             (i32.const 0)
@@ -9922,7 +9922,7 @@
           )
         )
         (set_local $i6
-          (i32.load align=4
+          (i32.load
             (get_local $i5)
           )
         )
@@ -9933,7 +9933,7 @@
           )
         )
         (set_local $i8
-          (i32.load align=4
+          (i32.load
             (get_local $i7)
           )
         )
@@ -9945,7 +9945,7 @@
           (call_indirect $FUNCSIG$iiii
             (i32.add
               (i32.and
-                (i32.load offset=40 align=4
+                (i32.load offset=40
                   (get_local $i1)
                 )
                 (i32.const 7)
@@ -9960,23 +9960,23 @@
             (i32.const 1)
           )
         )
-        (i32.store offset=16 align=4
+        (i32.store offset=16
           (get_local $i1)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $i3)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $i2)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $i7)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $i5)
           (i32.const 0)
         )
@@ -10037,9 +10037,9 @@
               (get_local $i4)
             )
           )
-          (i32.store8 align=1
+          (i32.store8
             (get_local $i1)
-            (i32.load8_s align=1
+            (i32.load8_s
               (get_local $i2)
             )
           )
@@ -10072,9 +10072,9 @@
             (nop)
             (br $while-out$2)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i1)
-            (i32.load align=4
+            (i32.load
               (get_local $i2)
             )
           )
@@ -10109,9 +10109,9 @@
         (nop)
         (br $while-out$4)
       )
-      (i32.store8 align=1
+      (i32.store8
         (get_local $i1)
-        (i32.load8_s align=1
+        (i32.load8_s
           (get_local $i2)
         )
       )
@@ -10222,7 +10222,7 @@
                 (nop)
                 (br $while-out$0)
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $i1)
                 (get_local $i2)
               )
@@ -10245,7 +10245,7 @@
             (nop)
             (br $while-out$2)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $i1)
             (get_local $i6)
           )
@@ -10268,7 +10268,7 @@
         (nop)
         (br $while-out$4)
       )
-      (i32.store8 align=1
+      (i32.store8
         (get_local $i1)
         (get_local $i2)
       )
@@ -10294,13 +10294,13 @@
     (local $i5 i32)
     (local $i3 i32)
     (set_local $i2
-      (i32.load align=4
+      (i32.load
         (i32.const 52)
       )
     )
     (if_else
       (i32.gt_s
-        (i32.load offset=76 align=4
+        (i32.load offset=76
           (get_local $i2)
         )
         (i32.const -1)
@@ -10330,7 +10330,7 @@
           (if
             (if_else
               (i32.ne
-                (i32.load8_s offset=75 align=1
+                (i32.load8_s offset=75
                   (get_local $i2)
                 )
                 (i32.const 10)
@@ -10343,13 +10343,13 @@
                   )
                 )
                 (set_local $i6
-                  (i32.load align=4
+                  (i32.load
                     (get_local $i5)
                   )
                 )
                 (i32.lt_u
                   (get_local $i6)
-                  (i32.load offset=16 align=4
+                  (i32.load offset=16
                     (get_local $i2)
                   )
                 )
@@ -10357,14 +10357,14 @@
               (i32.const 0)
             )
             (block
-              (i32.store align=4
+              (i32.store
                 (get_local $i5)
                 (i32.add
                   (get_local $i6)
                   (i32.const 1)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $i6)
                 (i32.const 10)
               )
@@ -10408,14 +10408,14 @@
     (local $i4 i32)
     (local $i7 i32)
     (set_local $i4
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 32)
@@ -10430,25 +10430,25 @@
         (i32.const 20)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $i5)
-      (i32.load offset=60 align=4
+      (i32.load offset=60
         (get_local $i1)
       )
     )
-    (i32.store offset=4 align=4
+    (i32.store offset=4
       (get_local $i5)
       (i32.const 0)
     )
-    (i32.store offset=8 align=4
+    (i32.store offset=8
       (get_local $i5)
       (get_local $i2)
     )
-    (i32.store offset=12 align=4
+    (i32.store offset=12
       (get_local $i5)
       (get_local $i6)
     )
-    (i32.store offset=16 align=4
+    (i32.store offset=16
       (get_local $i5)
       (get_local $i3)
     )
@@ -10463,7 +10463,7 @@
         (i32.const 0)
       )
       (block
-        (i32.store align=4
+        (i32.store
           (get_local $i6)
           (i32.const -1)
         )
@@ -10472,12 +10472,12 @@
         )
       )
       (set_local $i7
-        (i32.load align=4
+        (i32.load
           (get_local $i6)
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $i4)
     )
@@ -10496,11 +10496,11 @@
       )
     )
     (set_local $i3
-      (i32.load8_s align=1
+      (i32.load8_s
         (get_local $i2)
       )
     )
-    (i32.store8 align=1
+    (i32.store8
       (get_local $i2)
       (i32.or
         (i32.add
@@ -10511,7 +10511,7 @@
       )
     )
     (set_local $i3
-      (i32.load align=4
+      (i32.load
         (get_local $i1)
       )
     )
@@ -10524,32 +10524,32 @@
         (i32.const 0)
       )
       (block
-        (i32.store offset=8 align=4
+        (i32.store offset=8
           (get_local $i1)
           (i32.const 0)
         )
-        (i32.store offset=4 align=4
+        (i32.store offset=4
           (get_local $i1)
           (i32.const 0)
         )
         (set_local $i2
-          (i32.load offset=44 align=4
+          (i32.load offset=44
             (get_local $i1)
           )
         )
-        (i32.store offset=28 align=4
+        (i32.store offset=28
           (get_local $i1)
           (get_local $i2)
         )
-        (i32.store offset=20 align=4
+        (i32.store offset=20
           (get_local $i1)
           (get_local $i2)
         )
-        (i32.store offset=16 align=4
+        (i32.store offset=16
           (get_local $i1)
           (i32.add
             (get_local $i2)
-            (i32.load offset=48 align=4
+            (i32.load offset=48
               (get_local $i1)
             )
           )
@@ -10559,7 +10559,7 @@
         )
       )
       (block
-        (i32.store align=4
+        (i32.store
           (get_local $i1)
           (i32.or
             (get_local $i3)
@@ -10589,7 +10589,7 @@
     )
     (if_else
       (i32.gt_s
-        (i32.load offset=76 align=4
+        (i32.load offset=76
           (get_local $i4)
         )
         (i32.const -1)
@@ -10656,14 +10656,14 @@
     (local $i5 i32)
     (local $i4 i32)
     (set_local $i4
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 80)
@@ -10672,7 +10672,7 @@
     (set_local $i5
       (get_local $i4)
     )
-    (i32.store offset=36 align=4
+    (i32.store offset=36
       (get_local $i1)
       (i32.const 5)
     )
@@ -10680,7 +10680,7 @@
       (if_else
         (i32.eq
           (i32.and
-            (i32.load align=4
+            (i32.load
               (get_local $i1)
             )
             (i32.const 64)
@@ -10688,17 +10688,17 @@
           (i32.const 0)
         )
         (block
-          (i32.store align=4
+          (i32.store
             (get_local $i5)
-            (i32.load offset=60 align=4
+            (i32.load offset=60
               (get_local $i1)
             )
           )
-          (i32.store offset=4 align=4
+          (i32.store offset=4
             (get_local $i5)
             (i32.const 21505)
           )
-          (i32.store offset=8 align=4
+          (i32.store offset=8
             (get_local $i5)
             (i32.add
               (get_local $i4)
@@ -10715,7 +10715,7 @@
         )
         (i32.const 0)
       )
-      (i32.store8 offset=75 align=1
+      (i32.store8 offset=75
         (get_local $i1)
         (i32.const -1)
       )
@@ -10727,7 +10727,7 @@
         (get_local $i3)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $i4)
     )
@@ -10736,67 +10736,67 @@
     )
   )
   (func $copyTempDouble (param $i1 i32)
-    (i32.store8 align=1
-      (i32.load align=4
+    (i32.store8
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s align=1
+      (i32.load8_s
         (get_local $i1)
       )
     )
-    (i32.store8 offset=1 align=1
-      (i32.load align=4
+    (i32.store8 offset=1
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=1 align=1
+      (i32.load8_s offset=1
         (get_local $i1)
       )
     )
-    (i32.store8 offset=2 align=1
-      (i32.load align=4
+    (i32.store8 offset=2
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=2 align=1
+      (i32.load8_s offset=2
         (get_local $i1)
       )
     )
-    (i32.store8 offset=3 align=1
-      (i32.load align=4
+    (i32.store8 offset=3
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=3 align=1
+      (i32.load8_s offset=3
         (get_local $i1)
       )
     )
-    (i32.store8 offset=4 align=1
-      (i32.load align=4
+    (i32.store8 offset=4
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=4 align=1
+      (i32.load8_s offset=4
         (get_local $i1)
       )
     )
-    (i32.store8 offset=5 align=1
-      (i32.load align=4
+    (i32.store8 offset=5
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=5 align=1
+      (i32.load8_s offset=5
         (get_local $i1)
       )
     )
-    (i32.store8 offset=6 align=1
-      (i32.load align=4
+    (i32.store8 offset=6
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=6 align=1
+      (i32.load8_s offset=6
         (get_local $i1)
       )
     )
-    (i32.store8 offset=7 align=1
-      (i32.load align=4
+    (i32.store8 offset=7
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=7 align=1
+      (i32.load8_s offset=7
         (get_local $i1)
       )
     )
@@ -10805,14 +10805,14 @@
     (local $i3 i32)
     (local $i2 i32)
     (set_local $i2
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 16)
@@ -10821,9 +10821,9 @@
     (set_local $i3
       (get_local $i2)
     )
-    (i32.store align=4
+    (i32.store
       (get_local $i3)
-      (i32.load offset=60 align=4
+      (i32.load offset=60
         (get_local $i1)
       )
     )
@@ -10835,7 +10835,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $i2)
     )
@@ -10844,35 +10844,35 @@
     )
   )
   (func $copyTempFloat (param $i1 i32)
-    (i32.store8 align=1
-      (i32.load align=4
+    (i32.store8
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s align=1
+      (i32.load8_s
         (get_local $i1)
       )
     )
-    (i32.store8 offset=1 align=1
-      (i32.load align=4
+    (i32.store8 offset=1
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=1 align=1
+      (i32.load8_s offset=1
         (get_local $i1)
       )
     )
-    (i32.store8 offset=2 align=1
-      (i32.load align=4
+    (i32.store8 offset=2
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=2 align=1
+      (i32.load8_s offset=2
         (get_local $i1)
       )
     )
-    (i32.store8 offset=3 align=1
-      (i32.load align=4
+    (i32.store8 offset=3
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=3 align=1
+      (i32.load8_s offset=3
         (get_local $i1)
       )
     )
@@ -10885,7 +10885,7 @@
         (i32.const -4096)
       )
       (block
-        (i32.store align=4
+        (i32.store
           (call $___errno_location)
           (i32.sub
             (i32.const 0)
@@ -10923,24 +10923,24 @@
   (func $stackAlloc (param $i1 i32) (result i32)
     (local $i2 i32)
     (set_local $i2
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (get_local $i1)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.and
         (i32.add
-          (i32.load align=4
+          (i32.load
             (i32.const 8)
           )
           (i32.const 15)
@@ -10956,7 +10956,7 @@
     (local $i1 i32)
     (if_else
       (i32.eq
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 0)
@@ -10965,7 +10965,7 @@
         (i32.const 60)
       )
       (set_local $i1
-        (i32.load offset=60 align=4
+        (i32.load offset=60
           (call_import $_pthread_self)
         )
       )
@@ -10977,17 +10977,17 @@
   (func $setThrew (param $i1 i32) (param $i2 i32)
     (if
       (i32.eq
-        (i32.load align=4
+        (i32.load
           (i32.const 40)
         )
         (i32.const 0)
       )
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 40)
           (get_local $i1)
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 48)
           (get_local $i2)
         )
@@ -11026,7 +11026,7 @@
   (func $_cleanup_418 (param $i1 i32)
     (if
       (i32.eq
-        (i32.load offset=68 align=4
+        (i32.load offset=68
           (get_local $i1)
         )
         (i32.const 0)
@@ -11038,11 +11038,11 @@
     (return)
   )
   (func $establishStackSpace (param $i1 i32) (param $i2 i32)
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $i1)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 16)
       (get_local $i2)
     )
@@ -11068,13 +11068,13 @@
     )
   )
   (func $stackRestore (param $i1 i32)
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $i1)
     )
   )
   (func $setTempRet0 (param $i1 i32)
-    (i32.store align=4
+    (i32.store
       (i32.const 160)
       (get_local $i1)
     )
@@ -11097,7 +11097,7 @@
   )
   (func $getTempRet0 (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.const 160)
       )
     )
@@ -11112,7 +11112,7 @@
   )
   (func $stackSave (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -53,24 +53,24 @@
   (func $stackAlloc (param $size i32) (result i32)
     (local $ret i32)
     (set_local $ret
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (get_local $size)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.and
         (i32.add
-          (i32.load align=4
+          (i32.load
             (i32.const 8)
           )
           (i32.const 15)
@@ -80,10 +80,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -95,23 +95,23 @@
   )
   (func $stackSave (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
   )
   (func $stackRestore (param $top i32)
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $top)
     )
   )
   (func $establishStackSpace (param $stackBase i32) (param $stackMax i32)
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $stackBase)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 16)
       (get_local $stackMax)
     )
@@ -119,17 +119,17 @@
   (func $setThrew (param $threw i32) (param $value i32)
     (if
       (i32.eq
-        (i32.load align=4
+        (i32.load
           (i32.const 48)
         )
         (i32.const 0)
       )
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 48)
           (get_local $threw)
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 56)
           (get_local $value)
         )
@@ -137,114 +137,114 @@
     )
   )
   (func $copyTempFloat (param $ptr i32)
-    (i32.store8 align=1
-      (i32.load align=4
+    (i32.store8
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s align=1
+      (i32.load8_s
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=1 align=1
-      (i32.load align=4
+    (i32.store8 offset=1
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=1 align=1
+      (i32.load8_s offset=1
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=2 align=1
-      (i32.load align=4
+    (i32.store8 offset=2
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=2 align=1
+      (i32.load8_s offset=2
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=3 align=1
-      (i32.load align=4
+    (i32.store8 offset=3
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=3 align=1
+      (i32.load8_s offset=3
         (get_local $ptr)
       )
     )
   )
   (func $copyTempDouble (param $ptr i32)
-    (i32.store8 align=1
-      (i32.load align=4
+    (i32.store8
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s align=1
+      (i32.load8_s
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=1 align=1
-      (i32.load align=4
+    (i32.store8 offset=1
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=1 align=1
+      (i32.load8_s offset=1
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=2 align=1
-      (i32.load align=4
+    (i32.store8 offset=2
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=2 align=1
+      (i32.load8_s offset=2
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=3 align=1
-      (i32.load align=4
+    (i32.store8 offset=3
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=3 align=1
+      (i32.load8_s offset=3
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=4 align=1
-      (i32.load align=4
+    (i32.store8 offset=4
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=4 align=1
+      (i32.load8_s offset=4
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=5 align=1
-      (i32.load align=4
+    (i32.store8 offset=5
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=5 align=1
+      (i32.load8_s offset=5
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=6 align=1
-      (i32.load align=4
+    (i32.store8 offset=6
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=6 align=1
+      (i32.load8_s offset=6
         (get_local $ptr)
       )
     )
-    (i32.store8 offset=7 align=1
-      (i32.load align=4
+    (i32.store8 offset=7
+      (i32.load
         (i32.const 24)
       )
-      (i32.load8_s offset=7 align=1
+      (i32.load8_s offset=7
         (get_local $ptr)
       )
     )
   )
   (func $setTempRet0 (param $value i32)
-    (i32.store align=4
+    (i32.store
       (i32.const 168)
       (get_local $value)
     )
   )
   (func $getTempRet0 (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.const 168)
       )
     )
@@ -255,14 +255,14 @@
     (local $$retval i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 16)
@@ -270,10 +270,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -289,7 +289,7 @@
       (i32.const 672)
       (get_local $$vararg_buffer)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -318,26 +318,26 @@
     (local $$3 i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (f64.store align=8
-      (i32.load align=4
+    (f64.store
+      (i32.load
         (i32.const 24)
       )
       (get_local $$x)
     )
     (set_local $$0
-      (i32.load align=4
-        (i32.load align=4
+      (i32.load
+        (i32.load
           (i32.const 24)
         )
       )
     )
     (set_local $$1
-      (i32.load offset=4 align=4
-        (i32.load align=4
+      (i32.load offset=4
+        (i32.load
           (i32.const 24)
         )
       )
@@ -350,7 +350,7 @@
       )
     )
     (set_local $$3
-      (i32.load align=4
+      (i32.load
         (i32.const 168)
       )
     )
@@ -390,7 +390,7 @@
                 )
               )
               (set_local $$4
-                (i32.load align=4
+                (i32.load
                   (get_local $$e)
                 )
               )
@@ -416,7 +416,7 @@
               )
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$e)
             (get_local $$storemerge)
           )
@@ -442,7 +442,7 @@
               (i32.const -1022)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$e)
             (get_local $$sub8)
           )
@@ -458,21 +458,21 @@
               (i32.const 1071644672)
             )
           )
-          (i32.store align=4
-            (i32.load align=4
+          (i32.store
+            (i32.load
               (i32.const 24)
             )
             (get_local $$0)
           )
-          (i32.store offset=4 align=4
-            (i32.load align=4
+          (i32.store offset=4
+            (i32.load
               (i32.const 24)
             )
             (get_local $$6)
           )
           (set_local $$7
-            (f64.load align=8
-              (i32.load align=4
+            (f64.load
+              (i32.load
                 (i32.const 24)
               )
             )
@@ -492,7 +492,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -529,7 +529,7 @@
     (local $$0 i32)
     (local $sp i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -544,7 +544,7 @@
         )
       )
       (set_local $$0
-        (i32.load8_s align=1
+        (i32.load8_s
           (get_local $$arrayidx)
         )
       )
@@ -649,7 +649,7 @@
         )
         (loop $while-out$4 $while-in$5
           (set_local $$1
-            (i32.load8_s align=1
+            (i32.load8_s
               (get_local $$s$1)
             )
           )
@@ -734,12 +734,12 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (i32.const 16)
       )
     )
@@ -765,7 +765,7 @@
           )
         )
         (set_local $$1
-          (i32.load align=4
+          (i32.load
             (get_local $$errno_ptr)
           )
         )
@@ -787,14 +787,14 @@
     (local $$0 i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 16)
@@ -802,10 +802,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -821,11 +821,11 @@
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$fd)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$vararg_buffer)
       (get_local $$0)
     )
@@ -840,7 +840,7 @@
         (get_local $$call)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -866,14 +866,14 @@
     (local $$0 i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 80)
@@ -881,10 +881,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -905,12 +905,12 @@
         (i32.const 36)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$write)
       (i32.const 4)
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$f)
       )
     )
@@ -936,11 +936,11 @@
           )
         )
         (set_local $$1
-          (i32.load align=4
+          (i32.load
             (get_local $$fd)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$vararg_buffer)
           (get_local $$1)
         )
@@ -950,7 +950,7 @@
             (i32.const 4)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$vararg_ptr1)
           (i32.const 21505)
         )
@@ -960,7 +960,7 @@
             (i32.const 8)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$vararg_ptr2)
           (get_local $$tio)
         )
@@ -988,7 +988,7 @@
                 (i32.const 75)
               )
             )
-            (i32.store8 align=1
+            (i32.store8
               (get_local $$lbf)
               (i32.const -1)
             )
@@ -1003,7 +1003,7 @@
         (get_local $$len)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -1028,14 +1028,14 @@
     (local $$$pre i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 32)
@@ -1043,10 +1043,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -1068,11 +1068,11 @@
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$fd)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$vararg_buffer)
       (get_local $$0)
     )
@@ -1082,7 +1082,7 @@
         (i32.const 4)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$vararg_ptr1)
       (i32.const 0)
     )
@@ -1092,7 +1092,7 @@
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$vararg_ptr2)
       (get_local $$off)
     )
@@ -1102,7 +1102,7 @@
         (i32.const 12)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$vararg_ptr3)
       (get_local $$ret)
     )
@@ -1112,7 +1112,7 @@
         (i32.const 16)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$vararg_ptr4)
       (get_local $$whence)
     )
@@ -1136,7 +1136,7 @@
     (if_else
       (get_local $$cmp)
       (block
-        (i32.store align=4
+        (i32.store
           (get_local $$ret)
           (i32.const -1)
         )
@@ -1146,7 +1146,7 @@
       )
       (block
         (set_local $$$pre
-          (i32.load align=4
+          (i32.load
             (get_local $$ret)
           )
         )
@@ -1155,7 +1155,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -1203,7 +1203,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -1218,7 +1218,7 @@
         (get_local $$tobool)
         (block
           (set_local $$1
-            (i32.load align=4
+            (i32.load
               (i32.const 12)
             )
           )
@@ -1235,7 +1235,7 @@
             )
             (block
               (set_local $$2
-                (i32.load align=4
+                (i32.load
                   (i32.const 12)
                 )
               )
@@ -1253,7 +1253,7 @@
             (i32.const 44)
           )
           (set_local $$f$addr$0$19
-            (i32.load align=4
+            (i32.load
               (i32.const 40)
             )
           )
@@ -1283,7 +1283,7 @@
                   )
                 )
                 (set_local $$3
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$lock13)
                   )
                 )
@@ -1316,7 +1316,7 @@
                   )
                 )
                 (set_local $$4
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$wpos)
                   )
                 )
@@ -1327,7 +1327,7 @@
                   )
                 )
                 (set_local $$5
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$wbase)
                   )
                 )
@@ -1381,7 +1381,7 @@
                   )
                 )
                 (set_local $$f$addr$0
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$next)
                   )
                 )
@@ -1427,7 +1427,7 @@
             )
           )
           (set_local $$0
-            (i32.load align=4
+            (i32.load
               (get_local $$lock)
             )
           )
@@ -1498,14 +1498,14 @@
     (local $$0 i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 16)
@@ -1513,10 +1513,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -1525,12 +1525,12 @@
     (set_local $$ap
       (get_local $sp)
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$ap)
       (get_local $$varargs)
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -1541,7 +1541,7 @@
         (get_local $$ap)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -1553,7 +1553,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -1565,7 +1565,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -1644,14 +1644,14 @@
     (local $$1 i32)
     (local $$$pre i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 48)
@@ -1659,10 +1659,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -1690,11 +1690,11 @@
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$wbase)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$iovs)
       (get_local $$0)
     )
@@ -1711,7 +1711,7 @@
       )
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$wpos)
       )
     )
@@ -1721,7 +1721,7 @@
         (get_local $$0)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$iov_len)
       (get_local $$sub$ptr$sub)
     )
@@ -1731,7 +1731,7 @@
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$iov_base2)
       (get_local $$buf)
     )
@@ -1741,7 +1741,7 @@
         (i32.const 12)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$iov_len3)
       (get_local $$len)
     )
@@ -1774,7 +1774,7 @@
     )
     (loop $while-out$0 $while-in$1
       (set_local $$2
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -1788,11 +1788,11 @@
         (get_local $$tobool)
         (block
           (set_local $$4
-            (i32.load align=4
+            (i32.load
               (get_local $$fd8)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$vararg_buffer3)
             (get_local $$4)
           )
@@ -1802,7 +1802,7 @@
               (i32.const 4)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$vararg_ptr6)
             (get_local $$iov$0)
           )
@@ -1812,7 +1812,7 @@
               (i32.const 8)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$vararg_ptr7)
             (get_local $$iovcnt$0)
           )
@@ -1837,11 +1837,11 @@
             (get_local $$f)
           )
           (set_local $$3
-            (i32.load align=4
+            (i32.load
               (get_local $$fd8)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$vararg_buffer)
             (get_local $$3)
           )
@@ -1851,7 +1851,7 @@
               (i32.const 4)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$vararg_ptr1)
             (get_local $$iov$0)
           )
@@ -1861,7 +1861,7 @@
               (i32.const 8)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$vararg_ptr2)
             (get_local $$iovcnt$0)
           )
@@ -1933,7 +1933,7 @@
         )
       )
       (set_local $$10
-        (i32.load align=4
+        (i32.load
           (get_local $$iov_len28)
         )
       )
@@ -1947,15 +1947,15 @@
         (get_local $$cmp29)
         (block
           (set_local $$11
-            (i32.load align=4
+            (i32.load
               (get_local $$buf31)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$wbase)
             (get_local $$11)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$wpos)
             (get_local $$11)
           )
@@ -1984,7 +1984,7 @@
             )
           )
           (set_local $$$pre
-            (i32.load align=4
+            (i32.load
               (get_local $$iov_len50$phi$trans$insert)
             )
           )
@@ -2012,7 +2012,7 @@
             (get_local $$cmp38)
             (block
               (set_local $$12
-                (i32.load align=4
+                (i32.load
                   (get_local $$wbase)
                 )
               )
@@ -2022,7 +2022,7 @@
                   (get_local $$cnt$0)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$wbase)
                 (get_local $$add$ptr41)
               )
@@ -2057,7 +2057,7 @@
         )
       )
       (set_local $$13
-        (i32.load align=4
+        (i32.load
           (get_local $$iov$1)
         )
       )
@@ -2067,7 +2067,7 @@
           (get_local $$cnt$1)
         )
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$iov$1)
         (get_local $$add$ptr46)
       )
@@ -2083,7 +2083,7 @@
           (get_local $$cnt$1)
         )
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$iov_len50)
         (get_local $$sub51)
       )
@@ -2105,7 +2105,7 @@
       )
       (block
         (set_local $$5
-          (i32.load align=4
+          (i32.load
             (get_local $$buf31)
           )
         )
@@ -2116,7 +2116,7 @@
           )
         )
         (set_local $$6
-          (i32.load align=4
+          (i32.load
             (get_local $$buf_size)
           )
         )
@@ -2132,18 +2132,18 @@
             (i32.const 16)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wend)
           (get_local $$add$ptr)
         )
         (set_local $$7
           (get_local $$5)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wbase)
           (get_local $$7)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wpos)
           (get_local $$7)
         )
@@ -2163,20 +2163,20 @@
               (i32.const 16)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$wend19)
             (i32.const 0)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$wbase)
             (i32.const 0)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$wpos)
             (i32.const 0)
           )
           (set_local $$8
-            (i32.load align=4
+            (i32.load
               (get_local $$f)
             )
           )
@@ -2186,7 +2186,7 @@
               (i32.const 32)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$f)
             (get_local $$or)
           )
@@ -2209,7 +2209,7 @@
                 )
               )
               (set_local $$9
-                (i32.load align=4
+                (i32.load
                   (get_local $$iov_len24)
                 )
               )
@@ -2227,7 +2227,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -2284,14 +2284,14 @@
     (local $$$call21 i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 224)
@@ -2299,10 +2299,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -2339,7 +2339,7 @@
       )
     )
     (loop $do-out$0 $do-in$1
-      (i32.store align=4
+      (i32.store
         (get_local $dest)
         (i32.const 0)
       )
@@ -2357,11 +2357,11 @@
       )
     )
     (set_local $$vacopy_currentptr
-      (i32.load align=4
+      (i32.load
         (get_local $$ap)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$ap2)
       (get_local $$vacopy_currentptr)
     )
@@ -2393,7 +2393,7 @@
           )
         )
         (set_local $$0
-          (i32.load align=4
+          (i32.load
             (get_local $$lock)
           )
         )
@@ -2420,7 +2420,7 @@
           )
         )
         (set_local $$1
-          (i32.load align=4
+          (i32.load
             (get_local $$f)
           )
         )
@@ -2437,7 +2437,7 @@
           )
         )
         (set_local $$2
-          (i32.load8_s align=1
+          (i32.load8_s
             (get_local $$mode)
           )
         )
@@ -2462,7 +2462,7 @@
                 (i32.const -33)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$f)
               (get_local $$and11)
             )
@@ -2475,7 +2475,7 @@
           )
         )
         (set_local $$3
-          (i32.load align=4
+          (i32.load
             (get_local $$buf_size)
           )
         )
@@ -2495,11 +2495,11 @@
               )
             )
             (set_local $$4
-              (i32.load align=4
+              (i32.load
                 (get_local $$buf)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$buf)
               (get_local $$internal_buf)
             )
@@ -2509,7 +2509,7 @@
                 (i32.const 28)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$wbase)
               (get_local $$internal_buf)
             )
@@ -2519,11 +2519,11 @@
                 (i32.const 20)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$wpos)
               (get_local $$internal_buf)
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$buf_size)
               (i32.const 80)
             )
@@ -2539,7 +2539,7 @@
                 (i32.const 16)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$wend)
               (get_local $$add$ptr)
             )
@@ -2571,7 +2571,7 @@
                   )
                 )
                 (set_local $$5
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$write)
                   )
                 )
@@ -2588,7 +2588,7 @@
                   (i32.const 0)
                 )
                 (set_local $$6
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$wpos)
                   )
                 )
@@ -2605,23 +2605,23 @@
                     (get_local $$call21)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$buf)
                   (get_local $$4)
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$buf_size)
                   (i32.const 0)
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$wend)
                   (i32.const 0)
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$wbase)
                   (i32.const 0)
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$wpos)
                   (i32.const 0)
                 )
@@ -2647,7 +2647,7 @@
           )
         )
         (set_local $$7
-          (i32.load align=4
+          (i32.load
             (get_local $$f)
           )
         )
@@ -2676,7 +2676,7 @@
             (get_local $$and)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$f)
           (get_local $$or)
         )
@@ -2700,7 +2700,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -2753,7 +2753,7 @@
     (local $$$pre i32)
     (local $sp i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -2764,7 +2764,7 @@
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$wend)
       )
     )
@@ -2792,7 +2792,7 @@
           (get_local $$tobool1)
           (block
             (set_local $$$pre
-              (i32.load align=4
+              (i32.load
                 (get_local $$wend)
               )
             )
@@ -2834,7 +2834,7 @@
             )
           )
           (set_local $$2
-            (i32.load align=4
+            (i32.load
               (get_local $$wpos)
             )
           )
@@ -2863,7 +2863,7 @@
                 )
               )
               (set_local $$5
-                (i32.load align=4
+                (i32.load
                   (get_local $$write)
                 )
               )
@@ -2894,7 +2894,7 @@
             )
           )
           (set_local $$6
-            (i32.load8_s align=1
+            (i32.load8_s
               (get_local $$lbf)
             )
           )
@@ -2955,7 +2955,7 @@
                     )
                   )
                   (set_local $$7
-                    (i32.load8_s align=1
+                    (i32.load8_s
                       (get_local $$arrayidx)
                     )
                   )
@@ -2992,7 +2992,7 @@
                   )
                 )
                 (set_local $$8
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$write15)
                   )
                 )
@@ -3038,7 +3038,7 @@
                   )
                 )
                 (set_local $$$pre31
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$wpos)
                   )
                 )
@@ -3077,7 +3077,7 @@
             (get_local $$l$addr$0)
           )
           (set_local $$10
-            (i32.load align=4
+            (i32.load
               (get_local $$wpos)
             )
           )
@@ -3087,7 +3087,7 @@
               (get_local $$l$addr$0)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$wpos)
             (get_local $$add$ptr26)
           )
@@ -3133,7 +3133,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -3144,7 +3144,7 @@
       )
     )
     (set_local $$0
-      (i32.load8_s align=1
+      (i32.load8_s
         (get_local $$mode)
       )
     )
@@ -3175,12 +3175,12 @@
         (i32.const 255)
       )
     )
-    (i32.store8 align=1
+    (i32.store8
       (get_local $$mode)
       (get_local $$conv3)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$f)
       )
     )
@@ -3205,7 +3205,7 @@
             (i32.const 8)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$rend)
           (i32.const 0)
         )
@@ -3215,7 +3215,7 @@
             (i32.const 4)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$rpos)
           (i32.const 0)
         )
@@ -3226,7 +3226,7 @@
           )
         )
         (set_local $$2
-          (i32.load align=4
+          (i32.load
             (get_local $$buf)
           )
         )
@@ -3236,7 +3236,7 @@
             (i32.const 28)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wbase)
           (get_local $$2)
         )
@@ -3246,7 +3246,7 @@
             (i32.const 20)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wpos)
           (get_local $$2)
         )
@@ -3260,7 +3260,7 @@
           )
         )
         (set_local $$4
-          (i32.load align=4
+          (i32.load
             (get_local $$buf_size)
           )
         )
@@ -3276,7 +3276,7 @@
             (i32.const 16)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wend)
           (get_local $$add$ptr)
         )
@@ -3291,7 +3291,7 @@
             (i32.const 32)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$f)
           (get_local $$or5)
         )
@@ -3356,7 +3356,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -3388,7 +3388,7 @@
                   (i32.const 255)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$s)
                 (get_local $$conv)
               )
@@ -3431,7 +3431,7 @@
                   (i32.const 1)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$s)
                 (get_local $$conv5)
               )
@@ -3453,7 +3453,7 @@
                   (i32.const 255)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$incdec$ptr)
                 (get_local $$conv7)
               )
@@ -3514,7 +3514,7 @@
                   (i32.const 1)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$s)
                 (get_local $$conv16)
               )
@@ -3548,7 +3548,7 @@
                   (i32.const 2)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$incdec$ptr17)
                 (get_local $$conv21)
               )
@@ -3570,7 +3570,7 @@
                   (i32.const 255)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$incdec$ptr22)
                 (get_local $$conv25)
               )
@@ -3619,7 +3619,7 @@
                   (i32.const 1)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$s)
                 (get_local $$conv33)
               )
@@ -3653,7 +3653,7 @@
                   (i32.const 2)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$incdec$ptr34)
                 (get_local $$conv38)
               )
@@ -3687,7 +3687,7 @@
                   (i32.const 3)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$incdec$ptr39)
                 (get_local $$conv43)
               )
@@ -3709,7 +3709,7 @@
                   (i32.const 255)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$incdec$ptr44)
                 (get_local $$conv47)
               )
@@ -3722,7 +3722,7 @@
               (set_local $$call
                 (call $___errno_location)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$call)
                 (i32.const 84)
               )
@@ -3746,7 +3746,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -3838,7 +3838,7 @@
     (local $$0 i32)
     (local $sp i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -3893,7 +3893,7 @@
           )
           (loop $while-out$0 $while-in$1
             (set_local $$2
-              (i32.load8_s align=1
+              (i32.load8_s
                 (get_local $$s$044)
               )
             )
@@ -4050,7 +4050,7 @@
         )
         (block
           (set_local $$4
-            (i32.load8_s align=1
+            (i32.load8_s
               (get_local $$s$0$lcssa60)
             )
           )
@@ -4113,7 +4113,7 @@
                     )
                     (loop $while-out$2 $while-in$3
                       (set_local $$6
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$w$034)
                         )
                       )
@@ -4267,7 +4267,7 @@
               )
               (loop $while-out$4 $while-in$5
                 (set_local $$7
-                  (i32.load8_s align=1
+                  (i32.load8_s
                     (get_local $$s$128)
                   )
                 )
@@ -4371,7 +4371,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -4393,7 +4393,7 @@
         (set_local $$call
           (call $___errno_location)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$call)
           (get_local $$sub)
         )
@@ -4434,7 +4434,7 @@
     (local $$0 i32)
     (local $sp i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -4445,7 +4445,7 @@
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$wpos)
       )
     )
@@ -4456,7 +4456,7 @@
       )
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$wbase)
       )
     )
@@ -4476,7 +4476,7 @@
           )
         )
         (set_local $$2
-          (i32.load align=4
+          (i32.load
             (get_local $$write)
           )
         )
@@ -4493,7 +4493,7 @@
           (i32.const 0)
         )
         (set_local $$3
-          (i32.load align=4
+          (i32.load
             (get_local $$wpos)
           )
         )
@@ -4530,7 +4530,7 @@
           )
         )
         (set_local $$4
-          (i32.load align=4
+          (i32.load
             (get_local $$rpos)
           )
         )
@@ -4541,7 +4541,7 @@
           )
         )
         (set_local $$5
-          (i32.load align=4
+          (i32.load
             (get_local $$rend)
           )
         )
@@ -4561,7 +4561,7 @@
               )
             )
             (set_local $$6
-              (i32.load align=4
+              (i32.load
                 (get_local $$seek)
               )
             )
@@ -4597,23 +4597,23 @@
             (i32.const 16)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wend)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wbase)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$wpos)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$rend)
           (i32.const 0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$rpos)
           (i32.const 0)
         )
@@ -4633,7 +4633,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -4644,7 +4644,7 @@
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$lockcount)
       )
     )
@@ -5728,14 +5728,14 @@
     (local $$175 i32)
     (local $$166 i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 624)
@@ -5743,10 +5743,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -5922,7 +5922,7 @@
                 (set_local $$call
                   (call $___errno_location)
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$call)
                   (i32.const 75)
                 )
@@ -5951,7 +5951,7 @@
         )
       )
       (set_local $$0
-        (i32.load8_s align=1
+        (i32.load8_s
           (get_local $$incdec$ptr169275)
         )
       )
@@ -6041,7 +6041,7 @@
           )
         )
         (set_local $$$pre
-          (i32.load8_s align=1
+          (i32.load8_s
             (get_local $$incdec$ptr)
           )
         )
@@ -6070,7 +6070,7 @@
               )
             )
             (set_local $$2
-              (i32.load8_s align=1
+              (i32.load8_s
                 (get_local $$arrayidx16)
               )
             )
@@ -6114,7 +6114,7 @@
               )
             )
             (set_local $$3
-              (i32.load8_s align=1
+              (i32.load8_s
                 (get_local $$add$ptr)
               )
             )
@@ -6173,7 +6173,7 @@
         (get_local $$tobool25)
         (block
           (set_local $$4
-            (i32.load align=4
+            (i32.load
               (get_local $$f)
             )
           )
@@ -6236,7 +6236,7 @@
         )
       )
       (set_local $$5
-        (i32.load8_s align=1
+        (i32.load8_s
           (get_local $$arrayidx31)
         )
       )
@@ -6271,7 +6271,7 @@
             )
           )
           (set_local $$6
-            (i32.load8_s align=1
+            (i32.load8_s
               (get_local $$arrayidx35)
             )
           )
@@ -6315,7 +6315,7 @@
             )
           )
           (set_local $$$pre357
-            (i32.load8_s align=1
+            (i32.load8_s
               (get_local $$add$ptr43$arrayidx31)
             )
           )
@@ -6458,7 +6458,7 @@
                 )
               )
               (set_local $$10
-                (i32.load8_s align=1
+                (i32.load8_s
                   (get_local $$incdec$ptr62)
                 )
               )
@@ -6551,7 +6551,7 @@
               )
             )
             (set_local $$13
-              (i32.load8_s align=1
+              (i32.load8_s
                 (get_local $$arrayidx68)
               )
             )
@@ -6586,7 +6586,7 @@
                   )
                 )
                 (set_local $$14
-                  (i32.load8_s align=1
+                  (i32.load8_s
                     (get_local $$arrayidx73)
                   )
                 )
@@ -6614,12 +6614,12 @@
                         )
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$arrayidx81)
                       (i32.const 10)
                     )
                     (set_local $$15
-                      (i32.load8_s align=1
+                      (i32.load8_s
                         (get_local $$arrayidx68)
                       )
                     )
@@ -6654,7 +6654,7 @@
                       (get_local $$16)
                     )
                     (set_local $$18
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$17)
                       )
                     )
@@ -6668,7 +6668,7 @@
                       (get_local $$19)
                     )
                     (set_local $$21
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$20)
                       )
                     )
@@ -6746,7 +6746,7 @@
                   )
                 )
                 (set_local $$arglist_current
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$ap)
                   )
                 )
@@ -6805,7 +6805,7 @@
                   (get_local $$26)
                 )
                 (set_local $$28
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$27)
                   )
                 )
@@ -6815,7 +6815,7 @@
                     (i32.const 4)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$ap)
                   (get_local $$arglist_next)
                 )
@@ -6934,7 +6934,7 @@
                     )
                   )
                   (set_local $$30
-                    (i32.load8_s align=1
+                    (i32.load8_s
                       (get_local $$incdec$ptr$i)
                     )
                   )
@@ -7033,7 +7033,7 @@
         )
       )
       (set_local $$31
-        (i32.load8_s align=1
+        (i32.load8_s
           (get_local $$incdec$ptr169269)
         )
       )
@@ -7060,7 +7060,7 @@
               )
             )
             (set_local $$32
-              (i32.load8_s align=1
+              (i32.load8_s
                 (get_local $$arrayidx114)
               )
             )
@@ -7146,7 +7146,7 @@
                     )
                   )
                   (set_local $$50
-                    (i32.load8_s align=1
+                    (i32.load8_s
                       (get_local $$incdec$ptr$i$204)
                     )
                   )
@@ -7205,7 +7205,7 @@
               )
             )
             (set_local $$33
-              (i32.load8_s align=1
+              (i32.load8_s
                 (get_local $$arrayidx119)
               )
             )
@@ -7240,7 +7240,7 @@
                   )
                 )
                 (set_local $$34
-                  (i32.load8_s align=1
+                  (i32.load8_s
                     (get_local $$arrayidx124)
                   )
                 )
@@ -7268,12 +7268,12 @@
                         )
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$arrayidx132)
                       (i32.const 10)
                     )
                     (set_local $$35
-                      (i32.load8_s align=1
+                      (i32.load8_s
                         (get_local $$arrayidx119)
                       )
                     )
@@ -7308,7 +7308,7 @@
                       (get_local $$36)
                     )
                     (set_local $$38
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$37)
                       )
                     )
@@ -7322,7 +7322,7 @@
                       (get_local $$39)
                     )
                     (set_local $$41
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$40)
                       )
                     )
@@ -7365,7 +7365,7 @@
               (get_local $$tobool25)
               (block
                 (set_local $$arglist_current2
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$ap)
                   )
                 )
@@ -7424,7 +7424,7 @@
                   (get_local $$46)
                 )
                 (set_local $$48
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$47)
                   )
                 )
@@ -7434,7 +7434,7 @@
                     (i32.const 4)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$ap)
                   (get_local $$arglist_next3)
                 )
@@ -7473,7 +7473,7 @@
       )
       (loop $while-out$14 $while-in$15
         (set_local $$51
-          (i32.load8_s align=1
+          (i32.load8_s
             (get_local $$incdec$ptr169271)
           )
         )
@@ -7526,7 +7526,7 @@
           )
         )
         (set_local $$52
-          (i32.load8_s align=1
+          (i32.load8_s
             (get_local $$arrayidx173)
           )
         )
@@ -7646,7 +7646,7 @@
                     )
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$arrayidx192)
                   (get_local $$conv174$lcssa)
                 )
@@ -7666,7 +7666,7 @@
                   (get_local $$54)
                 )
                 (set_local $$56
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$55)
                   )
                 )
@@ -7680,7 +7680,7 @@
                   (get_local $$57)
                 )
                 (set_local $$59
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$58)
                   )
                 )
@@ -7690,7 +7690,7 @@
                 (set_local $$61
                   (get_local $$60)
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$61)
                   (get_local $$56)
                 )
@@ -7703,7 +7703,7 @@
                 (set_local $$63
                   (get_local $$62)
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$63)
                   (get_local $$59)
                 )
@@ -7766,7 +7766,7 @@
         )
       )
       (set_local $$64
-        (i32.load8_s align=1
+        (i32.load8_s
           (get_local $$incdec$ptr169271$lcssa414)
         )
       )
@@ -7859,11 +7859,11 @@
                 (case $switch-case$19
                   (block
                     (set_local $$71
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arg)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$71)
                       (get_local $$cnt$1)
                     )
@@ -7886,11 +7886,11 @@
                 (case $switch-case$20
                   (block
                     (set_local $$72
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arg)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$72)
                       (get_local $$cnt$1)
                     )
@@ -7928,7 +7928,7 @@
                       )
                     )
                     (set_local $$75
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arg)
                       )
                     )
@@ -7938,7 +7938,7 @@
                     (set_local $$77
                       (get_local $$76)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$77)
                       (get_local $$cnt$1)
                     )
@@ -7951,7 +7951,7 @@
                     (set_local $$79
                       (get_local $$78)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$79)
                       (get_local $$74)
                     )
@@ -7980,11 +7980,11 @@
                       )
                     )
                     (set_local $$80
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arg)
                       )
                     )
-                    (i32.store16 align=2
+                    (i32.store16
                       (get_local $$80)
                       (get_local $$conv229)
                     )
@@ -8013,11 +8013,11 @@
                       )
                     )
                     (set_local $$81
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arg)
                       )
                     )
-                    (i32.store8 align=1
+                    (i32.store8
                       (get_local $$81)
                       (get_local $$conv232)
                     )
@@ -8040,11 +8040,11 @@
                 (case $switch-case$24
                   (block
                     (set_local $$82
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arg)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$82)
                       (get_local $$cnt$1)
                     )
@@ -8082,7 +8082,7 @@
                       )
                     )
                     (set_local $$85
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arg)
                       )
                     )
@@ -8092,7 +8092,7 @@
                     (set_local $$87
                       (get_local $$86)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$87)
                       (get_local $$cnt$1)
                     )
@@ -8105,7 +8105,7 @@
                     (set_local $$89
                       (get_local $$88)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$89)
                       (get_local $$84)
                     )
@@ -8211,7 +8211,7 @@
                 (get_local $$116)
               )
               (set_local $$118
-                (i32.load align=4
+                (i32.load
                   (get_local $$117)
                 )
               )
@@ -8225,7 +8225,7 @@
                 (get_local $$119)
               )
               (set_local $$121
-                (i32.load align=4
+                (i32.load
                   (get_local $$120)
                 )
               )
@@ -8287,7 +8287,7 @@
                         (i32.const -1)
                       )
                     )
-                    (i32.store8 align=1
+                    (i32.store8
                       (get_local $$incdec$ptr$i$225)
                       (get_local $$128)
                     )
@@ -8299,7 +8299,7 @@
                       )
                     )
                     (set_local $$131
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 168)
                       )
                     )
@@ -8443,7 +8443,7 @@
                 (get_local $$135)
               )
               (set_local $$137
-                (i32.load align=4
+                (i32.load
                   (get_local $$136)
                 )
               )
@@ -8457,7 +8457,7 @@
                 (get_local $$138)
               )
               (set_local $$140
-                (i32.load align=4
+                (i32.load
                   (get_local $$139)
                 )
               )
@@ -8479,7 +8479,7 @@
                     )
                   )
                   (set_local $$143
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 168)
                     )
                   )
@@ -8489,7 +8489,7 @@
                   (set_local $$145
                     (get_local $$144)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$145)
                     (get_local $$142)
                   )
@@ -8502,7 +8502,7 @@
                   (set_local $$147
                     (get_local $$146)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$147)
                     (get_local $$143)
                   )
@@ -8604,7 +8604,7 @@
                 (get_local $$65)
               )
               (set_local $$67
-                (i32.load align=4
+                (i32.load
                   (get_local $$66)
                 )
               )
@@ -8618,7 +8618,7 @@
                 (get_local $$68)
               )
               (set_local $$70
-                (i32.load align=4
+                (i32.load
                   (get_local $$69)
                 )
               )
@@ -8649,7 +8649,7 @@
                 (get_local $$161)
               )
               (set_local $$163
-                (i32.load align=4
+                (i32.load
                   (get_local $$162)
                 )
               )
@@ -8663,7 +8663,7 @@
                 (get_local $$164)
               )
               (set_local $$166
-                (i32.load align=4
+                (i32.load
                   (get_local $$165)
                 )
               )
@@ -8673,7 +8673,7 @@
                   (i32.const 255)
                 )
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $$add$ptr340)
                 (get_local $$167)
               )
@@ -8704,7 +8704,7 @@
                 (call $___errno_location)
               )
               (set_local $$168
-                (i32.load align=4
+                (i32.load
                   (get_local $$call344)
                 )
               )
@@ -8725,7 +8725,7 @@
           (case $switch-case$39
             (block
               (set_local $$169
-                (i32.load align=4
+                (i32.load
                   (get_local $$arg)
                 )
               )
@@ -8760,7 +8760,7 @@
                 (get_local $$170)
               )
               (set_local $$172
-                (i32.load align=4
+                (i32.load
                   (get_local $$171)
                 )
               )
@@ -8774,19 +8774,19 @@
                 (get_local $$173)
               )
               (set_local $$175
-                (i32.load align=4
+                (i32.load
                   (get_local $$174)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$wc)
                 (get_local $$172)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$arrayidx370)
                 (i32.const 0)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$arg)
                 (get_local $$wc)
               )
@@ -8860,30 +8860,30 @@
           (case $switch-case$105
             (block
               (set_local $$181
-                (f64.load align=8
+                (f64.load
                   (get_local $$arg)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$e2$i)
                 (i32.const 0)
               )
-              (f64.store align=8
-                (i32.load align=4
+              (f64.store
+                (i32.load
                   (i32.const 24)
                 )
                 (get_local $$181)
               )
               (set_local $$182
-                (i32.load align=4
-                  (i32.load align=4
+                (i32.load
+                  (i32.load
                     (i32.const 24)
                   )
                 )
               )
               (set_local $$183
-                (i32.load offset=4 align=4
-                  (i32.load align=4
+                (i32.load offset=4
+                  (i32.load
                     (i32.const 24)
                   )
                 )
@@ -8971,22 +8971,22 @@
                   )
                 )
               )
-              (f64.store align=8
-                (i32.load align=4
+              (f64.store
+                (i32.load
                   (i32.const 24)
                 )
                 (get_local $$y$addr$0$i)
               )
               (set_local $$185
-                (i32.load align=4
-                  (i32.load align=4
+                (i32.load
+                  (i32.load
                     (i32.const 24)
                   )
                 )
               )
               (set_local $$186
-                (i32.load offset=4 align=4
-                  (i32.load align=4
+                (i32.load offset=4
+                  (i32.load
                     (i32.const 24)
                   )
                 )
@@ -9053,7 +9053,7 @@
                       (get_local $$tobool56$i)
                       (block
                         (set_local $$195
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$e2$i)
                           )
                         )
@@ -9063,7 +9063,7 @@
                             (i32.const -1)
                           )
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$e2$i)
                           (get_local $$dec$i)
                         )
@@ -9191,7 +9191,7 @@
                                 (br $while-in$52)
                               )
                               (set_local $$197
-                                (i32.load8_s align=1
+                                (i32.load8_s
                                   (get_local $$prefix$0$add$ptr65$i)
                                 )
                               )
@@ -9260,7 +9260,7 @@
                           )
                         )
                         (set_local $$198
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$e2$i)
                           )
                         )
@@ -9314,7 +9314,7 @@
                         (if_else
                           (get_local $$cmp103$i)
                           (block
-                            (i32.store8 align=1
+                            (i32.store8
                               (get_local $$incdec$ptr106$i)
                               (i32.const 48)
                             )
@@ -9356,7 +9356,7 @@
                             (i32.const -1)
                           )
                         )
-                        (i32.store8 align=1
+                        (i32.store8
                           (get_local $$incdec$ptr112$i)
                           (get_local $$conv111$i)
                         )
@@ -9378,7 +9378,7 @@
                             (i32.const -2)
                           )
                         )
-                        (i32.store8 align=1
+                        (i32.store8
                           (get_local $$incdec$ptr115$i)
                           (get_local $$conv114$i)
                         )
@@ -9419,7 +9419,7 @@
                             )
                           )
                           (set_local $$205
-                            (i32.load8_s align=1
+                            (i32.load8_s
                               (get_local $$arrayidx117$i)
                             )
                           )
@@ -9447,7 +9447,7 @@
                               (i32.const 1)
                             )
                           )
-                          (i32.store8 align=1
+                          (i32.store8
                             (get_local $$s$0$i)
                             (get_local $$conv121$i)
                           )
@@ -9520,7 +9520,7 @@
                                     (i32.const 2)
                                   )
                                 )
-                                (i32.store8 align=1
+                                (i32.store8
                                   (get_local $$incdec$ptr122$i)
                                   (i32.const 46)
                                 )
@@ -9636,7 +9636,7 @@
                           (get_local $$fl$1$and219)
                         )
                         (set_local $$206
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$f)
                           )
                         )
@@ -9680,7 +9680,7 @@
                           )
                         )
                         (set_local $$207
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$f)
                           )
                         )
@@ -9733,7 +9733,7 @@
                           (i32.const 0)
                         )
                         (set_local $$208
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$f)
                           )
                         )
@@ -9812,7 +9812,7 @@
                           )
                         )
                         (set_local $$209
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$e2$i)
                           )
                         )
@@ -9822,7 +9822,7 @@
                             (i32.const -28)
                           )
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$e2$i)
                           (get_local $$sub203$i)
                         )
@@ -9835,7 +9835,7 @@
                       )
                       (block
                         (set_local $$$pre564$i
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$e2$i)
                           )
                         )
@@ -9875,7 +9875,7 @@
                           (get_local $$y$addr$4$i)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$z$0$i)
                         (get_local $$conv216$i)
                       )
@@ -9928,7 +9928,7 @@
                       (br $while-in$57)
                     )
                     (set_local $$$pr$i
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$e2$i)
                       )
                     )
@@ -9991,7 +9991,7 @@
                                 )
                                 (loop $while-out$61 $while-in$62
                                   (set_local $$212
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $$d$0545$i)
                                     )
                                   )
@@ -10003,7 +10003,7 @@
                                     )
                                   )
                                   (set_local $$214
-                                    (i32.load align=4
+                                    (i32.load
                                       (i32.const 168)
                                     )
                                   )
@@ -10016,7 +10016,7 @@
                                     )
                                   )
                                   (set_local $$216
-                                    (i32.load align=4
+                                    (i32.load
                                       (i32.const 168)
                                     )
                                   )
@@ -10029,11 +10029,11 @@
                                     )
                                   )
                                   (set_local $$218
-                                    (i32.load align=4
+                                    (i32.load
                                       (i32.const 168)
                                     )
                                   )
-                                  (i32.store align=4
+                                  (i32.store
                                     (get_local $$d$0545$i)
                                     (get_local $$217)
                                   )
@@ -10046,7 +10046,7 @@
                                     )
                                   )
                                   (set_local $$220
-                                    (i32.load align=4
+                                    (i32.load
                                       (i32.const 168)
                                     )
                                   )
@@ -10102,7 +10102,7 @@
                                     (i32.const -4)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$incdec$ptr246$i)
                                   (get_local $$conv242$i$lcssa)
                                 )
@@ -10141,7 +10141,7 @@
                               )
                             )
                             (set_local $$221
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$arrayidx251$i)
                               )
                             )
@@ -10166,7 +10166,7 @@
                             (br $while-in$64)
                           )
                           (set_local $$222
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$e2$i)
                             )
                           )
@@ -10176,7 +10176,7 @@
                               (get_local $$cond233$i)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$e2$i)
                             (get_local $$sub256$i)
                           )
@@ -10328,7 +10328,7 @@
                                 )
                                 (loop $while-out$68 $while-in$69
                                   (set_local $$225
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $$d$1534$i)
                                     )
                                   )
@@ -10350,7 +10350,7 @@
                                       (get_local $$carry262$0535$i)
                                     )
                                   )
-                                  (i32.store align=4
+                                  (i32.store
                                     (get_local $$d$1534$i)
                                     (get_local $$add284$i)
                                   )
@@ -10392,7 +10392,7 @@
                                   (br $while-in$69)
                                 )
                                 (set_local $$226
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$a$3539$i)
                                   )
                                 )
@@ -10439,7 +10439,7 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$z$3538$i)
                                   (get_local $$mul286$i$lcssa)
                                 )
@@ -10452,7 +10452,7 @@
                               )
                               (block
                                 (set_local $$224
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$a$3539$i)
                                   )
                                 )
@@ -10532,7 +10532,7 @@
                             )
                           )
                           (set_local $$227
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$e2$i)
                             )
                           )
@@ -10542,7 +10542,7 @@
                               (get_local $$cond271$i)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$e2$i)
                             (get_local $$add313$i)
                           )
@@ -10619,7 +10619,7 @@
                             )
                           )
                           (set_local $$228
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$a$3$lcssa$i)
                             )
                           )
@@ -10888,7 +10888,7 @@
                           )
                         )
                         (set_local $$231
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$add$ptr358$i)
                           )
                         )
@@ -11032,7 +11032,7 @@
                                   )
                                   (block
                                     (set_local $$232
-                                      (i32.load8_s align=1
+                                      (i32.load8_s
                                         (get_local $$prefix$0$i)
                                       )
                                     )
@@ -11088,7 +11088,7 @@
                                   (get_local $$rem370$i)
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $$add$ptr358$i)
                                 (get_local $$sub409$i)
                               )
@@ -11128,7 +11128,7 @@
                                   (get_local $$i$1$lcssa$i)
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $$add$ptr358$i)
                                 (get_local $$add414$i)
                               )
@@ -11154,7 +11154,7 @@
                                         (i32.const -4)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$d$2520$i)
                                       (i32.const 0)
                                     )
@@ -11173,7 +11173,7 @@
                                             (i32.const -4)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$incdec$ptr423$i)
                                           (i32.const 0)
                                         )
@@ -11186,7 +11186,7 @@
                                       )
                                     )
                                     (set_local $$233
-                                      (i32.load align=4
+                                      (i32.load
                                         (get_local $$incdec$ptr419$i)
                                       )
                                     )
@@ -11196,7 +11196,7 @@
                                         (i32.const 1)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$incdec$ptr419$i)
                                       (get_local $$inc425$i)
                                     )
@@ -11260,7 +11260,7 @@
                                 )
                               )
                               (set_local $$234
-                                (i32.load align=4
+                                (i32.load
                                   (get_local $$a$5$lcssa$i)
                                 )
                               )
@@ -11419,7 +11419,7 @@
                         )
                       )
                       (set_local $$235
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$arrayidx453$i)
                         )
                       )
@@ -11576,7 +11576,7 @@
                                   )
                                 )
                                 (set_local $$237
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$arrayidx489$i)
                                   )
                                 )
@@ -11953,7 +11953,7 @@
                                   (i32.const -1)
                                 )
                               )
-                              (i32.store8 align=1
+                              (i32.store8
                                 (get_local $$incdec$ptr639$i)
                                 (i32.const 48)
                               )
@@ -12021,7 +12021,7 @@
                             (i32.const -1)
                           )
                         )
-                        (i32.store8 align=1
+                        (i32.store8
                           (get_local $$incdec$ptr645$i)
                           (get_local $$conv644$i)
                         )
@@ -12037,7 +12037,7 @@
                             (i32.const -2)
                           )
                         )
-                        (i32.store8 align=1
+                        (i32.store8
                           (get_local $$incdec$ptr647$i)
                           (get_local $$conv646$i)
                         )
@@ -12090,7 +12090,7 @@
                       (get_local $$fl$1$and219)
                     )
                     (set_local $$247
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$f)
                       )
                     )
@@ -12149,7 +12149,7 @@
                           )
                           (loop $while-out$90 $while-in$91
                             (set_local $$248
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$d$5494$i)
                               )
                             )
@@ -12188,7 +12188,7 @@
                                       (br $do-once$92)
                                     )
                                   )
-                                  (i32.store8 align=1
+                                  (i32.store8
                                     (get_local $$incdec$ptr689$i)
                                     (i32.const 48)
                                   )
@@ -12222,7 +12222,7 @@
                                         (i32.const -1)
                                       )
                                     )
-                                    (i32.store8 align=1
+                                    (i32.store8
                                       (get_local $$incdec$ptr681$i)
                                       (i32.const 48)
                                     )
@@ -12250,7 +12250,7 @@
                               )
                             )
                             (set_local $$250
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$f)
                               )
                             )
@@ -12325,7 +12325,7 @@
                               )
                               (block
                                 (set_local $$252
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$f)
                                   )
                                 )
@@ -12384,7 +12384,7 @@
                               )
                               (loop $while-out$96 $while-in$97
                                 (set_local $$254
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$d$6488$i)
                                   )
                                 )
@@ -12414,7 +12414,7 @@
                                           (i32.const -1)
                                         )
                                       )
-                                      (i32.store8 align=1
+                                      (i32.store8
                                         (get_local $$incdec$ptr725$i)
                                         (i32.const 48)
                                       )
@@ -12444,7 +12444,7 @@
                                   )
                                 )
                                 (set_local $$256
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$f)
                                   )
                                 )
@@ -12588,7 +12588,7 @@
                               )
                               (loop $while-out$100 $while-in$101
                                 (set_local $$258
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$d$7500$i)
                                   )
                                 )
@@ -12608,7 +12608,7 @@
                                 (if_else
                                   (get_local $$cmp760$i)
                                   (block
-                                    (i32.store8 align=1
+                                    (i32.store8
                                       (get_local $$incdec$ptr689$i)
                                       (i32.const 48)
                                     )
@@ -12637,7 +12637,7 @@
                                         )
                                       )
                                       (set_local $$260
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$f)
                                         )
                                       )
@@ -12683,7 +12683,7 @@
                                         )
                                       )
                                       (set_local $$261
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$f)
                                         )
                                       )
@@ -12746,7 +12746,7 @@
                                             (i32.const -1)
                                           )
                                         )
-                                        (i32.store8 align=1
+                                        (i32.store8
                                           (get_local $$incdec$ptr773$i)
                                           (i32.const 48)
                                         )
@@ -12783,7 +12783,7 @@
                                   )
                                 )
                                 (set_local $$262
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$f)
                                   )
                                 )
@@ -12890,7 +12890,7 @@
                             (i32.const 0)
                           )
                           (set_local $$264
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$f)
                             )
                           )
@@ -13026,7 +13026,7 @@
                       (get_local $$and219)
                     )
                     (set_local $$193
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$f)
                       )
                     )
@@ -13051,7 +13051,7 @@
                           (get_local $$f)
                         )
                         (set_local $$$pre$i
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$f)
                           )
                         )
@@ -13172,7 +13172,7 @@
               (get_local $$90)
             )
             (set_local $$92
-              (i32.load align=4
+              (i32.load
                 (get_local $$91)
               )
             )
@@ -13186,7 +13186,7 @@
               (get_local $$93)
             )
             (set_local $$95
-              (i32.load align=4
+              (i32.load
                 (get_local $$94)
               )
             )
@@ -13260,7 +13260,7 @@
                     )
                   )
                   (set_local $$100
-                    (i32.load8_s align=1
+                    (i32.load8_s
                       (get_local $$arrayidx$i)
                     )
                   )
@@ -13288,7 +13288,7 @@
                       (i32.const -1)
                     )
                   )
-                  (i32.store8 align=1
+                  (i32.store8
                     (get_local $$incdec$ptr$i$212)
                     (get_local $$conv1$i)
                   )
@@ -13300,7 +13300,7 @@
                     )
                   )
                   (set_local $$103
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 168)
                     )
                   )
@@ -13351,7 +13351,7 @@
                   (get_local $$107)
                 )
                 (set_local $$109
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$108)
                   )
                 )
@@ -13365,7 +13365,7 @@
                   (get_local $$110)
                 )
                 (set_local $$112
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$111)
                   )
                 )
@@ -13581,7 +13581,7 @@
                     (i32.const 0)
                   )
                   (set_local $$176
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arg)
                     )
                   )
@@ -13596,7 +13596,7 @@
                   )
                   (loop $while-out$109 $while-in$110
                     (set_local $$177
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$ws$0317)
                       )
                     )
@@ -13743,7 +13743,7 @@
                     )
                     (block
                       (set_local $$178
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$arg)
                         )
                       )
@@ -13755,7 +13755,7 @@
                       )
                       (loop $while-out$111 $while-in$112
                         (set_local $$179
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$ws$1326)
                           )
                         )
@@ -13814,7 +13814,7 @@
                           )
                         )
                         (set_local $$180
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$f)
                           )
                         )
@@ -13959,7 +13959,7 @@
             (get_local $$151)
           )
           (set_local $$153
-            (i32.load align=4
+            (i32.load
               (get_local $$152)
             )
           )
@@ -13973,7 +13973,7 @@
             (get_local $$154)
           )
           (set_local $$156
-            (i32.load align=4
+            (i32.load
               (get_local $$155)
             )
           )
@@ -14144,7 +14144,7 @@
         (get_local $$fl$6)
       )
       (set_local $$265
-        (i32.load align=4
+        (i32.load
           (get_local $$f)
         )
       )
@@ -14189,7 +14189,7 @@
         (i32.const 0)
       )
       (set_local $$266
-        (i32.load align=4
+        (i32.load
           (get_local $$f)
         )
       )
@@ -14282,7 +14282,7 @@
                       )
                     )
                     (set_local $$267
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arrayidx469)
                       )
                     )
@@ -14364,7 +14364,7 @@
                           )
                         )
                         (set_local $$268
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$arrayidx481)
                           )
                         )
@@ -14427,7 +14427,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -14625,7 +14625,7 @@
     (local $sp i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -14650,7 +14650,7 @@
           (case $switch-case$2
             (block
               (set_local $$arglist_current
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -14709,7 +14709,7 @@
                 (get_local $$4)
               )
               (set_local $$6
-                (i32.load align=4
+                (i32.load
                   (get_local $$5)
                 )
               )
@@ -14719,11 +14719,11 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$arg)
                 (get_local $$6)
               )
@@ -14734,7 +14734,7 @@
           (case $switch-case$3
             (block
               (set_local $$arglist_current2
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -14793,7 +14793,7 @@
                 (get_local $$11)
               )
               (set_local $$13
-                (i32.load align=4
+                (i32.load
                   (get_local $$12)
                 )
               )
@@ -14803,7 +14803,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next3)
               )
@@ -14828,7 +14828,7 @@
               (set_local $$17
                 (get_local $$16)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$17)
                 (get_local $$13)
               )
@@ -14841,7 +14841,7 @@
               (set_local $$19
                 (get_local $$18)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$19)
                 (get_local $$15)
               )
@@ -14852,7 +14852,7 @@
           (case $switch-case$4
             (block
               (set_local $$arglist_current5
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -14911,7 +14911,7 @@
                 (get_local $$24)
               )
               (set_local $$26
-                (i32.load align=4
+                (i32.load
                   (get_local $$25)
                 )
               )
@@ -14921,7 +14921,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next6)
               )
@@ -14931,7 +14931,7 @@
               (set_local $$28
                 (get_local $$27)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$28)
                 (get_local $$26)
               )
@@ -14944,7 +14944,7 @@
               (set_local $$30
                 (get_local $$29)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$30)
                 (i32.const 0)
               )
@@ -14955,7 +14955,7 @@
           (case $switch-case$5
             (block
               (set_local $$arglist_current8
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -15020,7 +15020,7 @@
                 (get_local $$37)
               )
               (set_local $$39
-                (i32.load align=4
+                (i32.load
                   (get_local $$38)
                 )
               )
@@ -15034,7 +15034,7 @@
                 (get_local $$40)
               )
               (set_local $$42
-                (i32.load align=4
+                (i32.load
                   (get_local $$41)
                 )
               )
@@ -15044,7 +15044,7 @@
                   (i32.const 8)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next9)
               )
@@ -15054,7 +15054,7 @@
               (set_local $$44
                 (get_local $$43)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$44)
                 (get_local $$39)
               )
@@ -15067,7 +15067,7 @@
               (set_local $$46
                 (get_local $$45)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$46)
                 (get_local $$42)
               )
@@ -15078,7 +15078,7 @@
           (case $switch-case$6
             (block
               (set_local $$arglist_current11
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -15137,7 +15137,7 @@
                 (get_local $$51)
               )
               (set_local $$53
-                (i32.load align=4
+                (i32.load
                   (get_local $$52)
                 )
               )
@@ -15147,7 +15147,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next12)
               )
@@ -15187,7 +15187,7 @@
               (set_local $$58
                 (get_local $$57)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$58)
                 (get_local $$54)
               )
@@ -15200,7 +15200,7 @@
               (set_local $$60
                 (get_local $$59)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$60)
                 (get_local $$56)
               )
@@ -15211,7 +15211,7 @@
           (case $switch-case$7
             (block
               (set_local $$arglist_current14
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -15270,7 +15270,7 @@
                 (get_local $$65)
               )
               (set_local $$67
-                (i32.load align=4
+                (i32.load
                   (get_local $$66)
                 )
               )
@@ -15280,7 +15280,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next15)
               )
@@ -15296,7 +15296,7 @@
               (set_local $$69
                 (get_local $$68)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$69)
                 (get_local $$conv17$mask)
               )
@@ -15309,7 +15309,7 @@
               (set_local $$71
                 (get_local $$70)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$71)
                 (i32.const 0)
               )
@@ -15320,7 +15320,7 @@
           (case $switch-case$8
             (block
               (set_local $$arglist_current17
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -15379,7 +15379,7 @@
                 (get_local $$76)
               )
               (set_local $$78
-                (i32.load align=4
+                (i32.load
                   (get_local $$77)
                 )
               )
@@ -15389,7 +15389,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next18)
               )
@@ -15429,7 +15429,7 @@
               (set_local $$83
                 (get_local $$82)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$83)
                 (get_local $$79)
               )
@@ -15442,7 +15442,7 @@
               (set_local $$85
                 (get_local $$84)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$85)
                 (get_local $$81)
               )
@@ -15453,7 +15453,7 @@
           (case $switch-case$9
             (block
               (set_local $$arglist_current20
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -15512,7 +15512,7 @@
                 (get_local $$90)
               )
               (set_local $$92
-                (i32.load align=4
+                (i32.load
                   (get_local $$91)
                 )
               )
@@ -15522,7 +15522,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next21)
               )
@@ -15538,7 +15538,7 @@
               (set_local $$94
                 (get_local $$93)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$94)
                 (get_local $$conv27$mask)
               )
@@ -15551,7 +15551,7 @@
               (set_local $$96
                 (get_local $$95)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$96)
                 (i32.const 0)
               )
@@ -15562,7 +15562,7 @@
           (case $switch-case$10
             (block
               (set_local $$arglist_current23
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -15621,7 +15621,7 @@
                 (get_local $$101)
               )
               (set_local $$103
-                (f64.load align=8
+                (f64.load
                   (get_local $$102)
                 )
               )
@@ -15631,11 +15631,11 @@
                   (i32.const 8)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next24)
               )
-              (f64.store align=8
+              (f64.store
                 (get_local $$arg)
                 (get_local $$103)
               )
@@ -15646,7 +15646,7 @@
           (case $switch-case$11
             (block
               (set_local $$arglist_current26
-                (i32.load align=4
+                (i32.load
                   (get_local $$ap)
                 )
               )
@@ -15705,7 +15705,7 @@
                 (get_local $$108)
               )
               (set_local $$110
-                (f64.load align=8
+                (f64.load
                   (get_local $$109)
                 )
               )
@@ -15715,11 +15715,11 @@
                   (i32.const 8)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$ap)
                 (get_local $$arglist_next27)
               )
-              (f64.store align=8
+              (f64.store
                 (get_local $$arg)
                 (get_local $$110)
               )
@@ -15774,7 +15774,7 @@
     (local $$10 i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -15830,7 +15830,7 @@
             )
           )
           (set_local $$10
-            (i32.load align=4
+            (i32.load
               (i32.const 168)
             )
           )
@@ -15852,7 +15852,7 @@
               (i32.const -1)
             )
           )
-          (i32.store8 align=1
+          (i32.store8
             (get_local $$incdec$ptr)
             (get_local $$12)
           )
@@ -15865,7 +15865,7 @@
             )
           )
           (set_local $$14
-            (i32.load align=4
+            (i32.load
               (i32.const 168)
             )
           )
@@ -15989,7 +15989,7 @@
               (i32.const -1)
             )
           )
-          (i32.store8 align=1
+          (i32.store8
             (get_local $$incdec$ptr7)
             (get_local $$conv6)
           )
@@ -16061,14 +16061,14 @@
     (local $$$pre i32)
     (local $label i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 256)
@@ -16076,10 +16076,10 @@
     )
     (if
       (i32.ge_s
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
-        (i32.load align=4
+        (i32.load
           (i32.const 16)
         )
       )
@@ -16147,7 +16147,7 @@
             )
           )
           (set_local $$0
-            (i32.load align=4
+            (i32.load
               (get_local $$f)
             )
           )
@@ -16191,7 +16191,7 @@
                       (get_local $$f)
                     )
                     (set_local $$$pre
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$f)
                       )
                     )
@@ -16274,7 +16274,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $sp)
     )
@@ -17471,7 +17471,7 @@
     (local $$$lcssa i32)
     (local $sp i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -17517,7 +17517,7 @@
             )
           )
           (set_local $$0
-            (i32.load align=4
+            (i32.load
               (i32.const 176)
             )
           )
@@ -17585,7 +17585,7 @@
                 )
               )
               (set_local $$2
-                (i32.load align=4
+                (i32.load
                   (get_local $$1)
                 )
               )
@@ -17596,7 +17596,7 @@
                 )
               )
               (set_local $$3
-                (i32.load align=4
+                (i32.load
                   (get_local $$fd9)
                 )
               )
@@ -17628,14 +17628,14 @@
                         (get_local $$neg13)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (i32.const 176)
                       (get_local $$and14)
                     )
                   )
                   (block
                     (set_local $$4
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 192)
                       )
                     )
@@ -17656,7 +17656,7 @@
                       )
                     )
                     (set_local $$5
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$bk)
                       )
                     )
@@ -17669,11 +17669,11 @@
                     (if_else
                       (get_local $$cmp16)
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$bk)
                           (get_local $$arrayidx)
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$1)
                           (get_local $$3)
                         )
@@ -17702,7 +17702,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head)
                 (get_local $$or23)
               )
@@ -17719,7 +17719,7 @@
                 )
               )
               (set_local $$6
-                (i32.load align=4
+                (i32.load
                   (get_local $$head25)
                 )
               )
@@ -17729,7 +17729,7 @@
                   (i32.const 1)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head25)
                 (get_local $$or26)
               )
@@ -17742,7 +17742,7 @@
             )
           )
           (set_local $$7
-            (i32.load align=4
+            (i32.load
               (i32.const 184)
             )
           )
@@ -17957,7 +17957,7 @@
                     )
                   )
                   (set_local $$9
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$8)
                     )
                   )
@@ -17968,7 +17968,7 @@
                     )
                   )
                   (set_local $$10
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$fd69)
                     )
                   )
@@ -18000,7 +18000,7 @@
                             (get_local $$neg73)
                           )
                         )
-                        (i32.store align=4
+                        (i32.store
                           (i32.const 176)
                           (get_local $$and74)
                         )
@@ -18010,7 +18010,7 @@
                       )
                       (block
                         (set_local $$11
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 192)
                           )
                         )
@@ -18031,7 +18031,7 @@
                           )
                         )
                         (set_local $$12
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$bk78)
                           )
                         )
@@ -18044,16 +18044,16 @@
                         (if_else
                           (get_local $$cmp79)
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$bk78)
                               (get_local $$arrayidx66)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$8)
                               (get_local $$10)
                             )
                             (set_local $$$pre
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 184)
                               )
                             )
@@ -18091,7 +18091,7 @@
                       (i32.const 4)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$head94)
                     (get_local $$or93)
                   )
@@ -18113,7 +18113,7 @@
                       (i32.const 4)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$head97)
                     (get_local $$or96)
                   )
@@ -18123,7 +18123,7 @@
                       (get_local $$sub91)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$add$ptr98)
                     (get_local $$sub91)
                   )
@@ -18140,7 +18140,7 @@
                     )
                     (block
                       (set_local $$14
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 196)
                         )
                       )
@@ -18166,7 +18166,7 @@
                         )
                       )
                       (set_local $$15
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 176)
                         )
                       )
@@ -18197,7 +18197,7 @@
                               (get_local $$shl105)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 176)
                             (get_local $$or110)
                           )
@@ -18222,12 +18222,12 @@
                             )
                           )
                           (set_local $$17
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$16)
                             )
                           )
                           (set_local $$18
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 192)
                             )
                           )
@@ -18251,7 +18251,7 @@
                           )
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$$pre$phiZ2D)
                         (get_local $$14)
                       )
@@ -18261,7 +18261,7 @@
                           (i32.const 12)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$bk122)
                         (get_local $$14)
                       )
@@ -18271,7 +18271,7 @@
                           (i32.const 8)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$fd123)
                         (get_local $$F104$0)
                       )
@@ -18281,17 +18281,17 @@
                           (i32.const 12)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$bk124)
                         (get_local $$arrayidx103)
                       )
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 184)
                     (get_local $$sub91)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 196)
                     (get_local $$add$ptr95)
                   )
@@ -18304,7 +18304,7 @@
                 )
               )
               (set_local $$19
-                (i32.load align=4
+                (i32.load
                   (i32.const 180)
                 )
               )
@@ -18468,7 +18468,7 @@
                     )
                   )
                   (set_local $$20
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx$i)
                     )
                   )
@@ -18479,7 +18479,7 @@
                     )
                   )
                   (set_local $$21
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$head$i)
                     )
                   )
@@ -18512,7 +18512,7 @@
                       )
                     )
                     (set_local $$22
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arrayidx23$i)
                       )
                     )
@@ -18532,7 +18532,7 @@
                           )
                         )
                         (set_local $$23
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$arrayidx27$i)
                           )
                         )
@@ -18569,7 +18569,7 @@
                       )
                     )
                     (set_local $$24
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$head29$i)
                       )
                     )
@@ -18617,7 +18617,7 @@
                     (br $while-in$4)
                   )
                   (set_local $$25
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -18657,7 +18657,7 @@
                     )
                   )
                   (set_local $$26
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$parent$i)
                     )
                   )
@@ -18668,7 +18668,7 @@
                     )
                   )
                   (set_local $$27
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$bk$i)
                     )
                   )
@@ -18689,7 +18689,7 @@
                           )
                         )
                         (set_local $$31
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$arrayidx61$i)
                           )
                         )
@@ -18709,7 +18709,7 @@
                               )
                             )
                             (set_local $$32
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$arrayidx65$i)
                               )
                             )
@@ -18754,7 +18754,7 @@
                             )
                           )
                           (set_local $$33
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$arrayidx71$i)
                             )
                           )
@@ -18786,7 +18786,7 @@
                             )
                           )
                           (set_local $$34
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$arrayidx75$i)
                             )
                           )
@@ -18828,7 +18828,7 @@
                           (get_local $$cmp81$i)
                           (call_import $_abort)
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$RP$1$i$lcssa)
                               (i32.const 0)
                             )
@@ -18847,7 +18847,7 @@
                           )
                         )
                         (set_local $$28
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$fd$i)
                           )
                         )
@@ -18868,7 +18868,7 @@
                           )
                         )
                         (set_local $$29
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$bk47$i)
                           )
                         )
@@ -18892,7 +18892,7 @@
                           )
                         )
                         (set_local $$30
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$fd50$i)
                           )
                         )
@@ -18905,11 +18905,11 @@
                         (if_else
                           (get_local $$cmp51$i)
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$bk47$i)
                               (get_local $$27)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$fd50$i)
                               (get_local $$28)
                             )
@@ -18943,7 +18943,7 @@
                           )
                         )
                         (set_local $$35
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$index$i)
                           )
                         )
@@ -18957,7 +18957,7 @@
                           )
                         )
                         (set_local $$36
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$arrayidx94$i)
                           )
                         )
@@ -18970,7 +18970,7 @@
                         (if_else
                           (get_local $$cmp95$i)
                           (block
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$arrayidx94$i)
                               (get_local $$R$3$i)
                             )
@@ -18996,7 +18996,7 @@
                                   )
                                 )
                                 (set_local $$37
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 180)
                                   )
                                 )
@@ -19006,7 +19006,7 @@
                                     (get_local $$neg$i)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (i32.const 180)
                                   (get_local $$and103$i)
                                 )
@@ -19016,7 +19016,7 @@
                           )
                           (block
                             (set_local $$38
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 192)
                               )
                             )
@@ -19037,7 +19037,7 @@
                               )
                             )
                             (set_local $$39
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$arrayidx113$i)
                               )
                             )
@@ -19049,7 +19049,7 @@
                             )
                             (if_else
                               (get_local $$cmp114$i)
-                              (i32.store align=4
+                              (i32.store
                                 (get_local $$arrayidx113$i)
                                 (get_local $$R$3$i)
                               )
@@ -19060,7 +19060,7 @@
                                     (i32.const 20)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$arrayidx121$i)
                                   (get_local $$R$3$i)
                                 )
@@ -19078,7 +19078,7 @@
                           )
                         )
                         (set_local $$40
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 192)
                           )
                         )
@@ -19098,7 +19098,7 @@
                             (i32.const 24)
                           )
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$parent135$i)
                           (get_local $$26)
                         )
@@ -19109,7 +19109,7 @@
                           )
                         )
                         (set_local $$41
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$arrayidx137$i)
                           )
                         )
@@ -19142,7 +19142,7 @@
                                       (i32.const 16)
                                     )
                                   )
-                                  (i32.store align=4
+                                  (i32.store
                                     (get_local $$arrayidx148$i)
                                     (get_local $$41)
                                   )
@@ -19152,7 +19152,7 @@
                                       (i32.const 24)
                                     )
                                   )
-                                  (i32.store align=4
+                                  (i32.store
                                     (get_local $$parent149$i)
                                     (get_local $$R$3$i)
                                   )
@@ -19169,7 +19169,7 @@
                           )
                         )
                         (set_local $$42
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$arrayidx154$i)
                           )
                         )
@@ -19186,7 +19186,7 @@
                           )
                           (block
                             (set_local $$43
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 192)
                               )
                             )
@@ -19206,7 +19206,7 @@
                                     (i32.const 20)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$arrayidx165$i)
                                   (get_local $$42)
                                 )
@@ -19216,7 +19216,7 @@
                                     (i32.const 24)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$parent166$i)
                                   (get_local $$R$3$i)
                                 )
@@ -19255,7 +19255,7 @@
                           (i32.const 4)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$head179$i)
                         (get_local $$or178$i)
                       )
@@ -19272,7 +19272,7 @@
                         )
                       )
                       (set_local $$44
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$head182$i)
                         )
                       )
@@ -19282,7 +19282,7 @@
                           (i32.const 1)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$head182$i)
                         (get_local $$or183$i)
                       )
@@ -19300,7 +19300,7 @@
                           (i32.const 4)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$head187$i)
                         (get_local $$or186$i)
                       )
@@ -19316,7 +19316,7 @@
                           (i32.const 4)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$head189$i)
                         (get_local $$or188$i)
                       )
@@ -19326,12 +19326,12 @@
                           (get_local $$rsize$0$i$lcssa)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$add$ptr190$i)
                         (get_local $$rsize$0$i$lcssa)
                       )
                       (set_local $$45
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 184)
                         )
                       )
@@ -19348,7 +19348,7 @@
                         )
                         (block
                           (set_local $$46
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 196)
                             )
                           )
@@ -19374,7 +19374,7 @@
                             )
                           )
                           (set_local $$47
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 176)
                             )
                           )
@@ -19405,7 +19405,7 @@
                                   (get_local $$shl198$i)
                                 )
                               )
-                              (i32.store align=4
+                              (i32.store
                                 (i32.const 176)
                                 (get_local $$or204$i)
                               )
@@ -19430,12 +19430,12 @@
                                 )
                               )
                               (set_local $$49
-                                (i32.load align=4
+                                (i32.load
                                   (get_local $$48)
                                 )
                               )
                               (set_local $$50
-                                (i32.load align=4
+                                (i32.load
                                   (i32.const 192)
                                 )
                               )
@@ -19459,7 +19459,7 @@
                               )
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$$pre$phi$iZ2D)
                             (get_local $$46)
                           )
@@ -19469,7 +19469,7 @@
                               (i32.const 12)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$bk218$i)
                             (get_local $$46)
                           )
@@ -19479,7 +19479,7 @@
                               (i32.const 8)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$fd219$i)
                             (get_local $$F197$0$i)
                           )
@@ -19489,17 +19489,17 @@
                               (i32.const 12)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$bk220$i)
                             (get_local $$arrayidx196$i)
                           )
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 184)
                         (get_local $$rsize$0$i$lcssa)
                       )
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 196)
                         (get_local $$add$ptr$i)
                       )
@@ -19551,7 +19551,7 @@
                 )
               )
               (set_local $$51
-                (i32.load align=4
+                (i32.load
                   (i32.const 180)
                 )
               )
@@ -19752,7 +19752,7 @@
                     )
                   )
                   (set_local $$52
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx$i$150)
                     )
                   )
@@ -19834,7 +19834,7 @@
                             )
                           )
                           (set_local $$53
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$head$i$154)
                             )
                           )
@@ -19908,7 +19908,7 @@
                             )
                           )
                           (set_local $$54
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$arrayidx40$i)
                             )
                           )
@@ -19931,7 +19931,7 @@
                             )
                           )
                           (set_local $$55
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$arrayidx44$i)
                             )
                           )
@@ -20238,7 +20238,7 @@
                             )
                           )
                           (set_local $$57
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$arrayidx94$i$156)
                             )
                           )
@@ -20299,7 +20299,7 @@
                         )
                       )
                       (set_local $$58
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$head99$i)
                         )
                       )
@@ -20342,7 +20342,7 @@
                         )
                       )
                       (set_local $$59
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$arrayidx106$i)
                         )
                       )
@@ -20380,7 +20380,7 @@
                         )
                       )
                       (set_local $$60
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$arrayidx113$i$159)
                         )
                       )
@@ -20432,7 +20432,7 @@
                     )
                     (block
                       (set_local $$61
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 184)
                         )
                       )
@@ -20452,7 +20452,7 @@
                         (get_local $$cmp119$i)
                         (block
                           (set_local $$62
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 192)
                             )
                           )
@@ -20492,7 +20492,7 @@
                             )
                           )
                           (set_local $$63
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$parent$i$162)
                             )
                           )
@@ -20503,7 +20503,7 @@
                             )
                           )
                           (set_local $$64
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$bk$i$163)
                             )
                           )
@@ -20524,7 +20524,7 @@
                                   )
                                 )
                                 (set_local $$68
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$arrayidx151$i)
                                   )
                                 )
@@ -20544,7 +20544,7 @@
                                       )
                                     )
                                     (set_local $$69
-                                      (i32.load align=4
+                                      (i32.load
                                         (get_local $$arrayidx155$i)
                                       )
                                     )
@@ -20589,7 +20589,7 @@
                                     )
                                   )
                                   (set_local $$70
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $$arrayidx161$i)
                                     )
                                   )
@@ -20621,7 +20621,7 @@
                                     )
                                   )
                                   (set_local $$71
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $$arrayidx165$i$169)
                                     )
                                   )
@@ -20663,7 +20663,7 @@
                                   (get_local $$cmp171$i)
                                   (call_import $_abort)
                                   (block
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$RP$1$i$167$lcssa)
                                       (i32.const 0)
                                     )
@@ -20682,7 +20682,7 @@
                                   )
                                 )
                                 (set_local $$65
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$fd$i$164)
                                   )
                                 )
@@ -20703,7 +20703,7 @@
                                   )
                                 )
                                 (set_local $$66
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$bk136$i)
                                   )
                                 )
@@ -20727,7 +20727,7 @@
                                   )
                                 )
                                 (set_local $$67
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$fd139$i)
                                   )
                                 )
@@ -20740,11 +20740,11 @@
                                 (if_else
                                   (get_local $$cmp140$i)
                                   (block
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$bk136$i)
                                       (get_local $$64)
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$fd139$i)
                                       (get_local $$65)
                                     )
@@ -20778,7 +20778,7 @@
                                   )
                                 )
                                 (set_local $$72
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$index$i$172)
                                   )
                                 )
@@ -20792,7 +20792,7 @@
                                   )
                                 )
                                 (set_local $$73
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$arrayidx184$i)
                                   )
                                 )
@@ -20805,7 +20805,7 @@
                                 (if_else
                                   (get_local $$cmp185$i)
                                   (block
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$arrayidx184$i)
                                       (get_local $$R$3$i$171)
                                     )
@@ -20831,7 +20831,7 @@
                                           )
                                         )
                                         (set_local $$74
-                                          (i32.load align=4
+                                          (i32.load
                                             (i32.const 180)
                                           )
                                         )
@@ -20841,7 +20841,7 @@
                                             (get_local $$neg$i$173)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (i32.const 180)
                                           (get_local $$and194$i)
                                         )
@@ -20851,7 +20851,7 @@
                                   )
                                   (block
                                     (set_local $$75
-                                      (i32.load align=4
+                                      (i32.load
                                         (i32.const 192)
                                       )
                                     )
@@ -20872,7 +20872,7 @@
                                       )
                                     )
                                     (set_local $$76
-                                      (i32.load align=4
+                                      (i32.load
                                         (get_local $$arrayidx204$i)
                                       )
                                     )
@@ -20884,7 +20884,7 @@
                                     )
                                     (if_else
                                       (get_local $$cmp205$i)
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$arrayidx204$i)
                                         (get_local $$R$3$i$171)
                                       )
@@ -20895,7 +20895,7 @@
                                             (i32.const 20)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$arrayidx212$i)
                                           (get_local $$R$3$i$171)
                                         )
@@ -20913,7 +20913,7 @@
                                   )
                                 )
                                 (set_local $$77
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 192)
                                   )
                                 )
@@ -20933,7 +20933,7 @@
                                     (i32.const 24)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$parent226$i)
                                   (get_local $$63)
                                 )
@@ -20944,7 +20944,7 @@
                                   )
                                 )
                                 (set_local $$78
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$arrayidx228$i)
                                   )
                                 )
@@ -20977,7 +20977,7 @@
                                               (i32.const 16)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$arrayidx239$i)
                                             (get_local $$78)
                                           )
@@ -20987,7 +20987,7 @@
                                               (i32.const 24)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$parent240$i)
                                             (get_local $$R$3$i$171)
                                           )
@@ -21004,7 +21004,7 @@
                                   )
                                 )
                                 (set_local $$79
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$arrayidx245$i)
                                   )
                                 )
@@ -21021,7 +21021,7 @@
                                   )
                                   (block
                                     (set_local $$80
-                                      (i32.load align=4
+                                      (i32.load
                                         (i32.const 192)
                                       )
                                     )
@@ -21041,7 +21041,7 @@
                                             (i32.const 20)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$arrayidx256$i)
                                           (get_local $$79)
                                         )
@@ -21051,7 +21051,7 @@
                                             (i32.const 24)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$parent257$i)
                                           (get_local $$R$3$i$171)
                                         )
@@ -21091,7 +21091,7 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$head271$i)
                                   (get_local $$or270$i)
                                 )
@@ -21108,7 +21108,7 @@
                                   )
                                 )
                                 (set_local $$81
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$head274$i)
                                   )
                                 )
@@ -21118,7 +21118,7 @@
                                     (i32.const 1)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$head274$i)
                                   (get_local $$or275$i)
                                 )
@@ -21136,7 +21136,7 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$head279$i)
                                   (get_local $$or278$i)
                                 )
@@ -21152,7 +21152,7 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$head281$i)
                                   (get_local $$or280$i)
                                 )
@@ -21162,7 +21162,7 @@
                                     (get_local $$rsize$4$lcssa$i)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$add$ptr282$i)
                                   (get_local $$rsize$4$lcssa$i)
                                 )
@@ -21197,7 +21197,7 @@
                                       )
                                     )
                                     (set_local $$82
-                                      (i32.load align=4
+                                      (i32.load
                                         (i32.const 176)
                                       )
                                     )
@@ -21228,7 +21228,7 @@
                                             (get_local $$shl291$i)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (i32.const 176)
                                           (get_local $$or297$i)
                                         )
@@ -21253,12 +21253,12 @@
                                           )
                                         )
                                         (set_local $$84
-                                          (i32.load align=4
+                                          (i32.load
                                             (get_local $$83)
                                           )
                                         )
                                         (set_local $$85
-                                          (i32.load align=4
+                                          (i32.load
                                             (i32.const 192)
                                           )
                                         )
@@ -21282,7 +21282,7 @@
                                         )
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$$pre$phi$i$178Z2D)
                                       (get_local $$add$ptr$i$161)
                                     )
@@ -21292,7 +21292,7 @@
                                         (i32.const 12)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$bk311$i)
                                       (get_local $$add$ptr$i$161)
                                     )
@@ -21302,7 +21302,7 @@
                                         (i32.const 8)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$fd312$i)
                                       (get_local $$F290$0$i)
                                     )
@@ -21312,7 +21312,7 @@
                                         (i32.const 12)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$bk313$i)
                                       (get_local $$arrayidx289$i)
                                     )
@@ -21503,7 +21503,7 @@
                                     (i32.const 28)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$index356$i)
                                   (get_local $$I316$0$i)
                                 )
@@ -21519,16 +21519,16 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$arrayidx358$i)
                                   (i32.const 0)
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$child357$i)
                                   (i32.const 0)
                                 )
                                 (set_local $$86
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 180)
                                   )
                                 )
@@ -21559,11 +21559,11 @@
                                         (get_local $$shl362$i)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (i32.const 180)
                                       (get_local $$or368$i)
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$arrayidx355$i)
                                       (get_local $$add$ptr$i$161)
                                     )
@@ -21573,7 +21573,7 @@
                                         (i32.const 24)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$parent369$i)
                                       (get_local $$arrayidx355$i)
                                     )
@@ -21583,7 +21583,7 @@
                                         (i32.const 12)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$bk370$i)
                                       (get_local $$add$ptr$i$161)
                                     )
@@ -21593,7 +21593,7 @@
                                         (i32.const 8)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$fd371$i)
                                       (get_local $$add$ptr$i$161)
                                     )
@@ -21601,7 +21601,7 @@
                                   )
                                 )
                                 (set_local $$87
-                                  (i32.load align=4
+                                  (i32.load
                                     (get_local $$arrayidx355$i)
                                   )
                                 )
@@ -21650,7 +21650,7 @@
                                     )
                                   )
                                   (set_local $$88
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $$head386$i)
                                     )
                                   )
@@ -21703,7 +21703,7 @@
                                     )
                                   )
                                   (set_local $$89
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $$arrayidx394$i)
                                     )
                                   )
@@ -21745,7 +21745,7 @@
                                   )
                                   (block
                                     (set_local $$90
-                                      (i32.load align=4
+                                      (i32.load
                                         (i32.const 192)
                                       )
                                     )
@@ -21759,7 +21759,7 @@
                                       (get_local $$cmp401$i)
                                       (call_import $_abort)
                                       (block
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$arrayidx394$i$lcssa)
                                           (get_local $$add$ptr$i$161)
                                         )
@@ -21769,7 +21769,7 @@
                                             (i32.const 24)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$parent406$i)
                                           (get_local $$T$0$i$lcssa293)
                                         )
@@ -21779,7 +21779,7 @@
                                             (i32.const 12)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$bk407$i)
                                           (get_local $$add$ptr$i$161)
                                         )
@@ -21789,7 +21789,7 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (i32.store align=4
+                                        (i32.store
                                           (get_local $$fd408$i)
                                           (get_local $$add$ptr$i$161)
                                         )
@@ -21810,12 +21810,12 @@
                                         )
                                       )
                                       (set_local $$91
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$fd416$i)
                                         )
                                       )
                                       (set_local $$92
-                                        (i32.load align=4
+                                        (i32.load
                                           (i32.const 192)
                                         )
                                       )
@@ -21846,11 +21846,11 @@
                                               (i32.const 12)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$bk429$i)
                                             (get_local $$add$ptr$i$161)
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$fd416$i)
                                             (get_local $$add$ptr$i$161)
                                           )
@@ -21860,7 +21860,7 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$fd431$i)
                                             (get_local $$91)
                                           )
@@ -21870,7 +21870,7 @@
                                               (i32.const 12)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$bk432$i)
                                             (get_local $$T$0$i$lcssa)
                                           )
@@ -21880,7 +21880,7 @@
                                               (i32.const 24)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$parent433$i)
                                             (i32.const 0)
                                           )
@@ -21921,7 +21921,7 @@
       )
     )
     (set_local $$94
-      (i32.load align=4
+      (i32.load
         (i32.const 184)
       )
     )
@@ -21944,7 +21944,7 @@
           )
         )
         (set_local $$95
-          (i32.load align=4
+          (i32.load
             (i32.const 196)
           )
         )
@@ -21963,11 +21963,11 @@
                 (get_local $$nb$0)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (get_local $$add$ptr166)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (get_local $$sub160)
             )
@@ -21983,7 +21983,7 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head168)
               (get_local $$or167)
             )
@@ -21993,7 +21993,7 @@
                 (get_local $$sub160)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$add$ptr169)
               (get_local $$sub160)
             )
@@ -22009,17 +22009,17 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head173)
               (get_local $$or172)
             )
           )
           (block
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (i32.const 0)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (i32.const 0)
             )
@@ -22035,7 +22035,7 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head177)
               (get_local $$or176)
             )
@@ -22052,7 +22052,7 @@
               )
             )
             (set_local $$96
-              (i32.load align=4
+              (i32.load
                 (get_local $$head179)
               )
             )
@@ -22062,7 +22062,7 @@
                 (i32.const 1)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head179)
               (get_local $$or180)
             )
@@ -22083,7 +22083,7 @@
       )
     )
     (set_local $$97
-      (i32.load align=4
+      (i32.load
         (i32.const 188)
       )
     )
@@ -22102,12 +22102,12 @@
             (get_local $$nb$0)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 188)
           (get_local $$sub190)
         )
         (set_local $$98
-          (i32.load align=4
+          (i32.load
             (i32.const 200)
           )
         )
@@ -22117,7 +22117,7 @@
             (get_local $$nb$0)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 200)
           (get_local $$add$ptr193)
         )
@@ -22133,7 +22133,7 @@
             (i32.const 4)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$head195)
           (get_local $$or194)
         )
@@ -22149,7 +22149,7 @@
             (i32.const 4)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$head198)
           (get_local $$or197)
         )
@@ -22168,7 +22168,7 @@
       )
     )
     (set_local $$99
-      (i32.load align=4
+      (i32.load
         (i32.const 648)
       )
     )
@@ -22208,27 +22208,27 @@
           (if_else
             (get_local $$cmp1$i$i)
             (block
-              (i32.store align=4
+              (i32.store
                 (i32.const 656)
                 (get_local $$call$i$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 652)
                 (get_local $$call$i$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 660)
                 (i32.const -1)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 664)
                 (i32.const -1)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 668)
                 (i32.const 0)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 620)
                 (i32.const 0)
               )
@@ -22249,7 +22249,7 @@
                   (i32.const 1431655768)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 648)
                 (get_local $$and7$i$i)
               )
@@ -22267,7 +22267,7 @@
       )
     )
     (set_local $$100
-      (i32.load align=4
+      (i32.load
         (i32.const 656)
       )
     )
@@ -22316,7 +22316,7 @@
       )
     )
     (set_local $$101
-      (i32.load align=4
+      (i32.load
         (i32.const 616)
       )
     )
@@ -22333,7 +22333,7 @@
       )
       (block
         (set_local $$102
-          (i32.load align=4
+          (i32.load
             (i32.const 608)
           )
         )
@@ -22375,7 +22375,7 @@
       )
     )
     (set_local $$103
-      (i32.load align=4
+      (i32.load
         (i32.const 620)
       )
     )
@@ -22396,7 +22396,7 @@
         (get_local $$tobool30$i)
         (block
           (set_local $$104
-            (i32.load align=4
+            (i32.load
               (i32.const 200)
             )
           )
@@ -22418,7 +22418,7 @@
                 )
                 (loop $while-out$23 $while-in$24
                   (set_local $$105
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$sp$0$i$i)
                     )
                   )
@@ -22441,7 +22441,7 @@
                         )
                       )
                       (set_local $$106
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$size$i$i)
                         )
                       )
@@ -22478,7 +22478,7 @@
                     )
                   )
                   (set_local $$107
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$next$i$i)
                     )
                   )
@@ -22503,7 +22503,7 @@
                   (br $while-in$24)
                 )
                 (set_local $$112
-                  (i32.load align=4
+                  (i32.load
                     (i32.const 188)
                   )
                 )
@@ -22534,12 +22534,12 @@
                       )
                     )
                     (set_local $$113
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$base$i$i$lcssa)
                       )
                     )
                     (set_local $$114
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$size$i$i$lcssa)
                       )
                     )
@@ -22628,7 +22628,7 @@
                       (get_local $$call37$i)
                     )
                     (set_local $$109
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 652)
                       )
                     )
@@ -22692,7 +22692,7 @@
                       )
                     )
                     (set_local $$110
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 608)
                       )
                     )
@@ -22724,7 +22724,7 @@
                       (get_local $$or$cond$i$189)
                       (block
                         (set_local $$111
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 616)
                           )
                         )
@@ -22855,7 +22855,7 @@
                     (get_local $$or$cond3$i)
                     (block
                       (set_local $$115
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 656)
                         )
                       )
@@ -22963,7 +22963,7 @@
             )
           )
           (set_local $$116
-            (i32.load align=4
+            (i32.load
               (i32.const 620)
             )
           )
@@ -22973,7 +22973,7 @@
               (i32.const 4)
             )
           )
-          (i32.store align=4
+          (i32.store
             (i32.const 620)
             (get_local $$or$i$195)
           )
@@ -23095,7 +23095,7 @@
       )
       (block
         (set_local $$117
-          (i32.load align=4
+          (i32.load
             (i32.const 608)
           )
         )
@@ -23105,12 +23105,12 @@
             (get_local $$tsize$795$i)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 608)
           (get_local $$add150$i)
         )
         (set_local $$118
-          (i32.load align=4
+          (i32.load
             (i32.const 612)
           )
         )
@@ -23122,13 +23122,13 @@
         )
         (if
           (get_local $$cmp151$i)
-          (i32.store align=4
+          (i32.store
             (i32.const 612)
             (get_local $$add150$i)
           )
         )
         (set_local $$119
-          (i32.load align=4
+          (i32.load
             (i32.const 200)
           )
         )
@@ -23143,7 +23143,7 @@
             (get_local $$cmp157$i)
             (block
               (set_local $$120
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -23167,33 +23167,33 @@
               )
               (if
                 (get_local $$or$cond8$i)
-                (i32.store align=4
+                (i32.store
                   (i32.const 192)
                   (get_local $$tbase$796$i)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 624)
                 (get_local $$tbase$796$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 628)
                 (get_local $$tsize$795$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 636)
                 (i32.const 0)
               )
               (set_local $$121
-                (i32.load align=4
+                (i32.load
                   (i32.const 648)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 212)
                 (get_local $$121)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 208)
                 (i32.const -1)
               )
@@ -23222,7 +23222,7 @@
                     (i32.const 12)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$122)
                   (get_local $$arrayidx$i$i)
                 )
@@ -23232,7 +23232,7 @@
                     (i32.const 8)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$123)
                   (get_local $$arrayidx$i$i)
                 )
@@ -23315,11 +23315,11 @@
                   (get_local $$cond$i$i)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 200)
                 (get_local $$add$ptr4$i$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 188)
                 (get_local $$sub5$i$i)
               )
@@ -23335,7 +23335,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head$i$i)
                 (get_local $$or$i$i)
               )
@@ -23351,16 +23351,16 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head7$i$i)
                 (i32.const 40)
               )
               (set_local $$126
-                (i32.load align=4
+                (i32.load
                   (i32.const 664)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 204)
                 (get_local $$126)
               )
@@ -23371,7 +23371,7 @@
               )
               (loop $while-out$30 $while-in$31
                 (set_local $$127
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$sp$0108$i)
                   )
                 )
@@ -23382,7 +23382,7 @@
                   )
                 )
                 (set_local $$128
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$size188$i)
                   )
                 )
@@ -23426,7 +23426,7 @@
                   )
                 )
                 (set_local $$129
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$next$i)
                   )
                 )
@@ -23458,7 +23458,7 @@
                     )
                   )
                   (set_local $$130
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$sflags193$i)
                     )
                   )
@@ -23504,12 +23504,12 @@
                               (get_local $$tsize$795$i)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$size188$i$lcssa)
                             (get_local $$add212$i)
                           )
                           (set_local $$131
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 188)
                             )
                           )
@@ -23571,11 +23571,11 @@
                               (get_local $$131)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 200)
                             (get_local $$add$ptr4$i$26$i)
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 188)
                             (get_local $$sub5$i$27$i)
                           )
@@ -23591,7 +23591,7 @@
                               (i32.const 4)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$head$i$29$i)
                             (get_local $$or$i$28$i)
                           )
@@ -23607,16 +23607,16 @@
                               (i32.const 4)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$head7$i$31$i)
                             (i32.const 40)
                           )
                           (set_local $$134
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 664)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 204)
                             (get_local $$134)
                           )
@@ -23628,7 +23628,7 @@
                 )
               )
               (set_local $$135
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -23641,7 +23641,7 @@
               (if_else
                 (get_local $$cmp218$i)
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 192)
                     (get_local $$tbase$796$i)
                   )
@@ -23664,7 +23664,7 @@
               )
               (loop $while-out$32 $while-in$33
                 (set_local $$136
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$sp$1107$i)
                   )
                 )
@@ -23696,7 +23696,7 @@
                   )
                 )
                 (set_local $$137
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$next231$i)
                   )
                 )
@@ -23733,7 +23733,7 @@
                     )
                   )
                   (set_local $$138
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$sflags235$i)
                     )
                   )
@@ -23752,7 +23752,7 @@
                   (if_else
                     (get_local $$tobool237$i)
                     (block
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$base226$i$lcssa)
                         (get_local $$tbase$796$i)
                       )
@@ -23763,7 +23763,7 @@
                         )
                       )
                       (set_local $$139
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$size245$i)
                         )
                       )
@@ -23773,7 +23773,7 @@
                           (get_local $$tsize$795$i)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$size245$i)
                         (get_local $$add246$i)
                       )
@@ -23905,7 +23905,7 @@
                           (i32.const 4)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$head$i$42$i)
                         (get_local $$or19$i$i)
                       )
@@ -23920,7 +23920,7 @@
                           (get_local $$cmp20$i$i)
                           (block
                             (set_local $$144
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 188)
                               )
                             )
@@ -23930,11 +23930,11 @@
                                 (get_local $$sub18$i$i)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (i32.const 188)
                               (get_local $$add$i$i)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (i32.const 200)
                               (get_local $$add$ptr17$i$i)
                             )
@@ -23950,14 +23950,14 @@
                                 (i32.const 4)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$head23$i$i)
                               (get_local $$or22$i$i)
                             )
                           )
                           (block
                             (set_local $$145
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 196)
                               )
                             )
@@ -23971,7 +23971,7 @@
                               (get_local $$cmp24$i$i)
                               (block
                                 (set_local $$146
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 184)
                                   )
                                 )
@@ -23981,11 +23981,11 @@
                                     (get_local $$sub18$i$i)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (i32.const 184)
                                   (get_local $$add26$i$i)
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (i32.const 196)
                                   (get_local $$add$ptr17$i$i)
                                 )
@@ -24001,7 +24001,7 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$head29$i$i)
                                   (get_local $$or28$i$i)
                                 )
@@ -24011,7 +24011,7 @@
                                     (get_local $$add26$i$i)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$add$ptr30$i$i)
                                   (get_local $$add26$i$i)
                                 )
@@ -24025,7 +24025,7 @@
                               )
                             )
                             (set_local $$147
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$head32$i$i)
                               )
                             )
@@ -24073,7 +24073,7 @@
                                         )
                                       )
                                       (set_local $$148
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$fd$i$i)
                                         )
                                       )
@@ -24084,7 +24084,7 @@
                                         )
                                       )
                                       (set_local $$149
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$bk$i$46$i)
                                         )
                                       )
@@ -24133,7 +24133,7 @@
                                               )
                                             )
                                             (set_local $$151
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $$bk43$i$i)
                                               )
                                             )
@@ -24172,7 +24172,7 @@
                                             )
                                           )
                                           (set_local $$152
-                                            (i32.load align=4
+                                            (i32.load
                                               (i32.const 176)
                                             )
                                           )
@@ -24182,7 +24182,7 @@
                                               (get_local $$neg$i$i)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (i32.const 176)
                                             (get_local $$and49$i$i)
                                           )
@@ -24227,7 +24227,7 @@
                                               )
                                             )
                                             (set_local $$153
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $$fd59$i$i)
                                               )
                                             )
@@ -24256,11 +24256,11 @@
                                           (i32.const 12)
                                         )
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$bk67$i$i)
                                         (get_local $$149)
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$fd68$pre$phi$i$iZ2D)
                                         (get_local $$148)
                                       )
@@ -24273,7 +24273,7 @@
                                         )
                                       )
                                       (set_local $$154
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$parent$i$51$i)
                                         )
                                       )
@@ -24284,7 +24284,7 @@
                                         )
                                       )
                                       (set_local $$155
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$bk74$i$i)
                                         )
                                       )
@@ -24311,7 +24311,7 @@
                                               )
                                             )
                                             (set_local $$159
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $$arrayidx96$i$i)
                                               )
                                             )
@@ -24325,7 +24325,7 @@
                                               (get_local $$cmp97$i$i)
                                               (block
                                                 (set_local $$160
-                                                  (i32.load align=4
+                                                  (i32.load
                                                     (get_local $$child$i$i)
                                                   )
                                                 )
@@ -24370,7 +24370,7 @@
                                                 )
                                               )
                                               (set_local $$161
-                                                (i32.load align=4
+                                                (i32.load
                                                   (get_local $$arrayidx103$i$i)
                                                 )
                                               )
@@ -24402,7 +24402,7 @@
                                                 )
                                               )
                                               (set_local $$162
-                                                (i32.load align=4
+                                                (i32.load
                                                   (get_local $$arrayidx107$i$i)
                                                 )
                                               )
@@ -24444,7 +24444,7 @@
                                               (get_local $$cmp112$i$i)
                                               (call_import $_abort)
                                               (block
-                                                (i32.store align=4
+                                                (i32.store
                                                   (get_local $$RP$1$i$i$lcssa)
                                                   (i32.const 0)
                                                 )
@@ -24463,7 +24463,7 @@
                                               )
                                             )
                                             (set_local $$156
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $$fd78$i$i)
                                               )
                                             )
@@ -24484,7 +24484,7 @@
                                               )
                                             )
                                             (set_local $$157
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $$bk82$i$i)
                                               )
                                             )
@@ -24508,7 +24508,7 @@
                                               )
                                             )
                                             (set_local $$158
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $$fd85$i$i)
                                               )
                                             )
@@ -24521,11 +24521,11 @@
                                             (if_else
                                               (get_local $$cmp86$i$i)
                                               (block
-                                                (i32.store align=4
+                                                (i32.store
                                                   (get_local $$bk82$i$i)
                                                   (get_local $$155)
                                                 )
-                                                (i32.store align=4
+                                                (i32.store
                                                   (get_local $$fd85$i$i)
                                                   (get_local $$156)
                                                 )
@@ -24555,7 +24555,7 @@
                                         )
                                       )
                                       (set_local $$163
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$index$i$54$i)
                                         )
                                       )
@@ -24569,7 +24569,7 @@
                                         )
                                       )
                                       (set_local $$164
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$arrayidx123$i$i)
                                         )
                                       )
@@ -24583,7 +24583,7 @@
                                         (if_else
                                           (get_local $$cmp124$i$i)
                                           (block
-                                            (i32.store align=4
+                                            (i32.store
                                               (get_local $$arrayidx123$i$i)
                                               (get_local $$R$3$i$i)
                                             )
@@ -24612,7 +24612,7 @@
                                               )
                                             )
                                             (set_local $$165
-                                              (i32.load align=4
+                                              (i32.load
                                                 (i32.const 180)
                                               )
                                             )
@@ -24622,7 +24622,7 @@
                                                 (get_local $$neg132$i$i)
                                               )
                                             )
-                                            (i32.store align=4
+                                            (i32.store
                                               (i32.const 180)
                                               (get_local $$and133$i$i)
                                             )
@@ -24630,7 +24630,7 @@
                                           )
                                           (block
                                             (set_local $$166
-                                              (i32.load align=4
+                                              (i32.load
                                                 (i32.const 192)
                                               )
                                             )
@@ -24651,7 +24651,7 @@
                                               )
                                             )
                                             (set_local $$167
-                                              (i32.load align=4
+                                              (i32.load
                                                 (get_local $$arrayidx143$i$i)
                                               )
                                             )
@@ -24663,7 +24663,7 @@
                                             )
                                             (if_else
                                               (get_local $$cmp144$i$i)
-                                              (i32.store align=4
+                                              (i32.store
                                                 (get_local $$arrayidx143$i$i)
                                                 (get_local $$R$3$i$i)
                                               )
@@ -24674,7 +24674,7 @@
                                                     (i32.const 20)
                                                   )
                                                 )
-                                                (i32.store align=4
+                                                (i32.store
                                                   (get_local $$arrayidx151$i$i)
                                                   (get_local $$R$3$i$i)
                                                 )
@@ -24693,7 +24693,7 @@
                                         )
                                       )
                                       (set_local $$168
-                                        (i32.load align=4
+                                        (i32.load
                                           (i32.const 192)
                                         )
                                       )
@@ -24713,7 +24713,7 @@
                                           (i32.const 24)
                                         )
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$parent165$i$i)
                                         (get_local $$154)
                                       )
@@ -24724,7 +24724,7 @@
                                         )
                                       )
                                       (set_local $$169
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$child166$i$i)
                                         )
                                       )
@@ -24757,7 +24757,7 @@
                                                     (i32.const 16)
                                                   )
                                                 )
-                                                (i32.store align=4
+                                                (i32.store
                                                   (get_local $$arrayidx178$i$i)
                                                   (get_local $$169)
                                                 )
@@ -24767,7 +24767,7 @@
                                                     (i32.const 24)
                                                   )
                                                 )
-                                                (i32.store align=4
+                                                (i32.store
                                                   (get_local $$parent179$i$i)
                                                   (get_local $$R$3$i$i)
                                                 )
@@ -24784,7 +24784,7 @@
                                         )
                                       )
                                       (set_local $$170
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$arrayidx184$i$i)
                                         )
                                       )
@@ -24798,7 +24798,7 @@
                                         (get_local $$cmp185$i$i)
                                       )
                                       (set_local $$171
-                                        (i32.load align=4
+                                        (i32.load
                                           (i32.const 192)
                                         )
                                       )
@@ -24818,7 +24818,7 @@
                                               (i32.const 20)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$arrayidx195$i$i)
                                             (get_local $$170)
                                           )
@@ -24828,7 +24828,7 @@
                                               (i32.const 24)
                                             )
                                           )
-                                          (i32.store align=4
+                                          (i32.store
                                             (get_local $$parent196$i$i)
                                             (get_local $$R$3$i$i)
                                           )
@@ -24873,7 +24873,7 @@
                               )
                             )
                             (set_local $$172
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$head208$i$i)
                               )
                             )
@@ -24883,7 +24883,7 @@
                                 (i32.const -2)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$head208$i$i)
                               (get_local $$and209$i$i)
                             )
@@ -24899,7 +24899,7 @@
                                 (i32.const 4)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$head211$i$i)
                               (get_local $$or210$i$i)
                             )
@@ -24909,7 +24909,7 @@
                                 (get_local $$qsize$0$i$i)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$add$ptr212$i$i)
                               (get_local $$qsize$0$i$i)
                             )
@@ -24944,7 +24944,7 @@
                                   )
                                 )
                                 (set_local $$173
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 176)
                                   )
                                 )
@@ -24976,7 +24976,7 @@
                                           (get_local $$shl226$i$i)
                                         )
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (i32.const 176)
                                         (get_local $$or232$i$i)
                                       )
@@ -25001,12 +25001,12 @@
                                         )
                                       )
                                       (set_local $$175
-                                        (i32.load align=4
+                                        (i32.load
                                           (get_local $$174)
                                         )
                                       )
                                       (set_local $$176
-                                        (i32.load align=4
+                                        (i32.load
                                           (i32.const 192)
                                         )
                                       )
@@ -25035,7 +25035,7 @@
                                     )
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$$pre$phi$i$57$iZ2D)
                                   (get_local $$add$ptr17$i$i)
                                 )
@@ -25045,7 +25045,7 @@
                                     (i32.const 12)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$bk246$i$i)
                                   (get_local $$add$ptr17$i$i)
                                 )
@@ -25055,7 +25055,7 @@
                                     (i32.const 8)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$fd247$i$i)
                                   (get_local $$F224$0$i$i)
                                 )
@@ -25065,7 +25065,7 @@
                                     (i32.const 12)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$bk248$i$i)
                                   (get_local $$arrayidx223$i$i)
                                 )
@@ -25259,7 +25259,7 @@
                                 (i32.const 28)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$index288$i$i)
                               (get_local $$I252$0$i$i)
                             )
@@ -25275,16 +25275,16 @@
                                 (i32.const 4)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$arrayidx290$i$i)
                               (i32.const 0)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$child289$i$i)
                               (i32.const 0)
                             )
                             (set_local $$177
-                              (i32.load align=4
+                              (i32.load
                                 (i32.const 180)
                               )
                             )
@@ -25315,11 +25315,11 @@
                                     (get_local $$shl294$i$i)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (i32.const 180)
                                   (get_local $$or300$i$i)
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$arrayidx287$i$i)
                                   (get_local $$add$ptr17$i$i)
                                 )
@@ -25329,7 +25329,7 @@
                                     (i32.const 24)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$parent301$i$i)
                                   (get_local $$arrayidx287$i$i)
                                 )
@@ -25339,7 +25339,7 @@
                                     (i32.const 12)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$bk302$i$i)
                                   (get_local $$add$ptr17$i$i)
                                 )
@@ -25349,7 +25349,7 @@
                                     (i32.const 8)
                                   )
                                 )
-                                (i32.store align=4
+                                (i32.store
                                   (get_local $$fd303$i$i)
                                   (get_local $$add$ptr17$i$i)
                                 )
@@ -25357,7 +25357,7 @@
                               )
                             )
                             (set_local $$178
-                              (i32.load align=4
+                              (i32.load
                                 (get_local $$arrayidx287$i$i)
                               )
                             )
@@ -25406,7 +25406,7 @@
                                 )
                               )
                               (set_local $$179
-                                (i32.load align=4
+                                (i32.load
                                   (get_local $$head317$i$i)
                                 )
                               )
@@ -25459,7 +25459,7 @@
                                 )
                               )
                               (set_local $$180
-                                (i32.load align=4
+                                (i32.load
                                   (get_local $$arrayidx325$i$i)
                                 )
                               )
@@ -25501,7 +25501,7 @@
                               )
                               (block
                                 (set_local $$181
-                                  (i32.load align=4
+                                  (i32.load
                                     (i32.const 192)
                                   )
                                 )
@@ -25515,7 +25515,7 @@
                                   (get_local $$cmp332$i$i)
                                   (call_import $_abort)
                                   (block
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$arrayidx325$i$i$lcssa)
                                       (get_local $$add$ptr17$i$i)
                                     )
@@ -25525,7 +25525,7 @@
                                         (i32.const 24)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$parent337$i$i)
                                       (get_local $$T$0$i$58$i$lcssa283)
                                     )
@@ -25535,7 +25535,7 @@
                                         (i32.const 12)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$bk338$i$i)
                                       (get_local $$add$ptr17$i$i)
                                     )
@@ -25545,7 +25545,7 @@
                                         (i32.const 8)
                                       )
                                     )
-                                    (i32.store align=4
+                                    (i32.store
                                       (get_local $$fd339$i$i)
                                       (get_local $$add$ptr17$i$i)
                                     )
@@ -25566,12 +25566,12 @@
                                     )
                                   )
                                   (set_local $$182
-                                    (i32.load align=4
+                                    (i32.load
                                       (get_local $$fd344$i$i)
                                     )
                                   )
                                   (set_local $$183
-                                    (i32.load align=4
+                                    (i32.load
                                       (i32.const 192)
                                     )
                                   )
@@ -25602,11 +25602,11 @@
                                           (i32.const 12)
                                         )
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$bk357$i$i)
                                         (get_local $$add$ptr17$i$i)
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$fd344$i$i)
                                         (get_local $$add$ptr17$i$i)
                                       )
@@ -25616,7 +25616,7 @@
                                           (i32.const 8)
                                         )
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$fd359$i$i)
                                         (get_local $$182)
                                       )
@@ -25626,7 +25626,7 @@
                                           (i32.const 12)
                                         )
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$bk360$i$i)
                                         (get_local $$T$0$i$58$i$lcssa)
                                       )
@@ -25636,7 +25636,7 @@
                                           (i32.const 24)
                                         )
                                       )
-                                      (i32.store align=4
+                                      (i32.store
                                         (get_local $$parent361$i$i)
                                         (i32.const 0)
                                       )
@@ -25671,7 +25671,7 @@
               )
               (loop $while-out$46 $while-in$47
                 (set_local $$185
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$sp$0$i$i$i)
                   )
                 )
@@ -25694,7 +25694,7 @@
                       )
                     )
                     (set_local $$186
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$size$i$i$i)
                       )
                     )
@@ -25728,7 +25728,7 @@
                   )
                 )
                 (set_local $$187
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$next$i$i$i)
                   )
                 )
@@ -25878,11 +25878,11 @@
                   (get_local $$cond$i$i$i)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 200)
                 (get_local $$add$ptr4$i$i$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 188)
                 (get_local $$sub5$i$i$i)
               )
@@ -25898,7 +25898,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head$i$i$i)
                 (get_local $$or$i$i$i)
               )
@@ -25914,16 +25914,16 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head7$i$i$i)
                 (i32.const 40)
               )
               (set_local $$192
-                (i32.load align=4
+                (i32.load
                   (i32.const 664)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 204)
                 (get_local $$192)
               )
@@ -25933,47 +25933,47 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head$i$17$i)
                 (i32.const 27)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$add$ptr14$i$i)
-                (i32.load align=4
+                (i32.load
                   (i32.const 624)
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $$add$ptr14$i$i)
-                (i32.load offset=4 align=4
+                (i32.load offset=4
                   (i32.const 624)
                 )
               )
-              (i32.store offset=8 align=4
+              (i32.store offset=8
                 (get_local $$add$ptr14$i$i)
-                (i32.load offset=8 align=4
+                (i32.load offset=8
                   (i32.const 624)
                 )
               )
-              (i32.store offset=12 align=4
+              (i32.store offset=12
                 (get_local $$add$ptr14$i$i)
-                (i32.load offset=12 align=4
+                (i32.load offset=12
                   (i32.const 624)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 624)
                 (get_local $$tbase$796$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 628)
                 (get_local $$tsize$795$i)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 636)
                 (i32.const 0)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 632)
                 (get_local $$add$ptr14$i$i)
               )
@@ -25987,7 +25987,7 @@
                     (i32.const 4)
                   )
                 )
-                (i32.store align=4
+                (i32.store
                   (get_local $$add$ptr24$i$i)
                   (i32.const 7)
                 )
@@ -26037,7 +26037,7 @@
                     )
                   )
                   (set_local $$194
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$head$i$17$i)
                     )
                   )
@@ -26047,7 +26047,7 @@
                       (i32.const -2)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$head$i$17$i)
                     (get_local $$and32$i$i)
                   )
@@ -26063,11 +26063,11 @@
                       (i32.const 4)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$head34$i$i)
                     (get_local $$or33$i$i)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$cond13$i$i)
                     (get_local $$sub$ptr$sub$i$i)
                   )
@@ -26102,7 +26102,7 @@
                         )
                       )
                       (set_local $$195
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 176)
                         )
                       )
@@ -26133,7 +26133,7 @@
                               (get_local $$shl39$i$i)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 176)
                             (get_local $$or44$i$i)
                           )
@@ -26158,12 +26158,12 @@
                             )
                           )
                           (set_local $$197
-                            (i32.load align=4
+                            (i32.load
                               (get_local $$196)
                             )
                           )
                           (set_local $$198
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 192)
                             )
                           )
@@ -26187,7 +26187,7 @@
                           )
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$$pre$phi$i$iZ2D)
                         (get_local $$119)
                       )
@@ -26197,7 +26197,7 @@
                           (i32.const 12)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$bk$i$i)
                         (get_local $$119)
                       )
@@ -26207,7 +26207,7 @@
                           (i32.const 8)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$fd54$i$i)
                         (get_local $$F$0$i$i)
                       )
@@ -26217,7 +26217,7 @@
                           (i32.const 12)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$bk55$i$i)
                         (get_local $$arrayidx$i$20$i)
                       )
@@ -26408,7 +26408,7 @@
                       (i32.const 28)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$index$i$i)
                     (get_local $$I57$0$i$i)
                   )
@@ -26418,16 +26418,16 @@
                       (i32.const 20)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$arrayidx92$i$i)
                     (i32.const 0)
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$add$ptr8$i122$i)
                     (i32.const 0)
                   )
                   (set_local $$199
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 180)
                     )
                   )
@@ -26458,11 +26458,11 @@
                           (get_local $$shl95$i$i)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 180)
                         (get_local $$or101$i$i)
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$arrayidx91$i$i)
                         (get_local $$119)
                       )
@@ -26472,7 +26472,7 @@
                           (i32.const 24)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$parent$i$i)
                         (get_local $$arrayidx91$i$i)
                       )
@@ -26482,7 +26482,7 @@
                           (i32.const 12)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$bk102$i$i)
                         (get_local $$119)
                       )
@@ -26492,7 +26492,7 @@
                           (i32.const 8)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$fd103$i$i)
                         (get_local $$119)
                       )
@@ -26500,7 +26500,7 @@
                     )
                   )
                   (set_local $$200
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx91$i$i)
                     )
                   )
@@ -26549,7 +26549,7 @@
                       )
                     )
                     (set_local $$201
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$head118$i$i)
                       )
                     )
@@ -26602,7 +26602,7 @@
                       )
                     )
                     (set_local $$202
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arrayidx126$i$i)
                       )
                     )
@@ -26644,7 +26644,7 @@
                     )
                     (block
                       (set_local $$203
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
@@ -26658,7 +26658,7 @@
                         (get_local $$cmp133$i$i)
                         (call_import $_abort)
                         (block
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$arrayidx126$i$i$lcssa)
                             (get_local $$119)
                           )
@@ -26668,7 +26668,7 @@
                               (i32.const 24)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$parent138$i$i)
                             (get_local $$T$0$i$i$lcssa284)
                           )
@@ -26678,7 +26678,7 @@
                               (i32.const 12)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$bk139$i$i)
                             (get_local $$119)
                           )
@@ -26688,7 +26688,7 @@
                               (i32.const 8)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$fd140$i$i)
                             (get_local $$119)
                           )
@@ -26709,12 +26709,12 @@
                           )
                         )
                         (set_local $$204
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$fd148$i$i)
                           )
                         )
                         (set_local $$205
-                          (i32.load align=4
+                          (i32.load
                             (i32.const 192)
                           )
                         )
@@ -26745,11 +26745,11 @@
                                 (i32.const 12)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$bk158$i$i)
                               (get_local $$119)
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$fd148$i$i)
                               (get_local $$119)
                             )
@@ -26759,7 +26759,7 @@
                                 (i32.const 8)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$fd160$i$i)
                               (get_local $$204)
                             )
@@ -26769,7 +26769,7 @@
                                 (i32.const 12)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$bk161$i$i)
                               (get_local $$T$0$i$i$lcssa)
                             )
@@ -26779,7 +26779,7 @@
                                 (i32.const 24)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$parent162$i$i)
                               (i32.const 0)
                             )
@@ -26796,7 +26796,7 @@
           )
         )
         (set_local $$207
-          (i32.load align=4
+          (i32.load
             (i32.const 188)
           )
         )
@@ -26815,12 +26815,12 @@
                 (get_local $$nb$0)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 188)
               (get_local $$sub260$i)
             )
             (set_local $$208
-              (i32.load align=4
+              (i32.load
                 (i32.const 200)
               )
             )
@@ -26830,7 +26830,7 @@
                 (get_local $$nb$0)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 200)
               (get_local $$add$ptr262$i)
             )
@@ -26846,7 +26846,7 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head265$i)
               (get_local $$or264$i)
             )
@@ -26862,7 +26862,7 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head268$i)
               (get_local $$or267$i)
             )
@@ -26885,7 +26885,7 @@
     (set_local $$call275$i
       (call $___errno_location)
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$call275$i)
       (i32.const 12)
     )
@@ -27251,7 +27251,7 @@
     (local $$$pre i32)
     (local $sp i32)
     (set_local $sp
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
@@ -27272,7 +27272,7 @@
       )
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (i32.const 192)
       )
     )
@@ -27293,7 +27293,7 @@
       )
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$head)
       )
     )
@@ -27342,7 +27342,7 @@
         (get_local $$tobool9)
         (block
           (set_local $$2
-            (i32.load align=4
+            (i32.load
               (get_local $$add$ptr)
             )
           )
@@ -27385,7 +27385,7 @@
             (call_import $_abort)
           )
           (set_local $$3
-            (i32.load align=4
+            (i32.load
               (i32.const 196)
             )
           )
@@ -27405,7 +27405,7 @@
                 )
               )
               (set_local $$27
-                (i32.load align=4
+                (i32.load
                   (get_local $$head209)
                 )
               )
@@ -27436,7 +27436,7 @@
                   (br $do-once$0)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 184)
                 (get_local $$add17)
               )
@@ -27446,7 +27446,7 @@
                   (i32.const -2)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head209)
                 (get_local $$and215)
               )
@@ -27462,7 +27462,7 @@
                   (i32.const 4)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$head216)
                 (get_local $$or)
               )
@@ -27472,7 +27472,7 @@
                   (get_local $$add17)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$add$ptr217)
                 (get_local $$add17)
               )
@@ -27501,7 +27501,7 @@
                 )
               )
               (set_local $$4
-                (i32.load align=4
+                (i32.load
                   (get_local $$fd)
                 )
               )
@@ -27512,7 +27512,7 @@
                 )
               )
               (set_local $$5
-                (i32.load align=4
+                (i32.load
                   (get_local $$bk)
                 )
               )
@@ -27560,7 +27560,7 @@
                     )
                   )
                   (set_local $$6
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$bk34)
                     )
                   )
@@ -27601,7 +27601,7 @@
                     )
                   )
                   (set_local $$7
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 176)
                     )
                   )
@@ -27611,7 +27611,7 @@
                       (get_local $$neg)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 176)
                     (get_local $$and46)
                   )
@@ -27661,7 +27661,7 @@
                     )
                   )
                   (set_local $$8
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$fd56)
                     )
                   )
@@ -27686,11 +27686,11 @@
                   (i32.const 12)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$bk66)
                 (get_local $$5)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$fd67$pre$phiZ2D)
                 (get_local $$4)
               )
@@ -27710,7 +27710,7 @@
             )
           )
           (set_local $$9
-            (i32.load align=4
+            (i32.load
               (get_local $$parent)
             )
           )
@@ -27721,7 +27721,7 @@
             )
           )
           (set_local $$10
-            (i32.load align=4
+            (i32.load
               (get_local $$bk73)
             )
           )
@@ -27748,7 +27748,7 @@
                   )
                 )
                 (set_local $$14
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$arrayidx99)
                   )
                 )
@@ -27762,7 +27762,7 @@
                   (get_local $$cmp100)
                   (block
                     (set_local $$15
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$child)
                       )
                     )
@@ -27807,7 +27807,7 @@
                     )
                   )
                   (set_local $$16
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx108)
                     )
                   )
@@ -27839,7 +27839,7 @@
                     )
                   )
                   (set_local $$17
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx113)
                     )
                   )
@@ -27881,7 +27881,7 @@
                   (get_local $$cmp118)
                   (call_import $_abort)
                   (block
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$RP$1$lcssa)
                       (i32.const 0)
                     )
@@ -27900,7 +27900,7 @@
                   )
                 )
                 (set_local $$11
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$fd78)
                   )
                 )
@@ -27921,7 +27921,7 @@
                   )
                 )
                 (set_local $$12
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$bk82)
                   )
                 )
@@ -27945,7 +27945,7 @@
                   )
                 )
                 (set_local $$13
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$fd86)
                   )
                 )
@@ -27958,11 +27958,11 @@
                 (if_else
                   (get_local $$cmp87)
                   (block
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$bk82)
                       (get_local $$10)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$fd86)
                       (get_local $$11)
                     )
@@ -28000,7 +28000,7 @@
                 )
               )
               (set_local $$18
-                (i32.load align=4
+                (i32.load
                   (get_local $$index)
                 )
               )
@@ -28014,7 +28014,7 @@
                 )
               )
               (set_local $$19
-                (i32.load align=4
+                (i32.load
                   (get_local $$arrayidx130)
                 )
               )
@@ -28027,7 +28027,7 @@
               (if_else
                 (get_local $$cmp131)
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$arrayidx130)
                     (get_local $$R$3)
                   )
@@ -28053,7 +28053,7 @@
                         )
                       )
                       (set_local $$20
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 180)
                         )
                       )
@@ -28063,7 +28063,7 @@
                           (get_local $$neg139)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 180)
                         (get_local $$and140)
                       )
@@ -28079,7 +28079,7 @@
                 )
                 (block
                   (set_local $$21
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -28100,7 +28100,7 @@
                     )
                   )
                   (set_local $$22
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx149)
                     )
                   )
@@ -28112,7 +28112,7 @@
                   )
                   (if_else
                     (get_local $$cmp150)
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$arrayidx149)
                       (get_local $$R$3)
                     )
@@ -28123,7 +28123,7 @@
                           (i32.const 20)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$arrayidx157)
                         (get_local $$R$3)
                       )
@@ -28150,7 +28150,7 @@
                 )
               )
               (set_local $$23
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -28170,7 +28170,7 @@
                   (i32.const 24)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$parent170)
                 (get_local $$9)
               )
@@ -28181,7 +28181,7 @@
                 )
               )
               (set_local $$24
-                (i32.load align=4
+                (i32.load
                   (get_local $$child171)
                 )
               )
@@ -28214,7 +28214,7 @@
                             (i32.const 16)
                           )
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$arrayidx182)
                           (get_local $$24)
                         )
@@ -28224,7 +28224,7 @@
                             (i32.const 24)
                           )
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$parent183)
                           (get_local $$R$3)
                         )
@@ -28241,7 +28241,7 @@
                 )
               )
               (set_local $$25
-                (i32.load align=4
+                (i32.load
                   (get_local $$arrayidx188)
                 )
               )
@@ -28263,7 +28263,7 @@
                 )
                 (block
                   (set_local $$26
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -28283,7 +28283,7 @@
                           (i32.const 20)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$arrayidx198)
                         (get_local $$25)
                       )
@@ -28293,7 +28293,7 @@
                           (i32.const 24)
                         )
                       )
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$parent199)
                         (get_local $$R$3)
                       )
@@ -28341,7 +28341,7 @@
       )
     )
     (set_local $$28
-      (i32.load align=4
+      (i32.load
         (get_local $$head231)
       )
     )
@@ -28377,7 +28377,7 @@
       (get_local $$tobool241)
       (block
         (set_local $$29
-          (i32.load align=4
+          (i32.load
             (i32.const 200)
           )
         )
@@ -28391,7 +28391,7 @@
           (get_local $$cmp243)
           (block
             (set_local $$30
-              (i32.load align=4
+              (i32.load
                 (i32.const 188)
               )
             )
@@ -28401,11 +28401,11 @@
                 (get_local $$psize$1)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 188)
               (get_local $$add246)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 200)
               (get_local $$p$1)
             )
@@ -28421,12 +28421,12 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head248)
               (get_local $$or247)
             )
             (set_local $$31
-              (i32.load align=4
+              (i32.load
                 (i32.const 196)
               )
             )
@@ -28443,11 +28443,11 @@
               )
               (return)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (i32.const 0)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (i32.const 0)
             )
@@ -28455,7 +28455,7 @@
           )
         )
         (set_local $$32
-          (i32.load align=4
+          (i32.load
             (i32.const 196)
           )
         )
@@ -28469,7 +28469,7 @@
           (get_local $$cmp255)
           (block
             (set_local $$33
-              (i32.load align=4
+              (i32.load
                 (i32.const 184)
               )
             )
@@ -28479,11 +28479,11 @@
                 (get_local $$psize$1)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (get_local $$add258)
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 196)
               (get_local $$p$1)
             )
@@ -28499,7 +28499,7 @@
                 (i32.const 4)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$head260)
               (get_local $$or259)
             )
@@ -28509,7 +28509,7 @@
                 (get_local $$add258)
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$add$ptr261)
               (get_local $$add258)
             )
@@ -28551,7 +28551,7 @@
                 )
               )
               (set_local $$34
-                (i32.load align=4
+                (i32.load
                   (get_local $$fd273)
                 )
               )
@@ -28562,7 +28562,7 @@
                 )
               )
               (set_local $$35
-                (i32.load align=4
+                (i32.load
                   (get_local $$bk275)
                 )
               )
@@ -28594,7 +28594,7 @@
                 )
                 (block
                   (set_local $$36
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -28615,7 +28615,7 @@
                     )
                   )
                   (set_local $$37
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$bk286)
                     )
                   )
@@ -28656,7 +28656,7 @@
                     )
                   )
                   (set_local $$38
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 176)
                     )
                   )
@@ -28666,7 +28666,7 @@
                       (get_local $$neg300)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 176)
                     (get_local $$and301)
                   )
@@ -28694,7 +28694,7 @@
                 )
                 (block
                   (set_local $$39
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -28715,7 +28715,7 @@
                     )
                   )
                   (set_local $$40
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$fd311)
                     )
                   )
@@ -28740,11 +28740,11 @@
                   (i32.const 12)
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$bk321)
                 (get_local $$35)
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$fd322$pre$phiZ2D)
                 (get_local $$34)
               )
@@ -28757,7 +28757,7 @@
                 )
               )
               (set_local $$41
-                (i32.load align=4
+                (i32.load
                   (get_local $$parent331)
                 )
               )
@@ -28768,7 +28768,7 @@
                 )
               )
               (set_local $$42
-                (i32.load align=4
+                (i32.load
                   (get_local $$bk333)
                 )
               )
@@ -28795,7 +28795,7 @@
                       )
                     )
                     (set_local $$47
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$arrayidx362)
                       )
                     )
@@ -28809,7 +28809,7 @@
                       (get_local $$cmp363)
                       (block
                         (set_local $$48
-                          (i32.load align=4
+                          (i32.load
                             (get_local $$child361)
                           )
                         )
@@ -28854,7 +28854,7 @@
                         )
                       )
                       (set_local $$49
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$arrayidx374)
                         )
                       )
@@ -28886,7 +28886,7 @@
                         )
                       )
                       (set_local $$50
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$arrayidx379)
                         )
                       )
@@ -28919,7 +28919,7 @@
                       (br $while-in$8)
                     )
                     (set_local $$51
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 192)
                       )
                     )
@@ -28933,7 +28933,7 @@
                       (get_local $$cmp386)
                       (call_import $_abort)
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$RP360$1$lcssa)
                           (i32.const 0)
                         )
@@ -28952,12 +28952,12 @@
                       )
                     )
                     (set_local $$43
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$fd338)
                       )
                     )
                     (set_local $$44
-                      (i32.load align=4
+                      (i32.load
                         (i32.const 192)
                       )
                     )
@@ -28978,7 +28978,7 @@
                       )
                     )
                     (set_local $$45
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$bk343)
                       )
                     )
@@ -29002,7 +29002,7 @@
                       )
                     )
                     (set_local $$46
-                      (i32.load align=4
+                      (i32.load
                         (get_local $$fd347)
                       )
                     )
@@ -29015,11 +29015,11 @@
                     (if_else
                       (get_local $$cmp348)
                       (block
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$bk343)
                           (get_local $$42)
                         )
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$fd347)
                           (get_local $$43)
                         )
@@ -29052,7 +29052,7 @@
                     )
                   )
                   (set_local $$52
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$index399)
                     )
                   )
@@ -29066,7 +29066,7 @@
                     )
                   )
                   (set_local $$53
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx400)
                     )
                   )
@@ -29079,7 +29079,7 @@
                   (if_else
                     (get_local $$cmp401)
                     (block
-                      (i32.store align=4
+                      (i32.store
                         (get_local $$arrayidx400)
                         (get_local $$R332$3)
                       )
@@ -29105,7 +29105,7 @@
                             )
                           )
                           (set_local $$54
-                            (i32.load align=4
+                            (i32.load
                               (i32.const 180)
                             )
                           )
@@ -29115,7 +29115,7 @@
                               (get_local $$neg409)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (i32.const 180)
                             (get_local $$and410)
                           )
@@ -29125,7 +29125,7 @@
                     )
                     (block
                       (set_local $$55
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
@@ -29146,7 +29146,7 @@
                         )
                       )
                       (set_local $$56
-                        (i32.load align=4
+                        (i32.load
                           (get_local $$arrayidx419)
                         )
                       )
@@ -29158,7 +29158,7 @@
                       )
                       (if_else
                         (get_local $$cmp420)
-                        (i32.store align=4
+                        (i32.store
                           (get_local $$arrayidx419)
                           (get_local $$R332$3)
                         )
@@ -29169,7 +29169,7 @@
                               (i32.const 20)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$arrayidx427)
                             (get_local $$R332$3)
                           )
@@ -29187,7 +29187,7 @@
                     )
                   )
                   (set_local $$57
-                    (i32.load align=4
+                    (i32.load
                       (i32.const 192)
                     )
                   )
@@ -29207,7 +29207,7 @@
                       (i32.const 24)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$parent442)
                     (get_local $$41)
                   )
@@ -29218,7 +29218,7 @@
                     )
                   )
                   (set_local $$58
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$child443)
                     )
                   )
@@ -29251,7 +29251,7 @@
                                 (i32.const 16)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$arrayidx454)
                               (get_local $$58)
                             )
@@ -29261,7 +29261,7 @@
                                 (i32.const 24)
                               )
                             )
-                            (i32.store align=4
+                            (i32.store
                               (get_local $$parent455)
                               (get_local $$R332$3)
                             )
@@ -29278,7 +29278,7 @@
                     )
                   )
                   (set_local $$59
-                    (i32.load align=4
+                    (i32.load
                       (get_local $$arrayidx460)
                     )
                   )
@@ -29295,7 +29295,7 @@
                     )
                     (block
                       (set_local $$60
-                        (i32.load align=4
+                        (i32.load
                           (i32.const 192)
                         )
                       )
@@ -29315,7 +29315,7 @@
                               (i32.const 20)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$arrayidx470)
                             (get_local $$59)
                           )
@@ -29325,7 +29325,7 @@
                               (i32.const 24)
                             )
                           )
-                          (i32.store align=4
+                          (i32.store
                             (get_local $$parent471)
                             (get_local $$R332$3)
                           )
@@ -29351,7 +29351,7 @@
             (i32.const 4)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$head481)
           (get_local $$or480)
         )
@@ -29361,12 +29361,12 @@
             (get_local $$add267)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$add$ptr482)
           (get_local $$add267)
         )
         (set_local $$61
-          (i32.load align=4
+          (i32.load
             (i32.const 196)
           )
         )
@@ -29379,7 +29379,7 @@
         (if_else
           (get_local $$cmp484)
           (block
-            (i32.store align=4
+            (i32.store
               (i32.const 184)
               (get_local $$add267)
             )
@@ -29397,7 +29397,7 @@
             (i32.const -2)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$head231)
           (get_local $$and495)
         )
@@ -29413,7 +29413,7 @@
             (i32.const 4)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$head497)
           (get_local $$or496)
         )
@@ -29423,7 +29423,7 @@
             (get_local $$psize$1)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$add$ptr498)
           (get_local $$psize$1)
         )
@@ -29463,7 +29463,7 @@
           )
         )
         (set_local $$62
-          (i32.load align=4
+          (i32.load
             (i32.const 176)
           )
         )
@@ -29494,7 +29494,7 @@
                 (get_local $$shl511)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 176)
               (get_local $$or516)
             )
@@ -29519,12 +29519,12 @@
               )
             )
             (set_local $$64
-              (i32.load align=4
+              (i32.load
                 (get_local $$63)
               )
             )
             (set_local $$65
-              (i32.load align=4
+              (i32.load
                 (i32.const 192)
               )
             )
@@ -29548,7 +29548,7 @@
             )
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$$pre$phiZ2D)
           (get_local $$p$1)
         )
@@ -29558,7 +29558,7 @@
             (i32.const 12)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$bk529)
           (get_local $$p$1)
         )
@@ -29568,7 +29568,7 @@
             (i32.const 8)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$fd530)
           (get_local $$F510$0)
         )
@@ -29578,7 +29578,7 @@
             (i32.const 12)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$bk531)
           (get_local $$arrayidx509)
         )
@@ -29769,7 +29769,7 @@
         (i32.const 28)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$index568)
       (get_local $$I534$0)
     )
@@ -29785,16 +29785,16 @@
         (i32.const 20)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$arrayidx570)
       (i32.const 0)
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$child569)
       (i32.const 0)
     )
     (set_local $$66
-      (i32.load align=4
+      (i32.load
         (i32.const 180)
       )
     )
@@ -29826,11 +29826,11 @@
               (get_local $$shl573)
             )
           )
-          (i32.store align=4
+          (i32.store
             (i32.const 180)
             (get_local $$or578)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$arrayidx567)
             (get_local $$p$1)
           )
@@ -29840,7 +29840,7 @@
               (i32.const 24)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$parent579)
             (get_local $$arrayidx567)
           )
@@ -29850,7 +29850,7 @@
               (i32.const 12)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$bk580)
             (get_local $$p$1)
           )
@@ -29860,14 +29860,14 @@
               (i32.const 8)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$fd581)
             (get_local $$p$1)
           )
         )
         (block
           (set_local $$67
-            (i32.load align=4
+            (i32.load
               (get_local $$arrayidx567)
             )
           )
@@ -29916,7 +29916,7 @@
               )
             )
             (set_local $$68
-              (i32.load align=4
+              (i32.load
                 (get_local $$head591)
               )
             )
@@ -29969,7 +29969,7 @@
               )
             )
             (set_local $$69
-              (i32.load align=4
+              (i32.load
                 (get_local $$arrayidx599)
               )
             )
@@ -30011,7 +30011,7 @@
             )
             (block
               (set_local $$70
-                (i32.load align=4
+                (i32.load
                   (i32.const 192)
                 )
               )
@@ -30025,7 +30025,7 @@
                 (get_local $$cmp605)
                 (call_import $_abort)
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$arrayidx599$lcssa)
                     (get_local $$p$1)
                   )
@@ -30035,7 +30035,7 @@
                       (i32.const 24)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$parent610)
                     (get_local $$T$0$lcssa319)
                   )
@@ -30045,7 +30045,7 @@
                       (i32.const 12)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$bk611)
                     (get_local $$p$1)
                   )
@@ -30055,7 +30055,7 @@
                       (i32.const 8)
                     )
                   )
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$fd612)
                     (get_local $$p$1)
                   )
@@ -30076,12 +30076,12 @@
                   )
                 )
                 (set_local $$71
-                  (i32.load align=4
+                  (i32.load
                     (get_local $$fd620)
                   )
                 )
                 (set_local $$72
-                  (i32.load align=4
+                  (i32.load
                     (i32.const 192)
                   )
                 )
@@ -30112,11 +30112,11 @@
                         (i32.const 12)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$bk631)
                       (get_local $$p$1)
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$fd620)
                       (get_local $$p$1)
                     )
@@ -30126,7 +30126,7 @@
                         (i32.const 8)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$fd633)
                       (get_local $$71)
                     )
@@ -30136,7 +30136,7 @@
                         (i32.const 12)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$bk634)
                       (get_local $$T$0$lcssa)
                     )
@@ -30146,7 +30146,7 @@
                         (i32.const 24)
                       )
                     )
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$parent635)
                       (i32.const 0)
                     )
@@ -30161,7 +30161,7 @@
       )
     )
     (set_local $$74
-      (i32.load align=4
+      (i32.load
         (i32.const 208)
       )
     )
@@ -30171,7 +30171,7 @@
         (i32.const -1)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 208)
       (get_local $$dec)
     )
@@ -30190,7 +30190,7 @@
     )
     (loop $while-out$13 $while-in$14
       (set_local $$sp$0$i
-        (i32.load align=4
+        (i32.load
           (get_local $$sp$0$in$i)
         )
       )
@@ -30215,7 +30215,7 @@
       )
       (br $while-in$14)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 208)
       (i32.const -1)
     )
@@ -30253,7 +30253,7 @@
     )
     (return
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (get_local $h)
         )
@@ -30284,7 +30284,7 @@
     )
     (return
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (get_local $h)
         )
@@ -30372,7 +30372,7 @@
                 (nop)
                 (br $while-out$0)
               )
-              (i32.store8 align=1
+              (i32.store8
                 (get_local $ptr)
                 (get_local $value)
               )
@@ -30395,7 +30395,7 @@
             (nop)
             (br $while-out$2)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $ptr)
             (get_local $value4)
           )
@@ -30418,7 +30418,7 @@
         (nop)
         (br $while-out$4)
       )
-      (i32.store8 align=1
+      (i32.store8
         (get_local $ptr)
         (get_local $value)
       )
@@ -30454,7 +30454,7 @@
             (i32.const 1)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (i32.shr_u
             (get_local $high)
@@ -30481,7 +30481,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 168)
       (i32.const 0)
     )
@@ -30512,7 +30512,7 @@
             (i32.const 1)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (i32.or
             (i32.shl
@@ -30545,7 +30545,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 168)
       (i32.shl
         (get_local $low)
@@ -30607,9 +30607,9 @@
               (get_local $ret)
             )
           )
-          (i32.store8 align=1
+          (i32.store8
             (get_local $dest)
-            (i32.load8_s align=1
+            (i32.load8_s
               (get_local $src)
             )
           )
@@ -30642,9 +30642,9 @@
             (nop)
             (br $while-out$2)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $dest)
-            (i32.load align=4
+            (i32.load
               (get_local $src)
             )
           )
@@ -30679,9 +30679,9 @@
         (nop)
         (br $while-out$4)
       )
-      (i32.store8 align=1
+      (i32.store8
         (get_local $dest)
-        (i32.load8_s align=1
+        (i32.load8_s
           (get_local $src)
         )
       )
@@ -30726,7 +30726,7 @@
             (i32.const 1)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (i32.shr_s
             (get_local $high)
@@ -30753,7 +30753,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 168)
       (if_else
         (i32.lt_s
@@ -30777,9 +30777,9 @@
   (func $_llvm_cttz_i32 (param $x i32) (result i32)
     (local $ret i32)
     (set_local $ret
-      (i32.load8_s align=1
+      (i32.load8_s
         (i32.add
-          (i32.load align=4
+          (i32.load
             (i32.const 40)
           )
           (i32.and
@@ -30799,9 +30799,9 @@
       )
     )
     (set_local $ret
-      (i32.load8_s align=1
+      (i32.load8_s
         (i32.add
-          (i32.load align=4
+          (i32.load
             (i32.const 40)
           )
           (i32.and
@@ -30827,9 +30827,9 @@
       )
     )
     (set_local $ret
-      (i32.load8_s align=1
+      (i32.load8_s
         (i32.add
-          (i32.load align=4
+          (i32.load
             (i32.const 40)
           )
           (i32.and
@@ -30856,9 +30856,9 @@
     )
     (return
       (i32.add
-        (i32.load8_s align=1
+        (i32.load8_s
           (i32.add
-            (i32.load align=4
+            (i32.load
               (i32.const 40)
             )
             (i32.shr_u
@@ -30929,7 +30929,7 @@
     )
     (return
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (i32.add
             (i32.add
@@ -31090,7 +31090,7 @@
       )
     )
     (set_local $$4$1
-      (i32.load align=4
+      (i32.load
         (i32.const 168)
       )
     )
@@ -31125,7 +31125,7 @@
         (get_local $$4$0)
         (get_local $$4$1)
         (get_local $$6$0)
-        (i32.load align=4
+        (i32.load
           (i32.const 168)
         )
         (i32.const 0)
@@ -31138,7 +31138,7 @@
           (get_local $$7$0)
         )
         (i32.xor
-          (i32.load align=4
+          (i32.load
             (i32.const 168)
           )
           (get_local $$7$1)
@@ -31164,14 +31164,14 @@
     (local $$10$1 i32)
     (local $$10$0 i32)
     (set_local $__stackBase__
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 16)
@@ -31285,7 +31285,7 @@
       )
     )
     (set_local $$4$1
-      (i32.load align=4
+      (i32.load
         (i32.const 168)
       )
     )
@@ -31307,7 +31307,7 @@
       (get_local $$4$0)
       (get_local $$4$1)
       (get_local $$6$0)
-      (i32.load align=4
+      (i32.load
         (i32.const 168)
       )
       (get_local $$rem)
@@ -31315,13 +31315,13 @@
     (set_local $$10$0
       (call $_i64Subtract
         (i32.xor
-          (i32.load align=4
+          (i32.load
             (get_local $$rem)
           )
           (get_local $$1$0)
         )
         (i32.xor
-          (i32.load offset=4 align=4
+          (i32.load offset=4
             (get_local $$rem)
           )
           (get_local $$1$1)
@@ -31331,17 +31331,17 @@
       )
     )
     (set_local $$10$1
-      (i32.load align=4
+      (i32.load
         (i32.const 168)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $__stackBase__)
     )
     (return
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (get_local $$10$1)
         )
@@ -31368,7 +31368,7 @@
       )
     )
     (set_local $$1$1
-      (i32.load align=4
+      (i32.load
         (i32.const 168)
       )
     )
@@ -31380,7 +31380,7 @@
     )
     (return
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (i32.or
             (i32.add
@@ -31428,14 +31428,14 @@
     (local $$rem i32)
     (local $__stackBase__ i32)
     (set_local $__stackBase__
-      (i32.load align=4
+      (i32.load
         (i32.const 8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (i32.add
-        (i32.load align=4
+        (i32.load
           (i32.const 8)
         )
         (i32.const 16)
@@ -31451,19 +31451,19 @@
       (get_local $$b$1)
       (get_local $$rem)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 8)
       (get_local $__stackBase__)
     )
     (return
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
-          (i32.load offset=4 align=4
+          (i32.load offset=4
             (get_local $$rem)
           )
         )
-        (i32.load align=4
+        (i32.load
           (get_local $$rem)
         )
       )
@@ -31573,14 +31573,14 @@
             (if
               (get_local $$4)
               (block
-                (i32.store align=4
+                (i32.store
                   (get_local $$rem)
                   (i32.rem_u
                     (get_local $$n_sroa_0_0_extract_trunc)
                     (get_local $$d_sroa_0_0_extract_trunc)
                   )
                 )
-                (i32.store offset=4 align=4
+                (i32.store offset=4
                   (get_local $$rem)
                   (i32.const 0)
                 )
@@ -31597,7 +31597,7 @@
             )
             (return
               (block
-                (i32.store align=4
+                (i32.store
                   (i32.const 168)
                   (get_local $$_0$1)
                 )
@@ -31620,7 +31620,7 @@
                 )
                 (return
                   (block
-                    (i32.store align=4
+                    (i32.store
                       (i32.const 168)
                       (get_local $$_0$1)
                     )
@@ -31629,14 +31629,14 @@
                 )
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$rem)
               (i32.and
                 (get_local $$a$0)
                 (i32.const -1)
               )
             )
-            (i32.store offset=4 align=4
+            (i32.store offset=4
               (get_local $$rem)
               (i32.and
                 (get_local $$a$1)
@@ -31651,7 +31651,7 @@
             )
             (return
               (block
-                (i32.store align=4
+                (i32.store
                   (i32.const 168)
                   (get_local $$_0$1)
                 )
@@ -31684,14 +31684,14 @@
                   (i32.const 0)
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$rem)
                     (i32.rem_u
                       (get_local $$n_sroa_1_4_extract_trunc)
                       (get_local $$d_sroa_0_0_extract_trunc)
                     )
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (get_local $$rem)
                     (i32.const 0)
                   )
@@ -31708,7 +31708,7 @@
               )
               (return
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 168)
                     (get_local $$_0$1)
                   )
@@ -31729,11 +31729,11 @@
                   (i32.const 0)
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$rem)
                     (i32.const 0)
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (get_local $$rem)
                     (i32.rem_u
                       (get_local $$n_sroa_1_4_extract_trunc)
@@ -31753,7 +31753,7 @@
               )
               (return
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 168)
                     (get_local $$_0$1)
                   )
@@ -31783,7 +31783,7 @@
                   (i32.const 0)
                 )
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (get_local $$rem)
                     (i32.or
                       (i32.const 0)
@@ -31793,7 +31793,7 @@
                       )
                     )
                   )
-                  (i32.store offset=4 align=4
+                  (i32.store offset=4
                     (get_local $$rem)
                     (i32.or
                       (i32.and
@@ -31821,7 +31821,7 @@
               )
               (return
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 168)
                     (get_local $$_0$1)
                   )
@@ -31908,7 +31908,7 @@
               )
               (return
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 168)
                     (get_local $$_0$1)
                   )
@@ -31917,7 +31917,7 @@
               )
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$rem)
             (i32.or
               (i32.const 0)
@@ -31927,7 +31927,7 @@
               )
             )
           )
-          (i32.store offset=4 align=4
+          (i32.store offset=4
             (get_local $$rem)
             (i32.or
               (get_local $$n_sroa_1_4_extract_shift$0)
@@ -31945,7 +31945,7 @@
           )
           (return
             (block
-              (i32.store align=4
+              (i32.store
                 (i32.const 168)
                 (get_local $$_0$1)
               )
@@ -32053,7 +32053,7 @@
                   )
                   (return
                     (block
-                      (i32.store align=4
+                      (i32.store
                         (i32.const 168)
                         (get_local $$_0$1)
                       )
@@ -32062,7 +32062,7 @@
                   )
                 )
               )
-              (i32.store align=4
+              (i32.store
                 (get_local $$rem)
                 (i32.or
                   (i32.const 0)
@@ -32072,7 +32072,7 @@
                   )
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $$rem)
                 (i32.or
                   (get_local $$n_sroa_1_4_extract_shift$0)
@@ -32090,7 +32090,7 @@
               )
               (return
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 168)
                     (get_local $$_0$1)
                   )
@@ -32250,14 +32250,14 @@
               (i32.const 0)
             )
             (block
-              (i32.store align=4
+              (i32.store
                 (get_local $$rem)
                 (i32.and
                   (get_local $$66)
                   (get_local $$n_sroa_0_0_extract_trunc)
                 )
               )
-              (i32.store offset=4 align=4
+              (i32.store offset=4
                 (get_local $$rem)
                 (i32.const 0)
               )
@@ -32289,7 +32289,7 @@
               )
               (return
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 168)
                     (get_local $$_0$1)
                   )
@@ -32329,7 +32329,7 @@
               )
               (return
                 (block
-                  (i32.store align=4
+                  (i32.store
                     (i32.const 168)
                     (get_local $$_0$1)
                   )
@@ -32394,7 +32394,7 @@
           )
         )
         (set_local $$137$1
-          (i32.load align=4
+          (i32.load
             (i32.const 168)
           )
         )
@@ -32472,7 +32472,7 @@
             (get_local $$r_sroa_0_0_insert_insert42$1)
           )
           (set_local $$150$1
-            (i32.load align=4
+            (i32.load
               (i32.const 168)
             )
           )
@@ -32542,7 +32542,7 @@
             (get_local $$154$0)
           )
           (set_local $$r_sroa_1_4_extract_trunc
-            (i32.load align=4
+            (i32.load
               (i32.const 168)
             )
           )
@@ -32619,14 +32619,14 @@
         (i32.const 0)
       )
       (block
-        (i32.store align=4
+        (i32.store
           (get_local $$rem)
           (i32.or
             (i32.const 0)
             (get_local $$r_sroa_0_1_lcssa)
           )
         )
-        (i32.store offset=4 align=4
+        (i32.store offset=4
           (get_local $$rem)
           (get_local $$r_sroa_1_1_lcssa)
         )
@@ -32685,7 +32685,7 @@
     )
     (return
       (block
-        (i32.store align=4
+        (i32.store
           (i32.const 168)
           (get_local $$_0$1)
         )

--- a/test/llvm_autogenerated/byval.wast
+++ b/test/llvm_autogenerated/byval.wast
@@ -21,7 +21,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -38,14 +38,14 @@
       (i32.const 1)
     )
     (set_local $$5
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$5)
       )
     )
-    (i32.store offset=12 align=4
+    (i32.store offset=12
       (get_local $$5)
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -74,7 +74,7 @@
       (i32.const 1)
     )
     (set_local $$5
-      (i32.store align=4
+      (i32.store
         (get_local $$3)
         (get_local $$5)
       )
@@ -91,7 +91,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -108,7 +108,7 @@
       (i32.const 1)
     )
     (set_local $$5
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$5)
       )
@@ -144,7 +144,7 @@
       (i32.const 1)
     )
     (set_local $$5
-      (i32.store align=4
+      (i32.store
         (get_local $$3)
         (get_local $$5)
       )
@@ -160,7 +160,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -177,26 +177,26 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$4)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$4)
         (i32.const 8)
       )
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$0)
           (i32.const 8)
         )
       )
     )
-    (i64.store align=8
+    (i64.store
       (get_local $$4)
-      (i64.load align=8
+      (i64.load
         (get_local $$0)
       )
     )
@@ -216,7 +216,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$3)
         (get_local $$4)
       )
@@ -237,7 +237,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -254,7 +254,7 @@
       (i32.const 1)
     )
     (set_local $$9
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$9)
       )
@@ -273,7 +273,7 @@
         (get_local $$4)
         (i32.const 32)
       )
-      (i32.load8_u align=1
+      (i32.load8_u
         (i32.add
           (get_local $$0)
           (i32.const 32)
@@ -374,7 +374,7 @@
       (i32.const 1)
     )
     (set_local $$9
-      (i32.store align=4
+      (i32.store
         (get_local $$3)
         (get_local $$9)
       )

--- a/test/llvm_autogenerated/cfg-stackify.wast
+++ b/test/llvm_autogenerated/cfg-stackify.wast
@@ -90,10 +90,10 @@
             (i32.const -1)
           )
         )
-        (f64.store align=8
+        (f64.store
           (get_local $$0)
           (f64.mul
-            (f64.load align=8
+            (f64.load
               (get_local $$0)
             )
             (f64.const 3.2)
@@ -113,7 +113,7 @@
     (return)
   )
   (func $doublediamond (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$2)
       (i32.const 0)
     )
@@ -122,13 +122,13 @@
         (br_if $label$1
           (get_local $$0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 1)
         )
         (br $label$0)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 2)
       )
@@ -136,18 +136,18 @@
         (br_if $label$2
           (get_local $$1)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 3)
         )
         (br $label$0)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 4)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$2)
       (i32.const 5)
     )
@@ -158,7 +158,7 @@
   (func $triangle (param $$0 i32) (param $$1 i32) (result i32)
     (local $$2 i32)
     (set_local $$2
-      (i32.store align=4
+      (i32.store
         (get_local $$0)
         (i32.const 0)
       )
@@ -167,12 +167,12 @@
       (br_if $label$0
         (get_local $$1)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$0)
         (i32.const 1)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 2)
     )
@@ -181,7 +181,7 @@
     )
   )
   (func $diamond (param $$0 i32) (param $$1 i32) (result i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
@@ -190,18 +190,18 @@
         (br_if $label$1
           (get_local $$1)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$0)
           (i32.const 1)
         )
         (br $label$0)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$0)
         (i32.const 2)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 3)
     )
@@ -211,19 +211,19 @@
   )
   (func $single_block (param $$0 i32) (result i32)
     (return
-      (i32.store align=4
+      (i32.store
         (get_local $$0)
         (i32.const 0)
       )
     )
   )
   (func $minimal_loop (param $$0 i32) (result i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store align=4
+      (i32.store
         (get_local $$0)
         (i32.const 1)
       )
@@ -231,12 +231,12 @@
     )
   )
   (func $simple_loop (param $$0 i32) (param $$1 i32) (result i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store align=4
+      (i32.store
         (get_local $$0)
         (i32.const 1)
       )
@@ -247,7 +247,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 2)
     )
@@ -258,7 +258,7 @@
   (func $doubletriangle (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
     (local $$3 i32)
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 0)
       )
@@ -267,7 +267,7 @@
       (br_if $label$0
         (get_local $$0)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 2)
       )
@@ -275,17 +275,17 @@
         (br_if $label$1
           (get_local $$1)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 3)
         )
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 4)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$2)
       (i32.const 5)
     )
@@ -294,7 +294,7 @@
     )
   )
   (func $ifelse_earlyexits (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$2)
       (i32.const 0)
     )
@@ -303,25 +303,25 @@
         (br_if $label$1
           (get_local $$0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 1)
         )
         (br $label$0)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 2)
       )
       (br_if $label$0
         (get_local $$1)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 3)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$2)
       (i32.const 4)
     )
@@ -331,7 +331,7 @@
   )
   (func $doublediamond_in_a_loop (param $$0 i32) (param $$1 i32) (param $$2 i32) (result i32)
     (loop $label$1 $label$0
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 0)
       )
@@ -340,13 +340,13 @@
           (br_if $label$3
             (get_local $$0)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$2)
             (i32.const 1)
           )
           (br $label$2)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 2)
         )
@@ -354,18 +354,18 @@
           (br_if $label$4
             (get_local $$1)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$2)
             (i32.const 3)
           )
           (br $label$2)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 4)
         )
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 5)
       )
@@ -457,7 +457,7 @@
     (block $label$0
       (loop $label$2 $label$1
         (set_local $$1
-          (i32.store align=4
+          (i32.store
             (i32.const 0)
             (i32.const 0)
           )
@@ -468,7 +468,7 @@
             (i32.const 0)
           )
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$1)
           (i32.const 1)
         )
@@ -476,13 +476,13 @@
           (get_local $$2)
         )
       )
-      (i32.store align=4
+      (i32.store
         (i32.const 0)
         (i32.const 3)
       )
       (return)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 0)
       (i32.const 2)
     )
@@ -502,7 +502,7 @@
       (block $label$1
         (loop $label$3 $label$2
           (set_local $$0
-            (i32.store align=4
+            (i32.store
               (i32.const 0)
               (i32.const 0)
             )
@@ -519,7 +519,7 @@
                 (i32.and
                   (get_local $$1)
                   (set_local $$4
-                    (i32.store align=4
+                    (i32.store
                       (get_local $$0)
                       (i32.const 1)
                     )
@@ -529,7 +529,7 @@
               (i32.const 0)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$0)
             (get_local $$4)
           )
@@ -537,18 +537,18 @@
             (get_local $$3)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 0)
           (i32.const 2)
         )
         (return)
       )
-      (i32.store align=4
+      (i32.store
         (i32.const 0)
         (i32.const 3)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 0)
       (i32.const 4)
     )
@@ -558,7 +558,7 @@
     (local $$2 i32)
     (local $$3 i32)
     (set_local $$2
-      (i32.store align=4
+      (i32.store
         (i32.const 0)
         (i32.const 0)
       )
@@ -571,7 +571,7 @@
     )
     (loop $label$1 $label$0
       (set_local $$0
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 1)
         )
@@ -580,7 +580,7 @@
         (br_if $label$2
           (get_local $$3)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$2)
           (i32.const 2)
         )
@@ -590,13 +590,13 @@
             (get_local $$0)
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 0)
           (i32.const 4)
         )
         (unreachable)
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (i32.const 3)
       )
@@ -607,7 +607,7 @@
         )
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 0)
       (i32.const 5)
     )
@@ -641,7 +641,7 @@
     (local $$0 i32)
     (local $$1 i32)
     (set_local $$0
-      (i32.store align=4
+      (i32.store
         (i32.const 0)
         (i32.const 0)
       )
@@ -651,7 +651,7 @@
         (i32.eq
           (i32.and
             (set_local $$1
-              (i32.store align=4
+              (i32.store
                 (get_local $$0)
                 (i32.const 1)
               )
@@ -662,7 +662,7 @@
         )
       )
       (loop $label$3 $label$2
-        (i32.store align=4
+        (i32.store
           (get_local $$0)
           (i32.const 2)
         )
@@ -676,7 +676,7 @@
               (i32.const 0)
             )
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$0)
             (i32.const 3)
           )
@@ -688,7 +688,7 @@
           )
           (br $label$0)
         )
-        (i32.store align=4
+        (i32.store
           (get_local $$0)
           (i32.const 4)
         )
@@ -701,7 +701,7 @@
         (br $label$0)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 0)
       (i32.const 5)
     )
@@ -778,13 +778,13 @@
           (block $label$3
             (br_if $label$3
               (set_local $$0
-                (i32.store align=4
+                (i32.store
                   (i32.const 0)
                   (i32.const 0)
                 )
               )
             )
-            (i32.store align=4
+            (i32.store
               (get_local $$0)
               (i32.const 1)
             )
@@ -792,7 +792,7 @@
               (br_if $label$4
                 (get_local $$0)
               )
-              (i32.store align=4
+              (i32.store
                 (i32.const 0)
                 (i32.const 2)
               )
@@ -800,20 +800,20 @@
                 (i32.const 0)
               )
             )
-            (i32.store align=4
+            (i32.store
               (i32.const 0)
               (i32.const 3)
             )
             (return)
           )
-          (i32.store align=4
+          (i32.store
             (get_local $$0)
             (i32.const 4)
           )
           (br_if $label$0
             (get_local $$0)
           )
-          (i32.store align=4
+          (i32.store
             (i32.const 0)
             (i32.const 5)
           )
@@ -824,19 +824,19 @@
             )
           )
         )
-        (i32.store align=4
+        (i32.store
           (i32.const 0)
           (i32.const 7)
         )
         (return)
       )
-      (i32.store align=4
+      (i32.store
         (i32.const 0)
         (i32.const 6)
       )
       (return)
     )
-    (i32.store align=4
+    (i32.store
       (i32.const 0)
       (i32.const 8)
     )
@@ -851,7 +851,7 @@
             (br_if $label$4
               (i32.gt_s
                 (set_local $$1
-                  (i32.load8_u align=1
+                  (i32.load8_u
                     (get_local $$0)
                   )
                 )

--- a/test/llvm_autogenerated/dead-vreg.wast
+++ b/test/llvm_autogenerated/dead-vreg.wast
@@ -45,7 +45,7 @@
             (get_local $$4)
           )
           (loop $label$5 $label$4
-            (i32.store align=4
+            (i32.store
               (get_local $$7)
               (get_local $$6)
             )

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -19,7 +19,7 @@
   (export "call_memcpy" $call_memcpy)
   (func $foo (result i32)
     (return
-      (i32.load offset=28 align=4
+      (i32.load offset=28
         (i32.const 0)
       )
     )

--- a/test/llvm_autogenerated/i32-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i32-load-store-alignment.wast
@@ -36,14 +36,14 @@
   )
   (func $ldi32_a4 (param $$0 i32) (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
   )
   (func $ldi32 (param $$0 i32) (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -57,7 +57,7 @@
   )
   (func $ldi8_a1 (param $$0 i32) (result i32)
     (return
-      (i32.load8_u align=1
+      (i32.load8_u
         (get_local $$0)
       )
     )
@@ -78,7 +78,7 @@
   )
   (func $ldi16_a2 (param $$0 i32) (result i32)
     (return
-      (i32.load16_u align=2
+      (i32.load16_u
         (get_local $$0)
       )
     )
@@ -105,14 +105,14 @@
     (return)
   )
   (func $sti32_a4 (param $$0 i32) (param $$1 i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $sti32 (param $$0 i32) (param $$1 i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (get_local $$1)
     )
@@ -126,7 +126,7 @@
     (return)
   )
   (func $sti8_a1 (param $$0 i32) (param $$1 i32)
-    (i32.store8 align=1
+    (i32.store8
       (get_local $$0)
       (get_local $$1)
     )
@@ -147,7 +147,7 @@
     (return)
   )
   (func $sti16_a2 (param $$0 i32) (param $$1 i32)
-    (i32.store16 align=2
+    (i32.store16
       (get_local $$0)
       (get_local $$1)
     )

--- a/test/llvm_autogenerated/i64-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i64-load-store-alignment.wast
@@ -53,14 +53,14 @@
   )
   (func $ldi64_a8 (param $$0 i32) (result i64)
     (return
-      (i64.load align=8
+      (i64.load
         (get_local $$0)
       )
     )
   )
   (func $ldi64 (param $$0 i32) (result i64)
     (return
-      (i64.load align=8
+      (i64.load
         (get_local $$0)
       )
     )
@@ -74,7 +74,7 @@
   )
   (func $ldi8_a1 (param $$0 i32) (result i64)
     (return
-      (i64.load8_u align=1
+      (i64.load8_u
         (get_local $$0)
       )
     )
@@ -95,7 +95,7 @@
   )
   (func $ldi16_a2 (param $$0 i32) (result i64)
     (return
-      (i64.load16_u align=2
+      (i64.load16_u
         (get_local $$0)
       )
     )
@@ -123,7 +123,7 @@
   )
   (func $ldi32_a4 (param $$0 i32) (result i64)
     (return
-      (i64.load32_u align=4
+      (i64.load32_u
         (get_local $$0)
       )
     )
@@ -157,14 +157,14 @@
     (return)
   )
   (func $sti64_a8 (param $$0 i32) (param $$1 i64)
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $sti64 (param $$0 i32) (param $$1 i64)
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (get_local $$1)
     )
@@ -178,7 +178,7 @@
     (return)
   )
   (func $sti8_a1 (param $$0 i32) (param $$1 i64)
-    (i64.store8 align=1
+    (i64.store8
       (get_local $$0)
       (get_local $$1)
     )
@@ -199,7 +199,7 @@
     (return)
   )
   (func $sti16_a2 (param $$0 i32) (param $$1 i64)
-    (i64.store16 align=2
+    (i64.store16
       (get_local $$0)
       (get_local $$1)
     )
@@ -227,7 +227,7 @@
     (return)
   )
   (func $sti32_a4 (param $$0 i32) (param $$1 i64)
-    (i64.store32 align=4
+    (i64.store32
       (get_local $$0)
       (get_local $$1)
     )

--- a/test/llvm_autogenerated/legalize.wast
+++ b/test/llvm_autogenerated/legalize.wast
@@ -45,7 +45,7 @@
   (func $fpext_f32_f64 (param $$0 i32) (result f64)
     (return
       (f64.promote/f32
-        (f32.load align=4
+        (f32.load
           (get_local $$0)
         )
       )
@@ -54,7 +54,7 @@
   (func $fpconv_f64_f32 (param $$0 i32) (result f32)
     (return
       (f32.demote/f64
-        (f64.load align=8
+        (f64.load
           (get_local $$0)
         )
       )
@@ -345,7 +345,7 @@
       (i32.const 1)
     )
     (set_local $$183
-      (i32.load align=4
+      (i32.load
         (get_local $$183)
       )
     )
@@ -362,7 +362,7 @@
       (i32.const 1)
     )
     (set_local $$312
-      (i32.store align=4
+      (i32.store
         (get_local $$184)
         (get_local $$312)
       )
@@ -1418,7 +1418,7 @@
       )
     )
     (set_local $$174
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$249)
           (i32.const 8)
@@ -1435,7 +1435,7 @@
       )
     )
     (set_local $$177
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$250)
           (i32.const 8)
@@ -1443,17 +1443,17 @@
       )
     )
     (set_local $$173
-      (i64.load offset=480 align=8
+      (i64.load offset=480
         (get_local $$312)
       )
     )
     (set_local $$181
-      (i64.load offset=464 align=8
+      (i64.load offset=464
         (get_local $$312)
       )
     )
     (set_local $$169
-      (i64.load offset=496 align=8
+      (i64.load offset=496
         (get_local $$312)
       )
     )
@@ -1467,7 +1467,7 @@
       )
     )
     (set_local $$179
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$251)
           (i32.const 8)
@@ -1484,7 +1484,7 @@
       )
     )
     (set_local $$175
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$252)
           (i32.const 8)
@@ -1501,7 +1501,7 @@
       )
     )
     (set_local $$45
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$253)
           (i32.const 8)
@@ -1518,7 +1518,7 @@
       )
     )
     (set_local $$46
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$254)
           (i32.const 8)
@@ -1535,7 +1535,7 @@
       )
     )
     (set_local $$47
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$255)
           (i32.const 8)
@@ -1552,7 +1552,7 @@
       )
     )
     (set_local $$48
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$256)
           (i32.const 8)
@@ -1569,7 +1569,7 @@
       )
     )
     (set_local $$49
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$257)
           (i32.const 8)
@@ -1586,7 +1586,7 @@
       )
     )
     (set_local $$50
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$258)
           (i32.const 8)
@@ -1603,7 +1603,7 @@
       )
     )
     (set_local $$51
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$259)
           (i32.const 8)
@@ -1620,7 +1620,7 @@
       )
     )
     (set_local $$52
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$260)
           (i32.const 8)
@@ -1637,7 +1637,7 @@
       )
     )
     (set_local $$53
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$261)
           (i32.const 8)
@@ -1654,7 +1654,7 @@
       )
     )
     (set_local $$54
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$262)
           (i32.const 8)
@@ -1671,7 +1671,7 @@
       )
     )
     (set_local $$55
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$263)
           (i32.const 8)
@@ -1688,7 +1688,7 @@
       )
     )
     (set_local $$67
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$264)
           (i32.const 8)
@@ -1705,7 +1705,7 @@
       )
     )
     (set_local $$68
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$265)
           (i32.const 8)
@@ -1722,7 +1722,7 @@
       )
     )
     (set_local $$69
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$266)
           (i32.const 8)
@@ -1739,7 +1739,7 @@
       )
     )
     (set_local $$70
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$267)
           (i32.const 8)
@@ -1756,7 +1756,7 @@
       )
     )
     (set_local $$71
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$268)
           (i32.const 8)
@@ -1764,17 +1764,17 @@
       )
     )
     (set_local $$59
-      (i64.load offset=80 align=8
+      (i64.load offset=80
         (get_local $$312)
       )
     )
     (set_local $$60
-      (i64.load offset=96 align=8
+      (i64.load offset=96
         (get_local $$312)
       )
     )
     (set_local $$61
-      (i64.load offset=112 align=8
+      (i64.load offset=112
         (get_local $$312)
       )
     )
@@ -1788,7 +1788,7 @@
       )
     )
     (set_local $$72
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$269)
           (i32.const 8)
@@ -1805,7 +1805,7 @@
       )
     )
     (set_local $$73
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$270)
           (i32.const 8)
@@ -1822,7 +1822,7 @@
       )
     )
     (set_local $$74
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$271)
           (i32.const 8)
@@ -1839,7 +1839,7 @@
       )
     )
     (set_local $$75
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$272)
           (i32.const 8)
@@ -1856,7 +1856,7 @@
       )
     )
     (set_local $$76
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$273)
           (i32.const 8)
@@ -1873,7 +1873,7 @@
       )
     )
     (set_local $$77
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$274)
           (i32.const 8)
@@ -1890,7 +1890,7 @@
       )
     )
     (set_local $$87
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$275)
           (i32.const 8)
@@ -1907,7 +1907,7 @@
       )
     )
     (set_local $$88
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$276)
           (i32.const 8)
@@ -1924,7 +1924,7 @@
       )
     )
     (set_local $$89
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$277)
           (i32.const 8)
@@ -1932,7 +1932,7 @@
       )
     )
     (set_local $$90
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$312)
           (i32.const 8)
@@ -1949,7 +1949,7 @@
       )
     )
     (set_local $$91
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$278)
           (i32.const 8)
@@ -1957,7 +1957,7 @@
       )
     )
     (set_local $$84
-      (i64.load offset=64 align=8
+      (i64.load offset=64
         (get_local $$312)
       )
     )
@@ -1971,7 +1971,7 @@
       )
     )
     (set_local $$93
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$279)
           (i32.const 8)
@@ -1988,7 +1988,7 @@
       )
     )
     (set_local $$92
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$280)
           (i32.const 8)
@@ -2005,7 +2005,7 @@
       )
     )
     (set_local $$94
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$281)
           (i32.const 8)
@@ -2022,7 +2022,7 @@
       )
     )
     (set_local $$95
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$282)
           (i32.const 8)
@@ -2039,7 +2039,7 @@
       )
     )
     (set_local $$109
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$283)
           (i32.const 8)
@@ -2056,7 +2056,7 @@
       )
     )
     (set_local $$110
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$284)
           (i32.const 8)
@@ -2064,17 +2064,17 @@
       )
     )
     (set_local $$81
-      (i64.load align=8
+      (i64.load
         (get_local $$312)
       )
     )
     (set_local $$82
-      (i64.load offset=16 align=8
+      (i64.load offset=16
         (get_local $$312)
       )
     )
     (set_local $$83
-      (i64.load offset=32 align=8
+      (i64.load offset=32
         (get_local $$312)
       )
     )
@@ -2088,7 +2088,7 @@
       )
     )
     (set_local $$111
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$285)
           (i32.const 8)
@@ -2096,47 +2096,47 @@
       )
     )
     (set_local $$96
-      (i64.load offset=192 align=8
+      (i64.load offset=192
         (get_local $$312)
       )
     )
     (set_local $$97
-      (i64.load offset=208 align=8
+      (i64.load offset=208
         (get_local $$312)
       )
     )
     (set_local $$98
-      (i64.load offset=224 align=8
+      (i64.load offset=224
         (get_local $$312)
       )
     )
     (set_local $$44
-      (i64.load offset=240 align=8
+      (i64.load offset=240
         (get_local $$312)
       )
     )
     (set_local $$62
-      (i64.load offset=48 align=8
+      (i64.load offset=48
         (get_local $$312)
       )
     )
     (set_local $$63
-      (i64.load offset=176 align=8
+      (i64.load offset=176
         (get_local $$312)
       )
     )
     (set_local $$78
-      (i64.load offset=128 align=8
+      (i64.load offset=128
         (get_local $$312)
       )
     )
     (set_local $$79
-      (i64.load offset=144 align=8
+      (i64.load offset=144
         (get_local $$312)
       )
     )
     (set_local $$80
-      (i64.load offset=160 align=8
+      (i64.load offset=160
         (get_local $$312)
       )
     )
@@ -2150,7 +2150,7 @@
       )
     )
     (set_local $$112
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$286)
           (i32.const 8)
@@ -2167,7 +2167,7 @@
       )
     )
     (set_local $$113
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$287)
           (i32.const 8)
@@ -2184,7 +2184,7 @@
       )
     )
     (set_local $$114
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$288)
           (i32.const 8)
@@ -2201,7 +2201,7 @@
       )
     )
     (set_local $$115
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$289)
           (i32.const 8)
@@ -2218,7 +2218,7 @@
       )
     )
     (set_local $$116
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$290)
           (i32.const 8)
@@ -2235,7 +2235,7 @@
       )
     )
     (set_local $$117
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$291)
           (i32.const 8)
@@ -2252,7 +2252,7 @@
       )
     )
     (set_local $$118
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$292)
           (i32.const 8)
@@ -2260,12 +2260,12 @@
       )
     )
     (set_local $$104
-      (i64.load offset=384 align=8
+      (i64.load offset=384
         (get_local $$312)
       )
     )
     (set_local $$105
-      (i64.load offset=400 align=8
+      (i64.load offset=400
         (get_local $$312)
       )
     )
@@ -2279,7 +2279,7 @@
       )
     )
     (set_local $$119
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$293)
           (i32.const 8)
@@ -2287,12 +2287,12 @@
       )
     )
     (set_local $$106
-      (i64.load offset=416 align=8
+      (i64.load offset=416
         (get_local $$312)
       )
     )
     (set_local $$36
-      (i64.load offset=432 align=8
+      (i64.load offset=432
         (get_local $$312)
       )
     )
@@ -2306,7 +2306,7 @@
       )
     )
     (set_local $$120
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$294)
           (i32.const 8)
@@ -2314,17 +2314,17 @@
       )
     )
     (set_local $$33
-      (i64.load offset=352 align=8
+      (i64.load offset=352
         (get_local $$312)
       )
     )
     (set_local $$34
-      (i64.load offset=336 align=8
+      (i64.load offset=336
         (get_local $$312)
       )
     )
     (set_local $$35
-      (i64.load offset=368 align=8
+      (i64.load offset=368
         (get_local $$312)
       )
     )
@@ -2338,7 +2338,7 @@
       )
     )
     (set_local $$121
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$295)
           (i32.const 8)
@@ -2346,32 +2346,32 @@
       )
     )
     (set_local $$64
-      (i64.load offset=288 align=8
+      (i64.load offset=288
         (get_local $$312)
       )
     )
     (set_local $$65
-      (i64.load offset=272 align=8
+      (i64.load offset=272
         (get_local $$312)
       )
     )
     (set_local $$66
-      (i64.load offset=304 align=8
+      (i64.load offset=304
         (get_local $$312)
       )
     )
     (set_local $$86
-      (i64.load offset=256 align=8
+      (i64.load offset=256
         (get_local $$312)
       )
     )
     (set_local $$107
-      (i64.load offset=320 align=8
+      (i64.load offset=320
         (get_local $$312)
       )
     )
     (set_local $$108
-      (i64.load offset=448 align=8
+      (i64.load offset=448
         (get_local $$312)
       )
     )
@@ -2385,7 +2385,7 @@
       )
     )
     (set_local $$129
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$296)
           (i32.const 8)
@@ -2402,7 +2402,7 @@
       )
     )
     (set_local $$130
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$297)
           (i32.const 8)
@@ -2410,17 +2410,17 @@
       )
     )
     (set_local $$37
-      (i64.load offset=864 align=8
+      (i64.load offset=864
         (get_local $$312)
       )
     )
     (set_local $$38
-      (i64.load offset=848 align=8
+      (i64.load offset=848
         (get_local $$312)
       )
     )
     (set_local $$39
-      (i64.load offset=880 align=8
+      (i64.load offset=880
         (get_local $$312)
       )
     )
@@ -2434,7 +2434,7 @@
       )
     )
     (set_local $$131
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$298)
           (i32.const 8)
@@ -2442,17 +2442,17 @@
       )
     )
     (set_local $$122
-      (i64.load offset=736 align=8
+      (i64.load offset=736
         (get_local $$312)
       )
     )
     (set_local $$123
-      (i64.load offset=720 align=8
+      (i64.load offset=720
         (get_local $$312)
       )
     )
     (set_local $$124
-      (i64.load offset=752 align=8
+      (i64.load offset=752
         (get_local $$312)
       )
     )
@@ -2466,7 +2466,7 @@
       )
     )
     (set_local $$132
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$299)
           (i32.const 8)
@@ -2483,7 +2483,7 @@
       )
     )
     (set_local $$133
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$300)
           (i32.const 8)
@@ -2500,7 +2500,7 @@
       )
     )
     (set_local $$134
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$301)
           (i32.const 8)
@@ -2517,7 +2517,7 @@
       )
     )
     (set_local $$135
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$302)
           (i32.const 8)
@@ -2534,7 +2534,7 @@
       )
     )
     (set_local $$141
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$303)
           (i32.const 8)
@@ -2551,7 +2551,7 @@
       )
     )
     (set_local $$142
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$304)
           (i32.const 8)
@@ -2559,17 +2559,17 @@
       )
     )
     (set_local $$99
-      (i64.load offset=768 align=8
+      (i64.load offset=768
         (get_local $$312)
       )
     )
     (set_local $$100
-      (i64.load offset=784 align=8
+      (i64.load offset=784
         (get_local $$312)
       )
     )
     (set_local $$101
-      (i64.load offset=800 align=8
+      (i64.load offset=800
         (get_local $$312)
       )
     )
@@ -2583,7 +2583,7 @@
       )
     )
     (set_local $$143
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$305)
           (i32.const 8)
@@ -2591,27 +2591,27 @@
       )
     )
     (set_local $$136
-      (i64.load offset=640 align=8
+      (i64.load offset=640
         (get_local $$312)
       )
     )
     (set_local $$137
-      (i64.load offset=656 align=8
+      (i64.load offset=656
         (get_local $$312)
       )
     )
     (set_local $$138
-      (i64.load offset=672 align=8
+      (i64.load offset=672
         (get_local $$312)
       )
     )
     (set_local $$43
-      (i64.load offset=816 align=8
+      (i64.load offset=816
         (get_local $$312)
       )
     )
     (set_local $$128
-      (i64.load offset=688 align=8
+      (i64.load offset=688
         (get_local $$312)
       )
     )
@@ -2625,7 +2625,7 @@
       )
     )
     (set_local $$144
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$306)
           (i32.const 8)
@@ -2633,12 +2633,12 @@
       )
     )
     (set_local $$103
-      (i64.load offset=832 align=8
+      (i64.load offset=832
         (get_local $$312)
       )
     )
     (set_local $$140
-      (i64.load offset=704 align=8
+      (i64.load offset=704
         (get_local $$312)
       )
     )
@@ -2652,7 +2652,7 @@
       )
     )
     (set_local $$145
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$307)
           (i32.const 8)
@@ -2669,7 +2669,7 @@
       )
     )
     (set_local $$149
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$308)
           (i32.const 8)
@@ -2686,7 +2686,7 @@
       )
     )
     (set_local $$150
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$309)
           (i32.const 8)
@@ -2703,7 +2703,7 @@
       )
     )
     (set_local $$151
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$310)
           (i32.const 8)
@@ -2711,82 +2711,82 @@
       )
     )
     (set_local $$40
-      (i64.load offset=1008 align=8
+      (i64.load offset=1008
         (get_local $$312)
       )
     )
     (set_local $$41
-      (i64.load offset=960 align=8
+      (i64.load offset=960
         (get_local $$312)
       )
     )
     (set_local $$42
-      (i64.load offset=976 align=8
+      (i64.load offset=976
         (get_local $$312)
       )
     )
     (set_local $$56
-      (i64.load offset=912 align=8
+      (i64.load offset=912
         (get_local $$312)
       )
     )
     (set_local $$57
-      (i64.load offset=928 align=8
+      (i64.load offset=928
         (get_local $$312)
       )
     )
     (set_local $$58
-      (i64.load offset=944 align=8
+      (i64.load offset=944
         (get_local $$312)
       )
     )
     (set_local $$85
-      (i64.load offset=896 align=8
+      (i64.load offset=896
         (get_local $$312)
       )
     )
     (set_local $$102
-      (i64.load offset=992 align=8
+      (i64.load offset=992
         (get_local $$312)
       )
     )
     (set_local $$125
-      (i64.load offset=592 align=8
+      (i64.load offset=592
         (get_local $$312)
       )
     )
     (set_local $$126
-      (i64.load offset=608 align=8
+      (i64.load offset=608
         (get_local $$312)
       )
     )
     (set_local $$127
-      (i64.load offset=624 align=8
+      (i64.load offset=624
         (get_local $$312)
       )
     )
     (set_local $$139
-      (i64.load offset=576 align=8
+      (i64.load offset=576
         (get_local $$312)
       )
     )
     (set_local $$146
-      (i64.load offset=528 align=8
+      (i64.load offset=528
         (get_local $$312)
       )
     )
     (set_local $$147
-      (i64.load offset=544 align=8
+      (i64.load offset=544
         (get_local $$312)
       )
     )
     (set_local $$148
-      (i64.load offset=560 align=8
+      (i64.load offset=560
         (get_local $$312)
       )
     )
     (set_local $$152
-      (i64.load offset=512 align=8
+      (i64.load offset=512
         (get_local $$312)
       )
     )
@@ -2799,7 +2799,7 @@
         (get_local $$311)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 8)
@@ -2807,7 +2807,7 @@
       (i64.select
         (i64.select
           (i64.select
-            (i64.load align=8
+            (i64.load
               (i32.add
                 (get_local $$311)
                 (i32.const 8)
@@ -2838,7 +2838,7 @@
         )
       )
     )
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (i64.select
         (i64.select
@@ -2854,7 +2854,7 @@
         (get_local $$166)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 24)
@@ -2885,7 +2885,7 @@
         (get_local $$166)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 16)
@@ -2911,7 +2911,7 @@
         (get_local $$166)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 56)
@@ -2974,7 +2974,7 @@
         (get_local $$166)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 48)
@@ -3022,7 +3022,7 @@
         (get_local $$166)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 40)
@@ -3068,7 +3068,7 @@
         (get_local $$166)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 32)
@@ -3109,7 +3109,7 @@
         (get_local $$166)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 120)
@@ -3249,7 +3249,7 @@
         (get_local $$165)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 112)
@@ -3349,7 +3349,7 @@
         (get_local $$165)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 104)
@@ -3452,7 +3452,7 @@
         (get_local $$165)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 96)
@@ -3545,7 +3545,7 @@
         (get_local $$165)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 72)
@@ -3621,7 +3621,7 @@
         (get_local $$165)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 64)
@@ -3692,7 +3692,7 @@
         (get_local $$165)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 88)
@@ -3775,7 +3775,7 @@
         (get_local $$165)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 80)
@@ -3866,7 +3866,7 @@
       (i32.const 1)
     )
     (set_local $$312
-      (i32.store align=4
+      (i32.store
         (get_local $$185)
         (get_local $$312)
       )

--- a/test/llvm_autogenerated/load-ext.wast
+++ b/test/llvm_autogenerated/load-ext.wast
@@ -12,70 +12,70 @@
   (export "zext_i32_i64" $zext_i32_i64)
   (func $sext_i8_i32 (param $$0 i32) (result i32)
     (return
-      (i32.load8_s align=1
+      (i32.load8_s
         (get_local $$0)
       )
     )
   )
   (func $zext_i8_i32 (param $$0 i32) (result i32)
     (return
-      (i32.load8_u align=1
+      (i32.load8_u
         (get_local $$0)
       )
     )
   )
   (func $sext_i16_i32 (param $$0 i32) (result i32)
     (return
-      (i32.load16_s align=2
+      (i32.load16_s
         (get_local $$0)
       )
     )
   )
   (func $zext_i16_i32 (param $$0 i32) (result i32)
     (return
-      (i32.load16_u align=2
+      (i32.load16_u
         (get_local $$0)
       )
     )
   )
   (func $sext_i8_i64 (param $$0 i32) (result i64)
     (return
-      (i64.load8_s align=1
+      (i64.load8_s
         (get_local $$0)
       )
     )
   )
   (func $zext_i8_i64 (param $$0 i32) (result i64)
     (return
-      (i64.load8_u align=1
+      (i64.load8_u
         (get_local $$0)
       )
     )
   )
   (func $sext_i16_i64 (param $$0 i32) (result i64)
     (return
-      (i64.load16_s align=2
+      (i64.load16_s
         (get_local $$0)
       )
     )
   )
   (func $zext_i16_i64 (param $$0 i32) (result i64)
     (return
-      (i64.load16_u align=2
+      (i64.load16_u
         (get_local $$0)
       )
     )
   )
   (func $sext_i32_i64 (param $$0 i32) (result i64)
     (return
-      (i64.load32_s align=4
+      (i64.load32_s
         (get_local $$0)
       )
     )
   )
   (func $zext_i32_i64 (param $$0 i32) (result i64)
     (return
-      (i64.load32_u align=4
+      (i64.load32_u
         (get_local $$0)
       )
     )

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -8,7 +8,7 @@
   (export "store_i64_i1" $store_i64_i1)
   (func $load_u_i1_i32 (param $$0 i32) (result i32)
     (return
-      (i32.load8_u align=1
+      (i32.load8_u
         (get_local $$0)
       )
     )
@@ -17,7 +17,7 @@
     (return
       (i32.shr_s
         (i32.shl
-          (i32.load8_u align=1
+          (i32.load8_u
             (get_local $$0)
           )
           (i32.const 31)
@@ -28,7 +28,7 @@
   )
   (func $load_u_i1_i64 (param $$0 i32) (result i64)
     (return
-      (i64.load8_u align=1
+      (i64.load8_u
         (get_local $$0)
       )
     )
@@ -37,7 +37,7 @@
     (return
       (i64.shr_s
         (i64.shl
-          (i64.load8_u align=1
+          (i64.load8_u
             (get_local $$0)
           )
           (i64.const 63)
@@ -47,7 +47,7 @@
     )
   )
   (func $store_i32_i1 (param $$0 i32) (param $$1 i32)
-    (i32.store8 align=1
+    (i32.store8
       (get_local $$0)
       (i32.and
         (get_local $$1)
@@ -57,7 +57,7 @@
     (return)
   )
   (func $store_i64_i1 (param $$0 i32) (param $$1 i64)
-    (i64.store8 align=1
+    (i64.store8
       (get_local $$0)
       (i64.and
         (get_local $$1)

--- a/test/llvm_autogenerated/load.wast
+++ b/test/llvm_autogenerated/load.wast
@@ -6,28 +6,28 @@
   (export "ldf64" $ldf64)
   (func $ldi32 (param $$0 i32) (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
   )
   (func $ldi64 (param $$0 i32) (result i64)
     (return
-      (i64.load align=8
+      (i64.load
         (get_local $$0)
       )
     )
   )
   (func $ldf32 (param $$0 i32) (result f32)
     (return
-      (f32.load align=4
+      (f32.load
         (get_local $$0)
       )
     )
   )
   (func $ldf64 (param $$0 i32) (result f64)
     (return
-      (f64.load align=8
+      (f64.load
         (get_local $$0)
       )
     )

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -75,7 +75,7 @@
       (i32.const 1)
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -92,7 +92,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$1)
         (get_local $$4)
       )
@@ -129,7 +129,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$4)
       )

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -37,21 +37,21 @@
   (export "aggregate_return_without_merge" $aggregate_return_without_merge)
   (func $load_i32_with_folded_offset (param $$0 i32) (result i32)
     (return
-      (i32.load offset=24 align=4
+      (i32.load offset=24
         (get_local $$0)
       )
     )
   )
   (func $load_i32_with_folded_gep_offset (param $$0 i32) (result i32)
     (return
-      (i32.load offset=24 align=4
+      (i32.load offset=24
         (get_local $$0)
       )
     )
   )
   (func $load_i32_with_unfolded_gep_negative_offset (param $$0 i32) (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.add
           (get_local $$0)
           (i32.const -24)
@@ -61,7 +61,7 @@
   )
   (func $load_i32_with_unfolded_offset (param $$0 i32) (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.add
           (get_local $$0)
           (i32.const 24)
@@ -71,7 +71,7 @@
   )
   (func $load_i32_with_unfolded_gep_offset (param $$0 i32) (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (i32.add
           (get_local $$0)
           (i32.const 24)
@@ -81,21 +81,21 @@
   )
   (func $load_i64_with_folded_offset (param $$0 i32) (result i64)
     (return
-      (i64.load offset=24 align=8
+      (i64.load offset=24
         (get_local $$0)
       )
     )
   )
   (func $load_i64_with_folded_gep_offset (param $$0 i32) (result i64)
     (return
-      (i64.load offset=24 align=8
+      (i64.load offset=24
         (get_local $$0)
       )
     )
   )
   (func $load_i64_with_unfolded_gep_negative_offset (param $$0 i32) (result i64)
     (return
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$0)
           (i32.const -24)
@@ -105,7 +105,7 @@
   )
   (func $load_i64_with_unfolded_offset (param $$0 i32) (result i64)
     (return
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$0)
           (i32.const 24)
@@ -115,7 +115,7 @@
   )
   (func $load_i64_with_unfolded_gep_offset (param $$0 i32) (result i64)
     (return
-      (i64.load align=8
+      (i64.load
         (i32.add
           (get_local $$0)
           (i32.const 24)
@@ -124,21 +124,21 @@
     )
   )
   (func $store_i32_with_folded_offset (param $$0 i32)
-    (i32.store offset=24 align=4
+    (i32.store offset=24
       (get_local $$0)
       (i32.const 0)
     )
     (return)
   )
   (func $store_i32_with_folded_gep_offset (param $$0 i32)
-    (i32.store offset=24 align=4
+    (i32.store offset=24
       (get_local $$0)
       (i32.const 0)
     )
     (return)
   )
   (func $store_i32_with_unfolded_gep_negative_offset (param $$0 i32)
-    (i32.store align=4
+    (i32.store
       (i32.add
         (get_local $$0)
         (i32.const -24)
@@ -148,7 +148,7 @@
     (return)
   )
   (func $store_i32_with_unfolded_offset (param $$0 i32)
-    (i32.store align=4
+    (i32.store
       (i32.add
         (get_local $$0)
         (i32.const 24)
@@ -158,7 +158,7 @@
     (return)
   )
   (func $store_i32_with_unfolded_gep_offset (param $$0 i32)
-    (i32.store align=4
+    (i32.store
       (i32.add
         (get_local $$0)
         (i32.const 24)
@@ -168,21 +168,21 @@
     (return)
   )
   (func $store_i64_with_folded_offset (param $$0 i32)
-    (i64.store offset=24 align=8
+    (i64.store offset=24
       (get_local $$0)
       (i64.const 0)
     )
     (return)
   )
   (func $store_i64_with_folded_gep_offset (param $$0 i32)
-    (i64.store offset=24 align=8
+    (i64.store offset=24
       (get_local $$0)
       (i64.const 0)
     )
     (return)
   )
   (func $store_i64_with_unfolded_gep_negative_offset (param $$0 i32)
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const -24)
@@ -192,7 +192,7 @@
     (return)
   )
   (func $store_i64_with_unfolded_offset (param $$0 i32)
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 24)
@@ -202,7 +202,7 @@
     (return)
   )
   (func $store_i64_with_unfolded_gep_offset (param $$0 i32)
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 24)
@@ -213,27 +213,27 @@
   )
   (func $load_i32_from_numeric_address (result i32)
     (return
-      (i32.load offset=42 align=4
+      (i32.load offset=42
         (i32.const 0)
       )
     )
   )
   (func $load_i32_from_global_address (result i32)
     (return
-      (i32.load offset=8 align=4
+      (i32.load offset=8
         (i32.const 0)
       )
     )
   )
   (func $store_i32_to_numeric_address
-    (i32.store offset=42 align=4
+    (i32.store offset=42
       (i32.const 0)
       (i32.const 0)
     )
     (return)
   )
   (func $store_i32_to_global_address
-    (i32.store offset=8 align=4
+    (i32.store offset=8
       (i32.const 0)
       (i32.const 0)
     )
@@ -241,41 +241,41 @@
   )
   (func $load_i8_s_with_folded_offset (param $$0 i32) (result i32)
     (return
-      (i32.load8_s offset=24 align=1
+      (i32.load8_s offset=24
         (get_local $$0)
       )
     )
   )
   (func $load_i8_s_with_folded_gep_offset (param $$0 i32) (result i32)
     (return
-      (i32.load8_s offset=24 align=1
+      (i32.load8_s offset=24
         (get_local $$0)
       )
     )
   )
   (func $load_i8_u_with_folded_offset (param $$0 i32) (result i32)
     (return
-      (i32.load8_u offset=24 align=1
+      (i32.load8_u offset=24
         (get_local $$0)
       )
     )
   )
   (func $load_i8_u_with_folded_gep_offset (param $$0 i32) (result i32)
     (return
-      (i32.load8_u offset=24 align=1
+      (i32.load8_u offset=24
         (get_local $$0)
       )
     )
   )
   (func $store_i8_with_folded_offset (param $$0 i32)
-    (i32.store8 offset=24 align=1
+    (i32.store8 offset=24
       (get_local $$0)
       (i32.const 0)
     )
     (return)
   )
   (func $store_i8_with_folded_gep_offset (param $$0 i32)
-    (i32.store8 offset=24 align=1
+    (i32.store8 offset=24
       (get_local $$0)
       (i32.const 0)
     )
@@ -286,35 +286,35 @@
     (local $$3 i32)
     (local $$4 i32)
     (set_local $$2
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
     (set_local $$3
-      (i32.load offset=4 align=4
+      (i32.load offset=4
         (get_local $$0)
       )
     )
     (set_local $$4
-      (i32.load offset=8 align=4
+      (i32.load offset=8
         (get_local $$0)
       )
     )
-    (i32.store offset=12 align=4
+    (i32.store offset=12
       (get_local $$1)
-      (i32.load offset=12 align=4
+      (i32.load offset=12
         (get_local $$0)
       )
     )
-    (i32.store offset=8 align=4
+    (i32.store offset=8
       (get_local $$1)
       (get_local $$4)
     )
-    (i32.store offset=4 align=4
+    (i32.store offset=4
       (get_local $$1)
       (get_local $$3)
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$1)
       (get_local $$2)
     )
@@ -331,17 +331,17 @@
     (return)
   )
   (func $aggregate_return_without_merge (param $$0 i32)
-    (i32.store offset=8 align=4
+    (i32.store offset=8
       (get_local $$0)
-      (i32.store16 offset=12 align=2
+      (i32.store16 offset=12
         (get_local $$0)
-        (i32.store8 offset=14 align=1
+        (i32.store8 offset=14
           (get_local $$0)
           (i32.const 0)
         )
       )
     )
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (i64.const 0)
     )

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -27,11 +27,11 @@
   (export "no_stackify_past_use" $no_stackify_past_use)
   (func $no0 (param $$0 i32) (param $$1 i32) (result i32)
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
@@ -41,11 +41,11 @@
   )
   (func $no1 (param $$0 i32) (param $$1 i32) (result i32)
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
@@ -54,19 +54,19 @@
     )
   )
   (func $yes0 (param $$0 i32) (param $$1 i32) (result i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
     (return
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
   )
   (func $yes1 (param $$0 i32) (result i32)
     (return
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -114,7 +114,7 @@
       (br_if $label$0
         (i32.ge_u
           (set_local $$3
-            (i32.load align=4
+            (i32.load
               (get_local $$2)
             )
           )
@@ -127,7 +127,7 @@
           (get_local $$0)
         )
       )
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$3)
       )
@@ -137,13 +137,13 @@
   (func $stackify_store_across_side_effects (param $$0 i32)
     (local $$1 i64)
     (set_local $$1
-      (i64.store align=8
+      (i64.store
         (get_local $$0)
         (i64.const 4611686018427387904)
       )
     )
     (call_import $evoke_side_effects)
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (get_local $$1)
     )

--- a/test/llvm_autogenerated/store-results.wast
+++ b/test/llvm_autogenerated/store-results.wast
@@ -6,7 +6,7 @@
   (export "fi_ret" $fi_ret)
   (func $single_block (param $$0 i32) (result i32)
     (return
-      (i32.store align=4
+      (i32.store
         (get_local $$0)
         (i32.const 0)
       )
@@ -18,7 +18,7 @@
       (i32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store offset=8 align=4
+      (i32.store offset=8
         (i32.const 0)
         (i32.const 0)
       )
@@ -43,7 +43,7 @@
       (f32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store offset=8 align=4
+      (i32.store offset=8
         (i32.const 0)
         (i32.const 0)
       )
@@ -71,7 +71,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -88,12 +88,12 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$4)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (get_local $$4)
     )
@@ -110,7 +110,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$3)
         (get_local $$4)
       )

--- a/test/llvm_autogenerated/store-trunc.wast
+++ b/test/llvm_autogenerated/store-trunc.wast
@@ -6,35 +6,35 @@
   (export "trunc_i16_i64" $trunc_i16_i64)
   (export "trunc_i32_i64" $trunc_i32_i64)
   (func $trunc_i8_i32 (param $$0 i32) (param $$1 i32)
-    (i32.store8 align=1
+    (i32.store8
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $trunc_i16_i32 (param $$0 i32) (param $$1 i32)
-    (i32.store16 align=2
+    (i32.store16
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $trunc_i8_i64 (param $$0 i32) (param $$1 i64)
-    (i64.store8 align=1
+    (i64.store8
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $trunc_i16_i64 (param $$0 i32) (param $$1 i64)
-    (i64.store16 align=2
+    (i64.store16
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $trunc_i32_i64 (param $$0 i32) (param $$1 i64)
-    (i64.store32 align=4
+    (i64.store32
       (get_local $$0)
       (get_local $$1)
     )

--- a/test/llvm_autogenerated/store.wast
+++ b/test/llvm_autogenerated/store.wast
@@ -5,28 +5,28 @@
   (export "stf32" $stf32)
   (export "stf64" $stf64)
   (func $sti32 (param $$0 i32) (param $$1 i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $sti64 (param $$0 i32) (param $$1 i64)
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $stf32 (param $$0 i32) (param $$1 f32)
-    (f32.store align=4
+    (f32.store
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
   (func $stf64 (param $$0 i32) (param $$1 f64)
-    (f64.store align=8
+    (f64.store
       (get_local $$0)
       (get_local $$1)
     )

--- a/test/llvm_autogenerated/userstack.wast
+++ b/test/llvm_autogenerated/userstack.wast
@@ -18,7 +18,7 @@
       (i32.const 1)
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -35,12 +35,12 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$1)
         (get_local $$3)
       )
     )
-    (i32.store offset=12 align=4
+    (i32.store offset=12
       (get_local $$3)
       (i32.const 0)
     )
@@ -57,7 +57,7 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$3)
       )
@@ -73,7 +73,7 @@
       (i32.const 1)
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -90,16 +90,16 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$1)
         (get_local $$3)
       )
     )
-    (i32.store offset=12 align=4
+    (i32.store offset=12
       (get_local $$3)
       (i32.const 0)
     )
-    (i64.store align=8
+    (i64.store
       (get_local $$3)
       (i64.const 0)
     )
@@ -116,7 +116,7 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$3)
       )
@@ -133,7 +133,7 @@
       (i32.const 1)
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -150,7 +150,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$1)
         (get_local $$4)
       )
@@ -164,12 +164,12 @@
         (get_local $$3)
       )
     )
-    (i32.store align=4
+    (i32.store
       (i32.add
         (get_local $$3)
         (i32.const 12)
       )
-      (i32.store offset=12 align=4
+      (i32.store offset=12
         (get_local $$4)
         (i32.const 1)
       )
@@ -187,7 +187,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$4)
       )
@@ -205,7 +205,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -222,7 +222,7 @@
       (i32.const 1)
     )
     (set_local $$6
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$6)
       )
@@ -251,7 +251,7 @@
         (get_local $$5)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (get_local $$5)
     )
@@ -268,7 +268,7 @@
       (i32.const 1)
     )
     (set_local $$6
-      (i32.store align=4
+      (i32.store
         (get_local $$3)
         (get_local $$6)
       )
@@ -284,7 +284,7 @@
       (i32.const 1)
     )
     (set_local $$0
-      (i32.load align=4
+      (i32.load
         (get_local $$0)
       )
     )
@@ -301,14 +301,14 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$1)
         (get_local $$3)
       )
     )
-    (i32.store offset=24 align=4
+    (i32.store offset=24
       (get_local $$3)
-      (i32.store offset=12 align=4
+      (i32.store offset=12
         (get_local $$3)
         (i32.const 1)
       )
@@ -326,7 +326,7 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$3)
       )
@@ -342,7 +342,7 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -367,7 +367,7 @@
     (set_local $$3
       (get_local $$0)
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
@@ -375,7 +375,7 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$4)
       )
@@ -392,7 +392,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -412,7 +412,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$4)
       )
@@ -435,7 +435,7 @@
     (set_local $$4
       (get_local $$0)
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.const 0)
     )
@@ -452,7 +452,7 @@
       (i32.const 1)
     )
     (set_local $$4
-      (i32.store align=4
+      (i32.store
         (get_local $$3)
         (get_local $$4)
       )

--- a/test/llvm_autogenerated/varargs.wast
+++ b/test/llvm_autogenerated/varargs.wast
@@ -13,9 +13,9 @@
     (return)
   )
   (func $copy (param $$0 i32) (param $$1 i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -23,11 +23,11 @@
   )
   (func $arg_i8 (param $$0 i32) (result i32)
     (local $$1 i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.add
         (set_local $$1
-          (i32.load align=4
+          (i32.load
             (get_local $$0)
           )
         )
@@ -35,20 +35,20 @@
       )
     )
     (return
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
   )
   (func $arg_i32 (param $$0 i32) (result i32)
     (local $$1 i32)
-    (i32.store align=4
+    (i32.store
       (get_local $$0)
       (i32.add
         (set_local $$1
           (i32.and
             (i32.add
-              (i32.load align=4
+              (i32.load
                 (get_local $$0)
               )
               (i32.const 3)
@@ -60,7 +60,7 @@
       )
     )
     (return
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -70,13 +70,13 @@
     (local $$3 i64)
     (local $$4 i32)
     (set_local $$2
-      (i32.store align=4
+      (i32.store
         (get_local $$1)
         (i32.add
           (set_local $$4
             (i32.and
               (i32.add
-                (i32.load align=4
+                (i32.load
                   (get_local $$1)
                 )
                 (i32.const 7)
@@ -89,27 +89,27 @@
       )
     )
     (set_local $$3
-      (i64.load align=8
+      (i64.load
         (get_local $$4)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$1)
       (i32.add
         (get_local $$4)
         (i32.const 16)
       )
     )
-    (i64.store align=8
+    (i64.store
       (i32.add
         (get_local $$0)
         (i32.const 8)
       )
-      (i64.load align=8
+      (i64.load
         (get_local $$2)
       )
     )
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (get_local $$3)
     )
@@ -133,7 +133,7 @@
       (i32.const 1)
     )
     (set_local $$5
-      (i32.load align=4
+      (i32.load
         (get_local $$5)
       )
     )
@@ -150,7 +150,7 @@
       (i32.const 1)
     )
     (set_local $$8
-      (i32.store align=4
+      (i32.store
         (get_local $$6)
         (get_local $$8)
       )
@@ -159,7 +159,7 @@
       (i32.const 1)
     )
     (set_local $$1
-      (i32.load align=4
+      (i32.load
         (get_local $$1)
       )
     )
@@ -176,12 +176,12 @@
       (i32.const 1)
     )
     (set_local $$8
-      (i32.store align=4
+      (i32.store
         (get_local $$2)
         (get_local $$8)
       )
     )
-    (i32.store align=4
+    (i32.store
       (get_local $$8)
       (i32.const 0)
     )
@@ -191,7 +191,7 @@
         (i32.const 8)
       )
     )
-    (i64.store align=8
+    (i64.store
       (get_local $$0)
       (i64.const 4611686018427387904)
     )
@@ -200,7 +200,7 @@
       (i32.const 1)
     )
     (set_local $$3
-      (i32.load align=4
+      (i32.load
         (get_local $$3)
       )
     )
@@ -217,7 +217,7 @@
       (i32.const 1)
     )
     (set_local $$8
-      (i32.store align=4
+      (i32.store
         (get_local $$4)
         (get_local $$8)
       )
@@ -235,7 +235,7 @@
       (i32.const 1)
     )
     (set_local $$8
-      (i32.store align=4
+      (i32.store
         (get_local $$7)
         (get_local $$8)
       )

--- a/test/min.fromasm
+++ b/test/min.fromasm
@@ -15,11 +15,11 @@
     (set_local $n
       (f32.neg
         (block
-          (i32.store align=4
+          (i32.store
             (get_local $k)
             (get_local $p)
           )
-          (f32.load align=4
+          (f32.load
             (get_local $k)
           )
         )

--- a/test/min.wast
+++ b/test/min.wast
@@ -13,11 +13,11 @@
     (set_local $n
       (f32.neg
         (block $block0
-          (i32.store align=4
+          (i32.store
             (get_local $k)
             (get_local $p)
           )
-          (f32.load align=4
+          (f32.load
             (get_local $k)
           )
         )

--- a/test/min.wast.fromBinary
+++ b/test/min.wast.fromBinary
@@ -17,11 +17,11 @@
     (set_local $var$2
       (f32.neg
         (block $label$0
-          (i32.store align=4
+          (i32.store
             (get_local $var$0)
             (get_local $var$1)
           )
-          (f32.load align=4
+          (f32.load
             (get_local $var$0)
           )
         )

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -32,21 +32,21 @@
       (f64.add
         (f64.add
           (f64.add
-            (f64.load align=8
+            (f64.load
               (i32.const 8)
             )
-            (f64.load align=8
+            (f64.load
               (i32.const 16)
             )
           )
           (f64.neg
-            (f64.load align=8
+            (f64.load
               (i32.const 16)
             )
           )
         )
         (f64.neg
-          (f64.load align=8
+          (f64.load
             (i32.const 8)
           )
         )
@@ -54,7 +54,7 @@
     )
     (if
       (i32.gt_s
-        (i32.load align=4
+        (i32.load
           (i32.const 24)
         )
         (i32.const 0)
@@ -65,7 +65,7 @@
     )
     (if
       (f64.gt
-        (f64.load align=8
+        (f64.load
           (i32.const 32)
         )
         (f64.const 0)

--- a/test/unit.wast
+++ b/test/unit.wast
@@ -38,21 +38,21 @@
         (f64.add
           (f64.add
             (f64.add
-              (f64.load align=8
+              (f64.load
                 (i32.const 8)
               )
-              (f64.load align=8
+              (f64.load
                 (i32.const 16)
               )
             )
             (f64.neg
-              (f64.load align=8
+              (f64.load
                 (i32.const 16)
               )
             )
           )
           (f64.neg
-            (f64.load align=8
+            (f64.load
               (i32.const 8)
             )
           )
@@ -60,7 +60,7 @@
       )
       (if
         (i32.gt_s
-          (i32.load align=4
+          (i32.load
             (i32.const 24)
           )
           (i32.const 0)
@@ -71,7 +71,7 @@
       )
       (if
         (f64.gt
-          (f64.load align=8
+          (f64.load
             (i32.const 32)
           )
           (f64.const 0)

--- a/test/unit.wast.fromBinary
+++ b/test/unit.wast.fromBinary
@@ -41,21 +41,21 @@
         (f64.add
           (f64.add
             (f64.add
-              (f64.load align=8
+              (f64.load
                 (i32.const 8)
               )
-              (f64.load align=8
+              (f64.load
                 (i32.const 16)
               )
             )
             (f64.neg
-              (f64.load align=8
+              (f64.load
                 (i32.const 16)
               )
             )
           )
           (f64.neg
-            (f64.load align=8
+            (f64.load
               (i32.const 8)
             )
           )
@@ -63,7 +63,7 @@
       )
       (if
         (i32.gt_s
-          (i32.load align=4
+          (i32.load
             (i32.const 24)
           )
           (i32.const 0)
@@ -74,7 +74,7 @@
       )
       (if
         (f64.gt
-          (f64.load align=8
+          (f64.load
             (i32.const 32)
           )
           (f64.const 0)


### PR DESCRIPTION
It's redundant.