### PR TITLE
Fix the maximum size to be valid.

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -491,7 +491,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     incIndent();
     doIndent(o, indent);
     printOpening(o, "memory") << " " << curr->memory.initial;
-    if (curr->memory.max && curr->memory.max != (uint32_t)-1) o << " " << curr->memory.max;
+    if (curr->memory.max && curr->memory.max != Memory::kMaxSize) o << " " << curr->memory.max;
     for (auto segment : curr->memory.segments) {
       o << maybeNewLine;
       o << (minify ? "" : "    ") << "(segment " << segment.offset << " \"";

--- a/src/wasm-js.cpp
+++ b/src/wasm-js.cpp
@@ -76,7 +76,7 @@ extern "C" void EMSCRIPTEN_KEEPALIVE load_asm2wasm(char *input) {
     exit(EXIT_FAILURE);
   }
   module->memory.initial = providedMemory / Memory::kPageSize;
-  module->memory.max = pre.memoryGrowth ? -1 : module->memory.initial;
+  module->memory.max = pre.memoryGrowth ? Memory::kMaxSize : module->memory.initial;
 
   if (wasmJSDebug) std::cerr << "wasming...\n";
   asm2wasm = new Asm2WasmBuilder(*module, pre.memoryGrowth, debug, false /* TODO: support imprecise? */);
@@ -110,7 +110,7 @@ void finalizeModule() {
     exit(EXIT_FAILURE);
   }
   module->memory.initial = providedMemory / Memory::kPageSize;
-  module->memory.max = module->checkExport(GROW_WASM_MEMORY) ? -1 : module->memory.initial;
+  module->memory.max = module->checkExport(GROW_WASM_MEMORY) ? Memory::kMaxSize : module->memory.initial;
 
   // global mapping is done in js in post.js
 }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1281,6 +1281,7 @@ public:
 class Memory {
 public:
   static const Address::address_t kPageSize = 64 * 1024;
+  static const Address::address_t kMaxSize = ~Address::address_t(0) / kPageSize;
   static const Address::address_t kPageMask = ~(kPageSize - 1);
   struct Segment {
     Address offset;
@@ -1299,7 +1300,7 @@ public:
   std::vector<Segment> segments;
   Name exportName;
 
-  Memory() : initial(0), max(-1U) {}
+  Memory() : initial(0), max(kMaxSize) {}
 };
 
 class Module {


### PR DESCRIPTION
Memory sizes are now specified in page-size units. Binaryen was using (uint32_t)-1 to indicate the lack of a maximum, but this evokes validation errors because scaling it up by the page size overflows. This patch changes it to use (uint32_t)-1 / kPageSize.

No tests yet because I don't understand how the tests work.