### PR TITLE
Fix LD_LIBRARY_PATH

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -2,7 +2,7 @@
 
 import os, sys, subprocess, difflib
 
-os.environ['LD_LIBRARY_PATH'] = 'lib' # find our dynamic libraries
+os.environ['LD_LIBRARY_PATH'] += os.pathsep + 'lib' # find our dynamic libraries
 
 print '[ processing and updating testcases... ]\n'
 

--- a/check.py
+++ b/check.py
@@ -49,7 +49,7 @@ WATERFALL_BUILD_DIR = os.path.join(BASE_DIR, 'wasm-install')
 BIN_DIR = os.path.abspath(os.path.join(WATERFALL_BUILD_DIR, 'wasm-install', 'bin'))
 
 os.environ['BINARYEN'] = os.getcwd()
-os.environ['LD_LIBRARY_PATH'] = 'lib' # find our dynamic libraries
+os.environ['LD_LIBRARY_PATH'] += os.pathsep + 'lib' # find our dynamic libraries
 
 def fetch_waterfall():
   rev = open(os.path.join('test', 'revision')).read().strip()


### PR DESCRIPTION
It needs to be concatenated, not overwritten.


RPATH is probably still a better solution, as discussed here:
https://github.com/WebAssembly/binaryen/pull/435#discussion_r62245931