### PR TITLE
Quiet Visual C++ unsigned warning

### DIFF
--- a/src/support/bits.h
+++ b/src/support/bits.h
@@ -70,13 +70,13 @@ template <typename T, typename U>
 inline static T RotateLeft(T val, U count) {
   T mask = sizeof(T) * CHAR_BIT - 1;
   count &= mask;
-  return (val << count) | (val >> (-count & mask));
+  return (val << count) | (val >> (-(int)count & mask));
 }
 template <typename T, typename U>
 inline static T RotateRight(T val, U count) {
   T mask = sizeof(T) * CHAR_BIT - 1;
   count &= mask;
-  return (val >> count) | (val << (-count & mask));
+  return (val >> count) | (val << (-(int)count & mask));
 }
 
 extern uint32_t Log2(uint32_t v);


### PR DESCRIPTION
Quiet Visual Studio 2015 warning that negation of unsigned is still unsigned. Fix uses a cast of (int) because only the least significant 5/6 bits will be used for shift count.
