### PR TITLE
Quiet Visual C++ unsigned negation warning

### DIFF
--- a/src/support/bits.cpp
+++ b/src/support/bits.cpp
@@ -68,7 +68,7 @@ int CountTrailingZeroes<uint32_t>(uint32_t v) {
     0,   1, 28,  2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17,  4, 8,
     31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18,  6, 11,  5, 10, 9
   };
-  return v ? (int)tbl[((uint32_t)((v & -v) * 0x077CB531U)) >> 27] : 32;
+  return v ? (int)tbl[((uint32_t)((v & -(int32_t)v) * 0x077CB531U)) >> 27] : 32;
 }
 
 template<>


### PR DESCRIPTION
Fix Visual Studio 2015 warning about negating an unsigned value.
