### PR TITLE
Repair broken file-size check

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -29,7 +29,7 @@ T wasm::read_file(const std::string &filename, bool debug) {
   }
   infile.seekg(0, std::ios::end);
   std::streampos insize = infile.tellg();
-  if (size_t(insize) >= std::numeric_limits<size_t>::max()) {
+  if (uint64_t(insize) >= std::numeric_limits<size_t>::max()) {
     // Building a 32-bit executable where size_t == 32 bits, we are not able to create strings larger than 2^32 bytes in length, so must abort here.
     std::cerr << "Failed opening '" << filename << "': Input file too large: " << insize << " bytes. Try rebuilding in 64-bit mode." << std::endl;
     exit(EXIT_FAILURE);


### PR DESCRIPTION
I build binaryen in 32 bit and it allowed a file with size > 4 GB. The
problem was, that you cast to size_t and then check if it fits into
size_t.