### PR TITLE
Split construction, scanning, and building phases of S2WasmBuilder

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -25,7 +25,7 @@
 #include "wasm.h"
 #include "emscripten-optimizer/optimizer.h"
 #include "mixed_arena.h"
-#include "shared-constants.h"
+#include "asmjs/shared-constants.h"
 #include "asm_v_wasm.h"
 #include "pass.h"
 #include "ast_utils.h"

--- a/src/asmjs/CMakeLists.txt
+++ b/src/asmjs/CMakeLists.txt
@@ -1,4 +1,5 @@
 SET(asmjs_SOURCES
   asm_v_wasm.cpp
+  shared-constants.cpp
 )
 ADD_LIBRARY(asmjs STATIC ${asmjs_SOURCES})

--- a/src/asmjs/shared-constants.cpp
+++ b/src/asmjs/shared-constants.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 WebAssembly Community Group participants
+ * Copyright 2016 WebAssembly Community Group participants
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-#ifndef wasm_shared_constants_h
-#define wasm_shared_constants_h
-
-#include "emscripten-optimizer/optimizer.h"
+#include "asmjs/shared-constants.h"
 
 namespace wasm {
 
@@ -100,5 +97,3 @@ cashew::IString GLOBAL("global"),
                 EXIT("exit");
 
 }
-
-#endif // wasm_shared_constants_h

--- a/src/asmjs/shared-constants.h
+++ b/src/asmjs/shared-constants.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_shared_constants_h
+#define wasm_shared_constants_h
+
+#include "emscripten-optimizer/optimizer.h"
+
+namespace wasm {
+
+extern cashew::IString GLOBAL,
+                NAN_,
+                INFINITY_,
+                NAN__,
+                INFINITY__,
+                TOPMOST,
+                INT8ARRAY,
+                INT16ARRAY,
+                INT32ARRAY,
+                UINT8ARRAY,
+                UINT16ARRAY,
+                UINT32ARRAY,
+                FLOAT32ARRAY,
+                FLOAT64ARRAY,
+                IMPOSSIBLE_CONTINUE,
+                MATH,
+                IMUL,
+                CLZ32,
+                FROUND,
+                ASM2WASM,
+                F64_REM,
+                F64_TO_INT,
+                GLOBAL_MATH,
+                ABS,
+                FLOOR,
+                CEIL,
+                SQRT,
+                I32_TEMP,
+                DEBUGGER,
+                GROW_WASM_MEMORY,
+                NEW_SIZE,
+                MODULE,
+                START,
+                FUNC,
+                PARAM,
+                RESULT,
+                MEMORY,
+                SEGMENT,
+                EXPORT,
+                IMPORT,
+                TABLE,
+                LOCAL,
+                TYPE,
+                CALL,
+                CALL_IMPORT,
+                CALL_INDIRECT,
+                BLOCK,
+                BR_IF,
+                THEN,
+                ELSE,
+                NEG_INFINITY,
+                NEG_NAN,
+                CASE,
+                BR,
+                USE_ASM,
+                BUFFER,
+                ENV,
+                FAKE_RETURN,
+                MATH_IMUL,
+                MATH_CLZ32,
+                MATH_CTZ32,
+                MATH_POPCNT32,
+                MATH_ABS,
+                MATH_CEIL,
+                MATH_FLOOR,
+                MATH_TRUNC,
+                MATH_NEAREST,
+                MATH_SQRT,
+                MATH_MIN,
+                MATH_MAX,
+                ASSERT_RETURN,
+                ASSERT_TRAP,
+                ASSERT_INVALID,
+                SPECTEST,
+                PRINT,
+                INVOKE,
+                EXIT;
+
+}
+
+#endif // wasm_shared_constants_h

--- a/src/asmjs/shared-constants.h
+++ b/src/asmjs/shared-constants.h
@@ -17,7 +17,7 @@
 #ifndef wasm_shared_constants_h
 #define wasm_shared_constants_h
 
-#include "emscripten-optimizer/optimizer.h"
+#include "emscripten-optimizer/istring.h"
 
 namespace wasm {
 

--- a/src/asmjs/shared-constants.h
+++ b/src/asmjs/shared-constants.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef wasm_shared_constants_h
-#define wasm_shared_constants_h
+#ifndef wasm_asmjs_shared_constants_h
+#define wasm_asmjs_shared_constants_h
 
 #include "emscripten-optimizer/istring.h"
 
@@ -101,4 +101,4 @@ extern cashew::IString GLOBAL,
 
 }
 
-#endif // wasm_shared_constants_h
+#endif // wasm_asmjs_shared_constants_h

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -19,14 +19,14 @@
 
 #include <sstream>
 
+#include "asmjs/shared-constants.h"
 #include "mixed_arena.h"
-#include "shared-constants.h"
 #include "support/utilities.h"
 #include "wasm.h"
 
 namespace wasm {
 
-Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) {
+inline Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allocator) {
   const char *str = s.str;
   auto ret = allocator.alloc<Const>();
   ret->type = type;

--- a/src/s2wasm-main.cpp
+++ b/src/s2wasm-main.cpp
@@ -104,7 +104,13 @@ int main(int argc, const char *argv[]) {
   Linker linker(globalBase, stackAllocation, initialMem, maxMem,
                 ignoreUnknownSymbols, startFunction, options.debug);
 
-  S2WasmBuilder s2wasm(linker.getOutput(), input.c_str(), options.debug);
+  S2WasmBuilder mainbuilder(input.c_str(), options.debug);
+  linker.linkObject(mainbuilder);
+
+  // In the future, there will be code to open additional files/buffers and
+  // link additional objects, as well as archive members (which only get linked if needed), e.g.:
+  // S2WasmBuilder lazyObject(some_other_buffer, options.debug)
+  // linker.linkLazyObject(lazyObject); // calls builder.scan to get symbol info, then build
 
   linker.layout();
 

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -56,8 +56,7 @@ class S2WasmBuilder {
 
   void build(LinkerObject *obj, LinkerObject::SymbolInfo* info) {
     if (!obj->isEmpty()) Fatal() << "Cannot construct an S2WasmBuilder in an non-empty LinkerObject";
-    if (!info)
-      info = getSymbolInfo();
+    if (!info) info = getSymbolInfo();
     linkerObj = obj;
     wasm = &obj->wasm;
     allocator = &wasm->allocator;
@@ -705,7 +704,7 @@ class S2WasmBuilder {
         auto input = inputs.begin();
         auto* target = *input;
         std::vector<Expression*> operands(++input, inputs.end());
-        auto* funcType = ensureFunctionType(getSig(type, operands), &wasm);
+        auto* funcType = ensureFunctionType(getSig(type, operands), wasm);
         assert(type == funcType->result);
         auto* indirect = builder.makeCallIndirect(funcType, target, std::move(operands));
         setOutput(indirect, assign);

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -55,10 +55,12 @@ class S2WasmBuilder {
         {}
 
   void build(LinkerObject *obj, LinkerObject::SymbolInfo* info) {
-    if (!linkerObj->isEmpty()) Fatal() << "Cannot construct an S2WasmBuilder in an non-empty LinkerObject";
+    if (!obj->isEmpty()) Fatal() << "Cannot construct an S2WasmBuilder in an non-empty LinkerObject";
     if (!info)
       info = getSymbolInfo();
     linkerObj = obj;
+    wasm = &obj->wasm;
+    allocator = &wasm->allocator;
 
     s = inputStart;
     process();

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -37,24 +37,37 @@ namespace wasm {
 //
 
 class S2WasmBuilder {
-  Module& wasm;
-  MixedArena& allocator;
+  const char* inputStart;
   const char* s;
   bool debug;
-  LinkerObject& linkerObj;
+  Module* wasm;
+  MixedArena* allocator;
+  LinkerObject* linkerObj;
 
  public:
-  S2WasmBuilder(LinkerObject& linkerObj, const char* input, bool debug)
-      : wasm(linkerObj.wasm),
-        allocator(wasm.allocator),
+  S2WasmBuilder(const char* input, bool debug)
+      : inputStart(input),
+        s(input),
         debug(debug),
-        linkerObj(linkerObj) {
-    if (!linkerObj.isEmpty()) Fatal() << "Cannot construct an S2WasmBuilder in an non-empty LinkerObject";
-    s = input;
-    scan();
-    s = input;
+        wasm(nullptr),
+        allocator(nullptr),
+        linkerObj(nullptr)
+        {}
 
+  void build(LinkerObject *obj, LinkerObject::SymbolInfo* info) {
+    if (!linkerObj->isEmpty()) Fatal() << "Cannot construct an S2WasmBuilder in an non-empty LinkerObject";
+    if (!info)
+      info = getSymbolInfo();
+    linkerObj = obj;
+
+    s = inputStart;
     process();
+  }
+
+  LinkerObject::SymbolInfo* getSymbolInfo() {
+    auto* info = new LinkerObject::SymbolInfo();
+    scan(info);
+    return info;
   }
 
  private:
@@ -209,7 +222,7 @@ class S2WasmBuilder {
         s++;
         offset = -getInt();
       }
-      linkerObj.addRelocation(kind, target, cleanFunction(name), offset);
+      linkerObj->addRelocation(kind, target, cleanFunction(name), offset);
       return true;
     }
   }
@@ -334,7 +347,8 @@ class S2WasmBuilder {
 
   // processors
 
-  void scan() {
+  void scan(LinkerObject::SymbolInfo* info) {
+    s = inputStart;
     while (*s) {
       skipWhitespace();
       s = strstr(s, ".type");
@@ -346,11 +360,11 @@ class S2WasmBuilder {
       if (match(".hidden")) mustMatch(name.str);
       mustMatch(name.str);
       if (match(":")) {
-        linkerObj.addImplementedFunction(name);
+        info->implementedFunctions.insert(name);
       } else if (match("=")) {
         Name alias = getAtSeparated();
         mustMatch("@FUNCTION");
-        linkerObj.addAliasedFunction(name, alias);
+        info->aliasedFunctions.insert({name, alias});
       } else {
         abort_on("unknown directive");
       }
@@ -402,7 +416,7 @@ class S2WasmBuilder {
     }
     mustMatch(".int32");
     do {
-      linkerObj.addInitializerFunction(cleanFunction(getStr()));
+      linkerObj->addInitializerFunction(cleanFunction(getStr()));
       skipWhitespace();
     } while (match(".int32"));
   }
@@ -437,7 +451,7 @@ class S2WasmBuilder {
   }
 
   void parseGlobl() {
-    linkerObj.addGlobal(getStr());
+    linkerObj->addGlobal(getStr());
     skipWhitespace();
   }
 
@@ -465,7 +479,7 @@ class S2WasmBuilder {
     auto getNextId = [&nextId]() {
       return cashew::IString(('$' + std::to_string(nextId++)).c_str(), false);
     };
-    wasm::Builder builder(wasm);
+    wasm::Builder builder(*wasm);
     std::vector<NameType> params;
     WasmType resultType = none;
     std::vector<NameType> vars;
@@ -498,7 +512,7 @@ class S2WasmBuilder {
     Function* func = builder.makeFunction(name, std::move(params), resultType, std::move(vars));
 
     // parse body
-    func->body = allocator.alloc<Block>();
+    func->body = allocator->alloc<Block>();
     std::vector<Expression*> bstack;
     auto addToBlock = [&bstack](Expression* curr) {
       Expression* last = bstack.back();
@@ -543,7 +557,7 @@ class S2WasmBuilder {
           skipToSep();
           inputs[i] = nullptr;
         } else {
-          auto curr = allocator.alloc<GetLocal>();
+          auto curr = allocator->alloc<GetLocal>();
           curr->index = func->getLocalIndex(getStrToSep());
           curr->type = func->getLocalType(curr->index);
           inputs[i] = curr;
@@ -569,7 +583,7 @@ class S2WasmBuilder {
       } else if (assign.str[1] == 'p') { // push
         push(curr);
       } else { // set to a local
-        auto set = allocator.alloc<SetLocal>();
+        auto set = allocator->alloc<SetLocal>();
         set->index = func->getLocalIndex(assign);
         set->value = curr;
         set->type = curr->type;
@@ -597,7 +611,7 @@ class S2WasmBuilder {
     auto makeBinary = [&](BinaryOp op, WasmType type) {
       Name assign = getAssign();
       skipComma();
-      auto curr = allocator.alloc<Binary>();
+      auto curr = allocator->alloc<Binary>();
       curr->op = op;
       auto inputs = getInputs(2);
       curr->left = inputs[0];
@@ -609,7 +623,7 @@ class S2WasmBuilder {
     auto makeUnary = [&](UnaryOp op, WasmType type) {
       Name assign = getAssign();
       skipComma();
-      auto curr = allocator.alloc<Unary>();
+      auto curr = allocator->alloc<Unary>();
       curr->op = op;
       curr->value = getInput();
       curr->type = type;
@@ -617,20 +631,20 @@ class S2WasmBuilder {
     };
     auto makeHost = [&](HostOp op) {
       Name assign = getAssign();
-      auto curr = allocator.alloc<Host>();
+      auto curr = allocator->alloc<Host>();
       curr->op = op;
       setOutput(curr, assign);
     };
     auto makeHost1 = [&](HostOp op) {
       Name assign = getAssign();
-      auto curr = allocator.alloc<Host>();
+      auto curr = allocator->alloc<Host>();
       curr->op = op;
       curr->operands.push_back(getInput());
       setOutput(curr, assign);
     };
     auto makeLoad = [&](WasmType type) {
       skipComma();
-      auto curr = allocator.alloc<Load>();
+      auto curr = allocator->alloc<Load>();
       curr->type = type;
       int32_t bytes = getInt() / CHAR_BIT;
       curr->bytes = bytes > 0 ? bytes : getWasmTypeSize(type);
@@ -650,7 +664,7 @@ class S2WasmBuilder {
     };
     auto makeStore = [&](WasmType type) {
       skipComma();
-      auto curr = allocator.alloc<Store>();
+      auto curr = allocator->alloc<Store>();
       curr->type = type;
       int32_t bytes = getInt() / CHAR_BIT;
       curr->bytes = bytes > 0 ? bytes : getWasmTypeSize(type);
@@ -671,7 +685,7 @@ class S2WasmBuilder {
     auto makeSelect = [&](WasmType type) {
       Name assign = getAssign();
       skipComma();
-      auto curr = allocator.alloc<Select>();
+      auto curr = allocator->alloc<Select>();
       auto inputs = getInputs(3);
       curr->ifTrue = inputs[0];
       curr->ifFalse = inputs[1];
@@ -697,13 +711,13 @@ class S2WasmBuilder {
       } else {
         // non-indirect call
         Name assign = getAssign();
-        Name target = linkerObj.resolveAlias(cleanFunction(getCommaSeparated()));
+        Name target = linkerObj->resolveAlias(cleanFunction(getCommaSeparated()));
 
-        Call* curr = allocator.alloc<Call>();
+        Call* curr = allocator->alloc<Call>();
         curr->target = target;
         curr->type = type;
-        if (!linkerObj.isFunctionImplemented(target)) {
-          linkerObj.addUndefinedFunctionCall(curr);
+        if (!linkerObj->isFunctionImplemented(target)) {
+          linkerObj->addUndefinedFunctionCall(curr);
         }
         skipWhitespace();
         if (*s == ',') {
@@ -731,13 +745,13 @@ class S2WasmBuilder {
             Name assign = getAssign();
             if (type == i32) {
               // may be a relocation
-              auto curr = allocator.alloc<Const>();
+              auto curr = allocator->alloc<Const>();
               curr->type = curr->value.type = i32;
               getConst((uint32_t*)curr->value.geti32Ptr());
               setOutput(curr, assign);
             } else {
               cashew::IString str = getStr();
-              setOutput(parseConst(str, type, allocator), assign);
+              setOutput(parseConst(str, type, *allocator), assign);
             }
           }
           else if (match("call")) makeCall(type);
@@ -891,7 +905,7 @@ class S2WasmBuilder {
       } else if (match("f64.")) {
         handleTyped(f64);
       } else if (match("block")) {
-        auto curr = allocator.alloc<Block>();
+        auto curr = allocator->alloc<Block>();
         curr->name = getNextLabel();
         addToBlock(curr);
         bstack.push_back(curr);
@@ -900,11 +914,11 @@ class S2WasmBuilder {
       } else if (match(".LBB")) {
         s = strchr(s, '\n');
       } else if (match("loop")) {
-        auto curr = allocator.alloc<Loop>();
+        auto curr = allocator->alloc<Loop>();
         addToBlock(curr);
         curr->in = getNextLabel();
         curr->out = getNextLabel();
-        auto block = allocator.alloc<Block>();
+        auto block = allocator->alloc<Block>();
         block->name = curr->out; // temporary, fake - this way, on bstack we have the right label at the right offset for a br
         curr->body = block;
         loopBlocks.push_back(block);
@@ -914,7 +928,7 @@ class S2WasmBuilder {
         bstack.pop_back();
         bstack.pop_back();
       } else if (match("br_table")) {
-        auto curr = allocator.alloc<Switch>();
+        auto curr = allocator->alloc<Switch>();
         curr->condition = getInput();
         while (skipComma()) {
           curr->targets.push_back(getBranchLabel(getInt()));
@@ -924,7 +938,7 @@ class S2WasmBuilder {
         curr->targets.pop_back();
         addToBlock(curr);
       } else if (match("br")) {
-        auto curr = allocator.alloc<Break>();
+        auto curr = allocator->alloc<Break>();
         bool hasCondition = false;
         if (*s == '_') {
           mustMatch("_if");
@@ -945,7 +959,7 @@ class S2WasmBuilder {
       } else if (match("tee_local")) {
         Name assign = getAssign();
         skipComma();
-        auto curr = allocator.alloc<SetLocal>();
+        auto curr = allocator->alloc<SetLocal>();
         curr->index = func->getLocalIndex(getAssign());
         skipComma();
         curr->value = getInput();
@@ -954,7 +968,7 @@ class S2WasmBuilder {
       } else if (match("return")) {
         addToBlock(builder.makeReturn(*s == '$' ? getInput() : nullptr));
       } else if (match("unreachable")) {
-        addToBlock(allocator.alloc<Unreachable>());
+        addToBlock(allocator->alloc<Unreachable>());
       } else if (match("memory_size")) {
         makeHost(CurrentMemory);
       } else if (match("grow_memory")) {
@@ -978,7 +992,7 @@ class S2WasmBuilder {
       block->name = Name();
     }
     func->body->dynCast<Block>()->finalize();
-    wasm.addFunction(func);
+    wasm->addFunction(func);
   }
 
   void parseType() {
@@ -1064,7 +1078,7 @@ class S2WasmBuilder {
         size_t size = raw->size();
         raw->resize(size + 4);
         if (getConst((uint32_t*)&(*raw)[size])) { // just the size, as we may reallocate; we must fix this later, if it's a relocation
-          currRelocations.emplace_back(linkerObj.getCurrentRelocation(), size);
+          currRelocations.emplace_back(linkerObj->getCurrentRelocation(), size);
         }
         zero = false;
       } else if (match(".int64")) {
@@ -1095,9 +1109,9 @@ class S2WasmBuilder {
       r->data = (uint32_t*)&(*raw)[i];
     }
     // assign the address, add to memory
-    linkerObj.addStatic(size, align, name);
+    linkerObj->addStatic(size, align, name);
     if (!zero) {
-      linkerObj.addSegment(name, (const char*)&(*raw)[0], size);
+      linkerObj->addSegment(name, (const char*)&(*raw)[0], size);
     }
   }
 
@@ -1109,7 +1123,7 @@ class S2WasmBuilder {
       skipComma();
       getInt();
     }
-    linkerObj.addStatic(size, align, name);
+    linkerObj->addStatic(size, align, name);
   }
 
   void skipImports() {

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -18,7 +18,7 @@
 // Implementation of the shell interpreter execution environment
 //
 
-#include "shared-constants.h"
+#include "asmjs/shared-constants.h"
 #include "wasm.h"
 #include "wasm-interpreter.h"
 
@@ -177,4 +177,3 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
 };
 
 }
-

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -26,7 +26,7 @@
 
 #include "wasm.h"
 #include "wasm-traversal.h"
-#include "shared-constants.h"
+#include "asmjs/shared-constants.h"
 #include "asm_v_wasm.h"
 #include "wasm-builder.h"
 #include "ast_utils.h"

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -27,8 +27,8 @@
 #include <limits>
 
 #include "wasm.h"
+#include "asmjs/shared-constants.h"
 #include "mixed_arena.h"
-#include "shared-constants.h"
 #include "parsing.h"
 #include "asm_v_wasm.h"
 #include "ast_utils.h"

--- a/src/wasm2asm.h
+++ b/src/wasm2asm.h
@@ -24,11 +24,11 @@
 
 #include <cmath>
 
+#include "asmjs/shared-constants.h"
 #include "wasm.h"
 #include "emscripten-optimizer/optimizer.h"
 #include "mixed_arena.h"
 #include "asm_v_wasm.h"
-#include "shared-constants.h"
 
 namespace wasm {
 


### PR DESCRIPTION
Instead of doing all of the S2Wasm work in the constructor, split
construction, scanning (to determine implemented functions) and building
of the wasm module.

This allows the linker to get the symbol information (e.g. implemented
functions) without having to build an entire module (which will be
useful for archives) and to allow the linker to link a new object into
the existing one by building the wasm module in place on the existing
module.