### PR TITLE
Use rpath instead of LD_LIBRARY_PATH for shared object use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ ELSE()
   ADD_COMPILE_FLAG("-Wextra")
   ADD_COMPILE_FLAG("-Wno-unused-parameter")
   ADD_COMPILE_FLAG("-fno-omit-frame-pointer")
+  ADD_COMPILE_FLAG("-fPIC")
   IF(CMAKE_THREAD_LIBS_INIT)
     ADD_LINK_FLAG("${CMAKE_THREAD_LIBS_INIT}")
   ENDIF()
@@ -116,6 +117,7 @@ SET(binaryen_c_SOURCES
   src/wasm.cpp
 )
 ADD_LIBRARY(binaryen-c SHARED ${binaryen_c_SOURCES})
+TARGET_LINK_LIBRARIES(binaryen-c asmjs support)
 
 SET(binaryen-shell_SOURCES
   src/binaryen-shell.cpp

--- a/check.py
+++ b/check.py
@@ -50,12 +50,6 @@ BIN_DIR = os.path.abspath(os.path.join(WATERFALL_BUILD_DIR, 'wasm-install', 'bin
 
 os.environ['BINARYEN'] = os.getcwd()
 
-# find our dynamic libraries
-if os.environ.get('LD_LIBRARY_PATH'):
-  os.environ['LD_LIBRARY_PATH'] += os.pathsep + 'lib'
-else:
-  os.environ['LD_LIBRARY_PATH'] = 'lib'
-
 def fetch_waterfall():
   rev = open(os.path.join('test', 'revision')).read().strip()
   try:
@@ -601,7 +595,8 @@ if has_vanilla_emcc and has_vanilla_llvm:
 print '\n[ checking example testcases... ]\n'
 
 for t in sorted(os.listdir(os.path.join('test', 'example'))):
-  cmd = ['-Isrc', '-g', '-lasmjs', '-lsupport', '-Llib/.', '-pthread']
+  output_file = os.path.join('bin', 'example')
+  cmd = ['-Isrc', '-g', '-lasmjs', '-lsupport', '-Llib/.', '-pthread', '-o', output_file]
   if t.endswith('.cpp'):
     cmd = [os.path.join('test', 'example', t),
            os.path.join('src', 'pass.cpp'),
@@ -614,7 +609,8 @@ for t in sorted(os.listdir(os.path.join('test', 'example'))):
              '-Isrc', '-g', '-lasmjs', '-lsupport', '-Llib/.', '-pthread']
     print ' '.join(extra)
     subprocess.check_call(extra)
-    cmd = ['example.o', '-lbinaryen-c'] + cmd
+    # Link against the binaryen C library DSO, using an executable-relative rpath
+    cmd = ['example.o', '-lbinaryen-c'] + cmd + ['-Wl,-rpath=$ORIGIN/../lib']
   else:
     continue
   if os.environ.get('COMPILER_FLAGS'):
@@ -622,9 +618,12 @@ for t in sorted(os.listdir(os.path.join('test', 'example'))):
       cmd.append(f)
   cmd = [os.environ.get('CXX') or 'g++', '-std=c++11'] + cmd
   print ' '.join(cmd)
-  subprocess.check_call(cmd)
-  actual = subprocess.Popen(['./a.out'], stdout=subprocess.PIPE).communicate()[0]
-  expected = open(os.path.join('test', 'example', '.'.join(t.split('.')[:-1]) + '.txt')).read()
+  try:
+    subprocess.check_call(cmd)
+    actual = subprocess.Popen([output_file], stdout=subprocess.PIPE).communicate()[0]
+    expected = open(os.path.join('test', 'example', '.'.join(t.split('.')[:-1]) + '.txt')).read()
+  finally:
+    os.remove(output_file)
   if actual != expected:
     fail(actual, expected)
 


### PR DESCRIPTION
Use the -rpath linker flag to locate libbinaryen-c.so instead of
injecting paths into the user's LD_LIBRARY_PATH.
Fixes #444 