### PR TITLE
Simplify statics, segments, and relocations

### DIFF
--- a/src/s2wasm-main.cpp
+++ b/src/s2wasm-main.cpp
@@ -102,7 +102,8 @@ int main(int argc, const char *argv[]) {
           : 0;
   if (options.debug) std::cerr << "Global base " << globalBase << '\n';
   Linker lm(wasm, globalBase, stackAllocation, initialMem, maxMem,
-                  ignoreUnknownSymbols, startFunction, options.debug);
+            ignoreUnknownSymbols, startFunction, options.debug);
+
   S2WasmBuilder s2wasm(wasm, input.c_str(), options.debug, lm);
 
   std::stringstream meta;

--- a/test/dot_s/basics.s
+++ b/test/dot_s/basics.s
@@ -48,7 +48,7 @@ main:                                   # @main
 	end_block
 	i32.const	$push11=, -12
 	i32.add 	$0=, $0, $pop11
-	i32.const	$discard=, main # just take address for testing
+	i32.const	$discard=, main@FUNCTION # just take address for testing
 	end_block
 	return  	$0
 .Lfunc_end0:


### PR DESCRIPTION
Also defer address assignment until layout time in preparation for
separating linker objects out from Linker