### PR TITLE
Fix signed integer overflow UB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
           packages: ['cmake', 'nodejs', 'clang-3.6']
 
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=shift,null,alignment,bool,bounds,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,object-size,return,returns-nonnull-attribute,unreachable,unsigned-integer-overflow,vla-bound,vptr -fsanitize-blacklist=`pwd`/ubsan.blacklist"
+    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fsanitize-blacklist=`pwd`/ubsan.blacklist"
       compiler: clang
       addons: *clang36
 

--- a/src/support/bits.cpp
+++ b/src/support/bits.cpp
@@ -68,7 +68,7 @@ int CountTrailingZeroes<uint32_t>(uint32_t v) {
     0,   1, 28,  2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17,  4, 8,
     31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18,  6, 11,  5, 10, 9
   };
-  return v ? (int)tbl[((uint32_t)((v & -(int32_t)v) * 0x077CB531U)) >> 27] : 32;
+  return v ? (int)tbl[((uint32_t)((v & -v) * 0x077CB531U)) >> 27] : 32;
 }
 
 template<>

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -409,8 +409,8 @@ public:
 
   Literal add(const Literal& other) const {
     switch (type) {
-      case WasmType::i32: return Literal(i32 + other.i32);
-      case WasmType::i64: return Literal(i64 + other.i64);
+      case WasmType::i32: return Literal(uint32_t(i32) + uint32_t(other.i32));
+      case WasmType::i64: return Literal(uint64_t(i64) + uint64_t(other.i64));
       case WasmType::f32: return Literal(getf32() + other.getf32());
       case WasmType::f64: return Literal(getf64() + other.getf64());
       default: WASM_UNREACHABLE();
@@ -418,8 +418,8 @@ public:
   }
   Literal sub(const Literal& other) const {
     switch (type) {
-      case WasmType::i32: return Literal(i32 - other.i32);
-      case WasmType::i64: return Literal(i64 - other.i64);
+      case WasmType::i32: return Literal(uint32_t(i32) - uint32_t(other.i32));
+      case WasmType::i64: return Literal(uint64_t(i64) - uint64_t(other.i64));
       case WasmType::f32: return Literal(getf32() - other.getf32());
       case WasmType::f64: return Literal(getf64() - other.getf64());
       default: WASM_UNREACHABLE();
@@ -427,8 +427,8 @@ public:
   }
   Literal mul(const Literal& other) const {
     switch (type) {
-      case WasmType::i32: return Literal(i32 * other.i32);
-      case WasmType::i64: return Literal(i64 * other.i64);
+      case WasmType::i32: return Literal(uint32_t(i32) * uint32_t(other.i32));
+      case WasmType::i64: return Literal(uint64_t(i64) * uint64_t(other.i64));
       case WasmType::f32: return Literal(getf32() * other.getf32());
       case WasmType::f64: return Literal(getf64() * other.getf64());
       default: WASM_UNREACHABLE();


### PR DESCRIPTION
This puts us back where #404 wanted to be: all UB that ubsan knows about now causes an abort. This ins't to say that it's all gone, merely that our tests don't trigger any more UB which ubsan knows how to find :-)