### PR TITLE
Fix shift UB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
           packages: ['cmake', 'nodejs', 'clang-3.6']
 
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=null,alignment,bool,bounds,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,object-size,return,returns-nonnull-attribute,unreachable,unsigned-integer-overflow,vla-bound,vptr -fsanitize-blacklist=`pwd`/ubsan.blacklist"
+    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=shift,null,alignment,bool,bounds,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,object-size,return,returns-nonnull-attribute,unreachable,unsigned-integer-overflow,vla-bound,vptr -fsanitize-blacklist=`pwd`/ubsan.blacklist"
       compiler: clang
       addons: *clang36
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -530,22 +530,22 @@ public:
   }
   Literal shl(const Literal& other) const {
     switch (type) {
-      case WasmType::i32: return Literal(i32 << other.i32);
-      case WasmType::i64: return Literal(i64 << other.i64);
+      case WasmType::i32: return Literal(uint32_t(i32) << (other.i32 & 0x1f));
+      case WasmType::i64: return Literal(uint64_t(i64) << (other.i64 & 0x3f));
       default: WASM_UNREACHABLE();
     }
   }
   Literal shrS(const Literal& other) const {
     switch (type) {
-      case WasmType::i32: return Literal(i32 >> other.i32);
-      case WasmType::i64: return Literal(i64 >> other.i64);
+      case WasmType::i32: return Literal(i32 >> (other.i32 & 0x1f));
+      case WasmType::i64: return Literal(i64 >> (other.i64 & 0x3f));
       default: WASM_UNREACHABLE();
     }
   }
   Literal shrU(const Literal& other) const {
     switch (type) {
-      case WasmType::i32: return Literal(uint32_t(i32) >> uint32_t(other.i32));
-      case WasmType::i64: return Literal(uint64_t(i64) >> uint64_t(other.i64));
+      case WasmType::i32: return Literal(uint32_t(i32) >> uint32_t(other.i32 & 0x1f));
+      case WasmType::i64: return Literal(uint64_t(i64) >> uint64_t(other.i64 & 0x3f));
       default: WASM_UNREACHABLE();
     }
   }


### PR DESCRIPTION
Getting close to finishing #404.

Also not the extra mask which just used to return the right result on x86. Those cases would have failed on A32.