### PR TITLE
Fix null UB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
           packages: ['cmake', 'nodejs', 'clang-3.6']
 
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=alignment,bool,bounds,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,object-size,return,returns-nonnull-attribute,unreachable,unsigned-integer-overflow,vla-bound,vptr -fsanitize-blacklist=`pwd`/ubsan.blacklist"
+    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=null,alignment,bool,bounds,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,object-size,return,returns-nonnull-attribute,unreachable,unsigned-integer-overflow,vla-bound,vptr -fsanitize-blacklist=`pwd`/ubsan.blacklist"
       compiler: clang
       addons: *clang36
 

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1067,42 +1067,46 @@ private:
       Element& curr = *s[i];
       assert(curr[0]->str() == SEGMENT);
       const char *input = curr[2]->c_str();
-      std::vector<char> data;
-      data.resize(strlen(input));
-      char *write = (char*)&data[0];
-      while (1) {
-        if (input[0] == 0) break;
-        if (input[0] == '\\') {
-          if (input[1] == '"') {
-            *write++ = '"';
-            input += 2;
-            continue;
-          } else if (input[1] == '\'') {
-            *write++ = '\'';
-            input += 2;
-            continue;
-          } else if (input[1] == '\\') {
-            *write++ = '\\';
-            input += 2;
-            continue;
-          } else if (input[1] == 'n') {
-            *write++ = '\n';
-            input += 2;
-            continue;
-          } else if (input[1] == 't') {
-            *write++ = '\t';
-            input += 2;
-            continue;
-          } else {
-            *write++ = (char)(unhex(input[1])*16 + unhex(input[2]));
-            input += 3;
-            continue;
+      if (auto size = strlen(input)) {
+        std::vector<char> data;
+        data.resize(size);
+        char *write = data.data();
+        while (1) {
+          if (input[0] == 0) break;
+          if (input[0] == '\\') {
+            if (input[1] == '"') {
+              *write++ = '"';
+              input += 2;
+              continue;
+            } else if (input[1] == '\'') {
+              *write++ = '\'';
+              input += 2;
+              continue;
+            } else if (input[1] == '\\') {
+              *write++ = '\\';
+              input += 2;
+              continue;
+            } else if (input[1] == 'n') {
+              *write++ = '\n';
+              input += 2;
+              continue;
+            } else if (input[1] == 't') {
+              *write++ = '\t';
+              input += 2;
+              continue;
+            } else {
+              *write++ = (char)(unhex(input[1])*16 + unhex(input[2]));
+              input += 3;
+              continue;
+            }
           }
+          *write++ = input[0];
+          input++;
         }
-        *write++ = input[0];
-        input++;
+        wasm.memory.segments.emplace_back(atoi(curr[1]->c_str()), data.data(), write - data.data());
+      } else {
+        wasm.memory.segments.emplace_back(atoi(curr[1]->c_str()), "", 0);
       }
-      wasm.memory.segments.emplace_back(atoi(curr[1]->c_str()), (const char*)&data[0], write - (const char*)&data[0]);
       i++;
     }
   }


### PR DESCRIPTION
As a continuation to #404, fix a dereference of a std::vector's zeroth element when the size of the vector is zero.

Symptom: stl_vector.h:866:9: runtime error: reference binding to null pointer of type 'char'