### PR TITLE
Allocate __dso_handle in s2wasm

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -79,8 +79,9 @@ class S2WasmBuilder {
     // address small (and thus with a small encoding).
     placeStackPointer(stackAllocation);
     // Allocate __dso_handle. For asm.js, emscripten provides this in JS, but
-    // wasm modules can't import data objects. Its value can be 0 for static
-    // linking. In the future this can go in a crtbegin or similar file.
+    // wasm modules can't import data objects. Its value is 0 for the main
+    // executable, which is all we have with static linking. In the future this
+    // can go in a crtbegin or similar file.
     allocateStatic(4, 4, "__dso_handle");
     process();
     // Place the stack after the user's static data, to keep those addresses

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -78,6 +78,10 @@ class S2WasmBuilder {
     // Place the stack pointer at the bottom of the linear memory, to keep its
     // address small (and thus with a small encoding).
     placeStackPointer(stackAllocation);
+    // Allocate __dso_handle. For asm.js, emscripten provides this in JS, but
+    // wasm modules can't import data objects. Its value can be 0 for static
+    // linking. In the future this can go in a crtbegin or similar file.
+    allocateStatic(4, 4, "__dso_handle");
     process();
     // Place the stack after the user's static data, to keep those addresses
     // small.

--- a/test/dot_s/alias.wast
+++ b/test/dot_s/alias.wast
@@ -12,4 +12,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/alternate-lcomm.wast
+++ b/test/dot_s/alternate-lcomm.wast
@@ -2,4 +2,4 @@
   (memory 1)
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }

--- a/test/dot_s/data-offset-folding.wast
+++ b/test/dot_s/data-offset-folding.wast
@@ -1,6 +1,6 @@
 (module
   (memory 1
-    (segment 8 "\00\00\00\00")
+    (segment 12 "\00\00\00\00")
     (segment 416 "`\00\00\00")
   )
   (export "memory" memory)

--- a/test/dot_s/dso_handle.s
+++ b/test/dot_s/dso_handle.s
@@ -1,0 +1,11 @@
+        .text
+        .file   "/tmp/tmplu1mMq/a.out.bc"
+        .globl  main
+        .type   main,@function
+main:                                   # @main
+        .result         i32
+# BB#0:
+        i32.const       $push0=, __dso_handle
+        return          $pop0
+.Lfunc_end0:
+        .size   main, .Lfunc_end0-main

--- a/test/dot_s/dso_handle.wast
+++ b/test/dot_s/dso_handle.wast
@@ -1,0 +1,11 @@
+(module
+  (memory 1)
+  (export "memory" memory)
+  (export "main" $main)
+  (func $main (result i32)
+    (return
+      (i32.const 8)
+    )
+  )
+)
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/exit.wast
+++ b/test/dot_s/exit.wast
@@ -11,4 +11,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/function-data-sections.wast
+++ b/test/dot_s/function-data-sections.wast
@@ -1,8 +1,8 @@
 (module
   (memory 1
-    (segment 8 "\00\00\00\00")
-    (segment 12 "\01\00\00\00")
-    (segment 16 "33\13@")
+    (segment 12 "\00\00\00\00")
+    (segment 16 "\01\00\00\00")
+    (segment 20 "33\13@")
   )
   (export "memory" memory)
   (export "foo" $foo)
@@ -25,4 +25,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 20, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 24, "initializers": [] }

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -12,4 +12,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": ["main", "f2", ] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": ["main", "f2", ] }

--- a/test/dot_s/lcomm-in-text-segment.wast
+++ b/test/dot_s/lcomm-in-text-segment.wast
@@ -1,7 +1,7 @@
 (module
   (memory 1
-    (segment 16 "\0c\00\00\00")
+    (segment 20 "\10\00\00\00")
   )
   (export "memory" memory)
 )
-;; METADATA: { "asmConsts": {},"staticBump": 20, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 24, "initializers": [] }

--- a/test/dot_s/minimal.wast
+++ b/test/dot_s/minimal.wast
@@ -8,4 +8,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/relocation.wast
+++ b/test/dot_s/relocation.wast
@@ -1,7 +1,7 @@
 (module
   (memory 1
-    (segment 8 "\0c\00\00\00")
-    (segment 12 "\08\00\00\00")
+    (segment 12 "\10\00\00\00")
+    (segment 16 "\0c\00\00\00")
   )
   (export "memory" memory)
   (export "main" $main)
@@ -9,9 +9,9 @@
     (local $$0 i32)
     (return
       (i32.load
-        (i32.const 12)
+        (i32.const 16)
       )
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 16, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 20, "initializers": [] }

--- a/test/dot_s/start_main0.wast
+++ b/test/dot_s/start_main0.wast
@@ -10,4 +10,4 @@
     (call $main)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/start_main2.wast
+++ b/test/dot_s/start_main2.wast
@@ -18,4 +18,4 @@
     )
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/dot_s/symbolic-offset.wast
+++ b/test/dot_s/symbolic-offset.wast
@@ -1,15 +1,15 @@
 (module
   (memory 1
-    (segment 8 "\01\00\00\00\00\00\00\00\00\00\00\00")
+    (segment 12 "\01\00\00\00\00\00\00\00\00\00\00\00")
   )
   (export "memory" memory)
   (export "f" $f)
   (func $f (param $$0 i32) (param $$1 i32)
-    (i32.store offset=12
+    (i32.store offset=16
       (get_local $$0)
       (get_local $$1)
     )
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 20, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 24, "initializers": [] }

--- a/test/dot_s/visibilities.wast
+++ b/test/dot_s/visibilities.wast
@@ -14,4 +14,4 @@
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 8, "initializers": [] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }

--- a/test/llvm_autogenerated/global.wast
+++ b/test/llvm_autogenerated/global.wast
@@ -1,10 +1,10 @@
 (module
   (memory 1
     (segment 4 "\b0\08\00\00")
-    (segment 8 "9\05\00\00")
-    (segment 24 "\01\00\00\00")
-    (segment 28 "*\00\00\00")
-    (segment 32 "\ff\ff\ff\ff")
+    (segment 12 "9\05\00\00")
+    (segment 28 "\01\00\00\00")
+    (segment 32 "*\00\00\00")
+    (segment 36 "\ff\ff\ff\ff")
     (segment 64 "\00\00\00\00\01\00\00\00")
     (segment 72 "\ff\ff\ff\ff\ff\ff\ff\ff")
     (segment 92 "\00\00\00\80")
@@ -21,7 +21,7 @@
   (export "call_memcpy" $call_memcpy)
   (func $foo (result i32)
     (return
-      (i32.load offset=28
+      (i32.load offset=32
         (i32.const 0)
       )
     )

--- a/test/llvm_autogenerated/offset-folding.wast
+++ b/test/llvm_autogenerated/offset-folding.wast
@@ -9,7 +9,7 @@
   (export "test3" $test3)
   (func $test0 (result i32)
     (return
-      (i32.const 196)
+      (i32.const 200)
     )
   )
   (func $test1 (result i32)
@@ -19,7 +19,7 @@
   )
   (func $test2 (result i32)
     (return
-      (i32.const 8)
+      (i32.const 12)
     )
   )
   (func $test3 (result i32)

--- a/test/llvm_autogenerated/offset.wast
+++ b/test/llvm_autogenerated/offset.wast
@@ -1,7 +1,7 @@
 (module
   (memory 1
     (segment 4 "\10\04\00\00")
-    (segment 8 "\00\00\00\00")
+    (segment 12 "\00\00\00\00")
   )
   (export "memory" memory)
   (export "load_i32_with_folded_offset" $load_i32_with_folded_offset)
@@ -222,7 +222,7 @@
   )
   (func $load_i32_from_global_address (result i32)
     (return
-      (i32.load offset=8
+      (i32.load offset=12
         (i32.const 0)
       )
     )
@@ -235,7 +235,7 @@
     (return)
   )
   (func $store_i32_to_global_address
-    (i32.store offset=8
+    (i32.store offset=12
       (i32.const 0)
       (i32.const 0)
     )

--- a/test/llvm_autogenerated/store-results.wast
+++ b/test/llvm_autogenerated/store-results.wast
@@ -21,7 +21,7 @@
       (i32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store offset=8
+      (i32.store offset=12
         (i32.const 0)
         (i32.const 0)
       )
@@ -46,7 +46,7 @@
       (f32.const 0)
     )
     (loop $label$1 $label$0
-      (i32.store offset=8
+      (i32.store offset=12
         (i32.const 0)
         (i32.const 0)
       )


### PR DESCRIPTION
Unlike asm.js modules, wasm modules cannot have imported/extern
objects. So allocate __dso_handle (which is traditionally defined in
a crtbegin or similar toolchain file linked with the user code) in s2wasm.