### PR TITLE
Fix Visual C++ warning

### DIFF
--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -131,7 +131,7 @@ struct Measurer : public PostWalker<Measurer, UnifiedExpressionVisitor<Measurer>
   static bool measure(Expression* tree) {
     Measurer measurer;
     measurer.walk(tree);
-    return measurer.size;
+    return !!measurer.size;
   }
 };
 


### PR DESCRIPTION
Fix Visual Studio 2015 C++ compiler warning about conversion from int to bool.