### PR TITLE
Introduce a separate type for linear memory addresses

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -111,7 +111,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     abort();
   }
 
-  Literal load(Load* load, size_t addr) override {
+  Literal load(Load* load, Address addr) override {
     switch (load->type) {
       case i32: {
         switch (load->bytes) {
@@ -138,7 +138,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     }
   }
 
-  void store(Store* store, size_t addr, Literal value) override {
+  void store(Store* store, Address addr, Literal value) override {
     switch (store->type) {
       case i32: {
         switch (store->bytes) {
@@ -166,7 +166,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     }
   }
 
-  void growMemory(size_t /*oldSize*/, size_t newSize) override {
+  void growMemory(Address /*oldSize*/, Address newSize) override {
     memory.resize(newSize);
   }
 

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -92,9 +92,9 @@ public:
   struct ExternalInterface {
     virtual void init(Module& wasm) {}
     virtual Literal callImport(Import* import, LiteralList& arguments) = 0;
-    virtual Literal load(Load* load, size_t addr) = 0;
-    virtual void store(Store* store, size_t addr, Literal value) = 0;
-    virtual void growMemory(size_t oldSize, size_t newSize) = 0;
+    virtual Literal load(Load* load, Address addr) = 0;
+    virtual void store(Store* store, Address addr, Literal value) = 0;
+    virtual void growMemory(Address oldSize, Address newSize) = 0;
     virtual void trap(const char* why) = 0;
   };
 
@@ -722,10 +722,10 @@ private:
     return ret;
   }
 
-  size_t memorySize; // in pages
+  Address memorySize; // in pages
 
   template <class LS>
-  size_t getFinalAddress(LS* curr, Literal ptr) {
+  Address getFinalAddress(LS* curr, Literal ptr) {
     auto trapIfGt = [this](uint64_t lhs, uint64_t rhs, const char* msg) {
       if (lhs > rhs) {
         std::stringstream ss;
@@ -733,7 +733,7 @@ private:
         externalInterface->trap(ss.str().c_str());
       }
     };
-    uint32_t memorySizeBytes = memorySize * Memory::kPageSize;
+    Address memorySizeBytes = memorySize * Memory::kPageSize;
     uint64_t addr = ptr.type == i32 ? ptr.geti32() : ptr.geti64();
     trapIfGt(curr->offset, memorySizeBytes, "offset > memory");
     trapIfGt(addr, memorySizeBytes - curr->offset, "final > memory");

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -100,12 +100,14 @@ class LinkerObject {
 
   // Add an initializer segment for the named static variable.
   void addSegment(Name name, const char* data, Address size) {
-    segments[name] = wasm.memory.segments.size();
+    assert(wasm.memory.segments.size() < std::numeric_limits<Address>::max());
+    segments[name] = static_cast<Address>(wasm.memory.segments.size());
     wasm.memory.segments.emplace_back(0, data, size);
   }
 
   void addSegment(Name name, std::vector<char>& data) {
-    segments[name] = wasm.memory.segments.size();
+    assert(wasm.memory.segments.size() < std::numeric_limits<Address>::max());
+    segments[name] = static_cast<Address>(wasm.memory.segments.size());
     wasm.memory.segments.emplace_back(0, data);
   }
 

--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -71,7 +71,7 @@ class LinkerObject {
   LinkerObject() {}
 
   // Allocate a static object
-  void addStatic(size_t allocSize, size_t alignment, Name name) {
+  void addStatic(Address allocSize, Address alignment, Name name) {
     staticObjects.emplace_back(allocSize, alignment, name);
   }
 
@@ -99,7 +99,7 @@ class LinkerObject {
   }
 
   // Add an initializer segment for the named static variable.
-  void addSegment(Name name, const char* data, size_t size) {
+  void addSegment(Name name, const char* data, Address size) {
     segments[name] = wasm.memory.segments.size();
     wasm.memory.segments.emplace_back(0, data, size);
   }
@@ -129,10 +129,10 @@ class LinkerObject {
 
  private:
   struct StaticObject {
-    size_t allocSize;
-    size_t alignment;
+    Address allocSize;
+    Address alignment;
     Name name;
-    StaticObject(size_t allocSize, size_t alignment, Name name) :
+    StaticObject(Address allocSize, Address alignment, Name name) :
         allocSize(allocSize), alignment(alignment), name(name) {}
   };
 
@@ -146,7 +146,7 @@ class LinkerObject {
   using CallList = std::vector<Call*>;
   std::map<Name, CallList> undefinedFunctionCalls;
 
-  std::map<Name, size_t> segments; // name => segment index (in wasm module)
+  std::map<Name, Address> segments; // name => segment index (in wasm module)
 
   std::vector<Name> initializerFunctions;
 
@@ -160,8 +160,8 @@ class LinkerObject {
 // applying the relocations, resulting in an executable wasm module.
 class Linker {
  public:
-  Linker(size_t globalBase, size_t stackAllocation,
-         size_t userInitialMemory, size_t userMaxMemory,
+  Linker(Address globalBase, Address stackAllocation,
+         Address userInitialMemory, Address userMaxMemory,
          bool ignoreUnknownSymbols, Name startFunction,
          bool debug) :
       ignoreUnknownSymbols(ignoreUnknownSymbols),
@@ -221,8 +221,8 @@ class Linker {
 
  private:
   // Allocate a static variable and return its address in linear memory
-  size_t allocateStatic(size_t allocSize, size_t alignment, Name name) {
-    size_t address = alignAddr(nextStatic, alignment);
+  Address allocateStatic(Address allocSize, Address alignment, Name name) {
+    Address address = alignAddr(nextStatic, alignment);
     staticAddresses[name] = address;
     nextStatic = address + allocSize;
     return address;
@@ -230,7 +230,7 @@ class Linker {
 
   // Allocate space for a stack pointer and (if stackAllocation > 0) set up a
   // relocation for it to point to the top of the stack.
-  void placeStackPointer(size_t stackAllocation);
+  void placeStackPointer(Address stackAllocation);
 
   template<class C>
   void printSet(std::ostream& o, C& c) {
@@ -248,7 +248,7 @@ class Linker {
   // signature in the indirect function table.
   void makeDynCallThunks();
 
-  static size_t roundUpToPageSize(size_t size) {
+  static Address roundUpToPageSize(Address size) {
     return (size + Memory::kPageSize - 1) & Memory::kPageMask;
   }
 
@@ -270,16 +270,16 @@ class Linker {
   Name startFunction;
 
   // where globals can start to be statically allocated, i.e., the data segment
-  size_t globalBase;
-  size_t nextStatic; // location of next static allocation
-  size_t userInitialMemory; // Initial memory size (in bytes) specified by the user.
-  size_t userMaxMemory; // Max memory size (in bytes) specified by the user.
+  Address globalBase;
+  Address nextStatic; // location of next static allocation
+  Address userInitialMemory; // Initial memory size (in bytes) specified by the user.
+  Address userMaxMemory; // Max memory size (in bytes) specified by the user.
   //(after linking, this is rounded and set on the wasm object in pages)
-  size_t stackAllocation;
+  Address stackAllocation;
   bool debug;
 
   std::unordered_map<cashew::IString, int32_t> staticAddresses; // name => address
-  std::unordered_map<size_t, size_t> segmentsByAddress; // address => segment index
+  std::unordered_map<Address, Address> segmentsByAddress; // address => segment index
   std::unordered_map<cashew::IString, size_t> functionIndexes;
 
 };

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -89,8 +89,10 @@ struct Name : public cashew::IString {
 };
 
 // An index in a wasm module
-
 typedef uint32_t Index;
+
+// An address in linear memory. For now only wasm32
+typedef uint32_t Address;
 
 // Types
 
@@ -1054,10 +1056,10 @@ public:
   Load() {}
   Load(MixedArena& allocator) {}
 
-  uint32_t bytes;
+  uint8_t bytes;
   bool signed_;
-  uint32_t offset;
-  uint32_t align;
+  Address offset;
+  Address align;
   Expression *ptr;
 
   // type must be set during creation, cannot be inferred
@@ -1068,9 +1070,9 @@ public:
   Store() {}
   Store(MixedArena& allocator) {}
 
-  unsigned bytes;
-  uint32_t offset;
-  unsigned align;
+  uint8_t bytes;
+  Address offset;
+  Address align;
   Expression *ptr, *value;
 
   void finalize() {
@@ -1264,26 +1266,26 @@ public:
 
 class Memory {
 public:
-  static const size_t kPageSize = 64 * 1024;
-  static const size_t kPageMask = ~(kPageSize - 1);
+  static const Address kPageSize = 64 * 1024;
+  static const Address kPageMask = ~(kPageSize - 1);
   struct Segment {
-    size_t offset;
+    Address offset;
     std::vector<char> data; // TODO: optimize
     Segment() {}
-    Segment(size_t offset, const char *init, size_t size) : offset(offset) {
+    Segment(Address offset, const char *init, Address size) : offset(offset) {
       data.resize(size);
       std::copy_n(init, size, data.begin());
     }
-    Segment(size_t offset, std::vector<char>& init) : offset(offset) {
+    Segment(Address offset, std::vector<char>& init) : offset(offset) {
       data.swap(init);
     }
   };
 
-  size_t initial, max; // sizes are in pages
+  Address initial, max; // sizes are in pages
   std::vector<Segment> segments;
   Name exportName;
 
-  Memory() : initial(0), max((uint32_t)-1) {}
+  Memory() : initial(0), max((Address)-1) {}
 };
 
 class Module {


### PR DESCRIPTION
We've been using size_t (and other things) for addresses, which is
generally wrong because it depends on the host, when it should in fact
depend on the target. This is a partial fix for #278 (i.e. it's the
right fix, I don't think it's applied quite everywhere yet).