### PR TITLE
Add remove unused functions pass.

### DIFF
--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -60,7 +60,7 @@ struct DirectCallGraphAnalyzer : public PostWalker<DirectCallGraphAnalyzer, Visi
     while (queue.size()) {
       Function* curr = queue.back();
       queue.pop_back();
-      if (reachable.find(curr) == reachable.end()) {
+      if (reachable.count(curr) == 0) {
         reachable.insert(curr);
         walk(curr->body);
       }
@@ -68,7 +68,7 @@ struct DirectCallGraphAnalyzer : public PostWalker<DirectCallGraphAnalyzer, Visi
   }
   void visitCall(Call *curr) {
     auto target = module->getFunction(curr->target);
-    if (reachable.find(target) == reachable.end()) {
+    if (reachable.count(target) == 0) {
       queue.push_back(target);
     }
   }

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -67,7 +67,7 @@ struct DirectCallGraphAnalyzer : public PostWalker<DirectCallGraphAnalyzer, Visi
     }
   }
   void visitCall(Call *curr) {
-    auto target = module->getFunction(curr->target);
+    auto* target = module->getFunction(curr->target);
     if (reachable.count(target) == 0) {
       queue.push_back(target);
     }

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -53,12 +53,12 @@ struct DirectCallGraphAnalyzer : public PostWalker<DirectCallGraphAnalyzer, Visi
   std::vector<Function*> queue;
   std::unordered_set<Function*> reachable;
 
-  DirectCallGraphAnalyzer(Module* module, std::vector<Function*> root) : module(module) {
-    for (auto curr : root) {
+  DirectCallGraphAnalyzer(Module* module, const std::vector<Function*>& root) : module(module) {
+    for (auto* curr : root) {
       queue.push_back(curr);
     }
     while (queue.size()) {
-      Function* curr = queue.back();
+      auto* curr = queue.back();
       queue.pop_back();
       if (reachable.count(curr) == 0) {
         reachable.insert(curr);

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(passes_SOURCES
   RemoveImports.cpp
   RemoveUnusedBrs.cpp
   RemoveUnusedNames.cpp
+  RemoveUnusedFunctions.cpp
   ReorderLocals.cpp
   SimplifyLocals.cpp
   Vacuum.cpp

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -47,7 +47,7 @@ struct RemoveUnusedFunctions : public Pass {
     // Remove unreachable functions.
     std::vector<std::unique_ptr<Function>>::iterator it = module->functions.begin();
     while (it != module->functions.end()) {
-      if (analyzer.reachable.find(it->get()) == analyzer.reachable.end()) {
+      if (analyzer.reachable.count(it->get()) == 0) {
         it = module->functions.erase(it);
       } else {
         it++;

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Removes functions that are never used.
+//
+
+
+#include <memory>
+
+#include <wasm.h>
+#include <pass.h>
+#include <ast_utils.h>
+
+namespace wasm {
+
+struct RemoveUnusedFunctions : public Pass {
+  void run(PassRunner* runner, Module* module) override {
+    std::vector<Function*> root;
+    // Module start is a root.
+    if (module->start.is()) {
+      root.push_back(module->getFunction(module->start));
+    }
+    // Exports are roots.
+    for (auto& curr : module->exports) {
+      root.push_back(module->getFunction(curr->value));
+    }
+    // For now, all functions that can be called indirectly are marked as roots.
+    for (auto& curr : module->table.names) {
+      root.push_back(module->getFunction(curr));
+    }
+    // Compute function reachability starting from the root set.
+    DirectCallGraphAnalyzer analyzer(module, root);
+    // Remove unreachable functions.
+    std::vector<std::unique_ptr<Function>>::iterator it = module->functions.begin();
+    while (it != module->functions.end()) {
+      if (analyzer.reachable.find(it->get()) == analyzer.reachable.end()) {
+        it = module->functions.erase(it);
+      } else {
+        it++;
+      }
+    }
+    assert(module->functions.size() == analyzer.reachable.size());
+  }
+};
+
+static RegisterPass<RemoveUnusedFunctions> registerPass("remove-unused-functions", "removes unused functions");
+
+} // namespace wasm

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -21,9 +21,9 @@
 
 #include <memory>
 
-#include <wasm.h>
-#include <pass.h>
-#include <ast_utils.h>
+#include "wasm.h"
+#include "pass.h"
+#include "ast_utils.h"
 
 namespace wasm {
 

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -45,16 +45,10 @@ struct RemoveUnusedFunctions : public Pass {
     // Compute function reachability starting from the root set.
     DirectCallGraphAnalyzer analyzer(module, root);
     // Remove unreachable functions.
-    auto it = module->functions.begin();
-    auto end = module->functions.end();
-    while (it != end) {
-      if (analyzer.reachable.count(it->get()) == 0) {
-        std::swap(it, --end);
-      } else {
-        it++;
-      }
-    }
-    module->functions.erase(it, module->functions.end());
+    auto& v = module->functions;
+    v.erase(std::remove_if(v.begin(), v.end(), [&](const std::unique_ptr<Function>& curr) {
+      return analyzer.reachable.count(curr.get()) == 0;
+    }), v.end());
     assert(module->functions.size() == analyzer.reachable.size());
   }
 };

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -45,7 +45,7 @@ struct RemoveUnusedFunctions : public Pass {
     // Compute function reachability starting from the root set.
     DirectCallGraphAnalyzer analyzer(module, root);
     // Remove unreachable functions.
-    std::vector<std::unique_ptr<Function>>::iterator it = module->functions.begin();
+    auto it = module->functions.begin();
     while (it != module->functions.end()) {
       if (analyzer.reachable.count(it->get()) == 0) {
         it = module->functions.erase(it);

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -46,13 +46,15 @@ struct RemoveUnusedFunctions : public Pass {
     DirectCallGraphAnalyzer analyzer(module, root);
     // Remove unreachable functions.
     auto it = module->functions.begin();
-    while (it != module->functions.end()) {
+    auto end = module->functions.end();
+    while (it != end) {
       if (analyzer.reachable.count(it->get()) == 0) {
-        it = module->functions.erase(it);
+        std::swap(it, --end);
       } else {
         it++;
       }
     }
+    module->functions.erase(it, module->functions.end());
     assert(module->functions.size() == analyzer.reachable.size());
   }
 };

--- a/test/passes/remove-unused-functions.txt
+++ b/test/passes/remove-unused-functions.txt
@@ -1,0 +1,21 @@
+(module
+  (memory 0)
+  (start $start)
+  (export "exported" $exported)
+  (table $called_indirect)
+  (func $start
+    (call $called0)
+  )
+  (func $called0
+    (call $called1)
+  )
+  (func $called1
+    (nop)
+  )
+  (func $called_indirect
+    (nop)
+  )
+  (func $exported
+    (nop)
+  )
+)

--- a/test/passes/remove-unused-functions.txt
+++ b/test/passes/remove-unused-functions.txt
@@ -16,6 +16,16 @@
     (nop)
   )
   (func $exported
-    (nop)
+    (call $called2)
+  )
+  (func $called2
+    (call $called2)
+    (call $called3)
+  )
+  (func $called3
+    (call $called4)
+  )
+  (func $called4
+    (call $called3)
   )
 )

--- a/test/passes/remove-unused-functions.wast
+++ b/test/passes/remove-unused-functions.wast
@@ -1,0 +1,27 @@
+(module
+  (export "exported" $exported)
+  (start $start)
+  (table $called_indirect)
+  (func $start
+    (call $called0)
+  )
+  (func $called0
+    (call $called1)
+  )
+  (func $called1
+    (nop)
+  )
+  (func $called_indirect
+    (nop)
+  )
+  (func $exported
+    (nop)
+  )
+  (func $remove0
+    (call $remove1)
+  )
+  (func $remove1
+    (nop)
+  )
+)
+

--- a/test/passes/remove-unused-functions.wast
+++ b/test/passes/remove-unused-functions.wast
@@ -1,6 +1,6 @@
 (module
-  (export "exported" $exported)
   (start $start)
+  (export "exported" $exported)
   (table $called_indirect)
   (func $start
     (call $called0)
@@ -15,13 +15,32 @@
     (nop)
   )
   (func $exported
-    (nop)
+    (call $called2)
+  )
+  (func $called2
+    (call $called2)
+    (call $called3)
+  )
+  (func $called3
+    (call $called4)
+  )
+  (func $called4
+    (call $called3)
   )
   (func $remove0
     (call $remove1)
   )
   (func $remove1
     (nop)
+  )
+  (func $remove2
+    (call $remove2)
+  )
+  (func $remove3
+    (call $remove4)
+  )
+  (func $remove4
+    (call $remove3)
   )
 )
 


### PR DESCRIPTION
This pass removes functions that are not reachable from a root set of functions. The root set includes the start function, all exported functions and all functions that can be called indirectly.

(We could make the pass more precise by using a type-based indirect call graph analysis. In large programs, each type is going to be called so it would probably not help much.)