### PR TITLE
Make wasm.js safe in closure compiler

### DIFF
--- a/src/js/wasm.js-post.js
+++ b/src/js/wasm.js-post.js
@@ -188,7 +188,7 @@ function integrateWasmJS(Module) {
     info['env'] = env;
     var instance;
     try {
-      instance = Wasm.instantiateModule(getBinary(), info);
+      instance = Wasm['instantiateModule'](getBinary(), info);
     } catch (e) {
       Module['printErr']('failed to compile wasm module: ' + e);
       return false;


### PR DESCRIPTION
We need to prevent closure from renaming the Wasm.* methods. Bug was reported on emscripten mailing list.