### PR TITLE
reduce build time 20%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,33 +67,16 @@ IF (UNIX AND
   ADD_COMPILE_FLAG("-fcolor-diagnostics")
 ENDIF()
 
+# Static libraries
+ADD_SUBDIRECTORY(src/support)
+ADD_SUBDIRECTORY(src/emscripten-optimizer)
+
 # Sources.
-
-SET(support_SOURCES
-  src/support/bits.cpp
-  src/support/colors.cpp
-  src/support/command-line.cpp
-  src/support/file.cpp
-  src/support/safe_integer.cpp
-)
-ADD_LIBRARY(support STATIC ${support_SOURCES})
-
-SET(optimizer_SOURCES
-  src/emscripten-optimizer/parser.cpp
-  src/emscripten-optimizer/simple_ast.cpp
-  src/emscripten-optimizer/optimizer-shared.cpp
-)
-ADD_LIBRARY(optimizer STATIC ${optimizer_SOURCES})
-
-
-SET(pass_SOURCES
-   src/pass.cpp
-   src/passes/Print.cpp
- )
-ADD_LIBRARY(pass STATIC ${pass_SOURCES})
 
 SET(binaryen-shell_SOURCES
   src/binaryen-shell.cpp
+  src/pass.cpp
+  src/passes/Print.cpp
   src/passes/LowerIfElse.cpp
   src/passes/MergeBlocks.cpp
   src/passes/NameManager.cpp
@@ -109,13 +92,15 @@ SET(binaryen-shell_SOURCES
 )
 ADD_EXECUTABLE(binaryen-shell
                ${binaryen-shell_SOURCES})
-TARGET_LINK_LIBRARIES(binaryen-shell pass support)
+TARGET_LINK_LIBRARIES(binaryen-shell support)
 SET_PROPERTY(TARGET binaryen-shell PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET binaryen-shell PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS binaryen-shell DESTINATION bin)
 
 SET(asm2wasm_SOURCES
   src/asm2wasm-main.cpp
+  src/pass.cpp
+  src/passes/Print.cpp
   src/passes/MergeBlocks.cpp
   src/passes/OptimizeInstructions.cpp
   src/passes/PostEmscripten.cpp
@@ -127,7 +112,7 @@ SET(asm2wasm_SOURCES
 )
 ADD_EXECUTABLE(asm2wasm
                ${asm2wasm_SOURCES})
-TARGET_LINK_LIBRARIES(asm2wasm optimizer pass support)
+TARGET_LINK_LIBRARIES(asm2wasm optimizer support)
 SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS asm2wasm DESTINATION bin)
@@ -144,10 +129,12 @@ INSTALL(TARGETS wasm2asm DESTINATION bin)
 
 SET(s2wasm_SOURCES
   src/s2wasm-main.cpp
+  src/pass.cpp
+  src/passes/Print.cpp
 )
 ADD_EXECUTABLE(s2wasm
                ${s2wasm_SOURCES})
-TARGET_LINK_LIBRARIES(s2wasm pass support)
+TARGET_LINK_LIBRARIES(s2wasm support)
 SET_PROPERTY(TARGET s2wasm PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET s2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS s2wasm DESTINATION bin)
@@ -164,10 +151,12 @@ INSTALL(TARGETS wasm-as DESTINATION bin)
 
 SET(wasm_dis_SOURCES
   src/wasm-dis.cpp
+  src/pass.cpp
+  src/passes/Print.cpp
 )
 ADD_EXECUTABLE(wasm-dis
                ${wasm_dis_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-dis pass support)
+TARGET_LINK_LIBRARIES(wasm-dis support)
 SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS wasm-dis DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,15 +78,27 @@ SET(support_SOURCES
 )
 ADD_LIBRARY(support STATIC ${support_SOURCES})
 
+SET(optimizer_SOURCES
+  src/emscripten-optimizer/parser.cpp
+  src/emscripten-optimizer/simple_ast.cpp
+  src/emscripten-optimizer/optimizer-shared.cpp
+)
+ADD_LIBRARY(optimizer STATIC ${optimizer_SOURCES})
+
+
+SET(pass_SOURCES
+   src/pass.cpp
+   src/passes/Print.cpp
+ )
+ADD_LIBRARY(pass STATIC ${pass_SOURCES})
+
 SET(binaryen-shell_SOURCES
   src/binaryen-shell.cpp
-  src/pass.cpp
   src/passes/LowerIfElse.cpp
   src/passes/MergeBlocks.cpp
   src/passes/NameManager.cpp
   src/passes/OptimizeInstructions.cpp
   src/passes/PostEmscripten.cpp
-  src/passes/Print.cpp
   src/passes/RemoveImports.cpp
   src/passes/RemoveUnusedBrs.cpp
   src/passes/RemoveUnusedNames.cpp
@@ -97,55 +109,45 @@ SET(binaryen-shell_SOURCES
 )
 ADD_EXECUTABLE(binaryen-shell
                ${binaryen-shell_SOURCES})
-TARGET_LINK_LIBRARIES(binaryen-shell support)
+TARGET_LINK_LIBRARIES(binaryen-shell pass support)
 SET_PROPERTY(TARGET binaryen-shell PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET binaryen-shell PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS binaryen-shell DESTINATION bin)
 
 SET(asm2wasm_SOURCES
   src/asm2wasm-main.cpp
-  src/pass.cpp
   src/passes/MergeBlocks.cpp
   src/passes/OptimizeInstructions.cpp
   src/passes/PostEmscripten.cpp
-  src/passes/Print.cpp
   src/passes/RemoveUnusedBrs.cpp
   src/passes/RemoveUnusedNames.cpp
   src/passes/SimplifyLocals.cpp
   src/passes/ReorderLocals.cpp
   src/passes/Vacuum.cpp
-  src/emscripten-optimizer/parser.cpp
-  src/emscripten-optimizer/simple_ast.cpp
-  src/emscripten-optimizer/optimizer-shared.cpp
 )
 ADD_EXECUTABLE(asm2wasm
                ${asm2wasm_SOURCES})
-TARGET_LINK_LIBRARIES(asm2wasm support)
+TARGET_LINK_LIBRARIES(asm2wasm optimizer pass support)
 SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS asm2wasm DESTINATION bin)
 
 SET(wasm2asm_SOURCES
   src/wasm2asm-main.cpp
-  src/emscripten-optimizer/parser.cpp
-  src/emscripten-optimizer/simple_ast.cpp
-  src/emscripten-optimizer/optimizer-shared.cpp
 )
 ADD_EXECUTABLE(wasm2asm
                ${wasm2asm_SOURCES})
-TARGET_LINK_LIBRARIES(wasm2asm support)
+TARGET_LINK_LIBRARIES(wasm2asm optimizer support)
 SET_PROPERTY(TARGET wasm2asm PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET wasm2asm PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS wasm2asm DESTINATION bin)
 
 SET(s2wasm_SOURCES
-  src/pass.cpp
-  src/passes/Print.cpp
   src/s2wasm-main.cpp
 )
 ADD_EXECUTABLE(s2wasm
                ${s2wasm_SOURCES})
-TARGET_LINK_LIBRARIES(s2wasm support)
+TARGET_LINK_LIBRARIES(s2wasm pass support)
 SET_PROPERTY(TARGET s2wasm PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET s2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS s2wasm DESTINATION bin)
@@ -161,13 +163,11 @@ SET_PROPERTY(TARGET wasm-as PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS wasm-as DESTINATION bin)
 
 SET(wasm_dis_SOURCES
-  src/pass.cpp
-  src/passes/Print.cpp
   src/wasm-dis.cpp
 )
 ADD_EXECUTABLE(wasm-dis
                ${wasm_dis_SOURCES})
-TARGET_LINK_LIBRARIES(wasm-dis support)
+TARGET_LINK_LIBRARIES(wasm-dis pass support)
 SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET wasm-dis PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS wasm-dis DESTINATION bin)

--- a/src/emscripten-optimizer/CMakeLists.txt
+++ b/src/emscripten-optimizer/CMakeLists.txt
@@ -1,0 +1,6 @@
+SET(optimizer_SOURCES
+  parser.cpp
+  simple_ast.cpp
+  optimizer-shared.cpp
+)
+ADD_LIBRARY(optimizer STATIC ${optimizer_SOURCES})

--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <pass.h>
+#include "pass.h"
 
 namespace wasm {
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -20,7 +20,7 @@
 
 #include <wasm.h>
 #include <wasm-printing.h>
-#include <pass.h>
+#include "pass.h"
 
 namespace wasm {
 

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -1,0 +1,8 @@
+SET(support_SOURCES
+  bits.cpp
+  colors.cpp
+  command-line.cpp
+  file.cpp
+  safe_integer.cpp
+)
+ADD_LIBRARY(support STATIC ${support_SOURCES})


### PR DESCRIPTION
I squashed commits and do force push, but github doesn't reopen the ticket I recreated pull request.

-------


CMake tries to build same source file multiple times for each target. Sharing source files(.cpp) increases build time instead of sharing static libraries.

Building time becomes 50s to 40s on my computer :)

Before
=========

```
[shibukawa.yoshiki]$ time make                                                                                                                                                                                                    [master]
-- No build type selected, default to Release
-- Building with -std=c++11
-- Building with -msse2
-- Building with -mfpmath=sse
-- Building with -Wall
-- Building with -Werror
-- Building with -Wextra
-- Building with -Wno-unused-parameter
-- Building with -fno-omit-frame-pointer
-- Building with -O2
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/shibukawa.yoshiki/Library/Caches/qtpm/binaryen
[  2%] Building CXX object CMakeFiles/support.dir/src/support/bits.cpp.o
[  4%] Building CXX object CMakeFiles/support.dir/src/support/colors.cpp.o
[  6%] Building CXX object CMakeFiles/support.dir/src/support/command-line.cpp.o
[  8%] Building CXX object CMakeFiles/support.dir/src/support/file.cpp.o
[ 10%] Building CXX object CMakeFiles/support.dir/src/support/safe_integer.cpp.o
[ 12%] Linking CXX static library lib/libsupport.a
[ 12%] Built target support
[ 14%] Building CXX object CMakeFiles/asm2wasm.dir/src/asm2wasm-main.cpp.o
[ 16%] Building CXX object CMakeFiles/asm2wasm.dir/src/pass.cpp.o
[ 18%] Building CXX object CMakeFiles/asm2wasm.dir/src/passes/MergeBlocks.cpp.o
[ 20%] Building CXX object CMakeFiles/asm2wasm.dir/src/passes/PostEmscripten.cpp.o
[ 22%] Building CXX object CMakeFiles/asm2wasm.dir/src/passes/Print.cpp.o
[ 25%] Building CXX object CMakeFiles/asm2wasm.dir/src/passes/RemoveUnusedBrs.cpp.o
[ 27%] Building CXX object CMakeFiles/asm2wasm.dir/src/passes/RemoveUnusedNames.cpp.o
[ 29%] Building CXX object CMakeFiles/asm2wasm.dir/src/passes/SimplifyLocals.cpp.o
[ 31%] Building CXX object CMakeFiles/asm2wasm.dir/src/passes/ReorderLocals.cpp.o
[ 33%] Building CXX object CMakeFiles/asm2wasm.dir/src/emscripten-optimizer/parser.cpp.o
[ 35%] Building CXX object CMakeFiles/asm2wasm.dir/src/emscripten-optimizer/simple_ast.cpp.o
[ 37%] Building CXX object CMakeFiles/asm2wasm.dir/src/emscripten-optimizer/optimizer-shared.cpp.o
[ 39%] Linking CXX executable bin/asm2wasm
[ 39%] Built target asm2wasm
[ 41%] Building CXX object CMakeFiles/binaryen-shell.dir/src/binaryen-shell.cpp.o
[ 43%] Building CXX object CMakeFiles/binaryen-shell.dir/src/pass.cpp.o
[ 45%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/LowerIfElse.cpp.o
[ 47%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/MergeBlocks.cpp.o
[ 50%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/NameManager.cpp.o
[ 52%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/PostEmscripten.cpp.o
[ 54%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/Print.cpp.o
[ 56%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/RemoveImports.cpp.o
[ 58%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/RemoveUnusedBrs.cpp.o
[ 60%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/RemoveUnusedNames.cpp.o
[ 62%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/SimplifyLocals.cpp.o
[ 64%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/ReorderLocals.cpp.o
[ 66%] Building CXX object CMakeFiles/binaryen-shell.dir/src/passes/Metrics.cpp.o
[ 68%] Linking CXX executable bin/binaryen-shell
[ 68%] Built target binaryen-shell
[ 70%] Building CXX object CMakeFiles/s2wasm.dir/src/pass.cpp.o
[ 72%] Building CXX object CMakeFiles/s2wasm.dir/src/passes/Print.cpp.o
[ 75%] Building CXX object CMakeFiles/s2wasm.dir/src/s2wasm-main.cpp.o
[ 77%] Linking CXX executable bin/s2wasm
[ 77%] Built target s2wasm
[ 79%] Building CXX object CMakeFiles/wasm-as.dir/src/wasm-as.cpp.o
[ 81%] Linking CXX executable bin/wasm-as
[ 81%] Built target wasm-as
[ 83%] Building CXX object CMakeFiles/wasm-dis.dir/src/pass.cpp.o
[ 85%] Building CXX object CMakeFiles/wasm-dis.dir/src/passes/Print.cpp.o
[ 87%] Building CXX object CMakeFiles/wasm-dis.dir/src/wasm-dis.cpp.o
[ 89%] Linking CXX executable bin/wasm-dis
[ 89%] Built target wasm-dis
[ 91%] Building CXX object CMakeFiles/wasm2asm.dir/src/wasm2asm-main.cpp.o
[ 93%] Building CXX object CMakeFiles/wasm2asm.dir/src/emscripten-optimizer/parser.cpp.o
[ 95%] Building CXX object CMakeFiles/wasm2asm.dir/src/emscripten-optimizer/simple_ast.cpp.o
[ 97%] Building CXX object CMakeFiles/wasm2asm.dir/src/emscripten-optimizer/optimizer-shared.cpp.o
[100%] Linking CXX executable bin/wasm2asm
[100%] Built target wasm2asm
make  47.60s user 2.67s system 99% cpu 50.739 total
```

After
=========

```
[shibukawa.yoshiki]$ time make                                                                                                                                                                                                    [master]
Scanning dependencies of target optimizer
[  2%] Building CXX object CMakeFiles/optimizer.dir/src/emscripten-optimizer/parser.cpp.o
[  5%] Building CXX object CMakeFiles/optimizer.dir/src/emscripten-optimizer/simple_ast.cpp.o
[  8%] Building CXX object CMakeFiles/optimizer.dir/src/emscripten-optimizer/optimizer-shared.cpp.o
[ 11%] Linking CXX static library lib/liboptimizer.a
[ 11%] Built target optimizer
[ 14%] Building CXX object CMakeFiles/support.dir/src/support/bits.cpp.o
[ 17%] Building CXX object CMakeFiles/support.dir/src/support/colors.cpp.o
[ 20%] Building CXX object CMakeFiles/support.dir/src/support/command-line.cpp.o
[ 22%] Building CXX object CMakeFiles/support.dir/src/support/file.cpp.o
[ 25%] Building CXX object CMakeFiles/support.dir/src/support/safe_integer.cpp.o
[ 28%] Linking CXX static library lib/libsupport.a
[ 28%] Built target support
Scanning dependencies of target pass
[ 31%] Building CXX object CMakeFiles/pass.dir/src/pass.cpp.o
[ 34%] Building CXX object CMakeFiles/pass.dir/src/passes/LowerIfElse.cpp.o
[ 37%] Building CXX object CMakeFiles/pass.dir/src/passes/MergeBlocks.cpp.o
[ 40%] Building CXX object CMakeFiles/pass.dir/src/passes/NameManager.cpp.o
[ 42%] Building CXX object CMakeFiles/pass.dir/src/passes/PostEmscripten.cpp.o
[ 45%] Building CXX object CMakeFiles/pass.dir/src/passes/Print.cpp.o
[ 48%] Building CXX object CMakeFiles/pass.dir/src/passes/RemoveImports.cpp.o
[ 51%] Building CXX object CMakeFiles/pass.dir/src/passes/RemoveUnusedBrs.cpp.o
[ 54%] Building CXX object CMakeFiles/pass.dir/src/passes/RemoveUnusedNames.cpp.o
[ 57%] Building CXX object CMakeFiles/pass.dir/src/passes/SimplifyLocals.cpp.o
[ 60%] Building CXX object CMakeFiles/pass.dir/src/passes/ReorderLocals.cpp.o
[ 62%] Building CXX object CMakeFiles/pass.dir/src/passes/Metrics.cpp.o
[ 65%] Linking CXX static library lib/libpass.a
[ 65%] Built target pass
Scanning dependencies of target asm2wasm
[ 68%] Building CXX object CMakeFiles/asm2wasm.dir/src/asm2wasm-main.cpp.o
[ 71%] Linking CXX executable bin/asm2wasm
[ 71%] Built target asm2wasm
Scanning dependencies of target binaryen-shell
[ 74%] Building CXX object CMakeFiles/binaryen-shell.dir/src/binaryen-shell.cpp.o
[ 77%] Linking CXX executable bin/binaryen-shell
[ 77%] Built target binaryen-shell
Scanning dependencies of target s2wasm
[ 80%] Building CXX object CMakeFiles/s2wasm.dir/src/s2wasm-main.cpp.o
[ 82%] Linking CXX executable bin/s2wasm
[ 82%] Built target s2wasm
[ 85%] Building CXX object CMakeFiles/wasm-as.dir/src/wasm-as.cpp.o
[ 88%] Linking CXX executable bin/wasm-as
[ 88%] Built target wasm-as
Scanning dependencies of target wasm-dis
[ 91%] Building CXX object CMakeFiles/wasm-dis.dir/src/wasm-dis.cpp.o
[ 94%] Linking CXX executable bin/wasm-dis
[ 94%] Built target wasm-dis
Scanning dependencies of target wasm2asm
[ 97%] Building CXX object CMakeFiles/wasm2asm.dir/src/wasm2asm-main.cpp.o
[100%] Linking CXX executable bin/wasm2asm
[100%] Built target wasm2asm
make  35.94s user 2.08s system 98% cpu 38.415 total
```