### PR TITLE
Fix Visual C++ uint64_t-to-Address warning

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -740,7 +740,7 @@ private:
     addr += curr->offset;
     trapIfGt(curr->bytes, memorySizeBytes, "bytes > memory");
     trapIfGt(addr, memorySizeBytes - curr->bytes, "highest > memory");
-    return addr;
+    return (Address)addr;
   }
 
   ExternalInterface* externalInterface;


### PR DESCRIPTION
Fix Visual Studio warning about coercion of uint64_t to Address.
