### PR TITLE
Nicer pass printing

### DIFF
--- a/src/pass.cpp
+++ b/src/pass.cpp
@@ -68,19 +68,36 @@ void PassRunner::addDefaultOptimizationPasses() {
 }
 
 void PassRunner::run(Module* module) {
+  std::chrono::high_resolution_clock::time_point beforeEverything;
+  size_t padding = 0;
+  if (debug) {
+    std::cerr << "[PassRunner] running passes..." << std::endl;
+    beforeEverything = std::chrono::high_resolution_clock::now();
+    for (auto pass : passes) {
+      padding = std::max(padding, pass->name.size());
+    }
+  }
   for (auto pass : passes) {
     currPass = pass;
     std::chrono::high_resolution_clock::time_point before;
     if (debug) {
-      std::cerr << "[PassRunner] running pass: " << pass->name << std::endl;
+      std::cerr << "[PassRunner]   running pass: " << pass->name << "... ";
+      for (size_t i = 0; i < padding - pass->name.size(); i++) {
+        std::cerr << ' ';
+      }
       before = std::chrono::high_resolution_clock::now();
     }
     pass->run(this, module);
     if (debug) {
       auto after = std::chrono::high_resolution_clock::now();
       std::chrono::duration<double> diff = after - before;
-      std::cerr << "[PassRunner]   pass took " << diff.count() << " seconds." << std::endl;
+      std::cerr << diff.count() << " seconds." << std::endl;
     }
+  }
+  if (debug) {
+    auto after = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> diff = after - beforeEverything;
+    std::cerr << "[PassRunner] passes took " << diff.count() << " seconds." << std::endl;
   }
 }
 


### PR DESCRIPTION
Example output:

````
[PassRunner] running passes...
[PassRunner]   running pass: remove-unused-brs...     0.0568142 seconds.
[PassRunner]   running pass: remove-unused-names...   0.0639781 seconds.
[PassRunner]   running pass: merge-blocks...          0.0497385 seconds.
[PassRunner]   running pass: optimize-instructions... 0.0520239 seconds.
[PassRunner]   running pass: simplify-locals...       1.04345 seconds.
[PassRunner]   running pass: reorder-locals...        0.109968 seconds.
[PassRunner]   running pass: vacuum...                0.0498161 seconds.
[PassRunner] passes took 1.42691 seconds.
````
