### PR TITLE
std::isdigit was missing

### DIFF
--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -23,6 +23,7 @@
 #define wasm_wasm_s_parser_h
 
 #include <cmath>
+#include <cctype>
 
 #include "wasm.h"
 #include "mixed_arena.h"


### PR DESCRIPTION
Compiling of **binaryen-shell** was failing under Win10 / Visual Studio 2015. The reason was the missing **std::isdigit** definition.

According to [CppReference](http://en.cppreference.com/w/cpp/string/byte/isdigit
) this function is located in **cctype** header file. 

I added ```#include <cctype>``` in **wasm-s-parser.h** to get them and the compilation succeeded.

I'm not sure if and how it could affect the other platforms so I'd like to ask for some help regarding this issue/PR.