### PR TITLE
added link to the tutorial on building under Win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,7 @@ Almost. Some decisions made in WebAssembly preclude that, for example, there are
 "Binaryen" is a combination of **binary** - since WebAssembly is a binary format for the web - and **Emscripten** - with which it can integrate in order to compile C and C++ all the way to WebAssembly, via asm.js. Binaryen began as Emscripten's WebAssembly processing library (`wasm-emscripten`).
 
 "Binaryen" is pronounced [in the same manner](http://www.makinggameofthrones.com/production-diary/2011/2/11/official-pronunciation-guide-for-game-of-thrones.html) as "[Targaryen](https://en.wikipedia.org/wiki/List_of_A_Song_of_Ice_and_Fire_characters#House_Targaryen)": *bi-NAIR-ee-in*. Or something like that? Anyhow, however Targaryen is correctly pronounced, they should rhyme. Aside from pronunciation, the Targaryen house words, "Fire and Blood", have also inspired Binaryen's: "Code and Bugs."
+
+* Does it compile under Windows and/or Visual Studio?
+
+Yes, it does. Here's a step-by-step <a href="https://github.com/brakmic/brakmic/blob/master/webassembly/COMPILING_WIN32.md">tutorial</a> on how to compile it under **Windows 10 x64** with **CMake** and **Visual Studio 2015**


### PR DESCRIPTION
This is a link to a tutorial on how to compile Binaryen under Windows 10 x64 with CMake & Visual Studio 2015.