### PR TITLE
s2wasm: Export all address-taken functions

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1278,6 +1278,9 @@ class S2WasmBuilder {
           std::cerr << "function index: " << name << ": "
                     << functionIndexes[name] << '\n';
         }
+        // For now export all address-taken functions because pointers to them
+        // may escape the wasm module.
+        exportFunction(name, true);
       }
     };
     for (auto& relocation : relocations) {

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1278,8 +1278,10 @@ class S2WasmBuilder {
           std::cerr << "function index: " << name << ": "
                     << functionIndexes[name] << '\n';
         }
-        // For now export all address-taken functions because pointers to them
-        // may escape the wasm module.
+        // For now export all address-taken functions. Pointers to them may
+        // escape the wasm module, and the dynCall mechanism for wasm currently
+        // relies on looking up the function by export name and calling it
+        // directly.
         exportFunction(name, true);
       }
     };


### PR DESCRIPTION
I'm proposing a dyncall implmentation (https://github.com/kripken/emscripten/pull/4236) for wasm that looks up the
function by name and calls it. This means that address-taken functions
need to be exported.

