### PR TITLE
Unified traversal option

### DIFF
--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -22,7 +22,7 @@
 
 namespace wasm {
 
-struct BreakSeeker : public PostWalker<BreakSeeker> {
+struct BreakSeeker : public PostWalker<BreakSeeker, Visitor<BreakSeeker>> {
   Name target; // look for this one
   size_t found;
 
@@ -42,7 +42,7 @@ struct BreakSeeker : public PostWalker<BreakSeeker> {
 // Look for side effects, including control flow
 // TODO: optimize
 
-struct EffectAnalyzer : public PostWalker<EffectAnalyzer> {
+struct EffectAnalyzer : public PostWalker<EffectAnalyzer, Visitor<EffectAnalyzer>> {
   bool branches = false;
   bool calls = false;
   std::set<Index> localsRead;

--- a/src/pass.h
+++ b/src/pass.h
@@ -143,7 +143,7 @@ public:
 // e.g. through PassRunner::getLast
 
 // Handles names in a module, in particular adding names without duplicates
-class NameManager : public WalkerPass<PostWalker<NameManager>> {
+class NameManager : public WalkerPass<PostWalker<NameManager, Visitor<NameManager>>> {
  public:
   Name getUnique(std::string prefix);
   // TODO: getUniqueInFunction

--- a/src/passes/LowerIfElse.cpp
+++ b/src/passes/LowerIfElse.cpp
@@ -32,7 +32,7 @@
 
 namespace wasm {
 
-struct LowerIfElse : public WalkerPass<PostWalker<LowerIfElse>> {
+struct LowerIfElse : public WalkerPass<PostWalker<LowerIfElse, Visitor<LowerIfElse>>> {
   MixedArena* allocator;
   std::unique_ptr<NameManager> namer;
 

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks>> {
+struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks, Visitor<MergeBlocks>>> {
   bool isFunctionParallel() { return true; }
 
   void visitBlock(Block *curr) {

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -24,7 +24,7 @@ namespace wasm {
 using namespace std;
 
 // Prints metrics between optimization passes.
-struct Metrics : public WalkerPass<PostWalker<Metrics>> {
+struct Metrics : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<Metrics>>> {
   static Metrics *lastMetricsPass;
 
   map<const char *, int> counts;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -25,7 +25,7 @@
 
 namespace wasm {
 
-struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions>> {
+struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions, Visitor<OptimizeInstructions>>> {
   bool isFunctionParallel() { return true; }
 
   void visitIf(If* curr) {

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten>> {
+struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten, Visitor<PostEmscripten>>> {
   bool isFunctionParallel() { return true; }
 
   // When we have a Load from a local value (typically a GetLocal) plus a constant offset,

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct RemoveImports : public WalkerPass<PostWalker<RemoveImports>> {
+struct RemoveImports : public WalkerPass<PostWalker<RemoveImports, Visitor<RemoveImports>>> {
   MixedArena* allocator;
   Module* module;
 

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
+struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<RemoveUnusedBrs>>> {
   bool isFunctionParallel() { return true; }
 
   // preparation: try to unify branches, as the fewer there are, the higher a chance we can remove them

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames>> {
+struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames, Visitor<RemoveUnusedNames>>> {
   bool isFunctionParallel() { return true; }
 
   // We maintain a list of branches that we saw in children, then when we reach

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -26,7 +26,7 @@
 
 namespace wasm {
 
-struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
+struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals, Visitor<ReorderLocals>>> {
   bool isFunctionParallel() { return true; }
 
   std::map<Index, uint32_t> counts;
@@ -79,7 +79,7 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
       }
     }
     // apply the renaming to AST nodes
-    struct ReIndexer : public PostWalker<ReIndexer> {
+    struct ReIndexer : public PostWalker<ReIndexer, Visitor<ReIndexer>> {
       Function* func;
       std::vector<Index>& oldToNew;
 

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -32,7 +32,7 @@
 
 namespace wasm {
 
-struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>> {
+struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, Visitor<SimplifyLocals>>> {
   bool isFunctionParallel() { return true; }
 
   struct SinkableInfo {
@@ -153,7 +153,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>>
         self->pushTask(scan, &list[i]);
       }
     } else {
-      WalkerPass<LinearExecutionWalker<SimplifyLocals>>::scan(self, currp);
+      WalkerPass<LinearExecutionWalker<SimplifyLocals, Visitor<SimplifyLocals>>>::scan(self, currp);
     }
 
     self->pushTask(visitPre, currp);
@@ -168,7 +168,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals>>
     do {
       sunk = false;
       // main operation
-      WalkerPass<LinearExecutionWalker<SimplifyLocals>>::walk(root);
+      WalkerPass<LinearExecutionWalker<SimplifyLocals, Visitor<SimplifyLocals>>>::walk(root);
       // after optimizing a function, we can see if we have set_locals
       // for a local with no remaining gets, in which case, we can
       // remove the set.

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct Vacuum : public WalkerPass<PostWalker<Vacuum>> {
+struct Vacuum : public WalkerPass<PostWalker<Vacuum, Visitor<Vacuum>>> {
   bool isFunctionParallel() { return true; }
 
   void visitBlock(Block *curr) {

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1396,7 +1396,7 @@ public:
 
     o << ";; METADATA: { ";
     // find asmConst calls, and emit their metadata
-    struct AsmConstWalker : public PostWalker<AsmConstWalker> {
+    struct AsmConstWalker : public PostWalker<AsmConstWalker, Visitor<AsmConstWalker>> {
       S2WasmBuilder* parent;
 
       std::map<std::string, std::set<std::string>> sigsForCode;

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -25,7 +25,7 @@
 
 namespace wasm {
 
-struct WasmValidator : public PostWalker<WasmValidator> {
+struct WasmValidator : public PostWalker<WasmValidator, Visitor<WasmValidator>> {
   bool valid;
 
   std::map<Name, WasmType> breakTypes; // breaks to a label must all have the same type, and the right type
@@ -118,7 +118,7 @@ public:
 private:
 
   // the "in" label has a none type, since no one can receive its value. make sure no one breaks to it with a value.
-  struct LoopChildChecker : public PostWalker<LoopChildChecker> {
+  struct LoopChildChecker : public PostWalker<LoopChildChecker, Visitor<LoopChildChecker>> {
     Name in;
     bool valid = true;
 

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -392,7 +392,7 @@ Ref Wasm2AsmBuilder::processFunction(Function* func) {
 }
 
 void Wasm2AsmBuilder::scanFunctionBody(Expression* curr) {
-  struct ExpressionScanner : public PostWalker<ExpressionScanner> {
+  struct ExpressionScanner : public PostWalker<ExpressionScanner, Visitor<ExpressionScanner>> {
     Wasm2AsmBuilder* parent;
 
     ExpressionScanner(Wasm2AsmBuilder* parent) : parent(parent) {}

--- a/test/example/find_div0s.cpp
+++ b/test/example/find_div0s.cpp
@@ -39,7 +39,7 @@ int main() {
 
   // Search it for divisions by zero: Walk the module, looking for
   // that operation.
-  struct DivZeroSeeker : public PostWalker<DivZeroSeeker> {
+  struct DivZeroSeeker : public PostWalker<DivZeroSeeker, Visitor<DivZeroSeeker>> {
     void visitBinary(Binary* curr) {
       // In every Binary, look for integer divisions
       if (curr->op == BinaryOp::DivS || curr->op == BinaryOp::DivU) {


### PR DESCRIPTION
Motivated by @dschuff 's comment that having visitBlock etc and also the generic visitExpression is confusing (what's the order, what happens if the node is replaced, etc.). This pull templates on the visitor, and there is the usual visitor that most want (visitBlock, etc.), but also a visitor with a unified single visitExpression for all expressions.

Depends on #355.