### PR TITLE
Update EqZ operators and support specifying memory size on the command line

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -259,7 +259,7 @@ struct PrintSExpression : public WasmVisitor<PrintSExpression, void> {
   }
   void visitUnary(Unary *curr) {
     o << '(';
-    prepareColor(o) << printWasmType(curr->type) << '.';
+    prepareColor(o) << printWasmType(curr->isRelational() ? curr->value->type : curr->type) << '.';
     switch (curr->op) {
       case Clz:              o << "clz";     break;
       case Ctz:              o << "ctz";     break;

--- a/src/s2wasm-main.cpp
+++ b/src/s2wasm-main.cpp
@@ -58,6 +58,16 @@ int main(int argc, const char *argv[]) {
            [](Options *o, const std::string &argument) {
              o->extra["stack-allocation"] = argument;
            })
+      .add("--initial-memory", "-i", "Initial size of the linear memory",
+           Options::Arguments::One,
+           [](Options *o, const std::string &argument) {
+             o->extra["initial-memory"] = argument;
+           })
+      .add("--max-memory", "-m", "Maximum size of the linear memory",
+           Options::Arguments::One,
+           [](Options *o, const std::string &argument) {
+             o->extra["max-memory"] = argument;
+           })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
                         o->extra["infile"] = argument;
@@ -75,9 +85,18 @@ int main(int argc, const char *argv[]) {
       options.extra.find("stack-allocation") != options.extra.end()
           ? std::stoull(options.extra["stack-allocation"])
           : 0;
+  size_t initialMem =
+      options.extra.find("initial-memory") != options.extra.end()
+          ? std::stoull(options.extra["initial-memory"])
+          : 0;
+  size_t maxMem =
+      options.extra.find("max-memory") != options.extra.end()
+          ? std::stoull(options.extra["max-memory"])
+          : 0;
   if (options.debug) std::cerr << "Global base " << globalBase << '\n';
   S2WasmBuilder s2wasm(wasm, input.c_str(), options.debug, globalBase,
-                       stackAllocation, ignoreUnknownSymbols, startFunction);
+                       stackAllocation, initialMem, maxMem, ignoreUnknownSymbols,
+                       startFunction);
 
   if (options.debug) std::cerr << "Emscripten gluing..." << std::endl;
   std::stringstream meta;

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -812,7 +812,8 @@ class S2WasmBuilder {
           break;
         }
         case 'e': {
-          if (match("eq")) makeBinary(BinaryOp::Eq, i32);
+          if (match("eqz")) makeUnary(UnaryOp::EqZ, i32);
+          else if (match("eq")) makeBinary(BinaryOp::Eq, i32);
           else if (match("extend_s/i32")) makeUnary(UnaryOp::ExtendSInt32, type);
           else if (match("extend_u/i32")) makeUnary(UnaryOp::ExtendUInt32, type);
           else abort_on("type.e");

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -489,7 +489,7 @@ public:
         case 'e': {
           if (op[1] == 'q') {
             if (op[2] == 0) return makeBinary(s, BinaryOp::Eq, type);
-            if (op[2] == 'z') return makeUnary(s, UnaryOp::EqZ, type);
+            if (op[2] == 'z') return makeUnary(s, UnaryOp::EqZ, i32);
           }
           if (op[1] == 'x') return makeUnary(s, op[7] == 'u' ? UnaryOp::ExtendUInt32 : UnaryOp::ExtendSInt32, type);
           abort_on(op);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -681,8 +681,10 @@ public:
 // Operators
 
 enum UnaryOp {
-  Clz, Ctz, Popcnt, EqZ, // int
+  Clz, Ctz, Popcnt, // int
   Neg, Abs, Ceil, Floor, Trunc, Nearest, Sqrt, // float
+  // relational
+  EqZ,
   // conversions
   ExtendSInt32, ExtendUInt32, WrapInt64, TruncSFloat32, TruncUFloat32, TruncSFloat64, TruncUFloat64, ReinterpretFloat, // int
   ConvertSInt32, ConvertUInt32, ConvertSInt64, ConvertUInt64, PromoteFloat32, DemoteFloat64, ReinterpretInt // float
@@ -972,6 +974,11 @@ public:
 
   UnaryOp op;
   Expression *value;
+
+  // the type is always the type of the operands,
+  // except for relationals
+
+  bool isRelational() { return op == EqZ; }
 };
 
 class Binary : public Expression {


### PR DESCRIPTION
Make type of EqZ unary operators always i32. This makes them symmetric to binary relational operators. Also support eqz in the s2wasm parser.
Also allow specifying --initial-memory and/or --max-memory flags on the command line to control the linear memory size. If they are not given, fall back to the calculated size.