### PR TITLE
Function parallelism

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ FUNCTION(ADD_COMPILE_FLAG value)
   ENDFOREACH(variable)
 ENDFUNCTION()
 
+FUNCTION(ADD_LINK_FLAG value)
+  MESSAGE(STATUS "Linking with ${value}")
+  FOREACH(variable CMAKE_EXE_LINKER_FLAGS)
+    SET(${variable} "${${variable}} ${value}" PARENT_SCOPE)
+  ENDFOREACH(variable)
+ENDFUNCTION()
+
 # Compiler setup.
 
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -51,6 +58,7 @@ ELSE()
   ADD_COMPILE_FLAG("-Wextra")
   ADD_COMPILE_FLAG("-Wno-unused-parameter")
   ADD_COMPILE_FLAG("-fno-omit-frame-pointer")
+  ADD_LINK_FLAG("-pthread")
   IF(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
     ADD_COMPILE_FLAG("-O0")
     ADD_COMPILE_FLAG("-g3")
@@ -75,6 +83,7 @@ SET(support_SOURCES
   src/support/command-line.cpp
   src/support/file.cpp
   src/support/safe_integer.cpp
+  src/support/threads.cpp
 )
 ADD_LIBRARY(support STATIC ${support_SOURCES})
 

--- a/check.py
+++ b/check.py
@@ -573,7 +573,7 @@ cmd = [os.environ.get('CXX') or 'g++', '-std=c++11',
        os.path.join('test', 'example', 'find_div0s.cpp'),
        os.path.join('src', 'pass.cpp'),
        os.path.join('src', 'passes', 'Print.cpp'),
-       '-Isrc', '-g', '-lsupport', '-Llib/.']
+       '-Isrc', '-g', '-lsupport', '-Llib/.', '-pthread']
 if os.environ.get('COMPILER_FLAGS'):
   for f in os.environ.get('COMPILER_FLAGS').split(' '):
     cmd.append(f)

--- a/src/emscripten-optimizer/istring.h
+++ b/src/emscripten-optimizer/istring.h
@@ -73,7 +73,6 @@ struct IString {
     if (existing == strings->end()) {
       // the StringSet is a global shared structure, which can be modified
       // only on the main thread and only when other threads cannot race.
-      assert(wasm::Thread::onMainThread());
       assert(!wasm::ThreadPool::isRunning());
       if (!reuse) {
         size_t len = strlen(s) + 1;

--- a/src/emscripten-optimizer/istring.h
+++ b/src/emscripten-optimizer/istring.h
@@ -71,8 +71,8 @@ struct IString {
     auto existing = strings->find(s);
 
     if (existing == strings->end()) {
-      // the StringSet is a global shared structure, which can be modified
-      // only on the main thread and only when other threads cannot race.
+      // the StringSet cache is a global shared structure, which should
+      // not be modified by multiple threads at once.
       assert(!wasm::ThreadPool::isRunning());
       if (!reuse) {
         size_t len = strlen(s) + 1;

--- a/src/emscripten-optimizer/istring.h
+++ b/src/emscripten-optimizer/istring.h
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <assert.h>
 
-#include "../support/threads.h"
+#include "support/threads.h"
 
 namespace cashew {
 

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -19,6 +19,8 @@
 
 #include <vector>
 
+#include "support/threads.h"
+
 //
 // Arena allocation for mixed-type data.
 //
@@ -29,6 +31,10 @@ struct MixedArena {
 
   template<class T>
   T* alloc() {
+    // allocations must be on main thread, and single-threaded
+    assert(wasm::Thread::onMainThread());
+    assert(!wasm::ThreadPool::isRunning());
+
     const size_t CHUNK = 10000;
     size_t currSize = (sizeof(T) + 7) & (-8); // same alignment as malloc TODO optimize?
     assert(currSize < CHUNK);
@@ -43,6 +49,9 @@ struct MixedArena {
   }
 
   void clear() {
+    assert(wasm::Thread::onMainThread());
+    assert(!wasm::ThreadPool::isRunning());
+
     for (char* chunk : chunks) {
       delete[] chunk;
     }

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -32,7 +32,6 @@ struct MixedArena {
   template<class T>
   T* alloc() {
     // allocations must be on main thread, and single-threaded
-    assert(wasm::Thread::onMainThread());
     assert(!wasm::ThreadPool::isRunning());
 
     const size_t CHUNK = 10000;
@@ -49,7 +48,6 @@ struct MixedArena {
   }
 
   void clear() {
-    assert(wasm::Thread::onMainThread());
     assert(!wasm::ThreadPool::isRunning());
 
     for (char* chunk : chunks) {

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -31,7 +31,7 @@ struct MixedArena {
 
   template<class T>
   T* alloc() {
-    // allocations must be on main thread, and single-threaded
+    // this structure should not be modified by multiple threads at once.
     assert(!wasm::ThreadPool::isRunning());
 
     const size_t CHUNK = 10000;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -24,6 +24,8 @@
 namespace wasm {
 
 struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks>> {
+  bool isFunctionParallel() { return true; }
+
   void visitBlock(Block *curr) {
     bool more = true;
     while (more) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -26,6 +26,8 @@
 namespace wasm {
 
 struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions>> {
+  bool isFunctionParallel() { return true; }
+
   void visitIf(If* curr) {
     // flip branches to get rid of an i32.eqz
     if (curr->ifFalse) {

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -25,6 +25,8 @@
 namespace wasm {
 
 struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten>> {
+  bool isFunctionParallel() { return true; }
+
   // When we have a Load from a local value (typically a GetLocal) plus a constant offset,
   // we may be able to fold it in.
   // The semantics of the Add are to wrap, while wasm offset semantics purposefully do

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -24,6 +24,8 @@
 namespace wasm {
 
 struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
+  bool isFunctionParallel() { return true; }
+
   // preparation: try to unify branches, as the fewer there are, the higher a chance we can remove them
   // specifically for if-else, turn an if-else with branches to the same target at the end of each
   // child, and with a value, to a branch to that target containing the if-else

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -24,6 +24,8 @@
 namespace wasm {
 
 struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames>> {
+  bool isFunctionParallel() { return true; }
+
   // We maintain a list of branches that we saw in children, then when we reach
   // a parent block, we know if it was branched to
   std::set<Name> branchesSeen;

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -27,6 +27,7 @@
 namespace wasm {
 
 struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
+  bool isFunctionParallel() { return true; }
 
   std::map<Name, uint32_t> counts;
 

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -33,6 +33,8 @@
 namespace wasm {
 
 struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>> {
+  bool isFunctionParallel() { return true; }
+
   struct SinkableInfo {
     Expression** item;
     EffectAnalyzer effects;
@@ -157,7 +159,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>>
     self->pushTask(visitPre, currp);
   }
 
-  void startWalk(Function *func) {
+  void walk(Expression*& root) {
     // multiple passes may be required per function, consider this:
     //    x = load
     //    y = store
@@ -166,7 +168,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>>
     do {
       sunk = false;
       // main operation
-      walk(func->body);
+      WalkerPass<LinearExecutionWalker<SimplifyLocals>>::walk(root);
       // after optimizing a function, we can see if we have set_locals
       // for a local with no remaining gets, in which case, we can
       // remove the set.
@@ -192,6 +194,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>>
       // clean up
       numGetLocals.clear();
       setLocalOrigins.clear();
+      sinkables.clear();
     } while (sunk);
   }
 };

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -24,6 +24,8 @@
 namespace wasm {
 
 struct Vacuum : public WalkerPass<PostWalker<Vacuum>> {
+  bool isFunctionParallel() { return true; }
+
   void visitBlock(Block *curr) {
     // compress out nops
     int skip = 0;

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1402,8 +1402,6 @@ public:
       std::map<std::string, size_t> ids;
       std::set<std::string> allSigs;
 
-      AsmConstWalker(S2WasmBuilder* parent) : parent(parent) {}
-
       void visitCallImport(CallImport* curr) {
         if (curr->target == EMSCRIPTEN_ASM_CONST) {
           auto arg = curr->operands[0]->cast<Const>();
@@ -1455,7 +1453,8 @@ public:
         return code;
       }
     };
-    AsmConstWalker walker(this);
+    AsmConstWalker walker;
+    walker.parent = this;
     walker.startWalk(&wasm);
     // print
     o << "\"asmConsts\": {";

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+
+#include <iostream>
+
+#include "threads.h"
+
+
+// debugging tools
+
+#ifdef BINARYEN_THREAD_DEBUG
+static std::mutex debug;
+#define DEBUG_PRINT(x) { std::lock_guard<std::mutex> lock(debug); x; }
+#else
+#define DEBUG_PRINT(x)
+#endif
+
+
+namespace wasm {
+
+// Global thread information
+
+std::atomic_bool setMainThreadId(false);
+std::thread::id mainThreadId;
+
+struct MainThreadNoter {
+  MainThreadNoter() {
+    // global ctors are called on main thread
+    mainThreadId = std::this_thread::get_id();
+    setMainThreadId = true;
+  }
+};
+
+static MainThreadNoter mainThreadNoter;
+
+static std::unique_ptr<ThreadPool> pool;
+
+
+// Thread
+
+Thread::Thread() {
+  // main thread object's constructor itself can
+  // happen before onMainThread is ready
+  assert(onMainThread());
+  thread = std::unique_ptr<std::thread>(new std::thread(mainLoop, this));
+}
+
+Thread::~Thread() {
+  assert(onMainThread());
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    done = true;
+    condition.notify_one();
+  }
+  thread->join();
+}
+
+void Thread::work(std::function<ThreadWorkState ()> doWork_) {
+  // TODO: fancy work stealing
+  DEBUG_PRINT(std::cerr << "[Thread] send work to thread\n");
+  assert(onMainThread());
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    doWork = doWork_;
+    condition.notify_one();
+    DEBUG_PRINT(std::cerr << "[Thread] work sent\n");
+  }
+}
+
+bool Thread::onMainThread() {
+  // mainThread Id might not be set yet if we are in a global ctor, but
+  // that is on the main thread anyhow
+  return !setMainThreadId || std::this_thread::get_id() == mainThreadId;
+}
+
+void Thread::mainLoop(void *self_) {
+  auto* self = static_cast<Thread*>(self_);
+  while (1) {
+    DEBUG_PRINT(std::cerr << "[Thread] checking for work\n");
+    {
+      std::unique_lock<std::mutex> lock(self->mutex);
+      if (self->doWork) {
+        DEBUG_PRINT(std::cerr << "[Thread] doing work\n");
+        // run tasks until they are all done
+        while (self->doWork() == ThreadWorkState::More) {}
+        self->doWork = nullptr;
+      } else if (self->done) {
+        DEBUG_PRINT(std::cerr << "[Thread] done\n");
+        return;
+      }
+    }
+    ThreadPool::get()->notifyThreadIsReady();
+    {
+      std::unique_lock<std::mutex> lock(self->mutex);
+      if (!self->done && !self->doWork) {
+        DEBUG_PRINT(std::cerr << "[Thread] thread waiting\n");
+        self->condition.wait(lock);
+      }
+    }
+  }
+}
+
+
+// ThreadPool
+
+void ThreadPool::initialize(size_t num) {
+  if (num == 1) return; // no multiple cores, don't create threads
+  DEBUG_PRINT(std::cerr << "[Pool] initialize()\n");
+  std::unique_lock<std::mutex> lock(mutex);
+  ready.store(threads.size()); // initial state before first resetThreadsAreReady()
+  resetThreadsAreReady();
+  for (size_t i = 0; i < num; i++) {
+    threads.emplace_back(std::unique_ptr<Thread>(new Thread()));
+  }
+  DEBUG_PRINT(std::cerr << "[Pool] initialize() waiting\n");
+  condition.wait(lock, [this]() { return areThreadsReady(); });
+  DEBUG_PRINT(std::cerr << "[Pool] initialize() is done\n");
+}
+
+ThreadPool* ThreadPool::get() {
+  if (!pool) {
+    assert(Thread::onMainThread());
+    size_t num = std::thread::hardware_concurrency();
+    if (num < 2) num = 1;
+    pool = std::unique_ptr<ThreadPool>(new ThreadPool());
+    pool->initialize(num);
+  }
+  return pool.get();
+}
+
+void ThreadPool::work(std::vector<std::function<ThreadWorkState ()>>& doWorkers) {
+  size_t num = threads.size();
+  // If no multiple cores, or on a side thread, do not use worker threads
+  if (num == 0 || !Thread::onMainThread()) {
+    // just run sequentially
+    DEBUG_PRINT(std::cerr << "[Pool] work() sequentially\n");
+    assert(doWorkers.size() > 0);
+    while (doWorkers[0]() == ThreadWorkState::More) {}
+    return;
+  }
+  // run in parallel on threads
+  // TODO: fancy work stealing
+  DEBUG_PRINT(std::cerr << "[Pool] work() on threads\n");
+  assert(doWorkers.size() == num);
+  assert(!running);
+  running = true;
+  std::unique_lock<std::mutex> lock(mutex);
+  resetThreadsAreReady();
+  for (size_t i = 0; i < num; i++) {
+    threads[i]->work(doWorkers[i]);
+  }
+  DEBUG_PRINT(std::cerr << "[Pool] main thread waiting\n");
+  condition.wait(lock, [this]() { return areThreadsReady(); });
+  DEBUG_PRINT(std::cerr << "[Pool] main thread waiting\n");
+  running = false;
+  DEBUG_PRINT(std::cerr << "[Pool] work() is done\n");
+}
+
+size_t ThreadPool::size() {
+  return threads.size();
+}
+
+bool ThreadPool::isRunning() {
+  return pool && pool->running;
+}
+
+void ThreadPool::notifyThreadIsReady() {
+  DEBUG_PRINT(std::cerr << "[Pool] notify thread is ready\n";)
+  std::lock_guard<std::mutex> lock(mutex);
+  ready.fetch_add(1);
+  condition.notify_one();
+}
+
+void ThreadPool::resetThreadsAreReady() {
+  DEBUG_PRINT(std::cerr << "[Pool] reset threads are ready\n";)
+  assert(ready.load() == threads.size());
+  ready.store(0);
+}
+
+bool ThreadPool::areThreadsReady() {
+  DEBUG_PRINT(std::cerr << "[Pool] are threads ready?\n";)
+  return ready.load() == threads.size();
+}
+
+} // namespace wasm
+

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -25,9 +25,11 @@
 
 #ifdef BINARYEN_THREAD_DEBUG
 static std::mutex debug;
-#define DEBUG_PRINT(x) { std::lock_guard<std::mutex> lock(debug); x; }
+#define DEBUG_THREAD(x) { std::lock_guard<std::mutex> lock(debug); std::cerr << "[THREAD " << std::this_thread::get_id() << "] " << x; }
+#define DEBUG_POOL(x) { std::lock_guard<std::mutex> lock(debug); std::cerr << "[POOL] " << x; }
 #else
-#define DEBUG_PRINT(x)
+#define DEBUG_THREAD(x)
+#define DEBUG_POOL(x)
 #endif
 
 
@@ -35,8 +37,8 @@ namespace wasm {
 
 // Global thread information
 
-std::atomic_bool setMainThreadId(false);
-std::thread::id mainThreadId;
+static std::atomic_bool setMainThreadId(false);
+static std::thread::id mainThreadId;
 
 struct MainThreadNoter {
   MainThreadNoter() {
@@ -64,6 +66,7 @@ Thread::~Thread() {
   assert(onMainThread());
   {
     std::lock_guard<std::mutex> lock(mutex);
+    // notify the thread that it can exit
     done = true;
     condition.notify_one();
   }
@@ -72,13 +75,14 @@ Thread::~Thread() {
 
 void Thread::work(std::function<ThreadWorkState ()> doWork_) {
   // TODO: fancy work stealing
-  DEBUG_PRINT(std::cerr << "[Thread] send work to thread\n");
+  DEBUG_THREAD("send work to thread\n");
   assert(onMainThread());
   {
     std::lock_guard<std::mutex> lock(mutex);
+    // notify the thread that it can do some work
     doWork = doWork_;
     condition.notify_one();
-    DEBUG_PRINT(std::cerr << "[Thread] work sent\n");
+    DEBUG_THREAD("work sent\n");
   }
 }
 
@@ -91,16 +95,16 @@ bool Thread::onMainThread() {
 void Thread::mainLoop(void *self_) {
   auto* self = static_cast<Thread*>(self_);
   while (1) {
-    DEBUG_PRINT(std::cerr << "[Thread] checking for work\n");
+    DEBUG_THREAD("checking for work\n");
     {
       std::unique_lock<std::mutex> lock(self->mutex);
       if (self->doWork) {
-        DEBUG_PRINT(std::cerr << "[Thread] doing work\n");
+        DEBUG_THREAD("doing work\n");
         // run tasks until they are all done
         while (self->doWork() == ThreadWorkState::More) {}
         self->doWork = nullptr;
       } else if (self->done) {
-        DEBUG_PRINT(std::cerr << "[Thread] done\n");
+        DEBUG_THREAD("done\n");
         return;
       }
     }
@@ -108,7 +112,7 @@ void Thread::mainLoop(void *self_) {
     {
       std::unique_lock<std::mutex> lock(self->mutex);
       if (!self->done && !self->doWork) {
-        DEBUG_PRINT(std::cerr << "[Thread] thread waiting\n");
+        DEBUG_THREAD("thread waiting\n");
         self->condition.wait(lock);
       }
     }
@@ -120,23 +124,22 @@ void Thread::mainLoop(void *self_) {
 
 void ThreadPool::initialize(size_t num) {
   if (num == 1) return; // no multiple cores, don't create threads
-  DEBUG_PRINT(std::cerr << "[Pool] initialize()\n");
+  DEBUG_POOL("initialize()\n");
   std::unique_lock<std::mutex> lock(mutex);
   ready.store(threads.size()); // initial state before first resetThreadsAreReady()
   resetThreadsAreReady();
   for (size_t i = 0; i < num; i++) {
     threads.emplace_back(std::unique_ptr<Thread>(new Thread()));
   }
-  DEBUG_PRINT(std::cerr << "[Pool] initialize() waiting\n");
+  DEBUG_POOL("initialize() waiting\n");
   condition.wait(lock, [this]() { return areThreadsReady(); });
-  DEBUG_PRINT(std::cerr << "[Pool] initialize() is done\n");
+  DEBUG_POOL("initialize() is done\n");
 }
 
 ThreadPool* ThreadPool::get() {
   if (!pool) {
     assert(Thread::onMainThread());
-    size_t num = std::thread::hardware_concurrency();
-    if (num < 2) num = 1;
+    size_t num = std::max(1U, std::thread::hardware_concurrency());
     pool = std::unique_ptr<ThreadPool>(new ThreadPool());
     pool->initialize(num);
   }
@@ -148,14 +151,14 @@ void ThreadPool::work(std::vector<std::function<ThreadWorkState ()>>& doWorkers)
   // If no multiple cores, or on a side thread, do not use worker threads
   if (num == 0 || !Thread::onMainThread()) {
     // just run sequentially
-    DEBUG_PRINT(std::cerr << "[Pool] work() sequentially\n");
+    DEBUG_POOL("work() sequentially\n");
     assert(doWorkers.size() > 0);
     while (doWorkers[0]() == ThreadWorkState::More) {}
     return;
   }
   // run in parallel on threads
   // TODO: fancy work stealing
-  DEBUG_PRINT(std::cerr << "[Pool] work() on threads\n");
+  DEBUG_POOL("work() on threads\n");
   assert(doWorkers.size() == num);
   assert(!running);
   running = true;
@@ -164,11 +167,11 @@ void ThreadPool::work(std::vector<std::function<ThreadWorkState ()>>& doWorkers)
   for (size_t i = 0; i < num; i++) {
     threads[i]->work(doWorkers[i]);
   }
-  DEBUG_PRINT(std::cerr << "[Pool] main thread waiting\n");
+  DEBUG_POOL("main thread waiting\n");
   condition.wait(lock, [this]() { return areThreadsReady(); });
-  DEBUG_PRINT(std::cerr << "[Pool] main thread waiting\n");
+  DEBUG_POOL("main thread waiting\n");
   running = false;
-  DEBUG_PRINT(std::cerr << "[Pool] work() is done\n");
+  DEBUG_POOL("work() is done\n");
 }
 
 size_t ThreadPool::size() {
@@ -180,20 +183,20 @@ bool ThreadPool::isRunning() {
 }
 
 void ThreadPool::notifyThreadIsReady() {
-  DEBUG_PRINT(std::cerr << "[Pool] notify thread is ready\n";)
+  DEBUG_POOL("notify thread is ready\n";)
   std::lock_guard<std::mutex> lock(mutex);
   ready.fetch_add(1);
   condition.notify_one();
 }
 
 void ThreadPool::resetThreadsAreReady() {
-  DEBUG_PRINT(std::cerr << "[Pool] reset threads are ready\n";)
-  assert(ready.load() == threads.size());
-  ready.store(0);
+  DEBUG_POOL("reset threads are ready\n";)
+  auto old = ready.exchange(0);
+  assert(old == threads.size());
 }
 
 bool ThreadPool::areThreadsReady() {
-  DEBUG_PRINT(std::cerr << "[Pool] are threads ready?\n";)
+  DEBUG_POOL("are threads ready?\n";)
   return ready.load() == threads.size();
 }
 

--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Threads helpers.
+//
+
+#ifndef wasm_support_threads_h
+#define wasm_support_threads_h
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace wasm {
+
+// The work state of a helper thread - is there more to do,
+// or are we finished for now.
+enum class ThreadWorkState {
+  More,
+  Finished
+};
+
+//
+// A helper thread.
+//
+// You can only create and destroy these on the main thread.
+//
+
+class Thread {
+  std::unique_ptr<std::thread> thread;
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool done = false;
+  std::function<ThreadWorkState ()> doWork = nullptr;
+
+public:
+  Thread();
+  ~Thread();
+
+  // Start to do work, calling doWork() until
+  // it returns false.
+  void work(std::function<ThreadWorkState ()> doWork);
+
+  // Checks if execution is the main thread.
+  static bool onMainThread();
+
+private:
+  static void mainLoop(void *self);
+};
+
+//
+// A pool of helper threads.
+//
+// There is only one, to avoid recursive pools using too many cores.
+//
+
+class ThreadPool {
+  std::vector<std::unique_ptr<Thread>> threads;
+  bool running = false;
+  std::mutex mutex;
+  std::condition_variable condition;
+  std::atomic<size_t> ready;
+
+private:
+  void initialize(size_t num);
+
+public:
+  // Get the singleton threadpool. This can return null
+  // if there is just one thread available.
+  static ThreadPool* get();
+
+  // Execute a bunch of tasks by the pool. This calls
+  // getTask() (in a thread-safe manner) to get tasks, and
+  // sends them to workers to be executed. This method
+  // blocks until all tasks are complete.
+  void work(std::vector<std::function<ThreadWorkState ()>>& doWorkers);
+
+  size_t size();
+
+  static bool isRunning();
+
+  // Called by helper threads when they are free and ready.
+  void notifyThreadIsReady();
+
+private:
+  void resetThreadsAreReady();
+
+  bool areThreadsReady();
+};
+
+} // namespace wasm
+
+#endif  // wasm_support_threads_h

--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -58,9 +58,6 @@ public:
   // it returns false.
   void work(std::function<ThreadWorkState ()> doWork);
 
-  // Checks if execution is the main thread.
-  static bool onMainThread();
-
 private:
   static void mainLoop(void *self);
 };


### PR DESCRIPTION
This adds function parallelism as an option to AST walking. Details are in `wasm-traversal.h`, but basically, this could apply to almost every pass, since the AST has by design no global data structures, so we can optimize using all cores.

I wanted to get parallelism working at this early stage because it will make sure we don't unknowingly add anything that prevents this later, and also I've already heard requests that new toolchain components are fast on big codebases, and this is a simple way to get a massive speedup.

I'm pretty sure this code could be even faster (there is no batching, no work-stealing, no optimization of atomics, nothing clever ;)), but benchmarks show good results already.

Also added are a bunch of asserts on some risky things that should not run in parallel, like the current interned strings and bump allocator implementations, so we don't get weird errors on new buggy passes. Few passes need those features anyhow. We can make them threadsafe later if necessary, I suppose.

Also added debug logging of pass times (`binaryen-shell --debug`).