### PR TITLE
Rename binaryen-c library to binaryen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ bin/wasm2asm
 bin/s2wasm
 bin/wasm-as
 bin/wasm-dis
-lib/libbinaryen-c.so
+lib/libbinaryen.so
 *.a
 *~
 *.diff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,13 +96,13 @@ ADD_SUBDIRECTORY(src/support)
 # Sources.
 
 
-SET(binaryen_c_SOURCES
+SET(binaryen_SOURCES
   src/binaryen-c.cpp
   src/cfg/Relooper.cpp
   src/wasm.cpp
 )
-ADD_LIBRARY(binaryen-c SHARED ${binaryen_c_SOURCES})
-TARGET_LINK_LIBRARIES(binaryen-c asmjs ${all_passes} support)
+ADD_LIBRARY(binaryen SHARED ${binaryen_SOURCES})
+TARGET_LINK_LIBRARIES(binaryen asmjs ${all_passes} support)
 
 SET(binaryen-shell_SOURCES
   src/binaryen-shell.cpp

--- a/check.py
+++ b/check.py
@@ -610,7 +610,7 @@ for t in sorted(os.listdir(os.path.join('test', 'example'))):
     print ' '.join(extra)
     subprocess.check_call(extra)
     # Link against the binaryen C library DSO, using an executable-relative rpath
-    cmd = ['example.o', '-lbinaryen-c'] + cmd + ['-Wl,-rpath=$ORIGIN/../lib']
+    cmd = ['example.o', '-lbinaryen'] + cmd + ['-Wl,-rpath=$ORIGIN/../lib']
   else:
     continue
   if os.environ.get('COMPILER_FLAGS'):


### PR DESCRIPTION
As suggested by @dschuff, since it contains the C++ API as well.