### PR TITLE
Removes wasm-s-parser debug logging from binaryen.idl.

### DIFF
--- a/src/js/binaryen.idl
+++ b/src/js/binaryen.idl
@@ -57,7 +57,7 @@ interface SExpressionParser {
 };
 
 interface SExpressionWasmBuilder {
-  void SExpressionWasmBuilder([Ref] Module wasm, [Ref] Element input, boolean debug);
+  void SExpressionWasmBuilder([Ref] Module wasm, [Ref] Element input);
 };
 
 // Wasm printing


### PR DESCRIPTION
Continuation of #345 (see https://github.com/WebAssembly/binaryen/commit/2887883029de293458344a5d564039074d93246e#diff-499c4e70c8aadb9837261ebcc4725f78R262)

Currently building of binaryen.js fails with
"src/../glue.cpp:102:14: error: no matching constructor for initialization of
      'wasm::SExpressionWasmBuilder'"