### PR TITLE
Properly align the stack pointer

### DIFF
--- a/src/s2wasm-main.cpp
+++ b/src/s2wasm-main.cpp
@@ -80,7 +80,7 @@ int main(int argc, const char *argv[]) {
   AllocatingModule wasm;
   uint64_t globalBase = options.extra.find("global-base") != options.extra.end()
                           ? std::stoull(options.extra["global-base"])
-                          : 1;
+                          : 0;
   uint64_t stackAllocation =
       options.extra.find("stack-allocation") != options.extra.end()
           ? std::stoull(options.extra["stack-allocation"])

--- a/test/dot_s/alias.wast
+++ b/test/dot_s/alias.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "__exit" $__exit)
   (export "__needs_exit" $__needs_exit)

--- a/test/dot_s/asm_const.wast
+++ b/test/dot_s/asm_const.wast
@@ -15,4 +15,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world!\"); }", ["vi"]]},"staticBump": 50, "initializers": [] }
+;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world!\"); }", ["vi"]]},"staticBump": 51, "initializers": [] }

--- a/test/dot_s/basics.wast
+++ b/test/dot_s/basics.wast
@@ -92,4 +92,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 51, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 52, "initializers": [] }

--- a/test/dot_s/bcp-1.wast
+++ b/test/dot_s/bcp-1.wast
@@ -306,4 +306,4 @@
     (unreachable)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 103, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 104, "initializers": [] }

--- a/test/dot_s/data-offset-folding.wast
+++ b/test/dot_s/data-offset-folding.wast
@@ -1,8 +1,8 @@
 (module
   (memory 1
-    (segment 8 "\00\00\00\00")
+    (segment 4 "\00\00\00\00")
     (segment 416 "`\00\00\00")
   )
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 419, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 420, "initializers": [] }

--- a/test/dot_s/exit.wast
+++ b/test/dot_s/exit.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$vi (func (param i32)))
   (import $exit "env" "exit" (param i32))

--- a/test/dot_s/function-data-sections.wast
+++ b/test/dot_s/function-data-sections.wast
@@ -1,8 +1,8 @@
 (module
   (memory 1
-    (segment 8 "\00\00\00\00")
-    (segment 12 "\01\00\00\00")
-    (segment 16 "33\13@")
+    (segment 4 "\00\00\00\00")
+    (segment 8 "\01\00\00\00")
+    (segment 12 "33\13@")
   )
   (export "memory" memory)
   (export "foo" $foo)
@@ -25,4 +25,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "main" $main)
   (export "f2" $f2)

--- a/test/dot_s/lcomm-in-text-segment.wast
+++ b/test/dot_s/lcomm-in-text-segment.wast
@@ -1,7 +1,7 @@
 (module
   (memory 1
-    (segment 16 "\t\00\00\00")
+    (segment 12 "\08\00\00\00")
   )
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }

--- a/test/dot_s/macClangMetaData.wast
+++ b/test/dot_s/macClangMetaData.wast
@@ -15,4 +15,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 29, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 30, "initializers": [] }

--- a/test/dot_s/memops.wast
+++ b/test/dot_s/memops.wast
@@ -205,4 +205,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }", ["vi"]]},"staticBump": 66, "initializers": [] }
+;; METADATA: { "asmConsts": {"0": ["{ Module.print(\"hello, world! \" + HEAP32[8>>2]); }", ["vi"]]},"staticBump": 67, "initializers": [] }

--- a/test/dot_s/minimal.wast
+++ b/test/dot_s/minimal.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "main" $main)
   (func $main (result i32)

--- a/test/dot_s/permute.wast
+++ b/test/dot_s/permute.wast
@@ -4,4 +4,4 @@
   )
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 271, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 272, "initializers": [] }

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -1,7 +1,7 @@
 (module
   (memory 1
-    (segment 8 "\0c\00\00\00")
-    (segment 12 "\08\00\00\00")
+    (segment 4 "\08\00\00\00")
+    (segment 8 "\04\00\00\00")
   )
   (export "memory" memory)
   (export "main" $main)
@@ -9,9 +9,9 @@
     (local $$0 i32)
     (return
       (i32.load
-        (i32.const 12)
+        (i32.const 8)
       )
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 15, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (start $_start)
   (export "main" $main)

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (start $_start)
   (export "main" $main)

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -1,15 +1,15 @@
 (module
   (memory 1
-    (segment 8 "\01\00\00\00\00\00\00\00\00\00\00\00")
+    (segment 4 "\01\00\00\00\00\00\00\00\00\00\00\00")
   )
   (export "memory" memory)
   (export "f" $f)
   (func $f (param $$0 i32) (param $$1 i32)
-    (i32.store offset=12
+    (i32.store offset=8
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }

--- a/test/dot_s/visibilities.wast
+++ b/test/dot_s/visibilities.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "foo" $foo)
   (export "bar" $bar)

--- a/test/llvm_autogenerated/byval.wast
+++ b/test/llvm_autogenerated/byval.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$vi (func (param i32)))
   (import $ext_byval_func "env" "ext_byval_func" (param i32))
@@ -19,7 +19,7 @@
     (local $$4 i32)
     (local $$5 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -36,7 +36,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$5
       (i32.store
@@ -72,7 +72,7 @@
       )
     )
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$5
       (i32.store
@@ -89,7 +89,7 @@
     (local $$4 i32)
     (local $$5 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -106,7 +106,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$5
       (i32.store
@@ -142,7 +142,7 @@
       )
     )
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$5
       (i32.store
@@ -158,7 +158,7 @@
     (local $$3 i32)
     (local $$4 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -175,7 +175,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -214,7 +214,7 @@
       )
     )
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -235,7 +235,7 @@
     (local $$8 i32)
     (local $$9 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -252,7 +252,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$9
       (i32.store
@@ -372,7 +372,7 @@
       )
     )
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$9
       (i32.store

--- a/test/llvm_autogenerated/call.wast
+++ b/test/llvm_autogenerated/call.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$i (func (result i32)))
   (type $FUNCSIG$j (func (result i64)))

--- a/test/llvm_autogenerated/cfg-stackify.wast
+++ b/test/llvm_autogenerated/cfg-stackify.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$v (func))
   (type $FUNCSIG$i (func (result i32)))

--- a/test/llvm_autogenerated/comparisons_f32.wast
+++ b/test/llvm_autogenerated/comparisons_f32.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "ord_f32" $ord_f32)
   (export "uno_f32" $uno_f32)

--- a/test/llvm_autogenerated/comparisons_f64.wast
+++ b/test/llvm_autogenerated/comparisons_f64.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "ord_f64" $ord_f64)
   (export "uno_f64" $uno_f64)

--- a/test/llvm_autogenerated/comparisons_i32.wast
+++ b/test/llvm_autogenerated/comparisons_i32.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "eq_i32" $eq_i32)
   (export "ne_i32" $ne_i32)

--- a/test/llvm_autogenerated/comparisons_i64.wast
+++ b/test/llvm_autogenerated/comparisons_i64.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "eq_i64" $eq_i64)
   (export "ne_i64" $ne_i64)

--- a/test/llvm_autogenerated/conv.wast
+++ b/test/llvm_autogenerated/conv.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "i32_wrap_i64" $i32_wrap_i64)
   (export "i64_extend_s_i32" $i64_extend_s_i32)

--- a/test/llvm_autogenerated/copysign-casts.wast
+++ b/test/llvm_autogenerated/copysign-casts.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "fold_promote" $fold_promote)
   (export "fold_demote" $fold_demote)

--- a/test/llvm_autogenerated/cpus.wast
+++ b/test/llvm_autogenerated/cpus.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "f" $f)
   (func $f (param $$0 i32) (result i32)

--- a/test/llvm_autogenerated/dead-vreg.wast
+++ b/test/llvm_autogenerated/dead-vreg.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "foo" $foo)
   (func $foo (param $$0 i32) (param $$1 i32) (param $$2 i32)

--- a/test/llvm_autogenerated/f32.wast
+++ b/test/llvm_autogenerated/f32.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$ffff (func (param f32 f32 f32) (result f32)))
   (import $fmaf "env" "fmaf" (param f32 f32 f32) (result f32))

--- a/test/llvm_autogenerated/f64.wast
+++ b/test/llvm_autogenerated/f64.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$dddd (func (param f64 f64 f64) (result f64)))
   (import $fma "env" "fma" (param f64 f64 f64) (result f64))

--- a/test/llvm_autogenerated/fast-isel.wast
+++ b/test/llvm_autogenerated/fast-isel.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "immediate_f32" $immediate_f32)
   (export "immediate_f64" $immediate_f64)

--- a/test/llvm_autogenerated/frem.wast
+++ b/test/llvm_autogenerated/frem.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$fff (func (param f32 f32) (result f32)))
   (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))

--- a/test/llvm_autogenerated/func.wast
+++ b/test/llvm_autogenerated/func.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "f0" $f0)
   (export "f1" $f1)

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -1,15 +1,15 @@
 (module
   (memory 1
-    (segment 8 "9\05\00\00")
-    (segment 24 "\01\00\00\00")
-    (segment 28 "*\00\00\00")
-    (segment 32 "\ff\ff\ff\ff")
-    (segment 64 "\00\00\00\00\01\00\00\00")
-    (segment 72 "\ff\ff\ff\ff\ff\ff\ff\ff")
-    (segment 92 "\00\00\00\80")
-    (segment 96 "\00\00\00@")
-    (segment 128 "\00\00\00\00\00\00\00\80")
-    (segment 136 "\00\00\00\00\00\00\00@")
+    (segment 4 "9\05\00\00")
+    (segment 20 "\01\00\00\00")
+    (segment 24 "*\00\00\00")
+    (segment 28 "\ff\ff\ff\ff")
+    (segment 56 "\00\00\00\00\01\00\00\00")
+    (segment 64 "\ff\ff\ff\ff\ff\ff\ff\ff")
+    (segment 84 "\00\00\00\80")
+    (segment 88 "\00\00\00@")
+    (segment 120 "\00\00\00\00\00\00\00\80")
+    (segment 128 "\00\00\00\00\00\00\00@")
     (segment 656 "\e0\00\00\00")
     (segment 1192 "\a4\04\00\00")
   )
@@ -20,7 +20,7 @@
   (export "call_memcpy" $call_memcpy)
   (func $foo (result i32)
     (return
-      (i32.load offset=28
+      (i32.load offset=24
         (i32.const 0)
       )
     )
@@ -35,4 +35,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 1195, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 1196, "initializers": [] }

--- a/test/llvm_autogenerated/globl.wast
+++ b/test/llvm_autogenerated/globl.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "foo" $foo)
   (func $foo

--- a/test/llvm_autogenerated/i32-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i32-load-store-alignment.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "ldi32_a1" $ldi32_a1)
   (export "ldi32_a2" $ldi32_a2)

--- a/test/llvm_autogenerated/i32.wast
+++ b/test/llvm_autogenerated/i32.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "add32" $add32)
   (export "sub32" $sub32)

--- a/test/llvm_autogenerated/i64-load-store-alignment.wast
+++ b/test/llvm_autogenerated/i64-load-store-alignment.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "ldi64_a1" $ldi64_a1)
   (export "ldi64_a2" $ldi64_a2)

--- a/test/llvm_autogenerated/i64.wast
+++ b/test/llvm_autogenerated/i64.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "add64" $add64)
   (export "sub64" $sub64)

--- a/test/llvm_autogenerated/ident.wast
+++ b/test/llvm_autogenerated/ident.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/immediates.wast
+++ b/test/llvm_autogenerated/immediates.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "zero_i32" $zero_i32)
   (export "one_i32" $one_i32)

--- a/test/llvm_autogenerated/legalize.wast
+++ b/test/llvm_autogenerated/legalize.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$vijjj (func (param i32 i64 i64 i64)))
   (import $__lshrti3 "env" "__lshrti3" (param i32 i64 i64 i64))
@@ -343,7 +343,7 @@
     (local $$311 i32)
     (local $$312 i32)
     (set_local $$183
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$183
       (i32.load
@@ -360,7 +360,7 @@
       )
     )
     (set_local $$184
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$312
       (i32.store
@@ -3864,7 +3864,7 @@
       )
     )
     (set_local $$185
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$312
       (i32.store

--- a/test/llvm_autogenerated/load-ext.wast
+++ b/test/llvm_autogenerated/load-ext.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "sext_i8_i32" $sext_i8_i32)
   (export "zext_i8_i32" $zext_i8_i32)

--- a/test/llvm_autogenerated/load-store-i1.wast
+++ b/test/llvm_autogenerated/load-store-i1.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "load_u_i1_i32" $load_u_i1_i32)
   (export "load_s_i1_i32" $load_s_i1_i32)

--- a/test/llvm_autogenerated/load.wast
+++ b/test/llvm_autogenerated/load.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "ldi32" $ldi32)
   (export "ldi64" $ldi64)

--- a/test/llvm_autogenerated/mem-intrinsics.wast
+++ b/test/llvm_autogenerated/mem-intrinsics.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
   (type $FUNCSIG$i (func (result i32)))
@@ -73,7 +73,7 @@
     (local $$3 i32)
     (local $$4 i32)
     (set_local $$0
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$0
       (i32.load
@@ -90,7 +90,7 @@
       )
     )
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -127,7 +127,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store

--- a/test/llvm_autogenerated/memory-addr32.wast
+++ b/test/llvm_autogenerated/memory-addr32.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "memory_size" $memory_size)
   (export "grow_memory" $grow_memory)

--- a/test/llvm_autogenerated/memory-addr64.wast
+++ b/test/llvm_autogenerated/memory-addr64.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "memory_size" $memory_size)
   (export "grow_memory" $grow_memory)

--- a/test/llvm_autogenerated/non-executable-stack.wast
+++ b/test/llvm_autogenerated/non-executable-stack.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
 )
 ;; METADATA: { "asmConsts": {},"staticBump": 4, "initializers": [] }

--- a/test/llvm_autogenerated/offset-folding.wast
+++ b/test/llvm_autogenerated/offset-folding.wast
@@ -7,7 +7,7 @@
   (export "test3" $test3)
   (func $test0 (result i32)
     (return
-      (i32.const 196)
+      (i32.const 192)
     )
   )
   (func $test1 (result i32)
@@ -17,7 +17,7 @@
   )
   (func $test2 (result i32)
     (return
-      (i32.const 8)
+      (i32.const 4)
     )
   )
   (func $test3 (result i32)
@@ -26,4 +26,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 215, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 216, "initializers": [] }

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -1,6 +1,6 @@
 (module
   (memory 1
-    (segment 8 "\00\00\00\00")
+    (segment 4 "\00\00\00\00")
   )
   (export "memory" memory)
   (export "load_i32_with_folded_offset" $load_i32_with_folded_offset)
@@ -221,7 +221,7 @@
   )
   (func $load_i32_from_global_address (result i32)
     (return
-      (i32.load offset=8
+      (i32.load offset=4
         (i32.const 0)
       )
     )
@@ -234,7 +234,7 @@
     (return)
   )
   (func $store_i32_to_global_address
-    (i32.store offset=8
+    (i32.store offset=4
       (i32.const 0)
       (i32.const 0)
     )
@@ -349,4 +349,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 11, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }

--- a/test/llvm_autogenerated/phi.wast
+++ b/test/llvm_autogenerated/phi.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "test0" $test0)
   (export "test1" $test1)

--- a/test/llvm_autogenerated/reg-stackify.wast
+++ b/test/llvm_autogenerated/reg-stackify.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$v (func))
   (type $FUNCSIG$vi (func (param i32)))

--- a/test/llvm_autogenerated/return-int32.wast
+++ b/test/llvm_autogenerated/return-int32.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "return_i32" $return_i32)
   (func $return_i32 (param $$0 i32) (result i32)

--- a/test/llvm_autogenerated/return-void.wast
+++ b/test/llvm_autogenerated/return-void.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "return_void" $return_void)
   (func $return_void

--- a/test/llvm_autogenerated/select.wast
+++ b/test/llvm_autogenerated/select.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "select_i32_bool" $select_i32_bool)
   (export "select_i32_eq" $select_i32_eq)

--- a/test/llvm_autogenerated/signext-zeroext.wast
+++ b/test/llvm_autogenerated/signext-zeroext.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "z2s_func" $z2s_func)
   (export "s2z_func" $s2z_func)

--- a/test/llvm_autogenerated/store-results.wast
+++ b/test/llvm_autogenerated/store-results.wast
@@ -19,7 +19,7 @@
       (i32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store offset=8
+      (i32.store offset=4
         (i32.const 0)
         (i32.const 0)
       )
@@ -44,7 +44,7 @@
       (f32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store offset=8
+      (i32.store offset=4
         (i32.const 0)
         (i32.const 0)
       )
@@ -69,7 +69,7 @@
     (local $$3 i32)
     (local $$4 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -86,7 +86,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -108,7 +108,7 @@
       )
     )
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -121,4 +121,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 19, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }

--- a/test/llvm_autogenerated/store-trunc.wast
+++ b/test/llvm_autogenerated/store-trunc.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "trunc_i8_i32" $trunc_i8_i32)
   (export "trunc_i16_i32" $trunc_i16_i32)

--- a/test/llvm_autogenerated/store.wast
+++ b/test/llvm_autogenerated/store.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (export "sti32" $sti32)
   (export "sti64" $sti64)

--- a/test/llvm_autogenerated/switch.wast
+++ b/test/llvm_autogenerated/switch.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$v (func))
   (import $foo0 "env" "foo0")

--- a/test/llvm_autogenerated/unreachable.wast
+++ b/test/llvm_autogenerated/unreachable.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$v (func))
   (import $abort "env" "abort")

--- a/test/llvm_autogenerated/unused-argument.wast
+++ b/test/llvm_autogenerated/unused-argument.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$i (func (result i32)))
   (import $return_something "env" "return_something" (result i32))

--- a/test/llvm_autogenerated/userstack.wast
+++ b/test/llvm_autogenerated/userstack.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$vi (func (param i32)))
   (import $ext_func "env" "ext_func" (param i32))
@@ -16,7 +16,7 @@
     (local $$2 i32)
     (local $$3 i32)
     (set_local $$0
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$0
       (i32.load
@@ -33,7 +33,7 @@
       )
     )
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.store
@@ -55,7 +55,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.store
@@ -71,7 +71,7 @@
     (local $$2 i32)
     (local $$3 i32)
     (set_local $$0
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$0
       (i32.load
@@ -88,7 +88,7 @@
       )
     )
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.store
@@ -114,7 +114,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.store
@@ -131,7 +131,7 @@
     (local $$3 i32)
     (local $$4 i32)
     (set_local $$0
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$0
       (i32.load
@@ -148,7 +148,7 @@
       )
     )
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -185,7 +185,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -203,7 +203,7 @@
     (local $$5 i32)
     (local $$6 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -220,7 +220,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$6
       (i32.store
@@ -266,7 +266,7 @@
       )
     )
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$6
       (i32.store
@@ -282,7 +282,7 @@
     (local $$2 i32)
     (local $$3 i32)
     (set_local $$0
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$0
       (i32.load
@@ -299,7 +299,7 @@
       )
     )
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.store
@@ -324,7 +324,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.store
@@ -340,7 +340,7 @@
     (local $$3 i32)
     (local $$4 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.load
@@ -373,7 +373,7 @@
       (i32.const 0)
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.store
@@ -390,7 +390,7 @@
     (local $$4 i32)
     (local $$5 i32)
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -410,7 +410,7 @@
       (get_local $$4)
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store
@@ -450,7 +450,7 @@
       )
     )
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$4
       (i32.store

--- a/test/llvm_autogenerated/varargs.wast
+++ b/test/llvm_autogenerated/varargs.wast
@@ -1,5 +1,5 @@
 (module
-  (memory 0)
+  (memory 1)
   (export "memory" memory)
   (type $FUNCSIG$v (func))
   (import $callee "env" "callee")
@@ -131,7 +131,7 @@
     (local $$7 i32)
     (local $$8 i32)
     (set_local $$5
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$5
       (i32.load
@@ -148,7 +148,7 @@
       )
     )
     (set_local $$6
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$8
       (i32.store
@@ -157,7 +157,7 @@
       )
     )
     (set_local $$1
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$1
       (i32.load
@@ -174,7 +174,7 @@
       )
     )
     (set_local $$2
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$8
       (i32.store
@@ -198,7 +198,7 @@
     )
     (call_import $callee)
     (set_local $$3
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$3
       (i32.load
@@ -215,7 +215,7 @@
       )
     )
     (set_local $$4
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$8
       (i32.store
@@ -233,7 +233,7 @@
       )
     )
     (set_local $$7
-      (i32.const 1)
+      (i32.const 0)
     )
     (set_local $$8
       (i32.store


### PR DESCRIPTION
By default (if no global base is given) the global base is 1, which
seems wrong. In this case the stack pointer gets an address of 1, which
is unaligned and definitely wrong. So, start the global base at 0 instead of
1 by default and align the stack pointer. Also factor allocation of
statics into a function.