### PR TITLE
Quiet Visual C++ ptr-to-bool warning

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -341,7 +341,7 @@ class S2WasmBuilder {
 
   // The LLVM backend emits function names as name@FUNCTION.
   bool isFunctionName(Name name) {
-    return strstr(name.str, "@FUNCTION");
+    return !!strstr(name.str, "@FUNCTION");
   }
   // Drop the @ and after it.
   Name cleanFunction(Name name) {


### PR DESCRIPTION
Fixes Visual Studio 2015 warning about returning a pointer as a bool.