### PR TITLE
Fix Visual Studio warning.

### DIFF
--- a/src/cfg/Relooper.h
+++ b/src/cfg/Relooper.h
@@ -347,7 +347,7 @@ struct Relooper {
   wasm::Expression* Render(RelooperBuilder& Builder);
 
   // Sets whether we must emulate everything with switch-loop code
-  void SetEmulate(int E) { Emulate = E; }
+  void SetEmulate(int E) { Emulate = !!E; }
 
   // Sets us to try to minimize size
   void SetMinSize(bool MinSize_) { MinSize = MinSize_; }


### PR DESCRIPTION
Fix Visual Studio 2015 compiler warning by using "!!".