### PR TITLE
Use an int32_t for BinaryenLiteral in the C API

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -85,7 +85,7 @@ BinaryenFunctionTypeRef BinaryenAddFunctionType(BinaryenModuleRef module, const 
 // Literals. These are passed by value.
 
 struct BinaryenLiteral {
-  int type; // size of enum in c++
+  int32_t type;
   union {
     int32_t i32;
     int64_t i64;


### PR DESCRIPTION
We convert the structs anyhow, and this makes it easier to bind to other languages, no int that depends on the arch.