### PR TITLE
Parse debug information such as files and locations from .s files.

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -167,14 +167,26 @@ private:
   size_t counter = 0;
 };
 
+struct PrinterArgs {
+  std::ostream& o;
+  bool minify;
+  bool fullAST;
+  bool debugInfo;
+
+  PrinterArgs(): o(std::cout), minify(false), fullAST(false), debugInfo(false) {}
+  PrinterArgs(std::ostream& o): o(o), minify(false), fullAST(false), debugInfo(false) {}
+  PrinterArgs(std::ostream& o, bool minify, bool fullAST, bool debugInfo): o(o), minify(minify), fullAST(fullAST), debugInfo(debugInfo) {}
+};
+
 // Prints out a module
 class Printer : public Pass {
 protected:
-  std::ostream& o;
+  PrinterArgs args;
 
 public:
-  Printer() : o(std::cout) {}
-  Printer(std::ostream& o) : o(o) {}
+  Printer() : args(PrinterArgs()) {}
+  Printer(std::ostream& o) : args(PrinterArgs(o)) {}
+  Printer(const PrinterArgs& args) : args(args) {}
 
   void run(PassRunner* runner, Module* module) override;
 };

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -399,6 +399,7 @@ class S2WasmBuilder {
       else if (match("data")) {}
       else if (match("ident")) {}
       else if (match("section")) parseToplevelSection();
+      else if (match("file")) parseFile();
       else if (match("align") || match("p2align")) s = strchr(s, '\n');
       else if (match("globl")) parseGlobl();
       else abort_on("process");
@@ -408,7 +409,8 @@ class S2WasmBuilder {
   void parseToplevelSection() {
     auto section = getCommaSeparated();
     // Skipping .debug_ sections
-    if (!strncmp(section.c_str(), ".debug_", strlen(".debug_"))) {
+    if (!strncmp(section.c_str(), ".debug_", strlen(".debug_")) ||
+        !strncmp(section.c_str(), ".apple_", strlen(".apple_"))) {
       s -= strlen(section.c_str()); // we want name as well
       const char *next = strstr(s, ".section");
       if (!next) next = s + strlen(s);
@@ -465,7 +467,6 @@ class S2WasmBuilder {
       auto quoted = getQuoted();
       Name filename(std::string(quoted.begin(), quoted.end()));
       wasm->addDebugFile(fileId, filename);
-      s = strchr(s, '\n');
       return;
     }
     // '.file' without first index argument points to bc-file
@@ -518,7 +519,6 @@ class S2WasmBuilder {
       auto quoted = getQuoted();
       Name filename(std::string(quoted.begin(), quoted.end()));
       wasm->addDebugFile(fileId, filename);
-      s = strchr(s, '\n');
     };
     auto recordLoc = [&]() {
       if (debug) dump("loc");

--- a/src/tools/s2wasm.cpp
+++ b/src/tools/s2wasm.cpp
@@ -31,6 +31,7 @@ using namespace wasm;
 int main(int argc, const char *argv[]) {
   bool ignoreUnknownSymbols = false;
   bool generateEmscriptenGlue = false;
+  bool addDebugInfoComments = false;
   std::string startFunction;
   std::vector<std::string> archiveLibraries;
   Options options("s2wasm", "Link .s file into .wast");
@@ -80,6 +81,11 @@ int main(int argc, const char *argv[]) {
            Options::Arguments::N,
            [&archiveLibraries](Options *o, const std::string &argument) {
              archiveLibraries.push_back(argument);
+           })
+      .add("--debug-info", "", "Add debug info comments to the AST",
+           Options::Arguments::Zero,
+           [&addDebugInfoComments](Options *, const std::string &) {
+             addDebugInfoComments = true;
            })
       .add_positional("INFILE", Options::Arguments::One,
                       [](Options *o, const std::string &argument) {
@@ -133,7 +139,8 @@ int main(int argc, const char *argv[]) {
 
   if (options.debug) std::cerr << "Printing..." << std::endl;
   Output output(options.extra["output"], Flags::Text, options.debug ? Flags::Debug : Flags::Release);
-  WasmPrinter::printModule(&linker.getOutput().wasm, output.getStream());
+  WasmPrinter::printModule(&linker.getOutput().wasm, PrinterArgs(output.getStream(), false, false, addDebugInfoComments));
+
   output << meta.str();
 
   if (options.debug) std::cerr << "Done." << std::endl;

--- a/src/wasm-printing.h
+++ b/src/wasm-printing.h
@@ -32,6 +32,12 @@ struct WasmPrinter {
     return o;
   }
 
+  static void printModule(Module* module, const PrinterArgs& args) {
+    PassRunner passRunner(module);
+    passRunner.add<Printer>(args);
+    passRunner.run();
+  }
+
   static std::ostream& printModule(Module* module) {
     return printModule(module, std::cout);
   }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -840,6 +840,14 @@ enum HostOp {
 // have internal allocation will need an allocator provided to them in order
 // to be constructed.
 
+struct DebugInfoRef {
+  size_t locationIndex; // the reference to debug location in the function, or 0
+  size_t labelIndex; // the reference to function label in the function, or 0
+
+  DebugInfoRef() : locationIndex(0), labelIndex(0) {}
+  DebugInfoRef(size_t locationIndex, size_t labelIndex) : locationIndex(locationIndex), labelIndex(labelIndex) {}
+};
+
 class Expression {
 public:
   enum Id {
@@ -869,8 +877,9 @@ public:
   Id _id;
 
   WasmType type; // the type of the expression: its *output*, not necessarily its input(s)
+  DebugInfoRef debugInfo; // the reference to debug info: location and label
 
-  Expression(Id id) : _id(id), type(none) {}
+  Expression(Id id) : _id(id), type(none), debugInfo() {}
 
   void finalize() {}
 
@@ -888,6 +897,11 @@ public:
   T* cast() {
     assert(int(_id) == int(T::SpecificId));
     return (T*)this;
+  }
+
+  void setDebugInfo(size_t locationIndex, size_t labelIndex) {
+    debugInfo.locationIndex = locationIndex;
+    debugInfo.labelIndex = labelIndex;
   }
 };
 
@@ -1304,6 +1318,16 @@ public:
 
 // Globals
 
+class DebugLocation {
+public:
+  size_t fileId;
+  size_t row;
+  size_t column;
+
+  DebugLocation(): fileId(0), row(0), column(0) {}
+  DebugLocation(size_t fileId, size_t row, size_t column) : fileId(fileId), row(row), column(column) {}
+};
+
 class Function {
 public:
   Name name;
@@ -1312,6 +1336,8 @@ public:
   std::vector<WasmType> vars;   // params plus vars
   Name type; // if null, it is implicit in params and result
   Expression *body;
+  std::vector<DebugLocation> debugLocations;
+  std::vector<Name> labels;
 
   // local names. these are optional.
   std::vector<Name> localNames;
@@ -1417,6 +1443,9 @@ public:
   std::vector<std::unique_ptr<Export>> exports;
   std::vector<std::unique_ptr<Function>> functions;
 
+  std::map<size_t, Name> debugFileMap;
+  std::vector<std::string> debugSections;
+
   Table table;
   Memory memory;
   Name start;
@@ -1490,6 +1519,9 @@ public:
   }
   void addStart(const Name &s) {
     start = s;
+  }
+  void addDebugFile(size_t id, Name name) {
+    debugFileMap[id] = name;
   }
 
   void removeImport(Name name) {


### PR DESCRIPTION
LLVM backend can provide debug information about source code locations
for compiled bytecode in form of .file and .loc directives. We can store
and use them in s-expression format (via comments?), asm.js via source maps
and later in binary in additional sections.
