### PR TITLE
Add binary format methods to C API

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -273,6 +273,13 @@ int BinaryenModuleValidate(BinaryenModuleRef module);
 // Run the standard optimization passes on the module.
 void BinaryenModuleOptimize(BinaryenModuleRef module);
 
+// Serialize a module into binary form.
+// @return how many bytes were written. This will be less than or equal to bufferSize
+size_t BinaryenModuleWrite(BinaryenModuleRef module, char* output, size_t outputSize);
+
+// Deserialize a module from binary form.
+BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize);
+
 //
 // ========== CFG / Relooper ==========
 //

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -377,8 +377,38 @@ void test_relooper() {
   BinaryenModuleDispose(module);
 }
 
+void test_binaries() {
+  char buffer[1024];
+  size_t size;
+
+  { // create a module and write it to binary
+    BinaryenModuleRef module = BinaryenModuleCreate();
+    BinaryenType params[2] = { BinaryenInt32(), BinaryenInt32() };
+    BinaryenFunctionTypeRef iii = BinaryenAddFunctionType(module, "iii", BinaryenInt32(), params, 2);
+    BinaryenExpressionRef x = BinaryenGetLocal(module, 0, BinaryenInt32()),
+                          y = BinaryenGetLocal(module, 1, BinaryenInt32());
+    BinaryenExpressionRef add = BinaryenBinary(module, BinaryenAdd(), x, y);
+    BinaryenFunctionRef adder = BinaryenAddFunction(module, "adder", iii, NULL, 0, add);
+    size = BinaryenModuleWrite(module, buffer, 1024); // write out the module
+    BinaryenModuleDispose(module);
+  }
+
+  assert(size > 0);
+  assert(size < 512); // this is a tiny module
+
+  // read the module from the binary
+  BinaryenModuleRef module = BinaryenModuleRead(buffer, size);
+
+  // validate, print, and free
+  assert(BinaryenModuleValidate(module));
+  printf("module loaded from binary form:\n");
+  BinaryenModulePrint(module);
+  BinaryenModuleDispose(module);
+}
+
 int main() {
   test_core();
   test_relooper();
+  test_binaries();
 }
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -761,3 +761,14 @@ optimized:
     (i32.const 6)
   )
 )
+module loaded from binary form:
+(module
+  (memory 0)
+  (type $0 (func (param i32 i32) (result i32)))
+  (func $adder (type $0) (param $var$0 i32) (param $var$1 i32) (result i32)
+    (i32.add
+      (get_local $var$0)
+      (get_local $var$1)
+    )
+  )
+)


### PR DESCRIPTION
Now the C API can write and read binaries. I suspect only writing is really going to be needed, at least for a while, but might as well add reading. Also nice for testing.

Depends on #439.