### PR TITLE
Spec test update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,17 +123,6 @@ SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD 11)
 SET_PROPERTY(TARGET asm2wasm PROPERTY CXX_STANDARD_REQUIRED ON)
 INSTALL(TARGETS asm2wasm DESTINATION bin)
 
-SET(wasm2asm_SOURCES
-  src/wasm2asm-main.cpp
-  src/wasm.cpp
-)
-ADD_EXECUTABLE(wasm2asm
-               ${wasm2asm_SOURCES})
-TARGET_LINK_LIBRARIES(wasm2asm asmjs emscripten-optimizer support)
-SET_PROPERTY(TARGET wasm2asm PROPERTY CXX_STANDARD 11)
-SET_PROPERTY(TARGET wasm2asm PROPERTY CXX_STANDARD_REQUIRED ON)
-INSTALL(TARGETS wasm2asm DESTINATION bin)
-
 SET(s2wasm_SOURCES
   src/wasm-linker.cpp
   src/s2wasm-main.cpp

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -416,7 +416,9 @@ BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize) {
   std::vector<char> buffer(false);
   buffer.resize(inputSize);
   std::copy_n(input, inputSize, buffer.begin());
-  WasmBinaryBuilder parser(*wasm, buffer, false);
+  WasmBinaryBuilder parser(*wasm, buffer, []() {
+    Fatal() << "error in parsing wasm binary";
+  }, false);
   parser.read();
   return wasm;
 }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1164,13 +1164,14 @@ class WasmBinaryBuilder {
   Module& wasm;
   MixedArena& allocator;
   std::vector<char>& input;
+  std::function<void ()> onError;
   bool debug;
 
   size_t pos = 0;
   int32_t startIndex = -1;
 
 public:
-  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), debug(debug) {}
+  WasmBinaryBuilder(Module& wasm, std::vector<char>& input, std::function<void ()> onError, bool debug) : wasm(wasm), allocator(wasm.allocator), input(input), onError(onError), debug(debug) {}
 
   void read() {
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1226,7 +1226,7 @@ public:
   }
 
   uint8_t getInt8() {
-    assert(more());
+    if (!more()) onError();
     if (debug) std::cerr << "getInt8: " << (int)(uint8_t)input[pos] << " (at " << pos << ")" << std::endl;
     return input[pos++];
   }
@@ -1330,27 +1330,27 @@ public:
 
   void verifyInt8(int8_t x) {
     int8_t y = getInt8();
-    assert(x == y);
+    if (x != y) onError();
   }
   void verifyInt16(int16_t x) {
     int16_t y = getInt16();
-    assert(x == y);
+    if (x != y) onError();
   }
   void verifyInt32(int32_t x) {
     int32_t y = getInt32();
-    assert(x == y);
+    if (x != y) onError();
   }
   void verifyInt64(int64_t x) {
     int64_t y = getInt64();
-    assert(x == y);
+    if (x != y) onError();
   }
   void verifyFloat32(float x) {
     float y = getFloat32();
-    assert(x == y);
+    if (x != y) onError();
   }
   void verifyFloat64(double x) {
     double y = getFloat64();
-    assert(x == y);
+    if (x != y) onError();
   }
 
   void ungetInt8() {

--- a/src/wasm-dis.cpp
+++ b/src/wasm-dis.cpp
@@ -45,7 +45,9 @@ int main(int argc, const char *argv[]) {
 
   if (options.debug) std::cerr << "parsing binary..." << std::endl;
   Module wasm;
-  WasmBinaryBuilder parser(wasm, input, options.debug);
+  WasmBinaryBuilder parser(wasm, input, []() {
+    Fatal() << "error in parsing wasm binary";
+  }, options.debug);
   parser.read();
 
   if (options.debug) std::cerr << "Printing..." << std::endl;

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -251,15 +251,16 @@ public:
     assert(module[0]->str() == MODULE);
     if (module.size() > 1 && module[1]->isStr()) {
       // these s-expressions contain a binary module, actually
-      auto str = module[1]->c_str();
-      if (auto size = strlen(str)) {
-        std::vector<char> data;
-        stringToBinary(str, size, data);
-        WasmBinaryBuilder binaryBuilder(wasm, data, false);
-        binaryBuilder.read();
-      } else {
-        onError();
+      std::vector<char> data;
+      size_t i = 1;
+      while (i < module.size()) {
+        auto str = module[i++]->c_str();
+        if (auto size = strlen(str)) {
+          stringToBinary(str, size, data);
+        }
       }
+      WasmBinaryBuilder binaryBuilder(wasm, data, false);
+      binaryBuilder.read();
       return;
     }
     functionCounter = 0;

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -259,7 +259,7 @@ public:
           stringToBinary(str, size, data);
         }
       }
-      WasmBinaryBuilder binaryBuilder(wasm, data, false);
+      WasmBinaryBuilder binaryBuilder(wasm, data, onError, false);
       binaryBuilder.read();
       return;
     }

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1066,9 +1066,11 @@ private:
   }
 
   // converts an s-expression string representing binary data into an output sequence of raw bytes
+  // this appends to data, which may already contain content.
   void stringToBinary(const char* input, size_t size, std::vector<char>& data) {
-    data.resize(size);
-    char *write = data.data();
+    auto originalSize = data.size();
+    data.resize(originalSize + size);
+    char *write = data.data() + originalSize;
     while (1) {
       if (input[0] == 0) break;
       if (input[0] == '\\') {
@@ -1102,9 +1104,9 @@ private:
       input++;
     }
     assert(write >= data.data());
-    size_t written = write - data.data();
-    assert(written <= data.size());
-    data.resize(written);
+    size_t actual = write - data.data();
+    assert(actual <= data.size());
+    data.resize(actual);
   }
 
   bool hasMemory = false;


### PR DESCRIPTION
Update spec tests, and add support for the new binary-in-wast stuff that they include.

Also remove wasm2asm from the build. It's not tested already, I was hoping to get back to it at some point, or that someone else would, but it looks like it's no longer maintained, and it's a burden to keep it building with updates like these.