### PR TITLE
ubsan: only recover from some of the failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
           packages: ['cmake', 'nodejs', 'clang-3.6']
 
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fsanitize-blacklist=`pwd`/ubsan.blacklist"
+    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=alignment,bool,bounds,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,object-size,return,returns-nonnull-attribute,unreachable,unsigned-integer-overflow,vla-bound,vptr -fsanitize-blacklist=`pwd`/ubsan.blacklist"
       compiler: clang
       addons: *clang36
 


### PR DESCRIPTION
I fixed a few of the existing ubsan failures as part of #404, but would
like to prevent regressions. This patch allows some of the sanitizer
checks to continue execution (null, shift, signed-integer-overflow) and
makes all the other ones hard errors (preventing regressions).

Once the remaining errors are addressed we should commit #404 which
moves ubsan to -fno-sanitize-recover=all. This likely requires a good
checked-math library.