### PR TITLE
Fix Visual C++ warnings about coercion of uint64_t to Address

### DIFF
--- a/src/s2wasm-main.cpp
+++ b/src/s2wasm-main.cpp
@@ -108,7 +108,7 @@ int main(int argc, const char *argv[]) {
           : 0;
   if (options.debug) std::cerr << "Global base " << globalBase << '\n';
 
-  Linker linker(globalBase, stackAllocation, initialMem, maxMem,
+  Linker linker((Address)globalBase, (Address)stackAllocation, (Address)initialMem, (Address)maxMem,
                 ignoreUnknownSymbols, startFunction, options.debug);
 
   S2WasmBuilder mainbuilder(input.c_str(), options.debug);


### PR DESCRIPTION
Fix Visual Studio 2015 warnings about coercion of uint64_t to Address (uint32_t).
