### PR TITLE
Fix switches in simplify-locals

### DIFF
--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -126,6 +126,7 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
       for (auto target : sw->targets) {
         self->unoptimizableBlocks.insert(target);
       }
+      self->unoptimizableBlocks.insert(sw->default_);
       // TODO: we could use this info to stop gathering data on these blocks
     }
     self->sinkables.clear();

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -162,12 +162,16 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
 
     // post-block cleanups
     if (curr->name.is()) {
-      unoptimizableBlocks.erase(curr->name);
-    }
-    if (hasBreaks) {
-      // more than one path to here, so nonlinear
-      sinkables.clear();
-      blockBreaks.erase(curr->name);
+      if (unoptimizableBlocks.count(curr->name)) {
+        sinkables.clear();
+        unoptimizableBlocks.erase(curr->name);
+      }
+
+      if (hasBreaks) {
+        // more than one path to here, so nonlinear
+        sinkables.clear();
+        blockBreaks.erase(curr->name);
+      }
     }
   }
 

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -517,4 +517,23 @@
     (get_local $m)
     (get_local $t)
   )
+  (func $switch-def (param $i3 i32) (result i32)
+    (local $i1 i32)
+    (set_local $i1
+      (i32.const 10)
+    )
+    (block $switch$def
+      (block $switch-case$1
+        (br_table $switch-case$1 $switch$def
+          (get_local $i3)
+        )
+      )
+      (set_local $i1
+        (i32.const 1)
+      )
+    )
+    (return
+      (get_local $i1)
+    )
+  )
 )

--- a/test/passes/simplify-locals.wast
+++ b/test/passes/simplify-locals.wast
@@ -451,5 +451,24 @@
     (get_local $s)
     (get_local $t)
   )
+  (func $switch-def (param $i3 i32) (result i32)
+    (local $i1 i32)
+    (set_local $i1
+      (i32.const 10)
+    )
+    (block $switch$def
+      (block $switch-case$1
+        (br_table $switch-case$1 $switch$def
+          (get_local $i3)
+        )
+      )
+      (set_local $i1
+        (i32.const 1)
+      )
+    )
+    (return
+      (get_local $i1)
+    )
+  )
 )
 


### PR DESCRIPTION
We failed to note that a block that is switched to has merging control flow, so we must clear sinkables on it, and not optimize a block return value.
