### PR TITLE
Fix asm2wasm f64->f32->i32 bitcast

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1579,6 +1579,10 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
                 auto conv = allocator.alloc<Unary>();
                 conv->op = ReinterpretFloat;
                 conv->value = process(writtenValue);
+                if (conv->value->type == f64) {
+                  // this has an implicit f64->f32 in the write to memory
+                  conv->value = builder.makeUnary(DemoteFloat64, conv->value, f32);
+                }
                 conv->type = WasmType::i32;
                 return conv;
               }

--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -207,9 +207,11 @@ function asm(global, env, buffer) {
   function bitcasts(i, f) {
     i = i | 0;
     f = Math_fround(f);
+    var d = 0.0;
     (HEAP32[tempDoublePtr >> 2] = i, Math_fround(HEAPF32[tempDoublePtr >> 2])); // i32->f32
     (HEAP32[tempDoublePtr >> 2] = i, +HEAPF32[tempDoublePtr >> 2]); // i32->f32, no fround
     (HEAPF32[tempDoublePtr >> 2] = f, HEAP32[tempDoublePtr >> 2] | 0); // f32->i32
+    (HEAPF32[tempDoublePtr >> 2] = d, HEAP32[tempDoublePtr >> 2] | 0); // f64 with implict f32 conversion, ->i32
   }
 
   function z() {

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -460,6 +460,7 @@
     )
   )
   (func $bitcasts (param $i i32) (param $f f32)
+    (local $d f64)
     (f32.reinterpret/i32
       (get_local $i)
     )
@@ -470,6 +471,11 @@
     )
     (i32.reinterpret/f32
       (get_local $f)
+    )
+    (i32.reinterpret/f32
+      (f32.demote/f64
+        (get_local $d)
+      )
     )
   )
   (func $z

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -454,6 +454,7 @@
     )
   )
   (func $bitcasts (param $i i32) (param $f f32)
+    (local $d f64)
     (f32.reinterpret/i32
       (get_local $i)
     )
@@ -464,6 +465,11 @@
     )
     (i32.reinterpret/f32
       (get_local $f)
+    )
+    (i32.reinterpret/f32
+      (f32.demote/f64
+        (get_local $d)
+      )
     )
   )
   (func $z


### PR DESCRIPTION
In asm.js we have an implicit cast of f64 to f32 when writing to memory in the bitcast pattern. In wasm we need to demote it explicitly.