### PR TITLE
Rename function->locals to function->vars

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -782,10 +782,10 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
          yl = func->params[2].name,
          yh = func->params[3].name,
          r = func->params[4].name;
-    func->locals.clear();
+    func->vars.clear();
     Name x64("x64"), y64("y64");
-    func->locals.emplace_back(x64, i64);
-    func->locals.emplace_back(y64, i64);
+    func->vars.emplace_back(x64, i64);
+    func->vars.emplace_back(y64, i64);
     auto* body = allocator.alloc<Block>();
     auto recreateI64 = [&](Name target, Name low, Name high) {
       return builder.makeSetLocal(
@@ -884,7 +884,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
     return IString((std::string("label$continue$") + label.str).c_str(), false);
   };
 
-  IStringSet functionVariables; // params or locals 
+  IStringSet functionVariables; // params or vars
 
   IString parentLabel; // set in LABEL, then read in WHILE/DO/SWITCH
   std::vector<IString> breakStack; // where a break will go
@@ -910,7 +910,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       Ref pair = curr[1][j];
       IString name = pair[0]->getIString();
       AsmType asmType = detectType(pair[1], nullptr, true, Math_fround);
-      function->locals.emplace_back(name, asmToWasmType(asmType));
+      function->vars.emplace_back(name, asmToWasmType(asmType));
       functionVariables.insert(name);
       asmData.addVar(name, asmType);
     }
@@ -921,7 +921,7 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
   auto ensureI32Temp = [&]() {
     if (addedI32Temp) return;
     addedI32Temp = true;
-    function->locals.emplace_back(I32_TEMP, i32);
+    function->vars.emplace_back(I32_TEMP, i32);
     functionVariables.insert(I32_TEMP);
     asmData.addVar(I32_TEMP, ASM_INT);
   };

--- a/src/passes/NameManager.cpp
+++ b/src/passes/NameManager.cpp
@@ -63,8 +63,8 @@ void NameManager::visitFunction(Function* curr) {
   for (auto& param : curr->params) {
     names.insert(param.name);
   }
-  for (auto& local : curr->locals) {
-    names.insert(local.name);
+  for (auto& var : curr->vars) {
+    names.insert(var.name);
   }
 }
 void NameManager::visitImport(Import* curr) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -438,7 +438,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
       printMinorOpening(o, "result ") << printWasmType(curr->result) << ")";
     }
     incIndent();
-    for (auto& local : curr->locals) {
+    for (auto& local : curr->vars) {
       doIndent(o, indent);
       printMinorOpening(o, "local ") << local.name << ' ' << printWasmType(local.type) << ")";
       o << maybeNewLine;

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -31,16 +31,16 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   std::map<Name, uint32_t> counts;
 
   void visitFunction(Function *curr) {
-    auto& locals = curr->locals;
-    sort(locals.begin(), locals.end(), [this](NameType a, NameType b) -> bool {
+    auto& vars = curr->vars;
+    sort(vars.begin(), vars.end(), [this](NameType a, NameType b) -> bool {
       if (this->counts[a.name] == this->counts[b.name]) {
         return strcmp(a.name.str, b.name.str) > 0;
       }
       return this->counts[a.name] > this->counts[b.name];
     });
-    // drop completely unused locals
-    while (locals.size() > 0 && counts[locals.back().name] == 0) {
-      locals.pop_back();
+    // drop completely unused vars
+    while (vars.size() > 0 && counts[vars.back().name] == 0) {
+      vars.pop_back();
     }
     counts.clear();
   }

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -562,7 +562,7 @@ class S2WasmBuilder {
     wasm::Builder builder(wasm);
     std::vector<NameType> params;
     WasmType resultType = none;
-    std::vector<NameType> locals;
+    std::vector<NameType> vars;
 
     std::map<Name, WasmType> localTypes;
     // params and result
@@ -582,14 +582,14 @@ class S2WasmBuilder {
         while (1) {
           Name name = getNextId();
           WasmType type = getType();
-          locals.emplace_back(name, type);
+          vars.emplace_back(name, type);
           localTypes[name] = type;
           skipWhitespace();
           if (!match(",")) break;
         }
       } else break;
     }
-    Function* func = builder.makeFunction(name, std::move(params), resultType, std::move(locals));
+    Function* func = builder.makeFunction(name, std::move(params), resultType, std::move(vars));
 
     // parse body
     func->body = allocator.alloc<Block>();
@@ -1351,7 +1351,7 @@ class S2WasmBuilder {
         size_t paramNum = 0;
         for (const NameType& nt : target->params) {
           Name name = Name::fromInt(paramNum++);
-          func->locals.emplace_back(name, nt.type);
+          func->vars.emplace_back(name, nt.type);
           auto* param = allocator.alloc<GetLocal>();
           param->name = name;
           param->type = nt.type;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -558,14 +558,14 @@ public:
       size_t curr = mappedLocals.size();
       mappedLocals[param.name] = curr;
     }
-    for (auto& local : function->locals) {
-      numLocalsByType[local.type]++;
+    for (auto& var : function->vars) {
+      numLocalsByType[var.type]++;
     }
     std::map<WasmType, size_t> currLocalsByType;
-    for (auto& local : function->locals) {
+    for (auto& var : function->vars) {
       size_t index = function->params.size();
-      Name name = local.name;
-      WasmType type = local.type;
+      Name name = var.name;
+      WasmType type = var.type;
       currLocalsByType[type]++; // increment now for simplicity, must decrement it in returns
       if (type == i32) {
         mappedLocals[name] = index + currLocalsByType[i32] - 1;
@@ -1416,7 +1416,7 @@ public:
         auto num = getU32LEB();
         auto type = getWasmType();
         while (num > 0) {
-          func->locals.emplace_back(addVar(), type);
+          func->vars.emplace_back(addVar(), type);
           num--;
         }
       }
@@ -1431,9 +1431,9 @@ public:
           mappedLocals.push_back(func->params[i].name);
           localTypes[func->params[i].name] = func->params[i].type;
         }
-        for (size_t i = 0; i < func->locals.size(); i++) {
-          mappedLocals.push_back(func->locals[i].name);
-          localTypes[func->locals[i].name] = func->locals[i].type;
+        for (size_t i = 0; i < func->vars.size(); i++) {
+          mappedLocals.push_back(func->vars[i].name);
+          localTypes[func->vars[i].name] = func->vars[i].type;
         }
         // process body
         assert(breakStack.empty());

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -30,12 +30,12 @@ public:
   Function* makeFunction(Name name,
                          std::vector<NameType>&& params,
                          WasmType resultType,
-                         std::vector<NameType>&& locals) {
+                         std::vector<NameType>&& vars) {
     auto* func = allocator.alloc<Function>();
     func->name = name;
     func->params = params;
     func->result = resultType;
-    func->locals = locals;
+    func->vars = vars;
     return func;
   }
 

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -166,7 +166,7 @@ private:
           }
           locals[function->params[i].name] = arguments[i];
         }
-        for (auto& local : function->locals) {
+        for (auto& local : function->vars) {
           locals[local.name].type = local.type;
         }
       }

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -318,7 +318,7 @@ private:
   // function parsing state
   Function *currFunction = nullptr;
   std::map<Name, WasmType> currLocalTypes;
-  size_t localIndex; // params and locals
+  size_t localIndex; // params and vars
   size_t otherIndex;
   std::vector<Name> labelStack;
 
@@ -381,7 +381,7 @@ private:
           if (id == PARAM) {
             func->params.emplace_back(name, type);
           } else {
-            func->locals.emplace_back(name, type);
+            func->vars.emplace_back(name, type);
           }
           localIndex++;
           currLocalTypes[name] = type;
@@ -712,7 +712,7 @@ private:
     if (i < numParams) {
       return currFunction->params[i].name;
     } else {
-      return currFunction->locals[i - currFunction->params.size()].name;
+      return currFunction->vars[i - currFunction->params.size()].name;
     }
   }
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1066,8 +1066,8 @@ class Function {
 public:
   Name name;
   WasmType result;
-  std::vector<NameType> params;
-  std::vector<NameType> locals;
+  std::vector<NameType> params; // function locals are params
+  std::vector<NameType> vars;   // plus vars
   Name type; // if null, it is implicit in params and result
   Expression *body;
 

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -366,9 +366,9 @@ Ref Wasm2AsmBuilder::processFunction(Function* func) {
       flattenAppend(ret, processFunctionBody(func->body, NO_RESULT));
     }
   }
-  // locals, including new temp locals
-  for (auto& local : func->locals) {
-    ValueBuilder::appendToVar(theVar, fromName(local.name), makeAsmCoercedZero(wasmToAsmType(local.type)));
+  // vars, including new temp vars
+  for (auto& var : func->vars) {
+    ValueBuilder::appendToVar(theVar, fromName(var.name), makeAsmCoercedZero(wasmToAsmType(var.type)));
   }
   for (auto f : frees[i32]) {
     ValueBuilder::appendToVar(theVar, f, makeAsmCoercedZero(ASM_INT));


### PR DESCRIPTION
Just a minor refactoring. Seems nice to do this before more major work on #336.

All this does is rename function->locals to vars. Before this, we have params and locals, and we also use the term "locals" to refer to both. Which makes sense, since the params are also locals, and can be used and written to, etc. After this change, we have params and vars, and together they can be called "locals" without risk of confusion.