### PR TITLE
Parses more than one entry in the .init_array section.

### DIFF
--- a/test/dot_s/initializers.s
+++ b/test/dot_s/initializers.s
@@ -9,15 +9,22 @@ main:                                   # @main
 	return  	$pop0
 .Lfunc_end0:
 	.size	main, .Lfunc_end0-main
+	.globl  f1
+	.type	f1,@function
+f1:
+	return
+.Lfunc_end1:
+	.size f1, .Lfunc_end1-f1
 	.globl  f2
 	.type	f2,@function
 f2:
 	return
-.Lfunc_end1:
-	.size f2, .Lfunc_end1-f2
+.Lfunc_end2:
+	.size f2, .Lfunc_end2-f2
 	.section	.init_array.101,"aw",@init_array
 	.p2align	2
 	.int32	main@FUNCTION
 	.section	.init_array,"aw",@init_array
 	.p2align	2
+	.int32  f1@FUNCTION
 	.int32	f2@FUNCTION

--- a/test/dot_s/initializers.wast
+++ b/test/dot_s/initializers.wast
@@ -2,14 +2,18 @@
   (memory 1)
   (export "memory" memory)
   (export "main" $main)
+  (export "f1" $f1)
   (export "f2" $f2)
   (func $main (result i32)
     (return
       (i32.const 5)
     )
   )
+  (func $f1
+    (return)
+  )
   (func $f2
     (return)
   )
 )
-;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": ["main", "f2"] }
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": ["main", "f1", "f2"] }


### PR DESCRIPTION
Allows more than one function in the the .init_array section to be parsed. Found during building of wast.js.

See also #315