### PR TITLE
Unify AllocatingModule into Module

### DIFF
--- a/src/asm2wasm-main.cpp
+++ b/src/asm2wasm-main.cpp
@@ -90,7 +90,7 @@ int main(int argc, const char *argv[]) {
   }
 
   if (options.debug) std::cerr << "wasming..." << std::endl;
-  AllocatingModule wasm;
+  Module wasm;
   wasm.memory.initial = wasm.memory.max = totalMemory / Memory::kPageSize;
   Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise);
   asm2wasm.processAsm(asmjs);

--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -129,7 +129,7 @@ struct Asm2WasmPreProcessor {
 //
 
 class Asm2WasmBuilder {
-  AllocatingModule& wasm;
+  Module& wasm;
 
   MixedArena &allocator;
 
@@ -266,7 +266,7 @@ private:
   }
 
 public:
- Asm2WasmBuilder(AllocatingModule& wasm, bool memoryGrowth, bool debug, bool imprecise)
+ Asm2WasmBuilder(Module& wasm, bool memoryGrowth, bool debug, bool imprecise)
      : wasm(wasm),
        allocator(wasm.allocator),
        builder(wasm),

--- a/src/binaryen-shell.cpp
+++ b/src/binaryen-shell.cpp
@@ -74,7 +74,7 @@ static void verify_result(Literal a, Literal b) {
   }
 }
 
-static void run_asserts(size_t* i, bool* checked, AllocatingModule* wasm,
+static void run_asserts(size_t* i, bool* checked, Module* wasm,
                         Element* root,
                         std::unique_ptr<SExpressionWasmBuilder>* builder,
                         Name entry) {
@@ -112,7 +112,7 @@ static void run_asserts(size_t* i, bool* checked, AllocatingModule* wasm,
     std::cerr << curr << '\n';
     if (id == ASSERT_INVALID) {
       // a module invalidity test
-      AllocatingModule wasm;
+      Module wasm;
       bool invalid = false;
       std::unique_ptr<SExpressionWasmBuilder> builder;
       try {
@@ -217,7 +217,7 @@ int main(int argc, const char* argv[]) {
     IString id = curr[0]->str();
     if (id == MODULE) {
       if (options.debug) std::cerr << "parsing s-expressions to wasm...\n";
-      AllocatingModule wasm;
+      Module wasm;
       std::unique_ptr<SExpressionWasmBuilder> builder(
           new SExpressionWasmBuilder(wasm, *root[i], [&]() { abort(); }));
       i++;

--- a/src/js/binaryen.idl
+++ b/src/js/binaryen.idl
@@ -13,12 +13,6 @@ interface Name {
 interface Module {
 };
 
-interface AllocatingModule {
-  void AllocatingModule();
-};
-
-AllocatingModule implements Module;
-
 [Prefix="ModuleInstance::", NoDelete]
 interface ExternalInterface {
 };
@@ -63,7 +57,7 @@ interface SExpressionParser {
 };
 
 interface SExpressionWasmBuilder {
-  void SExpressionWasmBuilder([Ref] AllocatingModule wasm, [Ref] Element input, boolean debug);
+  void SExpressionWasmBuilder([Ref] Module wasm, [Ref] Element input, boolean debug);
 };
 
 // Wasm printing

--- a/src/s2wasm-main.cpp
+++ b/src/s2wasm-main.cpp
@@ -83,7 +83,7 @@ int main(int argc, const char *argv[]) {
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text, options.debug ? Flags::Debug : Flags::Release));
 
   if (options.debug) std::cerr << "Parsing and wasming..." << std::endl;
-  AllocatingModule wasm;
+  Module wasm;
   uint64_t globalBase = options.extra.find("global-base") != options.extra.end()
                           ? std::stoull(options.extra["global-base"])
                           : 0;

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -39,7 +39,7 @@ cashew::IString EMSCRIPTEN_ASM_CONST("emscripten_asm_const");
 //
 
 class S2WasmBuilder {
-  AllocatingModule& wasm;
+  Module& wasm;
   MixedArena& allocator;
   const char* s;
   bool debug;
@@ -48,7 +48,7 @@ class S2WasmBuilder {
   std::vector<Name> globls;
 
  public:
-  S2WasmBuilder(AllocatingModule& wasm, const char* input, bool debug,
+  S2WasmBuilder(Module& wasm, const char* input, bool debug,
                 size_t globalBase, size_t stackAllocation,
                 size_t userInitialMemory, size_t userMaxMemory,
                 bool ignoreUnknownSymbols, Name startFunction)

--- a/src/wasm-as.cpp
+++ b/src/wasm-as.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char *argv[]) {
   Element& root = *parser.root;
 
   if (options.debug) std::cerr << "w-parsing..." << std::endl;
-  AllocatingModule wasm;
+  Module wasm;
   SExpressionWasmBuilder builder(wasm, *root[0], [&]() { abort(); });
 
   if (options.debug) std::cerr << "binarification..." << std::endl;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1120,7 +1120,7 @@ public:
 };
 
 class WasmBinaryBuilder {
-  AllocatingModule& wasm;
+  Module& wasm;
   MixedArena& allocator;
   std::vector<char>& input;
   bool debug;
@@ -1129,7 +1129,7 @@ class WasmBinaryBuilder {
   int32_t startIndex = -1;
 
 public:
-  WasmBinaryBuilder(AllocatingModule& wasm, std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
+  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
 
   void read() {
 

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -25,7 +25,7 @@ class Builder {
   MixedArena &allocator;
 
 public:
-  Builder(AllocatingModule& wasm) : allocator(wasm.allocator) {}
+  Builder(Module& wasm) : allocator(wasm.allocator) {}
 
   Function* makeFunction(Name name,
                          std::vector<NameType>&& params,

--- a/src/wasm-dis.cpp
+++ b/src/wasm-dis.cpp
@@ -44,7 +44,7 @@ int main(int argc, const char *argv[]) {
   auto input(read_file<std::vector<char>>(options.extra["infile"], Flags::Binary, options.debug ? Flags::Debug : Flags::Release));
 
   if (options.debug) std::cerr << "parsing binary..." << std::endl;
-  AllocatingModule wasm;
+  Module wasm;
   WasmBinaryBuilder parser(wasm, input, options.debug);
   parser.read();
 

--- a/src/wasm-js.cpp
+++ b/src/wasm-js.cpp
@@ -41,7 +41,7 @@ Asm2WasmBuilder* asm2wasm = nullptr;
 SExpressionParser* sExpressionParser = nullptr;
 SExpressionWasmBuilder* sExpressionWasmBuilder = nullptr;
 ModuleInstance* instance = nullptr;
-AllocatingModule* module = nullptr;
+Module* module = nullptr;
 bool wasmJSDebug = false;
 
 static void prepare2wasm() {
@@ -67,7 +67,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE load_asm2wasm(char *input) {
   cashew::Parser<Ref, DotZeroValueBuilder> builder;
   Ref asmjs = builder.parseToplevel(input);
 
-  module = new AllocatingModule();
+  module = new Module();
   uint32_t providedMemory = EM_ASM_INT_V({
     return Module['providedTotalMemory']; // we receive the size of memory from emscripten
   });
@@ -127,7 +127,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE load_s_expr2wasm(char *input) {
 
   if (wasmJSDebug) std::cerr << "wasming...\n";
 
-  module = new AllocatingModule();
+  module = new Module();
   // A .wast may have multiple modules, with some asserts after them, but we just read the first here.
   sExpressionWasmBuilder = new SExpressionWasmBuilder(*module, *root[0], [&]() {
     std::cerr << "error in parsing s-expressions to wasm\n";
@@ -143,7 +143,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE load_binary2wasm(char *raw, int32_t size) {
 
   if (wasmJSDebug) std::cerr << "wasm-binary parsing...\n";
 
-  module = new AllocatingModule();
+  module = new Module();
   std::vector<char> input;
   input.resize(size);
   for (int32_t i = 0; i < size; i++) {

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -235,7 +235,7 @@ private:
 //
 
 class SExpressionWasmBuilder {
-  AllocatingModule& wasm;
+  Module& wasm;
   MixedArena& allocator;
   std::function<void ()> onError;
   std::vector<Name> functionNames;
@@ -245,7 +245,7 @@ class SExpressionWasmBuilder {
 
 public:
   // Assumes control of and modifies the input.
-  SExpressionWasmBuilder(AllocatingModule& wasm, Element& module, std::function<void ()> onError) : wasm(wasm), allocator(wasm.allocator), onError(onError), importCounter(0) {
+  SExpressionWasmBuilder(Module& wasm, Element& module, std::function<void ()> onError) : wasm(wasm), allocator(wasm.allocator), onError(onError), importCounter(0) {
     assert(module[0]->str() == MODULE);
     functionCounter = 0;
     for (unsigned i = 1; i < module.size(); i++) {
@@ -259,7 +259,7 @@ public:
   }
 
   // constructor without onError
-  SExpressionWasmBuilder(AllocatingModule& wasm, Element& module) : SExpressionWasmBuilder(wasm, module, [&]() { abort(); }) {}
+  SExpressionWasmBuilder(Module& wasm, Element& module) : SExpressionWasmBuilder(wasm, module, [&]() { abort(); }) {}
 
 private:
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1124,6 +1124,8 @@ public:
   Memory memory;
   Name start;
 
+  MixedArena allocator;
+
 private:
   // TODO: add a build option where Names are just indices, and then these methods are not needed
   std::map<Name, FunctionType*> functionTypesMap;
@@ -1205,11 +1207,6 @@ public:
 
 private:
   size_t functionTypeIndex, importIndex, exportIndex, functionIndex;
-};
-
-class AllocatingModule : public Module {
- public:
-  MixedArena allocator;
 };
 
 } // namespace wasm

--- a/src/wasm2asm-main.cpp
+++ b/src/wasm2asm-main.cpp
@@ -51,7 +51,7 @@ int main(int argc, const char *argv[]) {
   Element &root = *parser.root;
 
   if (options.debug) std::cerr << "w-parsing..." << std::endl;
-  AllocatingModule wasm;
+  Module wasm;
   SExpressionWasmBuilder builder(wasm, *root[0], [&]() { abort(); });
 
   if (options.debug) std::cerr << "asming..." << std::endl;

--- a/test/example/find_div0s.cpp
+++ b/test/example/find_div0s.cpp
@@ -28,7 +28,7 @@ int main() {
   // Parse the S-Expression text, and prepare to build a WebAssembly module.
   SExpressionParser parser(input);
   Element& root = *parser.root;
-  AllocatingModule module;
+  Module module;
 
   // The parsed code has just one element, the module. Build the module
   // from that (and abort on any errors, but there won't be one here).


### PR DESCRIPTION
The distinction was not really that useful, and passes do need to allocate, so we would need to pass around AllocatingModules all around anyhow. All modules being as allocating modules in all the builders, as well.
