### PR TITLE
Fix grow_memory translation on s2wasm

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -639,13 +639,13 @@ class S2WasmBuilder {
     auto makeHost = [&](HostOp op) {
       Name assign = getAssign();
       auto curr = allocator.alloc<Host>();
-      curr->op = MemorySize;
+      curr->op = op;
       setOutput(curr, assign);
     };
     auto makeHost1 = [&](HostOp op) {
       Name assign = getAssign();
       auto curr = allocator.alloc<Host>();
-      curr->op = MemorySize;
+      curr->op = op;
       curr->operands.push_back(getInput());
       setOutput(curr, assign);
     };

--- a/test/llvm_autogenerated/memory-addr32.wast
+++ b/test/llvm_autogenerated/memory-addr32.wast
@@ -8,7 +8,9 @@
     )
   )
   (func $grow_memory (param $$0 i32)
-    (memory_size)
+    (grow_memory
+      (get_local $$0)
+    )
     (return)
   )
 )

--- a/test/llvm_autogenerated/memory-addr64.wast
+++ b/test/llvm_autogenerated/memory-addr64.wast
@@ -8,7 +8,9 @@
     )
   )
   (func $grow_memory (param $$0 i64)
-    (memory_size)
+    (grow_memory
+      (get_local $$0)
+    )
     (return)
   )
 )


### PR DESCRIPTION
s2wasm used to mistranslate grow_memory operation in .s into memory_size
in .wast, and this CL fixes it.