### PR TITLE
Handle static initializers

### DIFF
--- a/test/dot_s/alias.wast
+++ b/test/dot_s/alias.wast
@@ -12,4 +12,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/dot_s/alternate-lcomm.wast
+++ b/test/dot_s/alternate-lcomm.wast
@@ -2,4 +2,4 @@
   (memory 1)
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8 }
+;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }

--- a/test/dot_s/asm_const.wast
+++ b/test/dot_s/asm_const.wast
@@ -15,4 +15,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world!\"); }", ["vi"]]},"staticBump": 50 }
+;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world!\"); }", ["vi"]]},"staticBump": 50, "initializers": [] }

--- a/test/dot_s/basics.wast
+++ b/test/dot_s/basics.wast
@@ -92,4 +92,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 51 }
+;; METADATA: { "asmConsts": {},"staticBump": 51, "initializers": [] }

--- a/test/dot_s/bcp-1.wast
+++ b/test/dot_s/bcp-1.wast
@@ -306,4 +306,4 @@
     (unreachable)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 103 }
+;; METADATA: { "asmConsts": {},"staticBump": 103, "initializers": [] }

--- a/test/dot_s/data-offset-folding.wast
+++ b/test/dot_s/data-offset-folding.wast
@@ -5,4 +5,4 @@
   )
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 419 }
+;; METADATA: { "asmConsts": {},"staticBump": 419, "initializers": [] }

--- a/test/dot_s/exit.wast
+++ b/test/dot_s/exit.wast
@@ -11,4 +11,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/dot_s/function-data-sections.wast
+++ b/test/dot_s/function-data-sections.wast
@@ -25,4 +25,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19 }
+;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }

--- a/test/dot_s/initializers.s
+++ b/test/dot_s/initializers.s
@@ -1,0 +1,23 @@
+	.text
+	.file	"/tmp/tmpAEEklZ/a.out.bc"
+	.globl	main
+	.type	main,@function
+main:                                   # @main
+	.result 	i32
+# BB#0:
+	i32.const	$push0=, 5
+	return  	$pop0
+.Lfunc_end0:
+	.size	main, .Lfunc_end0-main
+	.globl  f2
+	.type	f2,@function
+f2:
+	return
+.Lfunc_end1:
+	.size f2, .Lfunc_end1-f2
+	.section	.init_array.101,"aw",@init_array
+	.p2align	2
+	.int32	main@FUNCTION
+	.section	.init_array,"aw",@init_array
+	.p2align	2
+	.int32	f2@FUNCTION

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -2,10 +2,14 @@
   (memory 0)
   (export "memory" memory)
   (export "main" $main)
+  (export "f2" $f2)
   (func $main (result i32)
     (return
       (i32.const 5)
     )
   )
+  (func $f2
+    (return)
+  )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": ["main", "f2", ] }

--- a/test/dot_s/lcomm-in-text-segment.wast
+++ b/test/dot_s/lcomm-in-text-segment.wast
@@ -4,4 +4,4 @@
   )
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19 }
+;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }

--- a/test/dot_s/macClangMetaData.wast
+++ b/test/dot_s/macClangMetaData.wast
@@ -15,4 +15,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 29 }
+;; METADATA: { "asmConsts": {},"staticBump": 29, "initializers": [] }

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -205,4 +205,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }", ["vi"]]},"staticBump": 66 }
+;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }", ["vi"]]},"staticBump": 66, "initializers": [] }

--- a/test/dot_s/permute.wast
+++ b/test/dot_s/permute.wast
@@ -4,4 +4,4 @@
   )
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 271 }
+;; METADATA: { "asmConsts": {},"staticBump": 271, "initializers": [] }

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -14,4 +14,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 15 }
+;; METADATA: { "asmConsts": {},"staticBump": 15, "initializers": [] }

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -10,4 +10,4 @@
     (call $main)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -18,4 +18,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -12,4 +12,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19 }
+;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }

--- a/test/dot_s/visibilities.wast
+++ b/test/dot_s/visibilities.wast
@@ -14,4 +14,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/byval.wast
+++ b/test/llvm_autogenerated/byval.wast
@@ -389,4 +389,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/call.wast
+++ b/test/llvm_autogenerated/call.wast
@@ -92,4 +92,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/cfg-stackify.wast
+++ b/test/llvm_autogenerated/cfg-stackify.wast
@@ -946,4 +946,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/comparisons_f32.wast
+++ b/test/llvm_autogenerated/comparisons_f32.wast
@@ -212,4 +212,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/comparisons_f64.wast
+++ b/test/llvm_autogenerated/comparisons_f64.wast
@@ -212,4 +212,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/comparisons_i32.wast
+++ b/test/llvm_autogenerated/comparisons_i32.wast
@@ -92,4 +92,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/comparisons_i64.wast
+++ b/test/llvm_autogenerated/comparisons_i64.wast
@@ -92,4 +92,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/conv.wast
+++ b/test/llvm_autogenerated/conv.wast
@@ -213,4 +213,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/copysign-casts.wast
+++ b/test/llvm_autogenerated/copysign-casts.wast
@@ -24,4 +24,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/cpus.wast
+++ b/test/llvm_autogenerated/cpus.wast
@@ -8,4 +8,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/dead-vreg.wast
+++ b/test/llvm_autogenerated/dead-vreg.wast
@@ -96,4 +96,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/f32.wast
+++ b/test/llvm_autogenerated/f32.wast
@@ -141,4 +141,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/f64.wast
+++ b/test/llvm_autogenerated/f64.wast
@@ -141,4 +141,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/fast-isel.wast
+++ b/test/llvm_autogenerated/fast-isel.wast
@@ -14,4 +14,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/frem.wast
+++ b/test/llvm_autogenerated/frem.wast
@@ -24,4 +24,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/func.wast
+++ b/test/llvm_autogenerated/func.wast
@@ -46,4 +46,4 @@
     (unreachable)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -35,4 +35,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 1195 }
+;; METADATA: { "asmConsts": {},"staticBump": 1195, "initializers": [] }

--- a/test/llvm_autogenerated/globl.wast
+++ b/test/llvm_autogenerated/globl.wast
@@ -6,4 +6,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/i32-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i32-load-store-alignment.wast
@@ -162,4 +162,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/i32.wast
+++ b/test/llvm_autogenerated/i32.wast
@@ -159,4 +159,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/i64-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i64-load-store-alignment.wast
@@ -242,4 +242,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/i64.wast
+++ b/test/llvm_autogenerated/i64.wast
@@ -159,4 +159,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/ident.wast
+++ b/test/llvm_autogenerated/ident.wast
@@ -2,4 +2,4 @@
   (memory 0)
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/immediates.wast
+++ b/test/llvm_autogenerated/immediates.wast
@@ -146,4 +146,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/legalize.wast
+++ b/test/llvm_autogenerated/legalize.wast
@@ -3875,4 +3875,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/load-ext.wast
+++ b/test/llvm_autogenerated/load-ext.wast
@@ -82,4 +82,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -68,4 +68,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/load.wast
+++ b/test/llvm_autogenerated/load.wast
@@ -34,4 +34,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -165,4 +165,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/memory-addr32.wast
+++ b/test/llvm_autogenerated/memory-addr32.wast
@@ -15,4 +15,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/memory-addr64.wast
+++ b/test/llvm_autogenerated/memory-addr64.wast
@@ -15,4 +15,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/non-executable-stack.wast
+++ b/test/llvm_autogenerated/non-executable-stack.wast
@@ -2,4 +2,4 @@
   (memory 0)
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/offset-folding.wast
+++ b/test/llvm_autogenerated/offset-folding.wast
@@ -26,4 +26,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 215 }
+;; METADATA: { "asmConsts": {},"staticBump": 215, "initializers": [] }

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -349,4 +349,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 11 }
+;; METADATA: { "asmConsts": {},"staticBump": 11, "initializers": [] }

--- a/test/llvm_autogenerated/phi.wast
+++ b/test/llvm_autogenerated/phi.wast
@@ -64,4 +64,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -261,4 +261,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/return-int32.wast
+++ b/test/llvm_autogenerated/return-int32.wast
@@ -8,4 +8,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/return-void.wast
+++ b/test/llvm_autogenerated/return-void.wast
@@ -6,4 +6,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/select.wast
+++ b/test/llvm_autogenerated/select.wast
@@ -122,4 +122,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/signext-zeroext.wast
+++ b/test/llvm_autogenerated/signext-zeroext.wast
@@ -54,4 +54,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/store-results.wast
+++ b/test/llvm_autogenerated/store-results.wast
@@ -121,4 +121,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19 }
+;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }

--- a/test/llvm_autogenerated/store-trunc.wast
+++ b/test/llvm_autogenerated/store-trunc.wast
@@ -42,4 +42,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/store.wast
+++ b/test/llvm_autogenerated/store.wast
@@ -34,4 +34,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/switch.wast
+++ b/test/llvm_autogenerated/switch.wast
@@ -87,4 +87,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/unreachable.wast
+++ b/test/llvm_autogenerated/unreachable.wast
@@ -19,4 +19,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/unused-argument.wast
+++ b/test/llvm_autogenerated/unused-argument.wast
@@ -21,4 +21,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/userstack.wast
+++ b/test/llvm_autogenerated/userstack.wast
@@ -461,4 +461,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/varargs.wast
+++ b/test/llvm_autogenerated/varargs.wast
@@ -244,4 +244,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 4 }
+;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }


### PR DESCRIPTION
LLVM emits static initializers in the ELF style, by placing pointers to
the constructor functions in a .init_array section. Handle this in
s2wasm for now by converting these to standard emscripten metadata.