### PR TITLE
Changed type of flags to fix Visual Studio 2015 Issue #414

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -23,7 +23,7 @@ template <typename T>
 T wasm::read_file(const std::string &filename, Flags::BinaryOption binary, Flags::DebugOption debug) {
   if (debug == Flags::Debug) std::cerr << "Loading '" << filename << "'..." << std::endl;
   std::ifstream infile;
-  auto flags = std::ifstream::in;
+  std::ios_base::openmode flags = std::ifstream::in;
   if (binary == Flags::Binary) flags |= std::ifstream::binary;
   infile.open(filename, flags);
   if (!infile.is_open()) {


### PR DESCRIPTION
Changed type of flags (line 26) in read_file() from auto to std::ios_base::openmode to fix Visual Studio 2015 error.

Visual Studio 2015 Build Error support/file.cpp #414