### PR TITLE
Check LEB128 encoding fits in destination integer

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -109,7 +109,7 @@ struct LEB {
         size_t sext_bits = 8 * sizeof(T) - size_t(shift);
         value <<= sext_bits;
         value >>= sext_bits;
-        assert(value < 0 && "signe-extend should produces a negative value");
+        assert(value < 0 && "sign-extend should produces a negative value");
       }
     }
   }


### PR DESCRIPTION
As found by #404, the insignificant LEB128 bits were silently dropped when dealing with signed LEB values which tripped UBSAN in hello_world.

This fixes #409.