### PR TITLE
Coalesce locals

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Convert the AST to a CFG, while traversing it.
+//
+// Note that this is not the same as the relooper CFG. The relooper is
+// designed for compilation to an AST, this is for processing. There is
+// no built-in support for transforming this CFG into the AST back
+// again, it is just metadata on the side for computation purposes.
+//
+// Usage: As the traversal proceeds, you can note information and add it to
+// the current basic block using currBasicBlock, on the contents
+// property, whose type is user-defined.
+//
+
+#ifndef cfg_traversal_h
+#define cfg_traversal_h
+
+#include "wasm.h"
+#include "wasm-traversal.h"
+
+namespace wasm {
+
+template<typename SubType, typename VisitorType, typename Contents>
+struct CFGWalker : public PostWalker<SubType, VisitorType> {
+
+  // public interface
+
+  struct BasicBlock {
+    Contents contents; // custom contents
+    std::vector<BasicBlock*> out, in;
+  };
+
+  BasicBlock* entry; // the entry block
+
+  BasicBlock* makeBasicBlock() { // override this with code to create a BasicBlock if necessary
+    return new BasicBlock();
+  }
+
+  // internal details
+
+  std::vector<std::unique_ptr<BasicBlock>> basicBlocks; // all the blocks
+
+  // traversal state
+  BasicBlock* currBasicBlock; // the current block in play during traversal
+  std::map<Name, std::vector<BasicBlock*>> branches;
+  std::vector<BasicBlock*> ifStack;
+  std::vector<BasicBlock*> loopStack;
+
+  static void doStartBasicBlock(SubType* self, Expression** currp) {
+    self->currBasicBlock = self->makeBasicBlock();
+    self->basicBlocks.push_back(std::unique_ptr<BasicBlock>(self->currBasicBlock));
+  }
+
+  void link(BasicBlock* from, BasicBlock* to) {
+    from->out.push_back(to);
+    to->in.push_back(from);
+  }
+
+  static void doEndBlock(SubType* self, Expression** currp) {
+    // TODO: if no name, no need for a new block
+    auto* last = self->currBasicBlock;
+    doStartBasicBlock(self, currp);
+    self->link(last, self->currBasicBlock); // fallthrough
+    // branches to the new one
+    auto* curr = (*currp)->cast<Block>();
+    if (curr->name.is()) {
+      auto& origins = self->branches[curr->name];
+      for (auto* origin : origins) {
+        self->link(origin, self->currBasicBlock);
+      }
+      self->branches.erase(curr->name);
+    }
+  }
+
+  static void doStartIfTrue(SubType* self, Expression** currp) {
+    auto* last = self->currBasicBlock;
+    doStartBasicBlock(self, currp);
+    self->link(last, self->currBasicBlock); // ifTrue
+    self->ifStack.push_back(last); // the block before the ifTrue
+  }
+
+  static void doStartIfFalse(SubType* self, Expression** currp) {
+    self->ifStack.push_back(self->currBasicBlock); // the ifTrue fallthrough
+    doStartBasicBlock(self, currp);
+    self->link(self->ifStack[self->ifStack.size() - 2], self->currBasicBlock); // before if -> ifFalse
+  }
+
+  static void doEndIf(SubType* self, Expression** currp) {
+    auto* last = self->currBasicBlock;
+    doStartBasicBlock(self, currp);
+    self->link(last, self->currBasicBlock); // last one is ifFalse's fallthrough if there was one, otherwise it's the ifTrue fallthrough
+    if ((*currp)->cast<If>()->ifFalse) {
+      // we just linked ifFalse, need to link ifTrue to the end
+      self->link(self->ifStack.back(), self->currBasicBlock);
+      self->ifStack.pop_back();
+    } else {
+      // no ifFalse, so add a fallthrough for if the if is not taken
+      self->link(self->ifStack.back(), self->currBasicBlock);
+    }
+    self->ifStack.pop_back();
+  }
+
+  static void doStartLoop(SubType* self, Expression** currp) {
+    auto* last = self->currBasicBlock;
+    doStartBasicBlock(self, currp);
+    self->link(last, self->currBasicBlock);
+    self->loopStack.push_back(self->currBasicBlock);
+  }
+
+  static void doEndLoop(SubType* self, Expression** currp) {
+    auto* last = self->currBasicBlock;
+    doStartBasicBlock(self, currp);
+    self->link(last, self->currBasicBlock); // fallthrough
+    // branches to the new one
+    auto* curr = (*currp)->cast<Loop>();
+    if (curr->out.is()) {
+      auto& origins = self->branches[curr->out];
+      for (auto* origin : origins) {
+        self->link(origin, self->currBasicBlock);
+      }
+      self->branches.erase(curr->out);
+    }
+    // branches to the top of the loop
+    if (curr->in.is()) {
+      auto* loopStart = self->loopStack.back();
+      auto& origins = self->branches[curr->in];
+      for (auto* origin : origins) {
+        self->link(origin, loopStart);
+      }
+      self->branches.erase(curr->in);
+    }
+    self->loopStack.pop_back();
+  }
+
+  static void doEndBreak(SubType* self, Expression** currp) {
+    auto* curr = (*currp)->cast<Break>();
+    self->branches[curr->name].push_back(self->currBasicBlock); // branch to the target
+    auto* last = self->currBasicBlock;
+    doStartBasicBlock(self, currp);
+    if (curr->condition) {
+      self->link(last, self->currBasicBlock); // we might fall through
+    }
+  }
+
+  static void doEndSwitch(SubType* self, Expression** currp) {
+    auto* curr = (*currp)->cast<Switch>();
+    std::set<Name> seen; // we might see the same label more than once; do not spam branches
+    for (Name target : curr->targets) {
+      if (!seen.count(target)) {
+        self->branches[target].push_back(self->currBasicBlock); // branch to the target
+        seen.insert(target);
+      }
+    }
+    if (!seen.count(curr->default_)) {
+      self->branches[curr->default_].push_back(self->currBasicBlock); // branch to the target
+    }
+    doStartBasicBlock(self, currp);
+  }
+
+  static void scan(SubType* self, Expression** currp) {
+    Expression* curr = *currp;
+
+    switch (curr->_id) {
+      case Expression::Id::BlockId: {
+        self->pushTask(SubType::doEndBlock, currp);
+        self->pushTask(SubType::doVisitBlock, currp);
+        auto& list = curr->cast<Block>()->list;
+        for (int i = int(list.size()) - 1; i >= 0; i--) {
+          self->pushTask(SubType::scan, &list[i]);
+        }
+        break;
+      }
+      case Expression::Id::IfId: {
+        self->pushTask(SubType::doEndIf, currp);
+        self->pushTask(SubType::doVisitIf, currp);
+        auto* ifFalse = curr->cast<If>()->ifFalse;
+        if (ifFalse) {
+          self->pushTask(SubType::scan, &curr->cast<If>()->ifFalse);
+          self->pushTask(SubType::doStartIfFalse, currp);
+        }
+        self->pushTask(SubType::scan, &curr->cast<If>()->ifTrue);
+        self->pushTask(SubType::doStartIfTrue, currp);
+        self->pushTask(SubType::scan, &curr->cast<If>()->condition);
+        break;
+      }
+      case Expression::Id::LoopId: {
+        self->pushTask(SubType::doEndLoop, currp);
+        self->pushTask(SubType::doVisitLoop, currp);
+        self->pushTask(SubType::scan, &curr->cast<Loop>()->body);
+        self->pushTask(SubType::doStartLoop, currp);
+        break;
+      }
+      case Expression::Id::BreakId: {
+        self->pushTask(SubType::doEndBreak, currp);
+        self->pushTask(SubType::doVisitBreak, currp);
+        self->maybePushTask(SubType::scan, &curr->cast<Break>()->condition);
+        self->maybePushTask(SubType::scan, &curr->cast<Break>()->value);
+        break;
+      }
+      case Expression::Id::SwitchId: {
+        self->pushTask(SubType::doEndSwitch, currp);
+        self->pushTask(SubType::doVisitSwitch, currp);
+        self->maybePushTask(SubType::scan, &curr->cast<Switch>()->value);
+        self->pushTask(SubType::scan, &curr->cast<Switch>()->condition);
+        break;
+      }
+      case Expression::Id::ReturnId: {
+        self->pushTask(SubType::doStartBasicBlock, currp);
+        self->pushTask(SubType::doVisitReturn, currp);
+        self->maybePushTask(SubType::scan, &curr->cast<Return>()->value);
+        break;
+      }
+      case Expression::Id::UnreachableId: {
+        self->pushTask(SubType::doStartBasicBlock, currp);
+        self->pushTask(SubType::doVisitUnreachable, currp);
+        break;
+      }
+      default: {
+        // other node types do not have control flow, use regular post-order
+        PostWalker<SubType, VisitorType>::scan(self, currp);
+      }
+    }
+  }
+
+  void walk(Expression*& root) {
+    basicBlocks.clear();
+
+    doStartBasicBlock(static_cast<SubType*>(this), nullptr);
+    entry = currBasicBlock;
+    PostWalker<SubType, VisitorType>::walk(root);
+
+    assert(branches.size() == 0);
+    assert(ifStack.size() == 0);
+    assert(loopStack.size() == 0);
+  }
+
+  std::unordered_set<BasicBlock*> findLiveBlocks() {
+    std::unordered_set<BasicBlock*> alive;
+    std::unordered_set<BasicBlock*> queue;
+    queue.insert(entry);
+    while (queue.size() > 0) {
+      auto iter = queue.begin();
+      auto* curr = *iter;
+      queue.erase(iter);
+      alive.insert(curr);
+      for (auto* out : curr->out) {
+        if (!alive.count(out)) queue.insert(out);
+      }
+    }
+    return alive;
+  }
+
+  void unlinkDeadBlocks(std::unordered_set<BasicBlock*> alive) {
+    for (auto& block : basicBlocks) {
+      if (!alive.count(block.get())) {
+        block->in.clear();
+        block->out.clear();
+        continue;
+      }
+      block->in.erase(std::remove_if(block->in.begin(), block->in.end(), [&alive](BasicBlock* other) {
+        return !alive.count(other);
+      }), block->in.end());
+      block->out.erase(std::remove_if(block->out.begin(), block->out.end(), [&alive](BasicBlock* other) {
+        return !alive.count(other);
+      }), block->out.end());
+    }
+  }
+
+  // TODO: utility method for optimizing cfg, removing empty blocks depending on their .content
+
+  std::map<BasicBlock*, size_t> debugIds;
+
+  void dumpCFG(std::string message, Function* func) {
+    std::cout << "<==\nCFG [" << message << "]:\n";
+    for (auto& block : basicBlocks) {
+      debugIds[block.get()] = debugIds.size();
+    }
+    for (auto& block : basicBlocks) {
+      assert(debugIds.count(block.get()) > 0);
+      std::cout << "  block " << debugIds[block.get()] << ":\n";
+      block->contents.dump(func);
+      for (auto& in : block->in) {
+        assert(debugIds.count(in) > 0);
+        assert(std::find(in->out.begin(), in->out.end(), block.get()) != in->out.end()); // must be a parallel link back
+      }
+      for (auto& out : block->out) {
+        assert(debugIds.count(out) > 0);
+        std::cout << "    out: " << debugIds[out] << "\n";
+        assert(std::find(out->in.begin(), out->in.end(), block.get()) != out->in.end()); // must be a parallel link back
+      }
+    }
+    std::cout << "==>\n";
+  }
+};
+
+} // namespace wasm
+
+#endif // cfg_traversal_h

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -72,14 +72,18 @@ struct CFGWalker : public PostWalker<SubType, VisitorType> {
   }
 
   static void doEndBlock(SubType* self, Expression** currp) {
-    // TODO: if no name, no need for a new block
+    auto* curr = (*currp)->cast<Block>();
+    if (!curr->name.is()) return;
+    auto iter = self->branches.find(curr->name);
+    if (iter == self->branches.end()) return;
+    auto& origins = iter->second;
+    if (origins.size() == 0) return;
+    // we have branches to here, so we need a new block
     auto* last = self->currBasicBlock;
     doStartBasicBlock(self, currp);
     self->link(last, self->currBasicBlock); // fallthrough
     // branches to the new one
-    auto* curr = (*currp)->cast<Block>();
     if (curr->name.is()) {
-      auto& origins = self->branches[curr->name];
       for (auto* origin : origins) {
         self->link(origin, self->currBasicBlock);
       }

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -1,5 +1,6 @@
 SET(passes_SOURCES
   pass.cpp
+  CoalesceLocals.cpp
   LowerIfElse.cpp
   MergeBlocks.cpp
   Metrics.cpp

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+//
+// Coalesce locals, in order to reduce the total number of locals. This
+// is similar to register allocation, however, there is never any
+// spilling, and there isn't a fixed number of locals.
+//
+
+
+#include <memory>
+#include <unordered_set>
+
+#include "wasm.h"
+#include "pass.h"
+#include "ast_utils.h"
+#include "cfg/cfg-traversal.h"
+
+namespace wasm {
+
+// A set of locals
+struct LocalSet : std::vector<bool> {
+  LocalSet() {}
+  LocalSet(size_t size) {
+    clear(size);
+  }
+
+  void clear(size_t size) {
+    resize(size);
+    std::fill(begin(), end(), 0);
+  }
+
+  size_t count() {
+    size_t ret = 0;
+    for (size_t i = 0; i < size(); i++) {
+      ret += (*this)[i];
+    }
+    return ret;
+  }
+};
+
+// a liveness-relevant action
+struct Action {
+  enum What {
+    Get, Set
+  };
+  What what;
+  Index index; // the local index read or written
+  Expression** origin; // the origin
+  bool effective; // whether a store is actually effective, i.e., may be read
+
+  Action(What what, Index index, Expression** origin) : what(what), index(index), origin(origin), effective(false) {}
+
+  bool isGet() { return what == Get; }
+  bool isSet() { return what == Set; }
+};
+
+// information about liveness in a basic block
+struct Liveness {
+  LocalSet start, end; // live locals at the start and end
+  std::vector<Action> actions; // actions occurring in this block
+
+  void dump(Function* func) {
+    if (actions.empty()) return;
+    std::cout << "    actions:\n";
+    for (auto& action : actions) {
+      std::cout << "      " << (action.isGet() ? "get" : "set") << " " << func->getLocalName(action.index) << "\n";
+    }
+  }
+};
+
+struct CoalesceLocals : public WalkerPass<CFGWalker<CoalesceLocals, Visitor<CoalesceLocals>, Liveness>> {
+  bool isFunctionParallel() { return true; }
+
+  Index numLocals;
+
+  BasicBlock* makeBasicBlock() {
+    auto ret = new BasicBlock();
+    ret->contents.start.clear(numLocals);
+    ret->contents.end.clear(numLocals);
+    return ret;
+  }
+
+  // cfg traversal work
+
+  static void doVisitGetLocal(CoalesceLocals* self, Expression** currp) {
+    auto* curr = (*currp)->cast<GetLocal>();
+    self->currBasicBlock->contents.actions.emplace_back(Action::Get, curr->index, currp);
+  }
+
+  static void doVisitSetLocal(CoalesceLocals* self, Expression** currp) {
+    auto* curr = (*currp)->cast<SetLocal>();
+    self->currBasicBlock->contents.actions.emplace_back(Action::Set, curr->index, currp);
+  }
+
+  // main entry point
+
+  void walk(Expression*& root) {
+    numLocals = getFunction()->getNumLocals();
+    // collect initial liveness info
+    WalkerPass<CFGWalker<CoalesceLocals, Visitor<CoalesceLocals>, Liveness>>::walk(root);
+    // ignore links to dead blocks, so they don't confuse us and we can see their stores are all ineffective
+    liveBlocks = findLiveBlocks();
+    unlinkDeadBlocks(liveBlocks);
+#ifdef CFG_DEBUG
+    dumpCFG("the cfg", getFunction());
+#endif
+    // flow liveness across blocks
+    flowLiveness();
+    // pick new indices
+    auto indices = pickIndices();
+    // apply indices
+    applyIndices(indices, root);
+  }
+
+  // inteference state
+
+  LocalSet interferences;
+  std::unordered_set<BasicBlock*> liveBlocks;
+
+  void interfere(Index i, Index j) {
+    if (i == j) return;
+#ifdef CFG_DEBUG
+    if (!interferences[i + j * numLocals]) {
+      std::cout << getFunction()->name << ": interfere " << getFunction()->getLocalName(std::min(i, j)) << " : " << getFunction()->getLocalName(std::max(i, j)) << "\n";
+    }
+#endif
+    interferences[i + j * numLocals] = 1;
+    interferences[j + i * numLocals] = 1;
+  }
+
+  void flowLiveness() {
+    interferences.clear(numLocals * numLocals);
+    // keep working while stuff is flowing
+    std::vector<BasicBlock*> queue; // TODO set to avoid inserting same block more than once at a time period. TODO optimize, an order might be more efficient
+    for (auto& curr : basicBlocks) {
+      if (liveBlocks.count(curr.get()) == 0) continue; // ignore dead blocks
+      queue.push_back(curr.get());
+      // do the first scan through the block, starting with nothing live at the end, and updating the liveness at the start
+      scanLivenessThroughActions(curr->contents.actions, curr->contents.start);
+    }
+    // at every point in time, we assume we already noted interferences between things already known alive at the end, and scanned back throught the block using that
+    while (queue.size() > 0) {
+      auto* curr = queue.back(); // TODO: order?
+      queue.pop_back();
+      LocalSet live(numLocals);
+      if (!mergeStartsAndCheckChange(curr->out, curr->contents.end, live)) continue;
+#ifdef CFG_DEBUG
+      std::cout << "change noticed at end of " << debugIds[curr] << " from " << curr->contents.end.count() << " to " << live.count() << " (out of " << numLocals << ")\n";
+#endif
+      assert(curr->contents.end.count() < live.count());
+      curr->contents.end = live;
+      scanLivenessThroughActions(curr->contents.actions, live);
+      // liveness is now calculated at the start. if something
+      // changed, all predecessor blocks need recomputation
+      if (curr->contents.start == live) continue;
+#ifdef CFG_DEBUG
+      std::cout << "change noticed at start of " << debugIds[curr] << " from " << curr->contents.start.count() << " to " << live.count() << ", more work to do\n";
+#endif
+      assert(curr->contents.start.count() < live.count());
+      curr->contents.start = live;
+      for (auto* in : curr->in) {
+        queue.push_back(in);
+#ifdef CFG_DEBUG_ORDER
+        // alternative code for changing the flow order; results must be the same, as we detect a property of the graph.
+        if (queue.empty()) {
+          queue.push_back(in);
+        } else {
+          //abort();
+          auto* front = queue[0];
+          queue[0] = in;
+          queue.push_back(front);
+        }
+#endif
+      }
+    }
+    // live locals at the entry block include params, obviously, but also
+    // vars, in which case the 0-init value is actually used.
+#ifdef CFG_DEBUG
+    std::hash<std::vector<bool>> hasher;
+    std::cout << getFunction()->name << ": interference hash: " << hasher(*(std::vector<bool>*)&interferences) << "\n";
+    for (size_t i = 0; i < numLocals; i++) {
+      std::cout << "int for " << getFunction()->getLocalName(i) << " [" << i << "]: ";
+      for (size_t j = 0; j < numLocals; j++) {
+        assert(interferences[i * numLocals + j] == interferences[j * numLocals + i]);
+        if (interferences[i * numLocals + j]) std::cout << getFunction()->getLocalName(j) << " ";
+      }
+      std::cout << "\n";
+    }
+#endif
+  }
+
+  // merge starts of a list of blocks, adding new interferences as necessary. return
+  // whether anything changed vs an old state (which indicates further processing is necessary).
+  bool mergeStartsAndCheckChange(std::vector<BasicBlock*>& blocks, LocalSet& old, LocalSet& ret) {
+    // merge all the live locals, and add interferences that show up from the merging.
+    // we can assume that locals live together already are already known to be in conflict.
+    if (blocks.size() == 0) return false;
+    if (blocks.size() == 1) {
+      // new interferences are impossible, they would have already been in conflict in the single predecessor.
+      ret = blocks[0]->contents.start;
+      return old != ret;
+    }
+    // more than one, so we must merge
+    for (auto* block : blocks) {
+      for (size_t i = 0; i < numLocals; i++) {
+        ret[i] = ret[i] || block->contents.start[i]; // TODO: optimize
+      }
+    }
+    // If there is no change in the merged result, then no new conflicts are possible.
+    // Assume the opposite, that we would be missing a conflict between x and y. Then
+    // since the merged result has not changed, x and y were present before as well.
+    // If they were present in the same origin block, then they were already in
+    // conflict there, and it is not a new conflict. If not, then they each arrive
+    // from different origins, with x arriving from X = { b_0..b_i } and y arriving from
+    // Y = { b_i+1..b_j }, where all those blocks are unique (since x and y never arrive from
+    // the same block, by assumption). Livenesses are monotonic, i.e., flowing only adds
+    // locals, never removes, so compared to the past state, we only added to X and Y.
+    // Mark the past arrivals X' and Y', and note that those two cannot be empty, since
+    // by assumption the merged result has not changed - x and y were already present
+    // before. But that means that x and y were already in conflict in the past, so
+    // this is not a new conflict.
+    if (ret == old) return false;
+    // look for conflicts TODO: optimize
+    for (size_t i = 0; i < numLocals; i++) {
+      for (size_t j = 0; j < numLocals; j++) {
+        if (ret[i] && ret[j]) interfere(i, j);
+      }
+    }
+    return true;
+  }
+
+  void scanLivenessThroughActions(std::vector<Action>& actions, LocalSet& live) {
+    // move towards the front
+    for (int i = int(actions.size()) - 1; i >= 0; i--) {
+      auto& action = actions[i];
+      if (action.isGet()) {
+        // new live local, interferes with all the rest
+        for (size_t i = 0; i < numLocals; i++) { // TODO: vector?
+          if (live[i]) interfere(i, action.index);
+        }
+        live[action.index] = 1;
+      } else {
+        if (live[action.index]) {
+          action.effective = true;
+          live[action.index] = 0;
+        }
+      }
+    }
+  }
+
+  // Indices decision making
+
+  std::vector<Index> pickIndices() { // returns a vector of oldIndex => newIndex
+    // simple greedy coloring
+    // TODO: multiple orderings
+    // TODO: take into account eliminated copies
+    // TODO: take into account distribution (99-1 is better than 50-50 with two registers, for gzip)
+    std::vector<Index> indices; // old => new
+    std::vector<WasmType> types;
+    LocalSet newInterferences; // new index * numLocals => list of all interferences of locals merged to it
+    indices.resize(numLocals);
+    types.resize(numLocals);
+    newInterferences.resize(numLocals * numLocals);
+    Index nextFree = 0;
+    // we can't reorder parameters, they are fixed in order, and cannot coalesce
+    auto numParams = getFunction()->getNumParams();
+    Index i = 0;
+    for (; i < numParams; i++) {
+      indices[i] = i;
+      types[i] = getFunction()->getLocalType(i);
+      std::copy(interferences.begin() + numLocals * i, interferences.begin() + numLocals * (i + 1), newInterferences.begin() + numLocals * i);
+      nextFree++;
+    }
+    for (; i < numLocals; i++) {
+      Index found = -1;
+      for (Index j = 0; j < nextFree; j++) {
+        if (!newInterferences[j * numLocals + i] && getFunction()->getLocalType(i) == types[j]) {
+          indices[i] = found = j;
+          break;
+        }
+      }
+      if (found == Index(-1)) {
+        indices[i] = found = nextFree;
+        types[found] = getFunction()->getLocalType(i);
+        nextFree++;
+      }
+      // merge new interferences for the new index
+      for (size_t j = 0; j < numLocals; j++) {
+        newInterferences[found * numLocals + j] = newInterferences[found * numLocals + j] | interferences[i * numLocals + j];
+      }
+    }
+    return indices;
+  }
+
+  void applyIndices(std::vector<Index>& indices, Expression* root) {
+    assert(indices.size() == numLocals);
+    for (auto& curr : basicBlocks) {
+      auto& actions = curr->contents.actions;
+      for (auto& action : actions) {
+        if (action.isGet()) {
+          auto* get = (*action.origin)->cast<GetLocal>();
+          get->index = indices[get->index];
+        } else {
+          auto* set = (*action.origin)->cast<SetLocal>();
+          set->index = indices[set->index];
+          // in addition, we can optimize out redundant copies and ineffective sets
+          GetLocal* get;
+          if ((get = set->value->dynCast<GetLocal>()) && get->index == set->index) {
+            *action.origin = get; // further optimizations may get rid of the get, if this is in a place where the output does not matter
+          } else if (!action.effective) {
+            *action.origin = set->value; // value may have no side effects, further optimizations can eliminate it
+          }
+        }
+      }
+    }
+    // update type list
+    auto numParams = getFunction()->getNumParams();
+    Index newNumLocals = 0;
+    for (auto index : indices) {
+      newNumLocals = std::max(newNumLocals, index + 1);
+    }
+    auto oldVars = getFunction()->vars;
+    getFunction()->vars.resize(newNumLocals - numParams);
+    for (size_t index = numParams; index < numLocals; index++) {
+      Index newIndex = indices[index];
+      if (newIndex >= numParams) {
+        getFunction()->vars[newIndex - numParams] = oldVars[index - numParams];
+      }
+    }
+    // names are gone
+    getFunction()->localNames.clear();
+    getFunction()->localIndices.clear();
+  }
+};
+
+static RegisterPass<CoalesceLocals> registerPass("coalesce-locals", "reduce # of locals by coalescing");
+
+} // namespace wasm

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -62,6 +62,7 @@ void PassRunner::addDefaultOptimizationPasses() {
   add("remove-unused-names");
   add("optimize-instructions");
   add("simplify-locals");
+  add("coalesce-locals");
   add("merge-blocks");
   add("reorder-locals");
   add("vacuum");

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -53,7 +53,7 @@ int main(int argc, const char *argv[]) {
     SExpressionWasmBuilder builder(wasm, *root[0]);
   } catch (ParseException& p) {
     p.dump(std::cerr);
-    Fatal() << "error in parsing wasm binary";
+    Fatal() << "error in parsing input";
   }
 
   if (options.debug) std::cerr << "binarification..." << std::endl;

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -42,126 +42,90 @@
   (export "dynCall_iiii" $dynCall_iiii)
   (export "dynCall_vi" $dynCall_vi)
   (table $b0 $___stdio_close $b1 $b1 $___stdout_write $___stdio_seek $b1 $___stdio_write $b1 $b1 $b2 $b2 $b2 $b2 $_cleanup_418 $b2 $b2 $b2)
-  (func $_malloc (param $i1 i32) (result i32)
-    (local $i5 i32)
-    (local $i7 i32)
-    (local $i63 i32)
-    (local $i43 i32)
-    (local $i62 i32)
-    (local $i8 i32)
-    (local $i15 i32)
-    (local $i45 i32)
-    (local $i44 i32)
-    (local $i60 i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i50 i32)
-    (local $i14 i32)
-    (local $i36 i32)
-    (local $i2 i32)
-    (local $i53 i32)
-    (local $i61 i32)
-    (local $i12 i32)
-    (local $i52 i32)
-    (local $i17 i32)
-    (local $i31 i32)
-    (local $i58 i32)
-    (local $i55 i32)
-    (local $i22 i32)
-    (local $i10 i32)
-    (local $i57 i32)
-    (local $i59 i32)
-    (local $i54 i32)
-    (local $i11 i32)
-    (local $i24 i32)
-    (local $i56 i32)
-    (local $i72 i32)
-    (local $i16 i32)
-    (local $i9 i32)
-    (local $i79 i32)
-    (local $i38 i32)
-    (local $i51 i32)
-    (local $i21 i32)
-    (local $i25 i32)
-    (local $i46 i32)
-    (local $i73 i32)
-    (local $i37 i32)
-    (local $i71 i32)
-    (local $i23 i32)
-    (local $i26 i32)
-    (local $i35 i32)
-    (local $i39 i32)
-    (local $i47 i32)
-    (local $i68 i32)
-    (local $i74 i32)
-    (local $i82 i32)
-    (local $i89 i32)
-    (local $i18 i32)
-    (local $i20 i32)
-    (local $i30 i32)
-    (local $i32 i32)
-    (local $i33 i32)
-    (local $i34 i32)
-    (local $i40 i32)
-    (local $i41 i32)
-    (local $i81 i32)
-    (local $i83 i32)
-    (local $i88 i32)
-    (local $i90 i32)
-    (local $i6 i32)
-    (local $i19 i32)
-    (local $i28 i32)
-    (local $i29 i32)
-    (local $i49 i32)
-    (local $i70 i32)
-    (local $i76 i32)
-    (local $i77 i32)
-    (local $i80 i32)
-    (local $i84 i32)
-    (local $i86 i32)
-    (local $i87 i32)
-    (local $i91 i32)
-    (local $i27 i32)
-    (local $i42 i32)
-    (local $i48 i32)
-    (local $i64 i32)
-    (local $i65 i32)
-    (local $i66 i32)
-    (local $i67 i32)
-    (local $i69 i32)
-    (local $i75 i32)
-    (local $i85 i32)
-    (local $i92 i32)
+  (func $_malloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 i32)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
+    (local $47 i32)
+    (local $48 i32)
+    (local $49 i32)
+    (local $50 i32)
+    (local $51 i32)
+    (local $52 i32)
+    (local $53 i32)
     (block $do-once$0
       (if
         (i32.lt_u
-          (get_local $i1)
+          (get_local $0)
           (i32.const 245)
         )
         (block
           (if
             (i32.and
-              (set_local $i5
+              (set_local $2
                 (i32.shr_u
-                  (set_local $i4
+                  (set_local $5
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (set_local $i3
+                  (set_local $4
                     (i32.shr_u
-                      (set_local $i2
+                      (set_local $0
                         (select
                           (i32.const 16)
                           (i32.and
                             (i32.add
-                              (get_local $i1)
+                              (get_local $0)
                               (i32.const 11)
                             )
                             (i32.const -8)
                           )
                           (i32.lt_u
-                            (get_local $i1)
+                            (get_local $0)
                             (i32.const 11)
                           )
                         )
@@ -174,29 +138,29 @@
               (i32.const 3)
             )
             (block
-              (set_local $i11
+              (set_local $2
                 (i32.load
-                  (set_local $i10
+                  (set_local $9
                     (i32.add
-                      (set_local $i9
+                      (set_local $4
                         (i32.load
-                          (set_local $i8
+                          (set_local $6
                             (i32.add
-                              (set_local $i7
+                              (set_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $i6
+                                      (set_local $0
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $i5)
+                                              (get_local $2)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $i3)
+                                          (get_local $4)
                                         )
                                       )
                                       (i32.const 1)
@@ -217,13 +181,13 @@
               )
               (if
                 (i32.ne
-                  (get_local $i7)
-                  (get_local $i11)
+                  (get_local $1)
+                  (get_local $2)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i11)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -233,23 +197,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i12
+                        (set_local $8
                           (i32.add
-                            (get_local $i11)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $i9)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
-                        (get_local $i12)
-                        (get_local $i7)
+                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.store
-                        (get_local $i8)
-                        (get_local $i11)
+                        (get_local $6)
+                        (get_local $2)
                       )
                     )
                     (call_import $_abort)
@@ -258,11 +222,11 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $i4)
+                    (get_local $5)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $i6)
+                        (get_local $0)
                       )
                       (i32.const -1)
                     )
@@ -270,11 +234,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $i9)
+                (get_local $4)
                 (i32.or
-                  (set_local $i11
+                  (set_local $2
                     (i32.shl
-                      (get_local $i6)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -282,31 +246,31 @@
                 )
               )
               (i32.store
-                (set_local $i8
+                (set_local $6
                   (i32.add
                     (i32.add
-                      (get_local $i9)
-                      (get_local $i11)
+                      (get_local $4)
+                      (get_local $2)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $i8)
+                    (get_local $6)
                   )
                   (i32.const 1)
                 )
               )
               (return
-                (get_local $i10)
+                (get_local $9)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $i2)
-              (set_local $i8
+              (get_local $0)
+              (set_local $6
                 (i32.load
                   (i32.const 184)
                 )
@@ -314,37 +278,37 @@
             )
             (block
               (if
-                (get_local $i5)
+                (get_local $2)
                 (block
-                  (set_local $i7
+                  (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (set_local $i11
+                        (set_local $2
                           (i32.add
                             (i32.and
-                              (set_local $i7
+                              (set_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $i5)
-                                    (get_local $i3)
+                                    (get_local $2)
+                                    (get_local $4)
                                   )
                                   (i32.or
-                                    (set_local $i11
+                                    (set_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $i3)
+                                        (get_local $4)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $i11)
+                                      (get_local $2)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i7)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -355,32 +319,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $i7
+                  (set_local $1
                     (i32.load
-                      (set_local $i12
+                      (set_local $8
                         (i32.add
-                          (set_local $i14
+                          (set_local $15
                             (i32.load
-                              (set_local $i16
+                              (set_local $18
                                 (i32.add
-                                  (set_local $i15
+                                  (set_local $10
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $i17
+                                          (set_local $19
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $i11
+                                                      (set_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $i12
+                                                            (set_local $8
                                                               (i32.shr_u
-                                                                (get_local $i11)
-                                                                (get_local $i7)
+                                                                (get_local $2)
+                                                                (get_local $1)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -388,15 +352,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $i7)
+                                                      (get_local $1)
                                                     )
-                                                    (set_local $i12
+                                                    (set_local $8
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $i14
+                                                          (set_local $15
                                                             (i32.shr_u
-                                                              (get_local $i12)
-                                                              (get_local $i11)
+                                                              (get_local $8)
+                                                              (get_local $2)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -405,13 +369,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $i14
+                                                  (set_local $15
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $i15
+                                                        (set_local $10
                                                           (i32.shr_u
-                                                            (get_local $i14)
-                                                            (get_local $i12)
+                                                            (get_local $15)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -420,13 +384,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $i15
+                                                (set_local $10
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $i16
+                                                      (set_local $18
                                                         (i32.shr_u
-                                                          (get_local $i15)
-                                                          (get_local $i14)
+                                                          (get_local $10)
+                                                          (get_local $15)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -436,8 +400,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $i16)
-                                                (get_local $i15)
+                                                (get_local $18)
+                                                (get_local $10)
                                               )
                                             )
                                           )
@@ -459,13 +423,13 @@
                   )
                   (if
                     (i32.ne
-                      (get_local $i15)
-                      (get_local $i7)
+                      (get_local $10)
+                      (get_local $1)
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $i7)
+                          (get_local $1)
                           (i32.load
                             (i32.const 192)
                           )
@@ -475,25 +439,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $i11
+                            (set_local $2
                               (i32.add
-                                (get_local $i7)
+                                (get_local $1)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $i14)
+                          (get_local $15)
                         )
                         (block
                           (i32.store
-                            (get_local $i11)
-                            (get_local $i15)
+                            (get_local $2)
+                            (get_local $10)
                           )
                           (i32.store
-                            (get_local $i16)
-                            (get_local $i7)
+                            (get_local $18)
+                            (get_local $1)
                           )
-                          (set_local $i18
+                          (set_local $9
                             (i32.load
                               (i32.const 184)
                             )
@@ -506,43 +470,43 @@
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $i4)
+                          (get_local $5)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i17)
+                              (get_local $19)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $i18
-                        (get_local $i8)
+                      (set_local $9
+                        (get_local $6)
                       )
                     )
                   )
                   (i32.store offset=4
-                    (get_local $i14)
+                    (get_local $15)
                     (i32.or
-                      (get_local $i2)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $i4
+                    (set_local $5
                       (i32.add
-                        (get_local $i14)
-                        (get_local $i2)
+                        (get_local $15)
+                        (get_local $0)
                       )
                     )
                     (i32.or
-                      (set_local $i8
+                      (set_local $6
                         (i32.sub
                           (i32.shl
-                            (get_local $i17)
+                            (get_local $19)
                             (i32.const 3)
                           )
-                          (get_local $i2)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
@@ -550,27 +514,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $i4)
-                      (get_local $i8)
+                      (get_local $5)
+                      (get_local $6)
                     )
-                    (get_local $i8)
+                    (get_local $6)
                   )
                   (if
-                    (get_local $i18)
+                    (get_local $9)
                     (block
-                      (set_local $i7
+                      (set_local $1
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $i15
+                      (set_local $10
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (set_local $i16
+                              (set_local $18
                                 (i32.shr_u
-                                  (get_local $i18)
+                                  (get_local $9)
                                   (i32.const 3)
                                 )
                               )
@@ -582,25 +546,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $i3
+                          (set_local $4
                             (i32.load
                               (i32.const 176)
                             )
                           )
-                          (set_local $i5
+                          (set_local $2
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i16)
+                              (get_local $18)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $i10
+                            (set_local $9
                               (i32.load
-                                (set_local $i16
+                                (set_local $18
                                   (i32.add
-                                    (get_local $i15)
+                                    (get_local $10)
                                     (i32.const 8)
                                   )
                                 )
@@ -612,11 +576,11 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $i19
-                              (get_local $i16)
+                            (set_local $39
+                              (get_local $18)
                             )
-                            (set_local $i20
-                              (get_local $i10)
+                            (set_local $31
+                              (get_local $9)
                             )
                           )
                         )
@@ -624,69 +588,69 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $i3)
-                              (get_local $i5)
+                              (get_local $4)
+                              (get_local $2)
                             )
                           )
-                          (set_local $i19
+                          (set_local $39
                             (i32.add
-                              (get_local $i15)
+                              (get_local $10)
                               (i32.const 8)
                             )
                           )
-                          (set_local $i20
-                            (get_local $i15)
+                          (set_local $31
+                            (get_local $10)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $i19)
-                        (get_local $i7)
+                        (get_local $39)
+                        (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $i20)
-                        (get_local $i7)
+                        (get_local $31)
+                        (get_local $1)
                       )
                       (i32.store offset=8
-                        (get_local $i7)
-                        (get_local $i20)
+                        (get_local $1)
+                        (get_local $31)
                       )
                       (i32.store offset=12
-                        (get_local $i7)
-                        (get_local $i15)
+                        (get_local $1)
+                        (get_local $10)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $i8)
+                    (get_local $6)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $i4)
+                    (get_local $5)
                   )
                   (return
-                    (get_local $i12)
+                    (get_local $8)
                   )
                 )
               )
               (if
-                (set_local $i4
+                (set_local $5
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (block
-                  (set_local $i4
+                  (set_local $5
                     (i32.and
                       (i32.shr_u
-                        (set_local $i8
+                        (set_local $6
                           (i32.add
                             (i32.and
-                              (get_local $i4)
+                              (get_local $5)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i4)
+                                (get_local $5)
                               )
                             )
                             (i32.const -1)
@@ -697,11 +661,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $i10
+                          (set_local $9
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -709,13 +673,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $i8
+                                          (set_local $6
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $i15
+                                                (set_local $10
                                                   (i32.shr_u
-                                                    (get_local $i8)
-                                                    (get_local $i4)
+                                                    (get_local $6)
+                                                    (get_local $5)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -723,15 +687,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $i4)
+                                          (get_local $5)
                                         )
-                                        (set_local $i15
+                                        (set_local $10
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $i7
+                                              (set_local $1
                                                 (i32.shr_u
-                                                  (get_local $i15)
-                                                  (get_local $i8)
+                                                  (get_local $10)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (i32.const 2)
@@ -740,13 +704,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $i7
+                                      (set_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $i5
+                                            (set_local $2
                                               (i32.shr_u
-                                                (get_local $i7)
-                                                (get_local $i15)
+                                                (get_local $1)
+                                                (get_local $10)
                                               )
                                             )
                                             (i32.const 1)
@@ -755,13 +719,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $i5
+                                    (set_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $i3
+                                          (set_local $4
                                             (i32.shr_u
-                                              (get_local $i5)
-                                              (get_local $i7)
+                                              (get_local $2)
+                                              (get_local $1)
                                             )
                                           )
                                           (i32.const 1)
@@ -771,8 +735,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $i3)
-                                    (get_local $i5)
+                                    (get_local $4)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 2)
@@ -782,84 +746,84 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $i2)
+                      (get_local $0)
                     )
                   )
-                  (set_local $i3
-                    (get_local $i10)
+                  (set_local $4
+                    (get_local $9)
                   )
-                  (set_local $i7
-                    (get_local $i10)
+                  (set_local $1
+                    (get_local $9)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $i10
+                      (set_local $9
                         (i32.load offset=16
-                          (get_local $i3)
+                          (get_local $4)
                         )
                       )
-                      (set_local $i23
-                        (get_local $i10)
+                      (set_local $5
+                        (get_local $9)
                       )
                       (if
-                        (set_local $i15
+                        (set_local $10
                           (i32.load offset=20
-                            (get_local $i3)
+                            (get_local $4)
                           )
                         )
-                        (set_local $i23
-                          (get_local $i15)
+                        (set_local $5
+                          (get_local $10)
                         )
                         (block
-                          (set_local $i21
-                            (get_local $i5)
+                          (set_local $5
+                            (get_local $2)
                           )
-                          (set_local $i22
-                            (get_local $i7)
+                          (set_local $6
+                            (get_local $1)
                           )
                           (br $while-out$6)
                         )
                       )
                     )
-                    (set_local $i15
+                    (set_local $10
                       (i32.lt_u
-                        (set_local $i10
+                        (set_local $9
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $i23)
+                                (get_local $5)
                               )
                               (i32.const -8)
                             )
-                            (get_local $i2)
+                            (get_local $0)
                           )
                         )
-                        (get_local $i5)
+                        (get_local $2)
                       )
                     )
-                    (set_local $i5
+                    (set_local $2
                       (select
-                        (get_local $i10)
-                        (get_local $i5)
-                        (get_local $i15)
+                        (get_local $9)
+                        (get_local $2)
+                        (get_local $10)
                       )
                     )
-                    (set_local $i3
-                      (get_local $i23)
+                    (set_local $4
+                      (get_local $5)
                     )
-                    (set_local $i7
+                    (set_local $1
                       (select
-                        (get_local $i23)
-                        (get_local $i7)
-                        (get_local $i15)
+                        (get_local $5)
+                        (get_local $1)
+                        (get_local $10)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i22)
-                      (set_local $i7
+                      (get_local $6)
+                      (set_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -869,72 +833,70 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $i22)
-                      (set_local $i3
+                      (get_local $6)
+                      (set_local $4
                         (i32.add
-                          (get_local $i22)
-                          (get_local $i2)
+                          (get_local $6)
+                          (get_local $0)
                         )
                       )
                     )
                     (call_import $_abort)
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.load offset=24
-                      (get_local $i22)
+                      (get_local $6)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $i12
+                        (set_local $8
                           (i32.load offset=12
-                            (get_local $i22)
+                            (get_local $6)
                           )
                         )
-                        (get_local $i22)
+                        (get_local $6)
                       )
                       (block
                         (if
-                          (set_local $i17
+                          (set_local $19
                             (i32.load
-                              (set_local $i14
+                              (set_local $15
                                 (i32.add
-                                  (get_local $i22)
+                                  (get_local $6)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $i25
-                              (get_local $i17)
+                            (set_local $9
+                              (get_local $19)
                             )
-                            (set_local $i26
-                              (get_local $i14)
+                            (set_local $8
+                              (get_local $15)
                             )
                           )
                           (if
-                            (set_local $i10
+                            (set_local $9
                               (i32.load
-                                (set_local $i15
+                                (set_local $10
                                   (i32.add
-                                    (get_local $i22)
+                                    (get_local $6)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i25
-                                (get_local $i10)
-                              )
-                              (set_local $i26
-                                (get_local $i15)
+                              (get_local $9)
+                              (set_local $8
+                                (get_local $10)
                               )
                             )
                             (block
-                              (set_local $i24
+                              (set_local $18
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -943,52 +905,48 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $i17
+                            (set_local $19
                               (i32.load
-                                (set_local $i14
+                                (set_local $15
                                   (i32.add
-                                    (get_local $i25)
+                                    (get_local $9)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i25
-                                (get_local $i17)
+                              (set_local $9
+                                (get_local $19)
                               )
-                              (set_local $i26
-                                (get_local $i14)
+                              (set_local $8
+                                (get_local $15)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
-                            (set_local $i17
+                            (set_local $19
                               (i32.load
-                                (set_local $i14
+                                (set_local $15
                                   (i32.add
-                                    (get_local $i25)
+                                    (get_local $9)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i25
-                                (get_local $i17)
+                              (set_local $9
+                                (get_local $19)
                               )
-                              (set_local $i26
-                                (get_local $i14)
+                              (set_local $8
+                                (get_local $15)
                               )
                             )
                             (block
-                              (set_local $i27
-                                (get_local $i25)
-                              )
-                              (set_local $i28
-                                (get_local $i26)
-                              )
+                              (get_local $9)
+                              (get_local $8)
                               (br $while-out$10)
                             )
                           )
@@ -996,17 +954,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $i28)
-                            (get_local $i7)
+                            (get_local $8)
+                            (get_local $1)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $i28)
+                              (get_local $8)
                               (i32.const 0)
                             )
-                            (set_local $i24
-                              (get_local $i27)
+                            (set_local $18
+                              (get_local $9)
                             )
                           )
                         )
@@ -1014,52 +972,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $i14
+                            (set_local $15
                               (i32.load offset=8
-                                (get_local $i22)
+                                (get_local $6)
                               )
                             )
-                            (get_local $i7)
+                            (get_local $1)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $i17
+                              (set_local $19
                                 (i32.add
-                                  (get_local $i14)
+                                  (get_local $15)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $i22)
+                            (get_local $6)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $i15
+                              (set_local $10
                                 (i32.add
-                                  (get_local $i12)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $i22)
+                            (get_local $6)
                           )
                           (block
                             (i32.store
-                              (get_local $i17)
-                              (get_local $i12)
+                              (get_local $19)
+                              (get_local $8)
                             )
                             (i32.store
-                              (get_local $i15)
-                              (get_local $i14)
+                              (get_local $10)
+                              (get_local $15)
                             )
-                            (set_local $i24
-                              (get_local $i12)
+                            (set_local $18
+                              (get_local $8)
                             )
                           )
                           (call_import $_abort)
@@ -1069,19 +1027,19 @@
                   )
                   (block $do-once$12
                     (if
-                      (get_local $i5)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
-                            (get_local $i22)
+                            (get_local $6)
                             (i32.load
-                              (set_local $i7
+                              (set_local $1
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (set_local $i12
+                                    (set_local $8
                                       (i32.load offset=28
-                                        (get_local $i22)
+                                        (get_local $6)
                                       )
                                     )
                                     (i32.const 2)
@@ -1092,12 +1050,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $i7)
-                              (get_local $i24)
+                              (get_local $1)
+                              (get_local $18)
                             )
                             (if
                               (i32.eqz
-                                (get_local $i24)
+                                (get_local $18)
                               )
                               (block
                                 (i32.store
@@ -1109,7 +1067,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $i12)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1122,7 +1080,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $i5)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -1132,35 +1090,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $i12
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $i5)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $i22)
+                                (get_local $6)
                               )
                               (i32.store
-                                (get_local $i12)
-                                (get_local $i24)
+                                (get_local $8)
+                                (get_local $18)
                               )
                               (i32.store offset=20
-                                (get_local $i5)
-                                (get_local $i24)
+                                (get_local $2)
+                                (get_local $18)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eqz
-                                (get_local $i24)
+                                (get_local $18)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $i24)
-                            (set_local $i12
+                            (get_local $18)
+                            (set_local $8
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1169,42 +1127,42 @@
                           (call_import $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $i24)
-                          (get_local $i5)
+                          (get_local $18)
+                          (get_local $2)
                         )
                         (if
-                          (set_local $i7
+                          (set_local $1
                             (i32.load offset=16
-                              (get_local $i22)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i7)
-                              (get_local $i12)
+                              (get_local $1)
+                              (get_local $8)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $i24)
-                                (get_local $i7)
+                                (get_local $18)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $i7)
-                                (get_local $i24)
+                                (get_local $1)
+                                (get_local $18)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $i7
+                          (set_local $1
                             (i32.load offset=20
-                              (get_local $i22)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i7)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1212,12 +1170,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $i24)
-                                (get_local $i7)
+                                (get_local $18)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $i7)
-                                (get_local $i24)
+                                (get_local $1)
+                                (get_local $18)
                               )
                             )
                           )
@@ -1227,35 +1185,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i21)
+                      (get_local $5)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $i22)
+                        (get_local $6)
                         (i32.or
-                          (set_local $i5
+                          (set_local $2
                             (i32.add
-                              (get_local $i21)
-                              (get_local $i2)
+                              (get_local $5)
+                              (get_local $0)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (set_local $i7
+                        (set_local $1
                           (i32.add
                             (i32.add
-                              (get_local $i22)
-                              (get_local $i5)
+                              (get_local $6)
+                              (get_local $2)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $i7)
+                            (get_local $1)
                           )
                           (i32.const 1)
                         )
@@ -1263,46 +1221,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $i22)
+                        (get_local $6)
                         (i32.or
-                          (get_local $i2)
+                          (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $i3)
+                        (get_local $4)
                         (i32.or
-                          (get_local $i21)
+                          (get_local $5)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $i3)
-                          (get_local $i21)
+                          (get_local $4)
+                          (get_local $5)
                         )
-                        (get_local $i21)
+                        (get_local $5)
                       )
                       (if
-                        (set_local $i7
+                        (set_local $1
                           (i32.load
                             (i32.const 184)
                           )
                         )
                         (block
-                          (set_local $i5
+                          (set_local $2
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $i7
+                          (set_local $1
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $i12
+                                  (set_local $8
                                     (i32.shr_u
-                                      (get_local $i7)
+                                      (get_local $1)
                                       (i32.const 3)
                                     )
                                   )
@@ -1314,25 +1272,25 @@
                           )
                           (if
                             (i32.and
-                              (set_local $i14
+                              (set_local $15
                                 (i32.load
                                   (i32.const 176)
                                 )
                               )
-                              (set_local $i15
+                              (set_local $10
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $i12)
+                                  (get_local $8)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $i17
+                                (set_local $19
                                   (i32.load
-                                    (set_local $i12
+                                    (set_local $8
                                       (i32.add
-                                        (get_local $i7)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
@@ -1344,11 +1302,11 @@
                               )
                               (call_import $_abort)
                               (block
-                                (set_local $i29
-                                  (get_local $i12)
+                                (set_local $40
+                                  (get_local $8)
                                 )
-                                (set_local $i30
-                                  (get_local $i17)
+                                (set_local $32
+                                  (get_local $19)
                                 )
                               )
                             )
@@ -1356,77 +1314,73 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $i14)
-                                  (get_local $i15)
+                                  (get_local $15)
+                                  (get_local $10)
                                 )
                               )
-                              (set_local $i29
+                              (set_local $40
                                 (i32.add
-                                  (get_local $i7)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $i30
-                                (get_local $i7)
+                              (set_local $32
+                                (get_local $1)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $i29)
-                            (get_local $i5)
+                            (get_local $40)
+                            (get_local $2)
                           )
                           (i32.store offset=12
-                            (get_local $i30)
-                            (get_local $i5)
+                            (get_local $32)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $i5)
-                            (get_local $i30)
+                            (get_local $2)
+                            (get_local $32)
                           )
                           (i32.store offset=12
-                            (get_local $i5)
-                            (get_local $i7)
+                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $i21)
+                        (get_local $5)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $i3)
+                        (get_local $4)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $i22)
+                      (get_local $6)
                       (i32.const 8)
                     )
                   )
                 )
-                (set_local $i31
-                  (get_local $i2)
-                )
+                (get_local $0)
               )
             )
-            (set_local $i31
-              (get_local $i2)
-            )
+            (get_local $0)
           )
         )
         (if
           (i32.le_u
-            (get_local $i1)
+            (get_local $0)
             (i32.const -65)
           )
           (block
-            (set_local $i5
+            (set_local $2
               (i32.and
-                (set_local $i7
+                (set_local $1
                   (i32.add
-                    (get_local $i1)
+                    (get_local $0)
                     (i32.const 11)
                   )
                 )
@@ -1434,60 +1388,60 @@
               )
             )
             (if
-              (set_local $i15
+              (set_local $10
                 (i32.load
                   (i32.const 180)
                 )
               )
               (block
-                (set_local $i14
+                (set_local $15
                   (i32.sub
                     (i32.const 0)
-                    (get_local $i5)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$L123
                   (if
-                    (set_local $i4
+                    (set_local $5
                       (i32.load offset=480
                         (i32.shl
-                          (set_local $i32
+                          (set_local $0
                             (if
-                              (set_local $i17
+                              (set_local $19
                                 (i32.shr_u
-                                  (get_local $i7)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (if
                                 (i32.gt_u
-                                  (get_local $i5)
+                                  (get_local $2)
                                   (i32.const 16777215)
                                 )
                                 (i32.const 31)
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $i5)
+                                      (get_local $2)
                                       (i32.add
-                                        (set_local $i4
+                                        (set_local $5
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (set_local $i17
+                                                  (set_local $19
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $i12
+                                                          (set_local $8
                                                             (i32.shl
-                                                              (get_local $i17)
-                                                              (set_local $i7
+                                                              (get_local $19)
+                                                              (set_local $1
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $i17)
+                                                                      (get_local $19)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -1504,16 +1458,16 @@
                                                       (i32.const 4)
                                                     )
                                                   )
-                                                  (get_local $i7)
+                                                  (get_local $1)
                                                 )
-                                                (set_local $i12
+                                                (set_local $8
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $i10
+                                                        (set_local $9
                                                           (i32.shl
-                                                            (get_local $i12)
-                                                            (get_local $i17)
+                                                            (get_local $8)
+                                                            (get_local $19)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -1527,8 +1481,8 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $i10)
-                                                (get_local $i12)
+                                                (get_local $9)
+                                                (get_local $8)
                                               )
                                               (i32.const 15)
                                             )
@@ -1540,7 +1494,7 @@
                                     (i32.const 1)
                                   )
                                   (i32.shl
-                                    (get_local $i4)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
@@ -1553,118 +1507,116 @@
                       )
                     )
                     (block
-                      (set_local $i12
-                        (get_local $i14)
+                      (set_local $8
+                        (get_local $15)
                       )
-                      (set_local $i10
+                      (set_local $9
                         (i32.const 0)
                       )
-                      (set_local $i7
+                      (set_local $1
                         (i32.shl
-                          (get_local $i5)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $i32)
+                                (get_local $0)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $i32)
+                              (get_local $0)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $i17
-                        (get_local $i4)
+                      (set_local $19
+                        (get_local $5)
                       )
-                      (set_local $i8
+                      (set_local $6
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $i9
+                            (set_local $4
                               (i32.sub
-                                (set_local $i16
+                                (set_local $18
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $i17)
+                                      (get_local $19)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $i5)
+                                (get_local $2)
                               )
                             )
-                            (get_local $i12)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
-                              (get_local $i16)
-                              (get_local $i5)
+                              (get_local $18)
+                              (get_local $2)
                             )
                             (block
-                              (set_local $i37
-                                (get_local $i9)
+                              (set_local $27
+                                (get_local $4)
                               )
-                              (set_local $i38
-                                (get_local $i17)
+                              (set_local $25
+                                (get_local $19)
                               )
-                              (set_local $i39
-                                (get_local $i17)
+                              (set_local $30
+                                (get_local $19)
                               )
-                              (set_local $i36
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $i40
-                                (get_local $i9)
+                              (set_local $5
+                                (get_local $4)
                               )
-                              (set_local $i41
-                                (get_local $i17)
+                              (set_local $6
+                                (get_local $19)
                               )
                             )
                           )
                           (block
-                            (set_local $i40
-                              (get_local $i12)
+                            (set_local $5
+                              (get_local $8)
                             )
-                            (set_local $i41
-                              (get_local $i8)
-                            )
+                            (get_local $6)
                           )
                         )
-                        (set_local $i16
+                        (set_local $18
                           (select
-                            (get_local $i10)
-                            (set_local $i9
+                            (get_local $9)
+                            (set_local $4
                               (i32.load offset=20
-                                (get_local $i17)
+                                (get_local $19)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $i9)
+                                (get_local $4)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $i9)
-                                (set_local $i17
+                                (get_local $4)
+                                (set_local $19
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $i17)
+                                        (get_local $19)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $i7)
+                                          (get_local $1)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1677,65 +1629,63 @@
                           )
                         )
                         (if
-                          (set_local $i9
+                          (set_local $4
                             (i32.eq
-                              (get_local $i17)
+                              (get_local $19)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $i33
-                              (get_local $i40)
+                            (set_local $33
+                              (get_local $5)
                             )
-                            (set_local $i34
-                              (get_local $i16)
+                            (set_local $34
+                              (get_local $18)
                             )
-                            (set_local $i35
-                              (get_local $i41)
+                            (set_local $29
+                              (get_local $6)
                             )
-                            (set_local $i36
+                            (set_local $8
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $i12
-                              (get_local $i40)
+                            (set_local $8
+                              (get_local $5)
                             )
-                            (set_local $i10
-                              (get_local $i16)
+                            (set_local $9
+                              (get_local $18)
                             )
-                            (set_local $i7
+                            (set_local $1
                               (i32.shl
-                                (get_local $i7)
+                                (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $i9)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
                                 )
                               )
                             )
-                            (set_local $i8
-                              (get_local $i41)
-                            )
+                            (get_local $6)
                           )
                         )
                         (br $while-in$18)
                       )
                     )
                     (block
-                      (set_local $i33
-                        (get_local $i14)
+                      (set_local $33
+                        (get_local $15)
                       )
-                      (set_local $i34
+                      (set_local $34
                         (i32.const 0)
                       )
-                      (set_local $i35
+                      (set_local $29
                         (i32.const 0)
                       )
-                      (set_local $i36
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1743,60 +1693,60 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $i36)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
-                    (set_local $i42
+                    (set_local $0
                       (if
                         (i32.and
                           (i32.eq
-                            (get_local $i34)
+                            (get_local $34)
                             (i32.const 0)
                           )
                           (i32.eq
-                            (get_local $i35)
+                            (get_local $29)
                             (i32.const 0)
                           )
                         )
                         (block
                           (if
                             (i32.eqz
-                              (set_local $i14
+                              (set_local $15
                                 (i32.and
-                                  (get_local $i15)
+                                  (get_local $10)
                                   (i32.or
-                                    (set_local $i4
+                                    (set_local $5
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $i32)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $i4)
+                                      (get_local $5)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i31
-                                (get_local $i5)
+                              (set_local $0
+                                (get_local $2)
                               )
                               (br $do-once$0)
                             )
                           )
-                          (set_local $i14
+                          (set_local $15
                             (i32.and
                               (i32.shr_u
-                                (set_local $i4
+                                (set_local $5
                                   (i32.add
                                     (i32.and
-                                      (get_local $i14)
+                                      (get_local $15)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $i14)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.const -1)
@@ -1814,13 +1764,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (set_local $i4
+                                        (set_local $5
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $i2
+                                              (set_local $0
                                                 (i32.shr_u
-                                                  (get_local $i4)
-                                                  (get_local $i14)
+                                                  (get_local $5)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (i32.const 5)
@@ -1828,15 +1778,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $i14)
+                                        (get_local $15)
                                       )
-                                      (set_local $i2
+                                      (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $i3
+                                            (set_local $4
                                               (i32.shr_u
-                                                (get_local $i2)
-                                                (get_local $i4)
+                                                (get_local $0)
+                                                (get_local $5)
                                               )
                                             )
                                             (i32.const 2)
@@ -1845,13 +1795,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $i3
+                                    (set_local $4
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $i8
+                                          (set_local $6
                                             (i32.shr_u
-                                              (get_local $i3)
-                                              (get_local $i2)
+                                              (get_local $4)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -1860,13 +1810,13 @@
                                       )
                                     )
                                   )
-                                  (set_local $i8
+                                  (set_local $6
                                     (i32.and
                                       (i32.shr_u
-                                        (set_local $i7
+                                        (set_local $1
                                           (i32.shr_u
-                                            (get_local $i8)
-                                            (get_local $i3)
+                                            (get_local $6)
+                                            (get_local $4)
                                           )
                                         )
                                         (i32.const 1)
@@ -1876,125 +1826,121 @@
                                   )
                                 )
                                 (i32.shr_u
-                                  (get_local $i7)
-                                  (get_local $i8)
+                                  (get_local $1)
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 2)
                             )
                           )
                         )
-                        (get_local $i34)
+                        (get_local $34)
                       )
                     )
                     (block
-                      (set_local $i37
-                        (get_local $i33)
+                      (set_local $27
+                        (get_local $33)
                       )
-                      (set_local $i38
-                        (get_local $i42)
+                      (set_local $25
+                        (get_local $0)
                       )
-                      (set_local $i39
-                        (get_local $i35)
+                      (set_local $30
+                        (get_local $29)
                       )
-                      (set_local $i36
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $i43
-                        (get_local $i33)
+                      (set_local $7
+                        (get_local $33)
                       )
-                      (set_local $i44
-                        (get_local $i35)
+                      (set_local $12
+                        (get_local $29)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $i36)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $i36
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $i7
+                    (set_local $1
                       (i32.lt_u
-                        (set_local $i8
+                        (set_local $6
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $i38)
+                                (get_local $25)
                               )
                               (i32.const -8)
                             )
-                            (get_local $i5)
+                            (get_local $2)
                           )
                         )
-                        (get_local $i37)
+                        (get_local $27)
                       )
                     )
-                    (set_local $i3
+                    (set_local $4
                       (select
-                        (get_local $i8)
-                        (get_local $i37)
-                        (get_local $i7)
+                        (get_local $6)
+                        (get_local $27)
+                        (get_local $1)
                       )
                     )
-                    (set_local $i8
+                    (set_local $6
                       (select
-                        (get_local $i38)
-                        (get_local $i39)
-                        (get_local $i7)
+                        (get_local $25)
+                        (get_local $30)
+                        (get_local $1)
                       )
                     )
                     (if
-                      (set_local $i7
+                      (set_local $1
                         (i32.load offset=16
-                          (get_local $i38)
+                          (get_local $25)
                         )
                       )
                       (block
-                        (set_local $i37
-                          (get_local $i3)
+                        (set_local $27
+                          (get_local $4)
                         )
-                        (set_local $i38
-                          (get_local $i7)
+                        (set_local $25
+                          (get_local $1)
                         )
-                        (set_local $i39
-                          (get_local $i8)
+                        (set_local $30
+                          (get_local $6)
                         )
-                        (set_local $i36
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                         (br $while-in$20)
                       )
                     )
                     (if
-                      (set_local $i38
+                      (set_local $25
                         (i32.load offset=20
-                          (get_local $i38)
+                          (get_local $25)
                         )
                       )
                       (block
-                        (set_local $i37
-                          (get_local $i3)
+                        (set_local $27
+                          (get_local $4)
                         )
-                        (set_local $i39
-                          (get_local $i8)
+                        (set_local $30
+                          (get_local $6)
                         )
-                        (set_local $i36
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                       )
                       (block
-                        (set_local $i43
-                          (get_local $i3)
+                        (set_local $7
+                          (get_local $4)
                         )
-                        (set_local $i44
-                          (get_local $i8)
+                        (set_local $12
+                          (get_local $6)
                         )
                         (br $while-out$19)
                       )
@@ -2005,25 +1951,25 @@
                 (if
                   (select
                     (i32.lt_u
-                      (get_local $i43)
+                      (get_local $7)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $i5)
+                        (get_local $2)
                       )
                     )
                     (i32.const 0)
                     (i32.ne
-                      (get_local $i44)
+                      (get_local $12)
                       (i32.const 0)
                     )
                   )
                   (block
                     (if
                       (i32.lt_u
-                        (get_local $i44)
-                        (set_local $i15
+                        (get_local $12)
+                        (set_local $10
                           (i32.load
                             (i32.const 192)
                           )
@@ -2033,72 +1979,70 @@
                     )
                     (if
                       (i32.ge_u
-                        (get_local $i44)
-                        (set_local $i8
+                        (get_local $12)
+                        (set_local $6
                           (i32.add
-                            (get_local $i44)
-                            (get_local $i5)
+                            (get_local $12)
+                            (get_local $2)
                           )
                         )
                       )
                       (call_import $_abort)
                     )
-                    (set_local $i3
+                    (set_local $4
                       (i32.load offset=24
-                        (get_local $i44)
+                        (get_local $12)
                       )
                     )
                     (block $do-once$21
                       (if
                         (i32.eq
-                          (set_local $i7
+                          (set_local $1
                             (i32.load offset=12
-                              (get_local $i44)
+                              (get_local $12)
                             )
                           )
-                          (get_local $i44)
+                          (get_local $12)
                         )
                         (block
                           (if
-                            (set_local $i14
+                            (set_local $15
                               (i32.load
-                                (set_local $i2
+                                (set_local $0
                                   (i32.add
-                                    (get_local $i44)
+                                    (get_local $12)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i46
-                                (get_local $i14)
+                              (set_local $1
+                                (get_local $15)
                               )
-                              (set_local $i47
-                                (get_local $i2)
+                              (set_local $5
+                                (get_local $0)
                               )
                             )
                             (if
-                              (set_local $i10
+                              (set_local $9
                                 (i32.load
-                                  (set_local $i4
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $i44)
+                                      (get_local $12)
                                       (i32.const 16)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $i46
-                                  (get_local $i10)
+                                (set_local $1
+                                  (get_local $9)
                                 )
-                                (set_local $i47
-                                  (get_local $i4)
-                                )
+                                (get_local $5)
                               )
                               (block
-                                (set_local $i45
+                                (set_local $11
                                   (i32.const 0)
                                 )
                                 (br $do-once$21)
@@ -2107,52 +2051,50 @@
                           )
                           (loop $while-out$23 $while-in$24
                             (if
-                              (set_local $i14
+                              (set_local $15
                                 (i32.load
-                                  (set_local $i2
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $i46)
+                                      (get_local $1)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $i46
-                                  (get_local $i14)
+                                (set_local $1
+                                  (get_local $15)
                                 )
-                                (set_local $i47
-                                  (get_local $i2)
+                                (set_local $5
+                                  (get_local $0)
                                 )
                                 (br $while-in$24)
                               )
                             )
                             (if
-                              (set_local $i14
+                              (set_local $15
                                 (i32.load
-                                  (set_local $i2
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $i46)
+                                      (get_local $1)
                                       (i32.const 16)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $i46
-                                  (get_local $i14)
+                                (set_local $1
+                                  (get_local $15)
                                 )
-                                (set_local $i47
-                                  (get_local $i2)
+                                (set_local $5
+                                  (get_local $0)
                                 )
                               )
                               (block
-                                (set_local $i48
-                                  (get_local $i46)
+                                (set_local $0
+                                  (get_local $1)
                                 )
-                                (set_local $i49
-                                  (get_local $i47)
-                                )
+                                (get_local $5)
                                 (br $while-out$23)
                               )
                             )
@@ -2160,17 +2102,17 @@
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i49)
-                              (get_local $i15)
+                              (get_local $5)
+                              (get_local $10)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store
-                                (get_local $i49)
+                                (get_local $5)
                                 (i32.const 0)
                               )
-                              (set_local $i45
-                                (get_local $i48)
+                              (set_local $11
+                                (get_local $0)
                               )
                             )
                           )
@@ -2178,52 +2120,52 @@
                         (block
                           (if
                             (i32.lt_u
-                              (set_local $i2
+                              (set_local $0
                                 (i32.load offset=8
-                                  (get_local $i44)
+                                  (get_local $12)
                                 )
                               )
-                              (get_local $i15)
+                              (get_local $10)
                             )
                             (call_import $_abort)
                           )
                           (if
                             (i32.ne
                               (i32.load
-                                (set_local $i14
+                                (set_local $15
                                   (i32.add
-                                    (get_local $i2)
+                                    (get_local $0)
                                     (i32.const 12)
                                   )
                                 )
                               )
-                              (get_local $i44)
+                              (get_local $12)
                             )
                             (call_import $_abort)
                           )
                           (if
                             (i32.eq
                               (i32.load
-                                (set_local $i4
+                                (set_local $5
                                   (i32.add
-                                    (get_local $i7)
+                                    (get_local $1)
                                     (i32.const 8)
                                   )
                                 )
                               )
-                              (get_local $i44)
+                              (get_local $12)
                             )
                             (block
                               (i32.store
-                                (get_local $i14)
-                                (get_local $i7)
+                                (get_local $15)
+                                (get_local $1)
                               )
                               (i32.store
-                                (get_local $i4)
-                                (get_local $i2)
+                                (get_local $5)
+                                (get_local $0)
                               )
-                              (set_local $i45
-                                (get_local $i7)
+                              (set_local $11
+                                (get_local $1)
                               )
                             )
                             (call_import $_abort)
@@ -2233,19 +2175,19 @@
                     )
                     (block $do-once$25
                       (if
-                        (get_local $i3)
+                        (get_local $4)
                         (block
                           (if
                             (i32.eq
-                              (get_local $i44)
+                              (get_local $12)
                               (i32.load
-                                (set_local $i15
+                                (set_local $10
                                   (i32.add
                                     (i32.const 480)
                                     (i32.shl
-                                      (set_local $i7
+                                      (set_local $1
                                         (i32.load offset=28
-                                          (get_local $i44)
+                                          (get_local $12)
                                         )
                                       )
                                       (i32.const 2)
@@ -2256,12 +2198,12 @@
                             )
                             (block
                               (i32.store
-                                (get_local $i15)
-                                (get_local $i45)
+                                (get_local $10)
+                                (get_local $11)
                               )
                               (if
                                 (i32.eqz
-                                  (get_local $i45)
+                                  (get_local $11)
                                 )
                                 (block
                                   (i32.store
@@ -2273,7 +2215,7 @@
                                       (i32.xor
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $i7)
+                                          (get_local $1)
                                         )
                                         (i32.const -1)
                                       )
@@ -2286,7 +2228,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $i3)
+                                  (get_local $4)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2296,35 +2238,35 @@
                               (if
                                 (i32.eq
                                   (i32.load
-                                    (set_local $i7
+                                    (set_local $1
                                       (i32.add
-                                        (get_local $i3)
+                                        (get_local $4)
                                         (i32.const 16)
                                       )
                                     )
                                   )
-                                  (get_local $i44)
+                                  (get_local $12)
                                 )
                                 (i32.store
-                                  (get_local $i7)
-                                  (get_local $i45)
+                                  (get_local $1)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=20
-                                  (get_local $i3)
-                                  (get_local $i45)
+                                  (get_local $4)
+                                  (get_local $11)
                                 )
                               )
                               (br_if $do-once$25
                                 (i32.eqz
-                                  (get_local $i45)
+                                  (get_local $11)
                                 )
                               )
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i45)
-                              (set_local $i7
+                              (get_local $11)
+                              (set_local $1
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2333,42 +2275,42 @@
                             (call_import $_abort)
                           )
                           (i32.store offset=24
-                            (get_local $i45)
-                            (get_local $i3)
+                            (get_local $11)
+                            (get_local $4)
                           )
                           (if
-                            (set_local $i15
+                            (set_local $10
                               (i32.load offset=16
-                                (get_local $i44)
+                                (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i15)
-                                (get_local $i7)
+                                (get_local $10)
+                                (get_local $1)
                               )
                               (call_import $_abort)
                               (block
                                 (i32.store offset=16
-                                  (get_local $i45)
-                                  (get_local $i15)
+                                  (get_local $11)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i15)
-                                  (get_local $i45)
+                                  (get_local $10)
+                                  (get_local $11)
                                 )
                               )
                             )
                           )
                           (if
-                            (set_local $i15
+                            (set_local $10
                               (i32.load offset=20
-                                (get_local $i44)
+                                (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i15)
+                                (get_local $10)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2376,12 +2318,12 @@
                               (call_import $_abort)
                               (block
                                 (i32.store offset=20
-                                  (get_local $i45)
-                                  (get_local $i15)
+                                  (get_local $11)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i15)
-                                  (get_local $i45)
+                                  (get_local $10)
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -2392,49 +2334,49 @@
                     (block $do-once$29
                       (if
                         (i32.ge_u
-                          (get_local $i43)
+                          (get_local $7)
                           (i32.const 16)
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $i44)
+                            (get_local $12)
                             (i32.or
-                              (get_local $i5)
+                              (get_local $2)
                               (i32.const 3)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $i8)
+                            (get_local $6)
                             (i32.or
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $i8)
-                              (get_local $i43)
+                              (get_local $6)
+                              (get_local $7)
                             )
-                            (get_local $i43)
+                            (get_local $7)
                           )
-                          (set_local $i3
+                          (set_local $4
                             (i32.shr_u
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $i15
+                              (set_local $10
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $i3)
+                                      (get_local $4)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2443,25 +2385,25 @@
                               )
                               (if
                                 (i32.and
-                                  (set_local $i7
+                                  (set_local $1
                                     (i32.load
                                       (i32.const 176)
                                     )
                                   )
-                                  (set_local $i2
+                                  (set_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $i3)
+                                      (get_local $4)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.lt_u
-                                    (set_local $i4
+                                    (set_local $5
                                       (i32.load
-                                        (set_local $i3
+                                        (set_local $4
                                           (i32.add
-                                            (get_local $i15)
+                                            (get_local $10)
                                             (i32.const 8)
                                           )
                                         )
@@ -2473,11 +2415,11 @@
                                   )
                                   (call_import $_abort)
                                   (block
-                                    (set_local $i50
-                                      (get_local $i3)
+                                    (set_local $14
+                                      (get_local $4)
                                     )
-                                    (set_local $i51
-                                      (get_local $i4)
+                                    (set_local $26
+                                      (get_local $5)
                                     )
                                   )
                                 )
@@ -2485,81 +2427,81 @@
                                   (i32.store
                                     (i32.const 176)
                                     (i32.or
-                                      (get_local $i7)
-                                      (get_local $i2)
+                                      (get_local $1)
+                                      (get_local $0)
                                     )
                                   )
-                                  (set_local $i50
+                                  (set_local $14
                                     (i32.add
-                                      (get_local $i15)
+                                      (get_local $10)
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $i51
-                                    (get_local $i15)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $i50)
-                                (get_local $i8)
+                                (get_local $14)
+                                (get_local $6)
                               )
                               (i32.store offset=12
-                                (get_local $i51)
-                                (get_local $i8)
+                                (get_local $26)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $i8)
-                                (get_local $i51)
+                                (get_local $6)
+                                (get_local $26)
                               )
                               (i32.store offset=12
-                                (get_local $i8)
-                                (get_local $i15)
+                                (get_local $6)
+                                (get_local $10)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $i3
+                          (set_local $4
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $i52
+                                (set_local $9
                                   (if
-                                    (set_local $i15
+                                    (set_local $10
                                       (i32.shr_u
-                                        (get_local $i43)
+                                        (get_local $7)
                                         (i32.const 8)
                                       )
                                     )
                                     (if
                                       (i32.gt_u
-                                        (get_local $i43)
+                                        (get_local $7)
                                         (i32.const 16777215)
                                       )
                                       (i32.const 31)
                                       (i32.or
                                         (i32.and
                                           (i32.shr_u
-                                            (get_local $i43)
+                                            (get_local $7)
                                             (i32.add
-                                              (set_local $i3
+                                              (set_local $4
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (set_local $i15
+                                                        (set_local $10
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $i7
+                                                                (set_local $1
                                                                   (i32.shl
-                                                                    (get_local $i15)
-                                                                    (set_local $i2
+                                                                    (get_local $10)
+                                                                    (set_local $0
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
-                                                                            (get_local $i15)
+                                                                            (get_local $10)
                                                                             (i32.const 1048320)
                                                                           )
                                                                           (i32.const 16)
@@ -2576,16 +2518,16 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $i2)
+                                                        (get_local $0)
                                                       )
-                                                      (set_local $i7
+                                                      (set_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $i4
+                                                              (set_local $5
                                                                 (i32.shl
-                                                                  (get_local $i7)
-                                                                  (get_local $i15)
+                                                                  (get_local $1)
+                                                                  (get_local $10)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -2599,8 +2541,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $i4)
-                                                      (get_local $i7)
+                                                      (get_local $5)
+                                                      (get_local $1)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -2612,7 +2554,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $i3)
+                                          (get_local $4)
                                           (i32.const 1)
                                         )
                                       )
@@ -2625,34 +2567,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $i8)
-                            (get_local $i52)
+                            (get_local $6)
+                            (get_local $9)
                           )
                           (i32.store offset=4
-                            (set_local $i7
+                            (set_local $1
                               (i32.add
-                                (get_local $i8)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $i7)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $i7
+                                (set_local $1
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $i4
+                                (set_local $5
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $i52)
+                                    (get_local $9)
                                   )
                                 )
                               )
@@ -2661,51 +2603,51 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $i7)
-                                  (get_local $i4)
+                                  (get_local $1)
+                                  (get_local $5)
                                 )
                               )
                               (i32.store
-                                (get_local $i3)
-                                (get_local $i8)
+                                (get_local $4)
+                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $i8)
-                                (get_local $i3)
+                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store offset=12
-                                (get_local $i8)
-                                (get_local $i8)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $i8)
-                                (get_local $i8)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $i4
+                          (set_local $5
                             (i32.shl
-                              (get_local $i43)
+                              (get_local $7)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $i52)
+                                    (get_local $9)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $i52)
+                                  (get_local $9)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $i7
+                          (set_local $1
                             (i32.load
-                              (get_local $i3)
+                              (get_local $4)
                             )
                           )
                           (loop $while-out$31 $while-in$32
@@ -2713,34 +2655,34 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $i7)
+                                    (get_local $1)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $i43)
+                                (get_local $7)
                               )
                               (block
-                                (set_local $i53
-                                  (get_local $i7)
+                                (set_local $16
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 148)
                                 )
                                 (br $while-out$31)
                               )
                             )
                             (if
-                              (set_local $i2
+                              (set_local $0
                                 (i32.load
-                                  (set_local $i3
+                                  (set_local $4
                                     (i32.add
                                       (i32.add
-                                        (get_local $i7)
+                                        (get_local $1)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $i4)
+                                          (get_local $5)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -2750,24 +2692,24 @@
                                 )
                               )
                               (block
-                                (set_local $i4
+                                (set_local $5
                                   (i32.shl
-                                    (get_local $i4)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $i7
-                                  (get_local $i2)
+                                (set_local $1
+                                  (get_local $0)
                                 )
                               )
                               (block
-                                (set_local $i54
-                                  (get_local $i3)
+                                (set_local $23
+                                  (get_local $4)
                                 )
-                                (set_local $i55
-                                  (get_local $i7)
+                                (set_local $21
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 145)
                                 )
                                 (br $while-out$31)
@@ -2777,12 +2719,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $i36)
+                              (get_local $8)
                               (i32.const 145)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i54)
+                                (get_local $23)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2790,71 +2732,71 @@
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $i54)
-                                  (get_local $i8)
+                                  (get_local $23)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i8)
-                                  (get_local $i55)
+                                  (get_local $6)
+                                  (get_local $21)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i8)
-                                  (get_local $i8)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i8)
-                                  (get_local $i8)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $i36)
+                                (get_local $8)
                                 (i32.const 148)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $i4
+                                    (set_local $5
                                       (i32.load
-                                        (set_local $i7
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $i53)
+                                            (get_local $16)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $i2
+                                    (set_local $0
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $i53)
-                                    (get_local $i2)
+                                    (get_local $16)
+                                    (get_local $0)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $i4)
-                                    (get_local $i8)
+                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (i32.store
-                                    (get_local $i7)
-                                    (get_local $i8)
+                                    (get_local $1)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=8
-                                    (get_local $i8)
-                                    (get_local $i4)
+                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=12
-                                    (get_local $i8)
-                                    (get_local $i53)
+                                    (get_local $6)
+                                    (get_local $16)
                                   )
                                   (i32.store offset=24
-                                    (get_local $i8)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -2865,30 +2807,30 @@
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $i44)
+                            (get_local $12)
                             (i32.or
-                              (set_local $i4
+                              (set_local $5
                                 (i32.add
-                                  (get_local $i43)
-                                  (get_local $i5)
+                                  (get_local $7)
+                                  (get_local $2)
                                 )
                               )
                               (i32.const 3)
                             )
                           )
                           (i32.store
-                            (set_local $i7
+                            (set_local $1
                               (i32.add
                                 (i32.add
-                                  (get_local $i44)
-                                  (get_local $i4)
+                                  (get_local $12)
+                                  (get_local $5)
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.or
                               (i32.load
-                                (get_local $i7)
+                                (get_local $1)
                               )
                               (i32.const 1)
                             )
@@ -2898,22 +2840,22 @@
                     )
                     (return
                       (i32.add
-                        (get_local $i44)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
                   )
-                  (set_local $i31
-                    (get_local $i5)
+                  (set_local $0
+                    (get_local $2)
                   )
                 )
               )
-              (set_local $i31
-                (get_local $i5)
+              (set_local $0
+                (get_local $2)
               )
             )
           )
-          (set_local $i31
+          (set_local $0
             (i32.const -1)
           )
         )
@@ -2921,25 +2863,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $i44
+        (set_local $12
           (i32.load
             (i32.const 184)
           )
         )
-        (get_local $i31)
+        (get_local $0)
       )
       (block
-        (set_local $i53
+        (set_local $16
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (set_local $i43
+            (set_local $7
               (i32.sub
-                (get_local $i44)
-                (get_local $i31)
+                (get_local $12)
+                (get_local $0)
               )
             )
             (i32.const 15)
@@ -2947,35 +2889,35 @@
           (block
             (i32.store
               (i32.const 196)
-              (set_local $i55
+              (set_local $21
                 (i32.add
-                  (get_local $i53)
-                  (get_local $i31)
+                  (get_local $16)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $i43)
+              (get_local $7)
             )
             (i32.store offset=4
-              (get_local $i55)
+              (get_local $21)
               (i32.or
-                (get_local $i43)
+                (get_local $7)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $i55)
-                (get_local $i43)
+                (get_local $21)
+                (get_local $7)
               )
-              (get_local $i43)
+              (get_local $7)
             )
             (i32.store offset=4
-              (get_local $i53)
+              (get_local $16)
               (i32.or
-                (get_local $i31)
+                (get_local $0)
                 (i32.const 3)
               )
             )
@@ -2990,25 +2932,25 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $i53)
+              (get_local $16)
               (i32.or
-                (get_local $i44)
+                (get_local $12)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $i43
+              (set_local $7
                 (i32.add
                   (i32.add
-                    (get_local $i53)
-                    (get_local $i44)
+                    (get_local $16)
+                    (get_local $12)
                   )
                   (i32.const 4)
                 )
               )
               (i32.or
                 (i32.load
-                  (get_local $i43)
+                  (get_local $7)
                 )
                 (i32.const 1)
               )
@@ -3017,7 +2959,7 @@
         )
         (return
           (i32.add
-            (get_local $i53)
+            (get_local $16)
             (i32.const 8)
           )
         )
@@ -3025,53 +2967,53 @@
     )
     (if
       (i32.gt_u
-        (set_local $i53
+        (set_local $16
           (i32.load
             (i32.const 188)
           )
         )
-        (get_local $i31)
+        (get_local $0)
       )
       (block
         (i32.store
           (i32.const 188)
-          (set_local $i43
+          (set_local $7
             (i32.sub
-              (get_local $i53)
-              (get_local $i31)
+              (get_local $16)
+              (get_local $0)
             )
           )
         )
         (i32.store
           (i32.const 200)
-          (set_local $i44
+          (set_local $12
             (i32.add
-              (set_local $i53
+              (set_local $16
                 (i32.load
                   (i32.const 200)
                 )
               )
-              (get_local $i31)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=4
-          (get_local $i44)
+          (get_local $12)
           (i32.or
-            (get_local $i43)
+            (get_local $7)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $i53)
+          (get_local $16)
           (i32.or
-            (get_local $i31)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (return
           (i32.add
-            (get_local $i53)
+            (get_local $16)
             (i32.const 8)
           )
         )
@@ -3086,24 +3028,24 @@
       (if
         (i32.and
           (i32.add
-            (set_local $i53
+            (set_local $16
               (call_import $_sysconf
                 (i32.const 30)
               )
             )
             (i32.const -1)
           )
-          (get_local $i53)
+          (get_local $16)
         )
         (call_import $_abort)
         (block
           (i32.store
             (i32.const 656)
-            (get_local $i53)
+            (get_local $16)
           )
           (i32.store
             (i32.const 652)
-            (get_local $i53)
+            (get_local $16)
           )
           (i32.store
             (i32.const 660)
@@ -3136,40 +3078,40 @@
         )
       )
     )
-    (set_local $i53
+    (set_local $16
       (i32.add
-        (get_local $i31)
+        (get_local $0)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $i43
+        (set_local $7
           (i32.and
-            (set_local $i55
+            (set_local $21
               (i32.add
-                (set_local $i43
+                (set_local $7
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (set_local $i44
+                (set_local $12
                   (i32.add
-                    (get_local $i31)
+                    (get_local $0)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $i54
+            (set_local $23
               (i32.sub
                 (i32.const 0)
-                (get_local $i43)
+                (get_local $7)
               )
             )
           )
         )
-        (get_local $i31)
+        (get_local $0)
       )
       (return
         (i32.const 0)
@@ -3178,7 +3120,7 @@
     (if
       (if
         (i32.ne
-          (set_local $i52
+          (set_local $9
             (i32.load
               (i32.const 616)
             )
@@ -3187,21 +3129,21 @@
         )
         (i32.or
           (i32.le_u
-            (set_local $i50
+            (set_local $14
               (i32.add
-                (set_local $i51
+                (set_local $26
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $i43)
+                (get_local $7)
               )
             )
-            (get_local $i51)
+            (get_local $26)
           )
           (i32.gt_u
-            (get_local $i50)
-            (get_local $i52)
+            (get_local $14)
+            (get_local $9)
           )
         )
         (i32.const 0)
@@ -3210,7 +3152,7 @@
         (i32.const 0)
       )
     )
-    (set_local $i36
+    (set_local $8
       (block $label$break$L257
         (if
           (i32.and
@@ -3223,62 +3165,62 @@
           (block
             (block $label$break$L259
               (if
-                (set_local $i52
+                (set_local $9
                   (i32.load
                     (i32.const 200)
                   )
                 )
                 (block
-                  (set_local $i50
+                  (set_local $14
                     (i32.const 624)
                   )
                   (loop $while-out$37 $while-in$38
                     (if
                       (if
                         (i32.le_u
-                          (set_local $i51
+                          (set_local $26
                             (i32.load
-                              (get_local $i50)
+                              (get_local $14)
                             )
                           )
-                          (get_local $i52)
+                          (get_local $9)
                         )
                         (i32.gt_u
                           (i32.add
-                            (get_local $i51)
+                            (get_local $26)
                             (i32.load
-                              (set_local $i45
+                              (set_local $11
                                 (i32.add
-                                  (get_local $i50)
+                                  (get_local $14)
                                   (i32.const 4)
                                 )
                               )
                             )
                           )
-                          (get_local $i52)
+                          (get_local $9)
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $i56
-                          (get_local $i50)
+                        (set_local $4
+                          (get_local $14)
                         )
-                        (set_local $i57
-                          (get_local $i45)
+                        (set_local $5
+                          (get_local $11)
                         )
                         (br $while-out$37)
                       )
                     )
                     (if
                       (i32.eqz
-                        (set_local $i50
+                        (set_local $14
                           (i32.load offset=8
-                            (get_local $i50)
+                            (get_local $14)
                           )
                         )
                       )
                       (block
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 173)
                         )
                         (br $label$break$L259)
@@ -3288,46 +3230,46 @@
                   )
                   (if
                     (i32.lt_u
-                      (set_local $i50
+                      (set_local $14
                         (i32.and
                           (i32.sub
-                            (get_local $i55)
+                            (get_local $21)
                             (i32.load
                               (i32.const 188)
                             )
                           )
-                          (get_local $i54)
+                          (get_local $23)
                         )
                       )
                       (i32.const 2147483647)
                     )
                     (if
                       (i32.eq
-                        (set_local $i45
+                        (set_local $11
                           (call_import $_sbrk
-                            (get_local $i50)
+                            (get_local $14)
                           )
                         )
                         (i32.add
                           (i32.load
-                            (get_local $i56)
+                            (get_local $4)
                           )
                           (i32.load
-                            (get_local $i57)
+                            (get_local $5)
                           )
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $i45)
+                          (get_local $11)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $i58
-                            (get_local $i45)
+                          (set_local $20
+                            (get_local $11)
                           )
-                          (set_local $i59
-                            (get_local $i50)
+                          (set_local $22
+                            (get_local $14)
                           )
                           (br $label$break$L257
                             (i32.const 193)
@@ -3335,20 +3277,20 @@
                         )
                       )
                       (block
-                        (set_local $i60
-                          (get_local $i45)
+                        (set_local $13
+                          (get_local $11)
                         )
-                        (set_local $i61
-                          (get_local $i50)
+                        (set_local $17
+                          (get_local $14)
                         )
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 183)
                         )
                       )
                     )
                   )
                 )
-                (set_local $i36
+                (set_local $8
                   (i32.const 173)
                 )
               )
@@ -3357,11 +3299,11 @@
               (if
                 (if
                   (i32.eq
-                    (get_local $i36)
+                    (get_local $8)
                     (i32.const 173)
                   )
                   (i32.ne
-                    (set_local $i52
+                    (set_local $9
                       (call_import $_sbrk
                         (i32.const 0)
                       )
@@ -3371,12 +3313,12 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $i62
+                  (set_local $1
                     (if
                       (i32.and
-                        (set_local $i45
+                        (set_local $11
                           (i32.add
-                            (set_local $i50
+                            (set_local $14
                               (i32.load
                                 (i32.const 652)
                               )
@@ -3384,47 +3326,47 @@
                             (i32.const -1)
                           )
                         )
-                        (set_local $i5
-                          (get_local $i52)
+                        (set_local $2
+                          (get_local $9)
                         )
                       )
                       (i32.add
                         (i32.sub
-                          (get_local $i43)
-                          (get_local $i5)
+                          (get_local $7)
+                          (get_local $2)
                         )
                         (i32.and
                           (i32.add
-                            (get_local $i45)
-                            (get_local $i5)
+                            (get_local $11)
+                            (get_local $2)
                           )
                           (i32.sub
                             (i32.const 0)
-                            (get_local $i50)
+                            (get_local $14)
                           )
                         )
                       )
-                      (get_local $i43)
+                      (get_local $7)
                     )
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.add
-                      (set_local $i50
+                      (set_local $14
                         (i32.load
                           (i32.const 608)
                         )
                       )
-                      (get_local $i62)
+                      (get_local $1)
                     )
                   )
                   (if
                     (i32.and
                       (i32.gt_u
-                        (get_local $i62)
-                        (get_local $i31)
+                        (get_local $1)
+                        (get_local $0)
                       )
                       (i32.lt_u
-                        (get_local $i62)
+                        (get_local $1)
                         (i32.const 2147483647)
                       )
                     )
@@ -3433,12 +3375,12 @@
                         (select
                           (i32.or
                             (i32.le_u
-                              (get_local $i5)
-                              (get_local $i50)
+                              (get_local $2)
+                              (get_local $14)
                             )
                             (i32.gt_u
-                              (get_local $i5)
-                              (set_local $i45
+                              (get_local $2)
+                              (set_local $11
                                 (i32.load
                                   (i32.const 616)
                                 )
@@ -3447,39 +3389,39 @@
                           )
                           (i32.const 0)
                           (i32.ne
-                            (get_local $i45)
+                            (get_local $11)
                             (i32.const 0)
                           )
                         )
                       )
                       (if
                         (i32.eq
-                          (set_local $i45
+                          (set_local $11
                             (call_import $_sbrk
-                              (get_local $i62)
+                              (get_local $1)
                             )
                           )
-                          (get_local $i52)
+                          (get_local $9)
                         )
                         (block
-                          (set_local $i58
-                            (get_local $i52)
+                          (set_local $20
+                            (get_local $9)
                           )
-                          (set_local $i59
-                            (get_local $i62)
+                          (set_local $22
+                            (get_local $1)
                           )
                           (br $label$break$L257
                             (i32.const 193)
                           )
                         )
                         (block
-                          (set_local $i60
-                            (get_local $i45)
+                          (set_local $13
+                            (get_local $11)
                           )
-                          (set_local $i61
-                            (get_local $i62)
+                          (set_local $17
+                            (get_local $1)
                           )
-                          (set_local $i36
+                          (set_local $8
                             (i32.const 183)
                           )
                         )
@@ -3492,43 +3434,43 @@
             (block $label$break$L279
               (if
                 (i32.eq
-                  (get_local $i36)
+                  (get_local $8)
                   (i32.const 183)
                 )
                 (block
-                  (set_local $i45
+                  (set_local $11
                     (i32.sub
                       (i32.const 0)
-                      (get_local $i61)
+                      (get_local $17)
                     )
                   )
                   (if
                     (if
                       (i32.and
                         (i32.gt_u
-                          (get_local $i53)
-                          (get_local $i61)
+                          (get_local $16)
+                          (get_local $17)
                         )
                         (i32.and
                           (i32.lt_u
-                            (get_local $i61)
+                            (get_local $17)
                             (i32.const 2147483647)
                           )
                           (i32.ne
-                            (get_local $i60)
+                            (get_local $13)
                             (i32.const -1)
                           )
                         )
                       )
                       (i32.lt_u
-                        (set_local $i5
+                        (set_local $2
                           (i32.and
                             (i32.add
                               (i32.sub
-                                (get_local $i44)
-                                (get_local $i61)
+                                (get_local $12)
+                                (get_local $17)
                               )
-                              (set_local $i52
+                              (set_local $9
                                 (i32.load
                                   (i32.const 656)
                                 )
@@ -3536,7 +3478,7 @@
                             )
                             (i32.sub
                               (i32.const 0)
-                              (get_local $i52)
+                              (get_local $9)
                             )
                           )
                         )
@@ -3547,38 +3489,38 @@
                     (if
                       (i32.eq
                         (call_import $_sbrk
-                          (get_local $i5)
+                          (get_local $2)
                         )
                         (i32.const -1)
                       )
                       (block
                         (call_import $_sbrk
-                          (get_local $i45)
+                          (get_local $11)
                         )
                         (br $label$break$L279)
                       )
-                      (set_local $i63
+                      (set_local $3
                         (i32.add
-                          (get_local $i5)
-                          (get_local $i61)
+                          (get_local $2)
+                          (get_local $17)
                         )
                       )
                     )
-                    (set_local $i63
-                      (get_local $i61)
+                    (set_local $3
+                      (get_local $17)
                     )
                   )
                   (if
                     (i32.ne
-                      (get_local $i60)
+                      (get_local $13)
                       (i32.const -1)
                     )
                     (block
-                      (set_local $i58
-                        (get_local $i60)
+                      (set_local $20
+                        (get_local $13)
                       )
-                      (set_local $i59
-                        (get_local $i63)
+                      (set_local $22
+                        (get_local $3)
                       )
                       (br $label$break$L257
                         (i32.const 193)
@@ -3607,23 +3549,23 @@
         (if
           (select
             (i32.lt_u
-              (get_local $i43)
+              (get_local $7)
               (i32.const 2147483647)
             )
             (i32.const 0)
             (i32.eq
-              (get_local $i36)
+              (get_local $8)
               (i32.const 190)
             )
           )
           (i32.and
             (i32.lt_u
-              (set_local $i63
+              (set_local $3
                 (call_import $_sbrk
-                  (get_local $i43)
+                  (get_local $7)
                 )
               )
-              (set_local $i43
+              (set_local $7
                 (call_import $_sbrk
                   (i32.const 0)
                 )
@@ -3631,11 +3573,11 @@
             )
             (i32.and
               (i32.ne
-                (get_local $i63)
+                (get_local $3)
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $i43)
+                (get_local $7)
                 (i32.const -1)
               )
             )
@@ -3643,86 +3585,86 @@
           (i32.const 0)
         )
         (i32.gt_u
-          (set_local $i60
+          (set_local $13
             (i32.sub
-              (get_local $i43)
-              (get_local $i63)
+              (get_local $7)
+              (get_local $3)
             )
           )
           (i32.add
-            (get_local $i31)
+            (get_local $0)
             (i32.const 40)
           )
         )
         (i32.const 0)
       )
       (block
-        (set_local $i58
-          (get_local $i63)
+        (set_local $20
+          (get_local $3)
         )
-        (set_local $i59
-          (get_local $i60)
+        (set_local $22
+          (get_local $13)
         )
-        (set_local $i36
+        (set_local $8
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $i36)
+        (get_local $8)
         (i32.const 193)
       )
       (block
         (i32.store
           (i32.const 608)
-          (set_local $i60
+          (set_local $13
             (i32.add
               (i32.load
                 (i32.const 608)
               )
-              (get_local $i59)
+              (get_local $22)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $i60)
+            (get_local $13)
             (i32.load
               (i32.const 612)
             )
           )
           (i32.store
             (i32.const 612)
-            (get_local $i60)
+            (get_local $13)
           )
         )
         (block $do-once$44
           (if
-            (set_local $i60
+            (set_local $13
               (i32.load
                 (i32.const 200)
               )
             )
             (block
-              (set_local $i63
+              (set_local $3
                 (i32.const 624)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $i58)
+                    (get_local $20)
                     (i32.add
-                      (set_local $i43
+                      (set_local $7
                         (i32.load
-                          (get_local $i63)
+                          (get_local $3)
                         )
                       )
-                      (set_local $i44
+                      (set_local $12
                         (i32.load
-                          (set_local $i61
+                          (set_local $17
                             (i32.add
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 4)
                             )
                           )
@@ -3731,19 +3673,19 @@
                     )
                   )
                   (block
-                    (set_local $i64
-                      (get_local $i43)
+                    (set_local $47
+                      (get_local $7)
                     )
-                    (set_local $i65
-                      (get_local $i61)
+                    (set_local $48
+                      (get_local $17)
                     )
-                    (set_local $i66
-                      (get_local $i44)
+                    (set_local $49
+                      (get_local $12)
                     )
-                    (set_local $i67
-                      (get_local $i63)
+                    (set_local $50
+                      (get_local $3)
                     )
-                    (set_local $i36
+                    (set_local $8
                       (i32.const 203)
                     )
                     (br $do-out$46)
@@ -3751,9 +3693,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $i63
+                    (set_local $3
                       (i32.load offset=8
-                        (get_local $i63)
+                        (get_local $3)
                       )
                     )
                     (i32.const 0)
@@ -3764,12 +3706,12 @@
                 (select
                   (i32.and
                     (i32.lt_u
-                      (get_local $i60)
-                      (get_local $i58)
+                      (get_local $13)
+                      (get_local $20)
                     )
                     (i32.ge_u
-                      (get_local $i60)
-                      (get_local $i64)
+                      (get_local $13)
+                      (get_local $47)
                     )
                   )
                   (i32.const 0)
@@ -3777,7 +3719,7 @@
                     (i32.eq
                       (i32.and
                         (i32.load offset=12
-                          (get_local $i67)
+                          (get_local $50)
                         )
                         (i32.const 8)
                       )
@@ -3785,31 +3727,31 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $i36)
+                      (get_local $8)
                       (i32.const 203)
                     )
                   )
                 )
                 (block
                   (i32.store
-                    (get_local $i65)
+                    (get_local $48)
                     (i32.add
-                      (get_local $i66)
-                      (get_local $i59)
+                      (get_local $49)
+                      (get_local $22)
                     )
                   )
-                  (set_local $i63
+                  (set_local $3
                     (i32.add
-                      (get_local $i60)
-                      (set_local $i44
+                      (get_local $13)
+                      (set_local $12
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $i63
+                              (set_local $3
                                 (i32.add
-                                  (get_local $i60)
+                                  (get_local $13)
                                   (i32.const 8)
                                 )
                               )
@@ -3818,7 +3760,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3827,11 +3769,11 @@
                       )
                     )
                   )
-                  (set_local $i61
+                  (set_local $17
                     (i32.add
                       (i32.sub
-                        (get_local $i59)
-                        (get_local $i44)
+                        (get_local $22)
+                        (get_local $12)
                       )
                       (i32.load
                         (i32.const 188)
@@ -3840,23 +3782,23 @@
                   )
                   (i32.store
                     (i32.const 200)
-                    (get_local $i63)
+                    (get_local $3)
                   )
                   (i32.store
                     (i32.const 188)
-                    (get_local $i61)
+                    (get_local $17)
                   )
                   (i32.store offset=4
-                    (get_local $i63)
+                    (get_local $3)
                     (i32.or
-                      (get_local $i61)
+                      (get_local $17)
                       (i32.const 1)
                     )
                   )
                   (i32.store offset=4
                     (i32.add
-                      (get_local $i63)
-                      (get_local $i61)
+                      (get_local $3)
+                      (get_local $17)
                     )
                     (i32.const 40)
                   )
@@ -3869,11 +3811,11 @@
                   (br $do-once$44)
                 )
               )
-              (set_local $i68
+              (set_local $6
                 (if
                   (i32.lt_u
-                    (get_local $i58)
-                    (set_local $i61
+                    (get_local $20)
+                    (set_local $17
                       (i32.load
                         (i32.const 192)
                       )
@@ -3882,38 +3824,38 @@
                   (block
                     (i32.store
                       (i32.const 192)
-                      (get_local $i58)
+                      (get_local $20)
                     )
-                    (get_local $i58)
+                    (get_local $20)
                   )
-                  (get_local $i61)
+                  (get_local $17)
                 )
               )
-              (set_local $i61
+              (set_local $17
                 (i32.add
-                  (get_local $i58)
-                  (get_local $i59)
+                  (get_local $20)
+                  (get_local $22)
                 )
               )
-              (set_local $i63
+              (set_local $3
                 (i32.const 624)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $i63)
+                      (get_local $3)
                     )
-                    (get_local $i61)
+                    (get_local $17)
                   )
                   (block
-                    (set_local $i69
-                      (get_local $i63)
+                    (set_local $51
+                      (get_local $3)
                     )
-                    (set_local $i70
-                      (get_local $i63)
+                    (set_local $41
+                      (get_local $3)
                     )
-                    (set_local $i36
+                    (set_local $8
                       (i32.const 211)
                     )
                     (br $while-out$48)
@@ -3921,14 +3863,14 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $i63
+                    (set_local $3
                       (i32.load offset=8
-                        (get_local $i63)
+                        (get_local $3)
                       )
                     )
                   )
                   (block
-                    (set_local $i71
+                    (set_local $28
                       (i32.const 624)
                     )
                     (br $while-out$48)
@@ -3938,49 +3880,49 @@
               )
               (if
                 (i32.eq
-                  (get_local $i36)
+                  (get_local $8)
                   (i32.const 211)
                 )
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $i70)
+                      (get_local $41)
                     )
                     (i32.const 8)
                   )
-                  (set_local $i71
+                  (set_local $28
                     (i32.const 624)
                   )
                   (block
                     (i32.store
-                      (get_local $i69)
-                      (get_local $i58)
+                      (get_local $51)
+                      (get_local $20)
                     )
                     (i32.store
-                      (set_local $i63
+                      (set_local $3
                         (i32.add
-                          (get_local $i70)
+                          (get_local $41)
                           (i32.const 4)
                         )
                       )
                       (i32.add
                         (i32.load
-                          (get_local $i63)
+                          (get_local $3)
                         )
-                        (get_local $i59)
+                        (get_local $22)
                       )
                     )
-                    (set_local $i44
+                    (set_local $12
                       (i32.add
-                        (get_local $i58)
+                        (get_local $20)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $i63
+                              (set_local $3
                                 (i32.add
-                                  (get_local $i58)
+                                  (get_local $20)
                                   (i32.const 8)
                                 )
                               )
@@ -3989,7 +3931,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3997,17 +3939,17 @@
                         )
                       )
                     )
-                    (set_local $i43
+                    (set_local $7
                       (i32.add
-                        (get_local $i61)
+                        (get_local $17)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $i63
+                              (set_local $3
                                 (i32.add
-                                  (get_local $i61)
+                                  (get_local $17)
                                   (i32.const 8)
                                 )
                               )
@@ -4016,7 +3958,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -4024,38 +3966,38 @@
                         )
                       )
                     )
-                    (set_local $i63
+                    (set_local $3
                       (i32.add
-                        (get_local $i44)
-                        (get_local $i31)
+                        (get_local $12)
+                        (get_local $0)
                       )
                     )
-                    (set_local $i53
+                    (set_local $16
                       (i32.sub
                         (i32.sub
-                          (get_local $i43)
-                          (get_local $i44)
+                          (get_local $7)
+                          (get_local $12)
                         )
-                        (get_local $i31)
+                        (get_local $0)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $i44)
+                      (get_local $12)
                       (i32.or
-                        (get_local $i31)
+                        (get_local $0)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$50
                       (if
                         (i32.ne
-                          (get_local $i43)
-                          (get_local $i60)
+                          (get_local $7)
+                          (get_local $13)
                         )
                         (block
                           (if
                             (i32.eq
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.load
                                 (i32.const 196)
                               )
@@ -4063,45 +4005,45 @@
                             (block
                               (i32.store
                                 (i32.const 184)
-                                (set_local $i62
+                                (set_local $1
                                   (i32.add
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $i53)
+                                    (get_local $16)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $i63)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.or
-                                  (get_local $i62)
+                                  (get_local $1)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $i63)
-                                  (get_local $i62)
+                                  (get_local $3)
+                                  (get_local $1)
                                 )
-                                (get_local $i62)
+                                (get_local $1)
                               )
                               (br $do-once$50)
                             )
                           )
                           (i32.store
-                            (set_local $i56
+                            (set_local $4
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $i62
+                                      (set_local $1
                                         (i32.load offset=4
-                                          (get_local $i43)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 3)
@@ -4109,49 +4051,49 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $i57
+                                    (set_local $5
                                       (i32.and
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $i56
+                                    (set_local $4
                                       (i32.shr_u
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$L331
                                       (if
                                         (i32.ge_u
-                                          (get_local $i62)
+                                          (get_local $1)
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $i54
+                                          (set_local $23
                                             (i32.load offset=24
-                                              (get_local $i43)
+                                              (get_local $7)
                                             )
                                           )
                                           (block $do-once$53
                                             (if
                                               (i32.eq
-                                                (set_local $i55
+                                                (set_local $21
                                                   (i32.load offset=12
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                 )
-                                                (get_local $i43)
+                                                (get_local $7)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $i52
+                                                  (set_local $9
                                                     (i32.load
-                                                      (set_local $i5
+                                                      (set_local $2
                                                         (i32.add
-                                                          (set_local $i45
+                                                          (set_local $11
                                                             (i32.add
-                                                              (get_local $i43)
+                                                              (get_local $7)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4161,29 +4103,29 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $i73
-                                                      (get_local $i52)
+                                                    (set_local $0
+                                                      (get_local $9)
                                                     )
-                                                    (set_local $i74
-                                                      (get_local $i5)
+                                                    (set_local $4
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $i50
+                                                    (set_local $14
                                                       (i32.load
-                                                        (get_local $i45)
+                                                        (get_local $11)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i73
-                                                        (get_local $i50)
+                                                      (set_local $0
+                                                        (get_local $14)
                                                       )
-                                                      (set_local $i74
-                                                        (get_local $i45)
+                                                      (set_local $4
+                                                        (get_local $11)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i72
+                                                      (set_local $24
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once$53)
@@ -4192,52 +4134,48 @@
                                                 )
                                                 (loop $while-out$55 $while-in$56
                                                   (if
-                                                    (set_local $i52
+                                                    (set_local $9
                                                       (i32.load
-                                                        (set_local $i5
+                                                        (set_local $2
                                                           (i32.add
-                                                            (get_local $i73)
+                                                            (get_local $0)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i73
-                                                        (get_local $i52)
+                                                      (set_local $0
+                                                        (get_local $9)
                                                       )
-                                                      (set_local $i74
-                                                        (get_local $i5)
+                                                      (set_local $4
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in$56)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $i52
+                                                    (set_local $9
                                                       (i32.load
-                                                        (set_local $i5
+                                                        (set_local $2
                                                           (i32.add
-                                                            (get_local $i73)
+                                                            (get_local $0)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i73
-                                                        (get_local $i52)
+                                                      (set_local $0
+                                                        (get_local $9)
                                                       )
-                                                      (set_local $i74
-                                                        (get_local $i5)
+                                                      (set_local $4
+                                                        (get_local $2)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i75
-                                                        (get_local $i73)
-                                                      )
-                                                      (set_local $i76
-                                                        (get_local $i74)
-                                                      )
+                                                      (get_local $0)
+                                                      (get_local $4)
                                                       (br $while-out$55)
                                                     )
                                                   )
@@ -4245,17 +4183,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i76)
-                                                    (get_local $i68)
+                                                    (get_local $4)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                   (block
                                                     (i32.store
-                                                      (get_local $i76)
+                                                      (get_local $4)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $i72
-                                                      (get_local $i75)
+                                                    (set_local $24
+                                                      (get_local $0)
                                                     )
                                                   )
                                                 )
@@ -4263,52 +4201,52 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (set_local $i5
+                                                    (set_local $2
                                                       (i32.load offset=8
-                                                        (get_local $i43)
+                                                        (get_local $7)
                                                       )
                                                     )
-                                                    (get_local $i68)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $i52
+                                                      (set_local $9
                                                         (i32.add
-                                                          (get_local $i5)
+                                                          (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $i45
+                                                      (set_local $11
                                                         (i32.add
-                                                          (get_local $i55)
+                                                          (get_local $21)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $i52)
-                                                      (get_local $i55)
+                                                      (get_local $9)
+                                                      (get_local $21)
                                                     )
                                                     (i32.store
-                                                      (get_local $i45)
-                                                      (get_local $i5)
+                                                      (get_local $11)
+                                                      (get_local $2)
                                                     )
-                                                    (set_local $i72
-                                                      (get_local $i55)
+                                                    (set_local $24
+                                                      (get_local $21)
                                                     )
                                                   )
                                                   (call_import $_abort)
@@ -4318,21 +4256,21 @@
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (get_local $i54)
+                                              (get_local $23)
                                             )
                                           )
                                           (block $do-once$57
                                             (if
                                               (i32.ne
-                                                (get_local $i43)
+                                                (get_local $7)
                                                 (i32.load
-                                                  (set_local $i5
+                                                  (set_local $2
                                                     (i32.add
                                                       (i32.const 480)
                                                       (i32.shl
-                                                        (set_local $i55
+                                                        (set_local $21
                                                           (i32.load offset=28
-                                                            (get_local $i43)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4344,7 +4282,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i54)
+                                                    (get_local $23)
                                                     (i32.load
                                                       (i32.const 192)
                                                     )
@@ -4354,37 +4292,37 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $i45
+                                                      (set_local $11
                                                         (i32.add
-                                                          (get_local $i54)
+                                                          (get_local $23)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (i32.store
-                                                    (get_local $i45)
-                                                    (get_local $i72)
+                                                    (get_local $11)
+                                                    (get_local $24)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $i54)
-                                                    (get_local $i72)
+                                                    (get_local $23)
+                                                    (get_local $24)
                                                   )
                                                 )
                                                 (br_if $label$break$L331
                                                   (i32.eqz
-                                                    (get_local $i72)
+                                                    (get_local $24)
                                                   )
                                                 )
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $i5)
-                                                  (get_local $i72)
+                                                  (get_local $2)
+                                                  (get_local $24)
                                                 )
                                                 (br_if $do-once$57
-                                                  (get_local $i72)
+                                                  (get_local $24)
                                                 )
                                                 (i32.store
                                                   (i32.const 180)
@@ -4395,7 +4333,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $i55)
+                                                        (get_local $21)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4407,8 +4345,8 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $i72)
-                                              (set_local $i55
+                                              (get_local $24)
+                                              (set_local $21
                                                 (i32.load
                                                   (i32.const 192)
                                                 )
@@ -4417,15 +4355,15 @@
                                             (call_import $_abort)
                                           )
                                           (i32.store offset=24
-                                            (get_local $i72)
-                                            (get_local $i54)
+                                            (get_local $24)
+                                            (get_local $23)
                                           )
                                           (if
-                                            (set_local $i45
+                                            (set_local $11
                                               (i32.load
-                                                (set_local $i5
+                                                (set_local $2
                                                   (i32.add
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4433,34 +4371,34 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $i45)
-                                                (get_local $i55)
+                                                (get_local $11)
+                                                (get_local $21)
                                               )
                                               (call_import $_abort)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $i72)
-                                                  (get_local $i45)
+                                                  (get_local $24)
+                                                  (get_local $11)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $i45)
-                                                  (get_local $i72)
+                                                  (get_local $11)
+                                                  (get_local $24)
                                                 )
                                               )
                                             )
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (set_local $i45
+                                              (set_local $11
                                                 (i32.load offset=4
-                                                  (get_local $i5)
+                                                  (get_local $2)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $i45)
+                                              (get_local $11)
                                               (i32.load
                                                 (i32.const 192)
                                               )
@@ -4468,36 +4406,36 @@
                                             (call_import $_abort)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $i72)
-                                                (get_local $i45)
+                                                (get_local $24)
+                                                (get_local $11)
                                               )
                                               (i32.store offset=24
-                                                (get_local $i45)
-                                                (get_local $i72)
+                                                (get_local $11)
+                                                (get_local $24)
                                               )
                                             )
                                           )
                                         )
                                         (block
-                                          (set_local $i55
+                                          (set_local $21
                                             (i32.load offset=12
-                                              (get_local $i43)
+                                              (get_local $7)
                                             )
                                           )
                                           (block $do-once$61
                                             (if
                                               (i32.ne
-                                                (set_local $i45
+                                                (set_local $11
                                                   (i32.load offset=8
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                 )
-                                                (set_local $i54
+                                                (set_local $23
                                                   (i32.add
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $i56)
+                                                        (get_local $4)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4508,17 +4446,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i45)
-                                                    (get_local $i68)
+                                                    (get_local $11)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (br_if $do-once$61
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $i45)
+                                                      (get_local $11)
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                 )
                                                 (call_import $_abort)
@@ -4527,8 +4465,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $i55)
-                                              (get_local $i45)
+                                              (get_local $21)
+                                              (get_local $11)
                                             )
                                             (block
                                               (i32.store
@@ -4540,7 +4478,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $i56)
+                                                      (get_local $4)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4552,38 +4490,38 @@
                                           (block $do-once$63
                                             (if
                                               (i32.eq
-                                                (get_local $i55)
-                                                (get_local $i54)
+                                                (get_local $21)
+                                                (get_local $23)
                                               )
-                                              (set_local $i77
+                                              (set_local $42
                                                 (i32.add
-                                                  (get_local $i55)
+                                                  (get_local $21)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i55)
-                                                    (get_local $i68)
+                                                    (get_local $21)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $i5
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $i55)
+                                                          (get_local $21)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (block
-                                                    (set_local $i77
-                                                      (get_local $i5)
+                                                    (set_local $42
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once$63)
                                                   )
@@ -4593,32 +4531,32 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $i45)
-                                            (get_local $i55)
+                                            (get_local $11)
+                                            (get_local $21)
                                           )
                                           (i32.store
-                                            (get_local $i77)
-                                            (get_local $i45)
+                                            (get_local $42)
+                                            (get_local $11)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $i79
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $i57)
-                                        (get_local $i53)
+                                        (get_local $5)
+                                        (get_local $16)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $i43)
-                                      (get_local $i57)
+                                      (get_local $7)
+                                      (get_local $5)
                                     )
                                   )
                                   (block
-                                    (set_local $i79
-                                      (get_local $i53)
+                                    (set_local $0
+                                      (get_local $16)
                                     )
-                                    (get_local $i43)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 4)
@@ -4626,43 +4564,43 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $i56)
+                                (get_local $4)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $i63)
+                            (get_local $3)
                             (i32.or
-                              (get_local $i79)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $i63)
-                              (get_local $i79)
+                              (get_local $3)
+                              (get_local $0)
                             )
-                            (get_local $i79)
+                            (get_local $0)
                           )
-                          (set_local $i56
+                          (set_local $4
                             (i32.shr_u
-                              (get_local $i79)
+                              (get_local $0)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i79)
+                              (get_local $0)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $i62
+                              (set_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $i56)
+                                      (get_local $4)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4672,26 +4610,26 @@
                               (block $do-once$65
                                 (if
                                   (i32.and
-                                    (set_local $i54
+                                    (set_local $23
                                       (i32.load
                                         (i32.const 176)
                                       )
                                     )
-                                    (set_local $i5
+                                    (set_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $i56)
+                                        (get_local $4)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $i52
+                                        (set_local $9
                                           (i32.load
-                                            (set_local $i56
+                                            (set_local $4
                                               (i32.add
-                                                (get_local $i62)
+                                                (get_local $1)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4702,11 +4640,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $i80
-                                          (get_local $i56)
+                                        (set_local $43
+                                          (get_local $4)
                                         )
-                                        (set_local $i81
-                                          (get_local $i52)
+                                        (set_local $35
+                                          (get_local $9)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4717,58 +4655,58 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $i54)
-                                        (get_local $i5)
+                                        (get_local $23)
+                                        (get_local $2)
                                       )
                                     )
-                                    (set_local $i80
+                                    (set_local $43
                                       (i32.add
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $i81
-                                      (get_local $i62)
+                                    (set_local $35
+                                      (get_local $1)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $i80)
-                                (get_local $i63)
+                                (get_local $43)
+                                (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $i81)
-                                (get_local $i63)
+                                (get_local $35)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $i63)
-                                (get_local $i81)
+                                (get_local $3)
+                                (get_local $35)
                               )
                               (i32.store offset=12
-                                (get_local $i63)
-                                (get_local $i62)
+                                (get_local $3)
+                                (get_local $1)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $i5
+                          (set_local $2
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $i82
+                                (set_local $4
                                   (block $do-once$67
                                     (if
-                                      (set_local $i5
+                                      (set_local $2
                                         (i32.shr_u
-                                          (get_local $i79)
+                                          (get_local $0)
                                           (i32.const 8)
                                         )
                                       )
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $i79)
+                                            (get_local $0)
                                             (i32.const 16777215)
                                           )
                                           (br $do-once$67
@@ -4778,26 +4716,26 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $i79)
+                                              (get_local $0)
                                               (i32.add
-                                                (set_local $i50
+                                                (set_local $14
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $i52
+                                                          (set_local $9
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $i57
+                                                                  (set_local $5
                                                                     (i32.shl
-                                                                      (get_local $i5)
-                                                                      (set_local $i54
+                                                                      (get_local $2)
+                                                                      (set_local $23
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $i5)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4814,16 +4752,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $i54)
+                                                          (get_local $23)
                                                         )
-                                                        (set_local $i57
+                                                        (set_local $5
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $i56
+                                                                (set_local $4
                                                                   (i32.shl
-                                                                    (get_local $i57)
-                                                                    (get_local $i52)
+                                                                    (get_local $5)
+                                                                    (get_local $9)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4837,8 +4775,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $i56)
-                                                        (get_local $i57)
+                                                        (get_local $4)
+                                                        (get_local $5)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4850,7 +4788,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $i50)
+                                            (get_local $14)
                                             (i32.const 1)
                                           )
                                         )
@@ -4864,34 +4802,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $i63)
-                            (get_local $i82)
+                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=4
-                            (set_local $i62
+                            (set_local $1
                               (i32.add
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $i62)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $i62
+                                (set_local $1
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $i50
+                                (set_local $14
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $i82)
+                                    (get_local $4)
                                   )
                                 )
                               )
@@ -4900,51 +4838,51 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $i62)
-                                  (get_local $i50)
+                                  (get_local $1)
+                                  (get_local $14)
                                 )
                               )
                               (i32.store
-                                (get_local $i5)
-                                (get_local $i63)
+                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $i63)
-                                (get_local $i5)
+                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $i63)
-                                (get_local $i63)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $i63)
-                                (get_local $i63)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $i50
+                          (set_local $14
                             (i32.shl
-                              (get_local $i79)
+                              (get_local $0)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $i82)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $i82)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $i62
+                          (set_local $1
                             (i32.load
-                              (get_local $i5)
+                              (get_local $2)
                             )
                           )
                           (loop $while-out$69 $while-in$70
@@ -4952,34 +4890,34 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $i62)
+                                    (get_local $1)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $i79)
+                                (get_local $0)
                               )
                               (block
-                                (set_local $i83
-                                  (get_local $i62)
+                                (set_local $36
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 281)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $i57
+                              (set_local $5
                                 (i32.load
-                                  (set_local $i5
+                                  (set_local $2
                                     (i32.add
                                       (i32.add
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $i50)
+                                          (get_local $14)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -4989,24 +4927,24 @@
                                 )
                               )
                               (block
-                                (set_local $i50
+                                (set_local $14
                                   (i32.shl
-                                    (get_local $i50)
+                                    (get_local $14)
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $i62
-                                  (get_local $i57)
+                                (set_local $1
+                                  (get_local $5)
                                 )
                               )
                               (block
-                                (set_local $i84
-                                  (get_local $i5)
+                                (set_local $44
+                                  (get_local $2)
                                 )
-                                (set_local $i85
-                                  (get_local $i62)
+                                (set_local $52
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 278)
                                 )
                                 (br $while-out$69)
@@ -5016,12 +4954,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $i36)
+                              (get_local $8)
                               (i32.const 278)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i84)
+                                (get_local $44)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -5029,71 +4967,71 @@
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $i84)
-                                  (get_local $i63)
+                                  (get_local $44)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i63)
-                                  (get_local $i85)
+                                  (get_local $3)
+                                  (get_local $52)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i63)
-                                  (get_local $i63)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i63)
-                                  (get_local $i63)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $i36)
+                                (get_local $8)
                                 (i32.const 281)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $i50
+                                    (set_local $14
                                       (i32.load
-                                        (set_local $i62
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $i83)
+                                            (get_local $36)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $i57
+                                    (set_local $5
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $i83)
-                                    (get_local $i57)
+                                    (get_local $36)
+                                    (get_local $5)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $i50)
-                                    (get_local $i63)
+                                    (get_local $14)
+                                    (get_local $3)
                                   )
                                   (i32.store
-                                    (get_local $i62)
-                                    (get_local $i63)
+                                    (get_local $1)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $i63)
-                                    (get_local $i50)
+                                    (get_local $3)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $i63)
-                                    (get_local $i83)
+                                    (get_local $3)
+                                    (get_local $36)
                                   )
                                   (i32.store offset=24
-                                    (get_local $i63)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -5105,23 +5043,23 @@
                         (block
                           (i32.store
                             (i32.const 188)
-                            (set_local $i50
+                            (set_local $14
                               (i32.add
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $i53)
+                                (get_local $16)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $i63)
+                            (get_local $3)
                           )
                           (i32.store offset=4
-                            (get_local $i63)
+                            (get_local $3)
                             (i32.or
-                              (get_local $i50)
+                              (get_local $14)
                               (i32.const 1)
                             )
                           )
@@ -5130,7 +5068,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $i44)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
@@ -5141,71 +5079,71 @@
                 (if
                   (if
                     (i32.le_u
-                      (set_local $i63
+                      (set_local $3
                         (i32.load
-                          (get_local $i71)
+                          (get_local $28)
                         )
                       )
-                      (get_local $i60)
+                      (get_local $13)
                     )
                     (i32.gt_u
-                      (set_local $i53
+                      (set_local $16
                         (i32.add
-                          (get_local $i63)
+                          (get_local $3)
                           (i32.load offset=4
-                            (get_local $i71)
+                            (get_local $28)
                           )
                         )
                       )
-                      (get_local $i60)
+                      (get_local $13)
                     )
                     (i32.const 0)
                   )
                   (block
-                    (set_local $i86
-                      (get_local $i53)
+                    (set_local $4
+                      (get_local $16)
                     )
                     (br $while-out$71)
                   )
                 )
-                (set_local $i71
+                (set_local $28
                   (i32.load offset=8
-                    (get_local $i71)
+                    (get_local $28)
                   )
                 )
                 (br $while-in$72)
               )
-              (set_local $i53
+              (set_local $16
                 (i32.add
-                  (set_local $i44
+                  (set_local $12
                     (i32.add
-                      (get_local $i86)
+                      (get_local $4)
                       (i32.const -47)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $i63
+              (set_local $3
                 (i32.add
-                  (set_local $i44
+                  (set_local $12
                     (select
-                      (get_local $i60)
-                      (set_local $i63
+                      (get_local $13)
+                      (set_local $3
                         (i32.add
-                          (get_local $i44)
+                          (get_local $12)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i53)
+                                (get_local $16)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $i53)
+                                (get_local $16)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5214,10 +5152,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $i63)
-                        (set_local $i53
+                        (get_local $3)
+                        (set_local $16
                           (i32.add
-                            (get_local $i60)
+                            (get_local $13)
                             (i32.const 16)
                           )
                         )
@@ -5229,18 +5167,18 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $i43
+                (set_local $7
                   (i32.add
-                    (get_local $i58)
-                    (set_local $i61
+                    (get_local $20)
+                    (set_local $17
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $i43
+                            (set_local $7
                               (i32.add
-                                (get_local $i58)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5249,7 +5187,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $i43)
+                            (get_local $7)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5261,27 +5199,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $i50
+                (set_local $14
                   (i32.sub
                     (i32.add
-                      (get_local $i59)
+                      (get_local $22)
                       (i32.const -40)
                     )
-                    (get_local $i61)
+                    (get_local $17)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $i43)
+                (get_local $7)
                 (i32.or
-                  (get_local $i50)
+                  (get_local $14)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $i43)
-                  (get_local $i50)
+                  (get_local $7)
+                  (get_local $14)
                 )
                 (i32.const 40)
               )
@@ -5292,45 +5230,45 @@
                 )
               )
               (i32.store
-                (set_local $i50
+                (set_local $14
                   (i32.add
-                    (get_local $i44)
+                    (get_local $12)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 628)
                 )
               )
               (i32.store offset=8
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 632)
                 )
               )
               (i32.store offset=12
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 636)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $i58)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $i59)
+                (get_local $22)
               )
               (i32.store
                 (i32.const 636)
@@ -5338,19 +5276,19 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $i63)
+                (get_local $3)
               )
-              (set_local $i63
+              (set_local $3
                 (i32.add
-                  (get_local $i44)
+                  (get_local $12)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $i63
+                  (set_local $3
                     (i32.add
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 4)
                     )
                   )
@@ -5359,62 +5297,62 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 4)
                     )
-                    (get_local $i86)
+                    (get_local $4)
                   )
                 )
               )
               (if
                 (i32.ne
-                  (get_local $i44)
-                  (get_local $i60)
+                  (get_local $12)
+                  (get_local $13)
                 )
                 (block
                   (i32.store
-                    (get_local $i50)
+                    (get_local $14)
                     (i32.and
                       (i32.load
-                        (get_local $i50)
+                        (get_local $14)
                       )
                       (i32.const -2)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $i60)
+                    (get_local $13)
                     (i32.or
-                      (set_local $i63
+                      (set_local $3
                         (i32.sub
-                          (get_local $i44)
-                          (get_local $i60)
+                          (get_local $12)
+                          (get_local $13)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $i44)
-                    (get_local $i63)
+                    (get_local $12)
+                    (get_local $3)
                   )
-                  (set_local $i43
+                  (set_local $7
                     (i32.shr_u
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $i61
+                      (set_local $17
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5423,25 +5361,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $i62
+                          (set_local $1
                             (i32.load
                               (i32.const 176)
                             )
                           )
-                          (set_local $i57
+                          (set_local $5
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i43)
+                              (get_local $7)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $i5
+                            (set_local $2
                               (i32.load
-                                (set_local $i43
+                                (set_local $7
                                   (i32.add
-                                    (get_local $i61)
+                                    (get_local $17)
                                     (i32.const 8)
                                   )
                                 )
@@ -5453,11 +5391,11 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $i87
-                              (get_local $i43)
+                            (set_local $45
+                              (get_local $7)
                             )
-                            (set_local $i88
-                              (get_local $i5)
+                            (set_local $37
+                              (get_local $2)
                             )
                           )
                         )
@@ -5465,81 +5403,81 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $i62)
-                              (get_local $i57)
+                              (get_local $1)
+                              (get_local $5)
                             )
                           )
-                          (set_local $i87
+                          (set_local $45
                             (i32.add
-                              (get_local $i61)
+                              (get_local $17)
                               (i32.const 8)
                             )
                           )
-                          (set_local $i88
-                            (get_local $i61)
+                          (set_local $37
+                            (get_local $17)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $i87)
-                        (get_local $i60)
+                        (get_local $45)
+                        (get_local $13)
                       )
                       (i32.store offset=12
-                        (get_local $i88)
-                        (get_local $i60)
+                        (get_local $37)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $i60)
-                        (get_local $i88)
+                        (get_local $13)
+                        (get_local $37)
                       )
                       (i32.store offset=12
-                        (get_local $i60)
-                        (get_local $i61)
+                        (get_local $13)
+                        (get_local $17)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $i43
+                  (set_local $7
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (set_local $i89
+                        (set_local $4
                           (if
-                            (set_local $i61
+                            (set_local $17
                               (i32.shr_u
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $i63)
+                                    (get_local $3)
                                     (i32.add
-                                      (set_local $i43
+                                      (set_local $7
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $i61
+                                                (set_local $17
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $i62
+                                                        (set_local $1
                                                           (i32.shl
-                                                            (get_local $i61)
-                                                            (set_local $i57
+                                                            (get_local $17)
+                                                            (set_local $5
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $i61)
+                                                                    (get_local $17)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5556,16 +5494,16 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $i57)
+                                                (get_local $5)
                                               )
-                                              (set_local $i62
+                                              (set_local $1
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $i5
+                                                      (set_local $2
                                                         (i32.shl
-                                                          (get_local $i62)
-                                                          (get_local $i61)
+                                                          (get_local $1)
+                                                          (get_local $17)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5579,8 +5517,8 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $i5)
-                                              (get_local $i62)
+                                              (get_local $2)
+                                              (get_local $1)
                                             )
                                             (i32.const 15)
                                           )
@@ -5592,7 +5530,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $i43)
+                                  (get_local $7)
                                   (i32.const 1)
                                 )
                               )
@@ -5605,29 +5543,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $i60)
-                    (get_local $i89)
+                    (get_local $13)
+                    (get_local $4)
                   )
                   (i32.store offset=20
-                    (get_local $i60)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $i53)
+                    (get_local $16)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $i62
+                        (set_local $1
                           (i32.load
                             (i32.const 180)
                           )
                         )
-                        (set_local $i5
+                        (set_local $2
                           (i32.shl
                             (i32.const 1)
-                            (get_local $i89)
+                            (get_local $4)
                           )
                         )
                       )
@@ -5636,51 +5574,51 @@
                       (i32.store
                         (i32.const 180)
                         (i32.or
-                          (get_local $i62)
-                          (get_local $i5)
+                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.store
-                        (get_local $i43)
-                        (get_local $i60)
+                        (get_local $7)
+                        (get_local $13)
                       )
                       (i32.store offset=24
-                        (get_local $i60)
-                        (get_local $i43)
+                        (get_local $13)
+                        (get_local $7)
                       )
                       (i32.store offset=12
-                        (get_local $i60)
-                        (get_local $i60)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $i60)
-                        (get_local $i60)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.shl
-                      (get_local $i63)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $i89)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $i89)
+                          (get_local $4)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $i62
+                  (set_local $1
                     (i32.load
-                      (get_local $i43)
+                      (get_local $7)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5688,34 +5626,34 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $i62)
+                            (get_local $1)
                           )
                           (i32.const -8)
                         )
-                        (get_local $i63)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $i90
-                          (get_local $i62)
+                        (set_local $38
+                          (get_local $1)
                         )
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 307)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $i57
+                      (set_local $5
                         (i32.load
-                          (set_local $i43
+                          (set_local $7
                             (i32.add
                               (i32.add
-                                (get_local $i62)
+                                (get_local $1)
                                 (i32.const 16)
                               )
                               (i32.shl
                                 (i32.shr_u
-                                  (get_local $i5)
+                                  (get_local $2)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5725,24 +5663,24 @@
                         )
                       )
                       (block
-                        (set_local $i5
+                        (set_local $2
                           (i32.shl
-                            (get_local $i5)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
-                        (set_local $i62
-                          (get_local $i57)
+                        (set_local $1
+                          (get_local $5)
                         )
                       )
                       (block
-                        (set_local $i91
-                          (get_local $i43)
+                        (set_local $46
+                          (get_local $7)
                         )
-                        (set_local $i92
-                          (get_local $i62)
+                        (set_local $53
+                          (get_local $1)
                         )
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 304)
                         )
                         (br $while-out$75)
@@ -5752,12 +5690,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $i36)
+                      (get_local $8)
                       (i32.const 304)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i91)
+                        (get_local $46)
                         (i32.load
                           (i32.const 192)
                         )
@@ -5765,71 +5703,71 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $i91)
-                          (get_local $i60)
+                          (get_local $46)
+                          (get_local $13)
                         )
                         (i32.store offset=24
-                          (get_local $i60)
-                          (get_local $i92)
+                          (get_local $13)
+                          (get_local $53)
                         )
                         (i32.store offset=12
-                          (get_local $i60)
-                          (get_local $i60)
+                          (get_local $13)
+                          (get_local $13)
                         )
                         (i32.store offset=8
-                          (get_local $i60)
-                          (get_local $i60)
+                          (get_local $13)
+                          (get_local $13)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $i36)
+                        (get_local $8)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $i5
+                            (set_local $2
                               (i32.load
-                                (set_local $i62
+                                (set_local $1
                                   (i32.add
-                                    (get_local $i90)
+                                    (get_local $38)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $i63
+                            (set_local $3
                               (i32.load
                                 (i32.const 192)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $i90)
-                            (get_local $i63)
+                            (get_local $38)
+                            (get_local $3)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $i5)
-                            (get_local $i60)
+                            (get_local $2)
+                            (get_local $13)
                           )
                           (i32.store
-                            (get_local $i62)
-                            (get_local $i60)
+                            (get_local $1)
+                            (get_local $13)
                           )
                           (i32.store offset=8
-                            (get_local $i60)
-                            (get_local $i5)
+                            (get_local $13)
+                            (get_local $2)
                           )
                           (i32.store offset=12
-                            (get_local $i60)
-                            (get_local $i90)
+                            (get_local $13)
+                            (get_local $38)
                           )
                           (i32.store offset=24
-                            (get_local $i60)
+                            (get_local $13)
                             (i32.const 0)
                           )
                         )
@@ -5844,7 +5782,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $i5
+                    (set_local $2
                       (i32.load
                         (i32.const 192)
                       )
@@ -5852,22 +5790,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $i58)
-                    (get_local $i5)
+                    (get_local $20)
+                    (get_local $2)
                   )
                 )
                 (i32.store
                   (i32.const 192)
-                  (get_local $i58)
+                  (get_local $20)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $i58)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $i59)
+                (get_local $22)
               )
               (i32.store
                 (i32.const 636)
@@ -5883,34 +5821,34 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $i5
+              (set_local $2
                 (i32.const 0)
               )
               (loop $do-out$77 $do-in$78
                 (i32.store offset=12
-                  (set_local $i62
+                  (set_local $1
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $i5)
+                          (get_local $2)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $i62)
+                  (get_local $1)
                 )
                 (i32.store offset=8
-                  (get_local $i62)
-                  (get_local $i62)
+                  (get_local $1)
+                  (get_local $1)
                 )
                 (br_if $do-in$78
                   (i32.ne
-                    (set_local $i5
+                    (set_local $2
                       (i32.add
-                        (get_local $i5)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
@@ -5920,18 +5858,18 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $i5
+                (set_local $2
                   (i32.add
-                    (get_local $i58)
-                    (set_local $i62
+                    (get_local $20)
+                    (set_local $1
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $i5
+                            (set_local $2
                               (i32.add
-                                (get_local $i58)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5940,7 +5878,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $i5)
+                            (get_local $2)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5952,27 +5890,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $i63
+                (set_local $3
                   (i32.sub
                     (i32.add
-                      (get_local $i59)
+                      (get_local $22)
                       (i32.const -40)
                     )
-                    (get_local $i62)
+                    (get_local $1)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $i5)
+                (get_local $2)
                 (i32.or
-                  (get_local $i63)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $i5)
-                  (get_local $i63)
+                  (get_local $2)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -5987,53 +5925,53 @@
         )
         (if
           (i32.gt_u
-            (set_local $i59
+            (set_local $22
               (i32.load
                 (i32.const 188)
               )
             )
-            (get_local $i31)
+            (get_local $0)
           )
           (block
             (i32.store
               (i32.const 188)
-              (set_local $i58
+              (set_local $20
                 (i32.sub
-                  (get_local $i59)
-                  (get_local $i31)
+                  (get_local $22)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (set_local $i60
+              (set_local $13
                 (i32.add
-                  (set_local $i59
+                  (set_local $22
                     (i32.load
                       (i32.const 200)
                     )
                   )
-                  (get_local $i31)
+                  (get_local $0)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $i60)
+              (get_local $13)
               (i32.or
-                (get_local $i58)
+                (get_local $20)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $i59)
+              (get_local $22)
               (i32.or
-                (get_local $i31)
+                (get_local $0)
                 (i32.const 3)
               )
             )
             (return
               (i32.add
-                (get_local $i59)
+                (get_local $22)
                 (i32.const 8)
               )
             )
@@ -6047,58 +5985,41 @@
     )
     (i32.const 0)
   )
-  (func $_free (param $i1 i32)
-    (local $i12 i32)
-    (local $i8 i32)
-    (local $i18 i32)
-    (local $i2 i32)
-    (local $i13 i32)
-    (local $i6 i32)
-    (local $i22 i32)
-    (local $i9 i32)
-    (local $i10 i32)
-    (local $i11 i32)
-    (local $i7 i32)
-    (local $i14 i32)
-    (local $i19 i32)
-    (local $i23 i32)
-    (local $i5 i32)
-    (local $i31 i32)
-    (local $i21 i32)
-    (local $i15 i32)
-    (local $i20 i32)
-    (local $i3 i32)
-    (local $i29 i32)
-    (local $i30 i32)
-    (local $i16 i32)
-    (local $i24 i32)
-    (local $i28 i32)
-    (local $i25 i32)
-    (local $i32 i32)
-    (local $i33 i32)
-    (local $i34 i32)
-    (local $i4 i32)
-    (local $i27 i32)
-    (local $i35 i32)
-    (local $i37 i32)
-    (local $i17 i32)
-    (local $i26 i32)
-    (local $i36 i32)
+  (func $_free (param $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
     (if
       (i32.eqz
-        (get_local $i1)
+        (get_local $0)
       )
       (return)
     )
     (if
       (i32.lt_u
-        (set_local $i2
+        (set_local $1
           (i32.add
-            (get_local $i1)
+            (get_local $0)
             (i32.const -8)
           )
         )
-        (set_local $i3
+        (set_local $12
           (i32.load
             (i32.const 192)
           )
@@ -6108,12 +6029,12 @@
     )
     (if
       (i32.eq
-        (set_local $i1
+        (set_local $0
           (i32.and
-            (set_local $i4
+            (set_local $9
               (i32.load
                 (i32.add
-                  (get_local $i1)
+                  (get_local $0)
                   (i32.const -4)
                 )
               )
@@ -6125,12 +6046,12 @@
       )
       (call_import $_abort)
     )
-    (set_local $i6
+    (set_local $8
       (i32.add
-        (get_local $i2)
-        (set_local $i5
+        (get_local $1)
+        (set_local $3
           (i32.and
-            (get_local $i4)
+            (get_local $9)
             (i32.const -8)
           )
         )
@@ -6139,53 +6060,53 @@
     (block $do-once$0
       (if
         (i32.and
-          (get_local $i4)
+          (get_local $9)
           (i32.const 1)
         )
         (block
-          (set_local $i12
-            (get_local $i2)
+          (set_local $2
+            (get_local $1)
           )
-          (set_local $i13
-            (get_local $i5)
+          (set_local $7
+            (get_local $3)
           )
         )
         (block
-          (set_local $i7
+          (set_local $9
             (i32.load
-              (get_local $i2)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $i1)
+              (get_local $0)
             )
             (return)
           )
-          (set_local $i9
+          (set_local $3
             (i32.add
-              (get_local $i7)
-              (get_local $i5)
+              (get_local $9)
+              (get_local $3)
             )
           )
           (if
             (i32.lt_u
-              (set_local $i8
+              (set_local $0
                 (i32.add
-                  (get_local $i2)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $i7)
+                    (get_local $9)
                   )
                 )
               )
-              (get_local $i3)
+              (get_local $12)
             )
             (call_import $_abort)
           )
           (if
             (i32.eq
-              (get_local $i8)
+              (get_local $0)
               (i32.load
                 (i32.const 196)
               )
@@ -6194,11 +6115,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $i11
+                    (set_local $5
                       (i32.load
-                        (set_local $i10
+                        (set_local $1
                           (i32.add
-                            (get_local $i6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -6209,73 +6130,73 @@
                   (i32.const 3)
                 )
                 (block
-                  (set_local $i12
-                    (get_local $i8)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i13
-                    (get_local $i9)
+                  (set_local $7
+                    (get_local $3)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $i9)
+                (get_local $3)
               )
               (i32.store
-                (get_local $i10)
+                (get_local $1)
                 (i32.and
-                  (get_local $i11)
+                  (get_local $5)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $i8)
+                (get_local $0)
                 (i32.or
-                  (get_local $i9)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $i8)
-                  (get_local $i9)
+                  (get_local $0)
+                  (get_local $3)
                 )
-                (get_local $i9)
+                (get_local $3)
               )
               (return)
             )
           )
-          (set_local $i11
+          (set_local $5
             (i32.shr_u
-              (get_local $i7)
+              (get_local $9)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $i7)
+              (get_local $9)
               (i32.const 256)
             )
             (block
-              (set_local $i10
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $i8)
+                  (get_local $0)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $i7
+                  (set_local $9
                     (i32.load offset=8
-                      (get_local $i8)
+                      (get_local $0)
                     )
                   )
-                  (set_local $i14
+                  (set_local $6
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $i11)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6286,17 +6207,17 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i7)
-                      (get_local $i3)
+                      (get_local $9)
+                      (get_local $12)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $i7)
+                        (get_local $9)
                       )
-                      (get_local $i8)
+                      (get_local $0)
                     )
                     (call_import $_abort)
                   )
@@ -6304,8 +6225,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $i10)
-                  (get_local $i7)
+                  (get_local $1)
+                  (get_local $9)
                 )
                 (block
                   (i32.store
@@ -6317,100 +6238,100 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $i11)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
-                  (set_local $i12
-                    (get_local $i8)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i13
-                    (get_local $i9)
+                  (set_local $7
+                    (get_local $3)
                   )
                   (br $do-once$0)
                 )
               )
               (if
                 (i32.ne
-                  (get_local $i10)
-                  (get_local $i14)
+                  (get_local $1)
+                  (get_local $6)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i10)
-                      (get_local $i3)
+                      (get_local $1)
+                      (get_local $12)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i14
+                        (set_local $6
                           (i32.add
-                            (get_local $i10)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $i8)
+                      (get_local $0)
                     )
-                    (set_local $i15
-                      (get_local $i14)
+                    (set_local $11
+                      (get_local $6)
                     )
                     (call_import $_abort)
                   )
                 )
-                (set_local $i15
+                (set_local $11
                   (i32.add
-                    (get_local $i10)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $i7)
-                (get_local $i10)
+                (get_local $9)
+                (get_local $1)
               )
               (i32.store
-                (get_local $i15)
-                (get_local $i7)
+                (get_local $11)
+                (get_local $9)
               )
-              (set_local $i12
-                (get_local $i8)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $i13
-                (get_local $i9)
+              (set_local $7
+                (get_local $3)
               )
               (br $do-once$0)
             )
           )
-          (set_local $i7
+          (set_local $9
             (i32.load offset=24
-              (get_local $i8)
+              (get_local $0)
             )
           )
           (block $do-once$2
             (if
               (i32.eq
-                (set_local $i10
+                (set_local $1
                   (i32.load offset=12
-                    (get_local $i8)
+                    (get_local $0)
                   )
                 )
-                (get_local $i8)
+                (get_local $0)
               )
               (block
                 (if
-                  (set_local $i16
+                  (set_local $11
                     (i32.load
-                      (set_local $i11
+                      (set_local $5
                         (i32.add
-                          (set_local $i14
+                          (set_local $6
                             (i32.add
-                              (get_local $i8)
+                              (get_local $0)
                               (i32.const 16)
                             )
                           )
@@ -6420,29 +6341,25 @@
                     )
                   )
                   (block
-                    (set_local $i19
-                      (get_local $i16)
+                    (set_local $1
+                      (get_local $11)
                     )
-                    (set_local $i20
-                      (get_local $i11)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                   (if
-                    (set_local $i17
+                    (set_local $1
                       (i32.load
-                        (get_local $i14)
+                        (get_local $6)
                       )
                     )
                     (block
-                      (set_local $i19
-                        (get_local $i17)
-                      )
-                      (set_local $i20
-                        (get_local $i14)
-                      )
+                      (get_local $1)
+                      (get_local $6)
                     )
                     (block
-                      (set_local $i18
+                      (set_local $4
                         (i32.const 0)
                       )
                       (br $do-once$2)
@@ -6451,51 +6368,51 @@
                 )
                 (loop $while-out$4 $while-in$5
                   (if
-                    (set_local $i16
+                    (set_local $11
                       (i32.load
-                        (set_local $i11
+                        (set_local $5
                           (i32.add
-                            (get_local $i19)
+                            (get_local $1)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $i19
-                        (get_local $i16)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $i20
-                        (get_local $i11)
+                      (set_local $6
+                        (get_local $5)
                       )
                       (br $while-in$5)
                     )
                   )
                   (if
-                    (set_local $i16
+                    (set_local $11
                       (i32.load
-                        (set_local $i11
+                        (set_local $5
                           (i32.add
-                            (get_local $i19)
+                            (get_local $1)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $i19
-                        (get_local $i16)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $i20
-                        (get_local $i11)
+                      (set_local $6
+                        (get_local $5)
                       )
                     )
                     (block
-                      (set_local $i21
-                        (get_local $i19)
+                      (set_local $5
+                        (get_local $1)
                       )
-                      (set_local $i22
-                        (get_local $i20)
+                      (set_local $10
+                        (get_local $6)
                       )
                       (br $while-out$4)
                     )
@@ -6504,17 +6421,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $i22)
-                    (get_local $i3)
+                    (get_local $10)
+                    (get_local $12)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store
-                      (get_local $i22)
+                      (get_local $10)
                       (i32.const 0)
                     )
-                    (set_local $i18
-                      (get_local $i21)
+                    (set_local $4
+                      (get_local $5)
                     )
                   )
                 )
@@ -6522,52 +6439,52 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $i11
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $i8)
+                        (get_local $0)
                       )
                     )
-                    (get_local $i3)
+                    (get_local $12)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.ne
                     (i32.load
-                      (set_local $i16
+                      (set_local $11
                         (i32.add
-                          (get_local $i11)
+                          (get_local $5)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $i8)
+                    (get_local $0)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $i14
+                      (set_local $6
                         (i32.add
-                          (get_local $i10)
+                          (get_local $1)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $i8)
+                    (get_local $0)
                   )
                   (block
                     (i32.store
-                      (get_local $i16)
-                      (get_local $i10)
+                      (get_local $11)
+                      (get_local $1)
                     )
                     (i32.store
-                      (get_local $i14)
-                      (get_local $i11)
+                      (get_local $6)
+                      (get_local $5)
                     )
-                    (set_local $i18
-                      (get_local $i10)
+                    (set_local $4
+                      (get_local $1)
                     )
                   )
                   (call_import $_abort)
@@ -6576,19 +6493,19 @@
             )
           )
           (if
-            (get_local $i7)
+            (get_local $9)
             (block
               (if
                 (i32.eq
-                  (get_local $i8)
+                  (get_local $0)
                   (i32.load
-                    (set_local $i11
+                    (set_local $5
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (set_local $i10
+                          (set_local $1
                             (i32.load offset=28
-                              (get_local $i8)
+                              (get_local $0)
                             )
                           )
                           (i32.const 2)
@@ -6599,12 +6516,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $i11)
-                    (get_local $i18)
+                    (get_local $5)
+                    (get_local $4)
                   )
                   (if
                     (i32.eqz
-                      (get_local $i18)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
@@ -6616,17 +6533,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i10)
+                              (get_local $1)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $i12
-                        (get_local $i8)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $i13
-                        (get_local $i9)
+                      (set_local $7
+                        (get_local $3)
                       )
                       (br $do-once$0)
                     )
@@ -6635,7 +6552,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i7)
+                      (get_local $9)
                       (i32.load
                         (i32.const 192)
                       )
@@ -6645,34 +6562,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i10
+                        (set_local $1
                           (i32.add
-                            (get_local $i7)
+                            (get_local $9)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $i8)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $i10)
-                      (get_local $i18)
+                      (get_local $1)
+                      (get_local $4)
                     )
                     (i32.store offset=20
-                      (get_local $i7)
-                      (get_local $i18)
+                      (get_local $9)
+                      (get_local $4)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $i18)
+                      (get_local $4)
                     )
                     (block
-                      (set_local $i12
-                        (get_local $i8)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $i13
-                        (get_local $i9)
+                      (set_local $7
+                        (get_local $3)
                       )
                       (br $do-once$0)
                     )
@@ -6681,8 +6598,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $i18)
-                  (set_local $i10
+                  (get_local $4)
+                  (set_local $1
                     (i32.load
                       (i32.const 192)
                     )
@@ -6691,15 +6608,15 @@
                 (call_import $_abort)
               )
               (i32.store offset=24
-                (get_local $i18)
-                (get_local $i7)
+                (get_local $4)
+                (get_local $9)
               )
               (if
-                (set_local $i14
+                (set_local $6
                   (i32.load
-                    (set_local $i11
+                    (set_local $5
                       (i32.add
-                        (get_local $i8)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
@@ -6707,31 +6624,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $i14)
-                    (get_local $i10)
+                    (get_local $6)
+                    (get_local $1)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $i18)
-                      (get_local $i14)
+                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $i14)
-                      (get_local $i18)
+                      (get_local $6)
+                      (get_local $4)
                     )
                   )
                 )
               )
               (if
-                (set_local $i14
+                (set_local $6
                   (i32.load offset=4
-                    (get_local $i11)
+                    (get_local $5)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $i14)
+                    (get_local $6)
                     (i32.load
                       (i32.const 192)
                     )
@@ -6739,37 +6656,37 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $i18)
-                      (get_local $i14)
+                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $i14)
-                      (get_local $i18)
+                      (get_local $6)
+                      (get_local $4)
                     )
-                    (set_local $i12
-                      (get_local $i8)
+                    (set_local $2
+                      (get_local $0)
                     )
-                    (set_local $i13
-                      (get_local $i9)
+                    (set_local $7
+                      (get_local $3)
                     )
                   )
                 )
                 (block
-                  (set_local $i12
-                    (get_local $i8)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i13
-                    (get_local $i9)
+                  (set_local $7
+                    (get_local $3)
                   )
                 )
               )
             )
             (block
-              (set_local $i12
-                (get_local $i8)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $i13
-                (get_local $i9)
+              (set_local $7
+                (get_local $3)
               )
             )
           )
@@ -6778,19 +6695,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $i12)
-        (get_local $i6)
+        (get_local $2)
+        (get_local $8)
       )
       (call_import $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (set_local $i2
+          (set_local $1
             (i32.load
-              (set_local $i5
+              (set_local $3
                 (i32.add
-                  (get_local $i6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -6803,39 +6720,39 @@
     )
     (if
       (i32.and
-        (get_local $i2)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $i5)
+          (get_local $3)
           (i32.and
-            (get_local $i2)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $i12)
+          (get_local $2)
           (i32.or
-            (get_local $i13)
+            (get_local $7)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $i12)
-            (get_local $i13)
+            (get_local $2)
+            (get_local $7)
           )
-          (get_local $i13)
+          (get_local $7)
         )
-        (set_local $i29
-          (get_local $i13)
+        (set_local $0
+          (get_local $7)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $i6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -6843,29 +6760,29 @@
           (block
             (i32.store
               (i32.const 188)
-              (set_local $i18
+              (set_local $4
                 (i32.add
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $i13)
+                  (get_local $7)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $i12)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $i12)
+              (get_local $2)
               (i32.or
-                (get_local $i18)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (if
               (i32.ne
-                (get_local $i12)
+                (get_local $2)
                 (i32.load
                   (i32.const 196)
                 )
@@ -6885,7 +6802,7 @@
         )
         (if
           (i32.eq
-            (get_local $i6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -6893,82 +6810,82 @@
           (block
             (i32.store
               (i32.const 184)
-              (set_local $i18
+              (set_local $4
                 (i32.add
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $i13)
+                  (get_local $7)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $i12)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $i12)
+              (get_local $2)
               (i32.or
-                (get_local $i18)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $i12)
-                (get_local $i18)
+                (get_local $2)
+                (get_local $4)
               )
-              (get_local $i18)
+              (get_local $4)
             )
             (return)
           )
         )
-        (set_local $i18
+        (set_local $4
           (i32.add
             (i32.and
-              (get_local $i2)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $i13)
+            (get_local $7)
           )
         )
-        (set_local $i3
+        (set_local $12
           (i32.shr_u
-            (get_local $i2)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once$8
           (if
             (i32.ge_u
-              (get_local $i2)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $i21
+              (set_local $5
                 (i32.load offset=24
-                  (get_local $i6)
+                  (get_local $8)
                 )
               )
               (block $do-once$10
                 (if
                   (i32.eq
-                    (set_local $i22
+                    (set_local $10
                       (i32.load offset=12
-                        (get_local $i6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $i6)
+                    (get_local $8)
                   )
                   (block
                     (if
-                      (set_local $i15
+                      (set_local $11
                         (i32.load
-                          (set_local $i19
+                          (set_local $1
                             (i32.add
-                              (set_local $i20
+                              (set_local $6
                                 (i32.add
-                                  (get_local $i6)
+                                  (get_local $8)
                                   (i32.const 16)
                                 )
                               )
@@ -6978,29 +6895,27 @@
                         )
                       )
                       (block
-                        (set_local $i24
-                          (get_local $i15)
+                        (set_local $0
+                          (get_local $11)
                         )
-                        (set_local $i25
-                          (get_local $i19)
+                        (set_local $12
+                          (get_local $1)
                         )
                       )
                       (if
-                        (set_local $i1
+                        (set_local $0
                           (i32.load
-                            (get_local $i20)
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $i24
-                            (get_local $i1)
-                          )
-                          (set_local $i25
-                            (get_local $i20)
+                          (get_local $0)
+                          (set_local $12
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $i23
+                          (set_local $13
                             (i32.const 0)
                           )
                           (br $do-once$10)
@@ -7009,51 +6924,49 @@
                     )
                     (loop $while-out$12 $while-in$13
                       (if
-                        (set_local $i15
+                        (set_local $11
                           (i32.load
-                            (set_local $i19
+                            (set_local $1
                               (i32.add
-                                (get_local $i24)
+                                (get_local $0)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $i24
-                            (get_local $i15)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $i25
-                            (get_local $i19)
+                          (set_local $12
+                            (get_local $1)
                           )
                           (br $while-in$13)
                         )
                       )
                       (if
-                        (set_local $i15
+                        (set_local $11
                           (i32.load
-                            (set_local $i19
+                            (set_local $1
                               (i32.add
-                                (get_local $i24)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $i24
-                            (get_local $i15)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $i25
-                            (get_local $i19)
+                          (set_local $12
+                            (get_local $1)
                           )
                         )
                         (block
-                          (set_local $i26
-                            (get_local $i24)
-                          )
-                          (set_local $i27
-                            (get_local $i25)
+                          (get_local $0)
+                          (set_local $1
+                            (get_local $12)
                           )
                           (br $while-out$12)
                         )
@@ -7062,7 +6975,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i27)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7070,11 +6983,11 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $i27)
+                          (get_local $1)
                           (i32.const 0)
                         )
-                        (set_local $i23
-                          (get_local $i26)
+                        (set_local $13
+                          (get_local $0)
                         )
                       )
                     )
@@ -7082,9 +6995,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (set_local $i19
+                        (set_local $1
                           (i32.load offset=8
-                            (get_local $i6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -7096,40 +7009,40 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $i15
+                          (set_local $11
                             (i32.add
-                              (get_local $i19)
+                              (get_local $1)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $i6)
+                        (get_local $8)
                       )
                       (call_import $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $i20
+                          (set_local $6
                             (i32.add
-                              (get_local $i22)
+                              (get_local $10)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $i6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $i15)
-                          (get_local $i22)
+                          (get_local $11)
+                          (get_local $10)
                         )
                         (i32.store
-                          (get_local $i20)
-                          (get_local $i19)
+                          (get_local $6)
+                          (get_local $1)
                         )
-                        (set_local $i23
-                          (get_local $i22)
+                        (set_local $13
+                          (get_local $10)
                         )
                       )
                       (call_import $_abort)
@@ -7138,19 +7051,19 @@
                 )
               )
               (if
-                (get_local $i21)
+                (get_local $5)
                 (block
                   (if
                     (i32.eq
-                      (get_local $i6)
+                      (get_local $8)
                       (i32.load
-                        (set_local $i9
+                        (set_local $3
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (set_local $i22
+                              (set_local $10
                                 (i32.load offset=28
-                                  (get_local $i6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -7161,12 +7074,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $i9)
-                        (get_local $i23)
+                        (get_local $3)
+                        (get_local $13)
                       )
                       (if
                         (i32.eqz
-                          (get_local $i23)
+                          (get_local $13)
                         )
                         (block
                           (i32.store
@@ -7178,7 +7091,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $i22)
+                                  (get_local $10)
                                 )
                                 (i32.const -1)
                               )
@@ -7191,7 +7104,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $i21)
+                          (get_local $5)
                           (i32.load
                             (i32.const 192)
                           )
@@ -7201,35 +7114,35 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $i22
+                            (set_local $10
                               (i32.add
-                                (get_local $i21)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $i6)
+                          (get_local $8)
                         )
                         (i32.store
-                          (get_local $i22)
-                          (get_local $i23)
+                          (get_local $10)
+                          (get_local $13)
                         )
                         (i32.store offset=20
-                          (get_local $i21)
-                          (get_local $i23)
+                          (get_local $5)
+                          (get_local $13)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eqz
-                          (get_local $i23)
+                          (get_local $13)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i23)
-                      (set_local $i22
+                      (get_local $13)
+                      (set_local $10
                         (i32.load
                           (i32.const 192)
                         )
@@ -7238,15 +7151,15 @@
                     (call_import $_abort)
                   )
                   (i32.store offset=24
-                    (get_local $i23)
-                    (get_local $i21)
+                    (get_local $13)
+                    (get_local $5)
                   )
                   (if
-                    (set_local $i8
+                    (set_local $0
                       (i32.load
-                        (set_local $i9
+                        (set_local $3
                           (i32.add
-                            (get_local $i6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
@@ -7254,31 +7167,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i8)
-                        (get_local $i22)
+                        (get_local $0)
+                        (get_local $10)
                       )
                       (call_import $_abort)
                       (block
                         (i32.store offset=16
-                          (get_local $i23)
-                          (get_local $i8)
+                          (get_local $13)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $i8)
-                          (get_local $i23)
+                          (get_local $0)
+                          (get_local $13)
                         )
                       )
                     )
                   )
                   (if
-                    (set_local $i8
+                    (set_local $0
                       (i32.load offset=4
-                        (get_local $i9)
+                        (get_local $3)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i8)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7286,12 +7199,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=20
-                          (get_local $i23)
-                          (get_local $i8)
+                          (get_local $13)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $i8)
-                          (get_local $i23)
+                          (get_local $0)
+                          (get_local $13)
                         )
                       )
                     )
@@ -7300,24 +7213,24 @@
               )
             )
             (block
-              (set_local $i22
+              (set_local $10
                 (i32.load offset=12
-                  (get_local $i6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $i8
+                  (set_local $0
                     (i32.load offset=8
-                      (get_local $i6)
+                      (get_local $8)
                     )
                   )
-                  (set_local $i21
+                  (set_local $5
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $i3)
+                          (get_local $12)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -7328,7 +7241,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i8)
+                      (get_local $0)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7338,9 +7251,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $i8)
+                        (get_local $0)
                       )
-                      (get_local $i6)
+                      (get_local $8)
                     )
                     (call_import $_abort)
                   )
@@ -7348,8 +7261,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $i22)
-                  (get_local $i8)
+                  (get_local $10)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
@@ -7361,7 +7274,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $i3)
+                          (get_local $12)
                         )
                         (i32.const -1)
                       )
@@ -7372,13 +7285,13 @@
               )
               (if
                 (i32.ne
-                  (get_local $i22)
-                  (get_local $i21)
+                  (get_local $10)
+                  (get_local $5)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i22)
+                      (get_local $10)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7388,56 +7301,56 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i21
+                        (set_local $5
                           (i32.add
-                            (get_local $i22)
+                            (get_local $10)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $i6)
+                      (get_local $8)
                     )
-                    (set_local $i28
-                      (get_local $i21)
+                    (set_local $16
+                      (get_local $5)
                     )
                     (call_import $_abort)
                   )
                 )
-                (set_local $i28
+                (set_local $16
                   (i32.add
-                    (get_local $i22)
+                    (get_local $10)
                     (i32.const 8)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $i8)
-                (get_local $i22)
+                (get_local $0)
+                (get_local $10)
               )
               (i32.store
-                (get_local $i28)
-                (get_local $i8)
+                (get_local $16)
+                (get_local $0)
               )
             )
           )
         )
         (i32.store offset=4
-          (get_local $i12)
+          (get_local $2)
           (i32.or
-            (get_local $i18)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $i12)
-            (get_local $i18)
+            (get_local $2)
+            (get_local $4)
           )
-          (get_local $i18)
+          (get_local $4)
         )
         (if
           (i32.eq
-            (get_local $i12)
+            (get_local $2)
             (i32.load
               (i32.const 196)
             )
@@ -7445,34 +7358,34 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $i18)
+              (get_local $4)
             )
             (return)
           )
-          (set_local $i29
-            (get_local $i18)
+          (set_local $0
+            (get_local $4)
           )
         )
       )
     )
-    (set_local $i13
+    (set_local $7
       (i32.shr_u
-        (get_local $i29)
+        (get_local $0)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $i29)
+        (get_local $0)
         (i32.const 256)
       )
       (block
-        (set_local $i2
+        (set_local $1
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $i13)
+                (get_local $7)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7481,25 +7394,25 @@
         )
         (if
           (i32.and
-            (set_local $i5
+            (set_local $3
               (i32.load
                 (i32.const 176)
               )
             )
-            (set_local $i18
+            (set_local $4
               (i32.shl
                 (i32.const 1)
-                (get_local $i13)
+                (get_local $7)
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $i28
+              (set_local $16
                 (i32.load
-                  (set_local $i13
+                  (set_local $7
                     (i32.add
-                      (get_local $i2)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -7511,11 +7424,11 @@
             )
             (call_import $_abort)
             (block
-              (set_local $i30
-                (get_local $i13)
+              (set_local $15
+                (get_local $7)
               )
-              (set_local $i31
-                (get_local $i28)
+              (set_local $14
+                (get_local $16)
               )
             )
           )
@@ -7523,81 +7436,81 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $i5)
-                (get_local $i18)
+                (get_local $3)
+                (get_local $4)
               )
             )
-            (set_local $i30
+            (set_local $15
               (i32.add
-                (get_local $i2)
+                (get_local $1)
                 (i32.const 8)
               )
             )
-            (set_local $i31
-              (get_local $i2)
+            (set_local $14
+              (get_local $1)
             )
           )
         )
         (i32.store
-          (get_local $i30)
-          (get_local $i12)
+          (get_local $15)
+          (get_local $2)
         )
         (i32.store offset=12
-          (get_local $i31)
-          (get_local $i12)
+          (get_local $14)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $i12)
-          (get_local $i31)
+          (get_local $2)
+          (get_local $14)
         )
         (i32.store offset=12
-          (get_local $i12)
-          (get_local $i2)
+          (get_local $2)
+          (get_local $1)
         )
         (return)
       )
     )
-    (set_local $i5
+    (set_local $3
       (i32.add
         (i32.const 480)
         (i32.shl
-          (set_local $i32
+          (set_local $1
             (if
-              (set_local $i2
+              (set_local $1
                 (i32.shr_u
-                  (get_local $i29)
+                  (get_local $0)
                   (i32.const 8)
                 )
               )
               (if
                 (i32.gt_u
-                  (get_local $i29)
+                  (get_local $0)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $i29)
+                      (get_local $0)
                       (i32.add
-                        (set_local $i5
+                        (set_local $3
                           (i32.add
                             (i32.sub
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (set_local $i2
+                                  (set_local $1
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (set_local $i30
+                                          (set_local $15
                                             (i32.shl
-                                              (get_local $i2)
-                                              (set_local $i31
+                                              (get_local $1)
+                                              (set_local $14
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (get_local $i2)
+                                                      (get_local $1)
                                                       (i32.const 1048320)
                                                     )
                                                     (i32.const 16)
@@ -7614,16 +7527,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $i31)
+                                  (get_local $14)
                                 )
-                                (set_local $i30
+                                (set_local $15
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $i18
+                                        (set_local $4
                                           (i32.shl
-                                            (get_local $i30)
-                                            (get_local $i2)
+                                            (get_local $15)
+                                            (get_local $1)
                                           )
                                         )
                                         (i32.const 245760)
@@ -7637,8 +7550,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $i18)
-                                (get_local $i30)
+                                (get_local $4)
+                                (get_local $15)
                               )
                               (i32.const 15)
                             )
@@ -7650,7 +7563,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $i5)
+                    (get_local $3)
                     (i32.const 1)
                   )
                 )
@@ -7663,54 +7576,54 @@
       )
     )
     (i32.store offset=28
-      (get_local $i12)
-      (get_local $i32)
+      (get_local $2)
+      (get_local $1)
     )
     (i32.store offset=20
-      (get_local $i12)
+      (get_local $2)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $i12)
+      (get_local $2)
       (i32.const 0)
     )
     (if
       (i32.and
-        (set_local $i30
+        (set_local $15
           (i32.load
             (i32.const 180)
           )
         )
-        (set_local $i18
+        (set_local $4
           (i32.shl
             (i32.const 1)
-            (get_local $i32)
+            (get_local $1)
           )
         )
       )
       (block
-        (set_local $i31
+        (set_local $14
           (i32.shl
-            (get_local $i29)
+            (get_local $0)
             (select
               (i32.const 0)
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $i32)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $i32)
+                (get_local $1)
                 (i32.const 31)
               )
             )
           )
         )
-        (set_local $i2
+        (set_local $1
           (i32.load
-            (get_local $i5)
+            (get_local $3)
           )
         )
         (loop $while-out$18 $while-in$19
@@ -7718,34 +7631,34 @@
             (i32.eq
               (i32.and
                 (i32.load offset=4
-                  (get_local $i2)
+                  (get_local $1)
                 )
                 (i32.const -8)
               )
-              (get_local $i29)
+              (get_local $0)
             )
             (block
-              (set_local $i33
-                (get_local $i2)
+              (set_local $17
+                (get_local $1)
               )
-              (set_local $i34
+              (set_local $0
                 (i32.const 130)
               )
               (br $while-out$18)
             )
           )
           (if
-            (set_local $i13
+            (set_local $7
               (i32.load
-                (set_local $i28
+                (set_local $16
                   (i32.add
                     (i32.add
-                      (get_local $i2)
+                      (get_local $1)
                       (i32.const 16)
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $i31)
+                        (get_local $14)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7755,24 +7668,24 @@
               )
             )
             (block
-              (set_local $i31
+              (set_local $14
                 (i32.shl
-                  (get_local $i31)
+                  (get_local $14)
                   (i32.const 1)
                 )
               )
-              (set_local $i2
-                (get_local $i13)
+              (set_local $1
+                (get_local $7)
               )
             )
             (block
-              (set_local $i35
-                (get_local $i28)
+              (set_local $18
+                (get_local $16)
               )
-              (set_local $i36
-                (get_local $i2)
+              (set_local $19
+                (get_local $1)
               )
-              (set_local $i34
+              (set_local $0
                 (i32.const 127)
               )
               (br $while-out$18)
@@ -7782,12 +7695,12 @@
         )
         (if
           (i32.eq
-            (get_local $i34)
+            (get_local $0)
             (i32.const 127)
           )
           (if
             (i32.lt_u
-              (get_local $i35)
+              (get_local $18)
               (i32.load
                 (i32.const 192)
               )
@@ -7795,71 +7708,71 @@
             (call_import $_abort)
             (block
               (i32.store
-                (get_local $i35)
-                (get_local $i12)
+                (get_local $18)
+                (get_local $2)
               )
               (i32.store offset=24
-                (get_local $i12)
-                (get_local $i36)
+                (get_local $2)
+                (get_local $19)
               )
               (i32.store offset=12
-                (get_local $i12)
-                (get_local $i12)
+                (get_local $2)
+                (get_local $2)
               )
               (i32.store offset=8
-                (get_local $i12)
-                (get_local $i12)
+                (get_local $2)
+                (get_local $2)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $i34)
+              (get_local $0)
               (i32.const 130)
             )
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $i31
+                  (set_local $14
                     (i32.load
-                      (set_local $i2
+                      (set_local $1
                         (i32.add
-                          (get_local $i33)
+                          (get_local $17)
                           (i32.const 8)
                         )
                       )
                     )
                   )
-                  (set_local $i9
+                  (set_local $3
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.ge_u
-                  (get_local $i33)
-                  (get_local $i9)
+                  (get_local $17)
+                  (get_local $3)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $i31)
-                  (get_local $i12)
+                  (get_local $14)
+                  (get_local $2)
                 )
                 (i32.store
-                  (get_local $i2)
-                  (get_local $i12)
+                  (get_local $1)
+                  (get_local $2)
                 )
                 (i32.store offset=8
-                  (get_local $i12)
-                  (get_local $i31)
+                  (get_local $2)
+                  (get_local $14)
                 )
                 (i32.store offset=12
-                  (get_local $i12)
-                  (get_local $i33)
+                  (get_local $2)
+                  (get_local $17)
                 )
                 (i32.store offset=24
-                  (get_local $i12)
+                  (get_local $2)
                   (i32.const 0)
                 )
               )
@@ -7872,31 +7785,31 @@
         (i32.store
           (i32.const 180)
           (i32.or
-            (get_local $i30)
-            (get_local $i18)
+            (get_local $15)
+            (get_local $4)
           )
         )
         (i32.store
-          (get_local $i5)
-          (get_local $i12)
+          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=24
-          (get_local $i12)
-          (get_local $i5)
+          (get_local $2)
+          (get_local $3)
         )
         (i32.store offset=12
-          (get_local $i12)
-          (get_local $i12)
+          (get_local $2)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $i12)
-          (get_local $i12)
+          (get_local $2)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 208)
-      (set_local $i12
+      (set_local $2
         (i32.add
           (i32.load
             (i32.const 208)
@@ -7906,22 +7819,22 @@
       )
     )
     (if
-      (get_local $i12)
+      (get_local $2)
       (return)
-      (set_local $i37
+      (set_local $0
         (i32.const 632)
       )
     )
     (loop $while-out$20 $while-in$21
       (if
-        (set_local $i12
+        (set_local $2
           (i32.load
-            (get_local $i37)
+            (get_local $0)
           )
         )
-        (set_local $i37
+        (set_local $0
           (i32.add
-            (get_local $i12)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -7934,29 +7847,24 @@
       (i32.const -1)
     )
   )
-  (func $___stdio_write (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i7 i32)
-    (local $i12 i32)
-    (local $i14 i32)
-    (local $i9 i32)
-    (local $i21 i32)
-    (local $i8 i32)
-    (local $i11 i32)
-    (local $i13 i32)
-    (local $i4 i32)
-    (local $i5 i32)
-    (local $i6 i32)
-    (local $i20 i32)
-    (local $i10 i32)
-    (local $i15 i32)
-    (local $i18 i32)
-    (local $i22 i32)
-    (local $i24 i32)
-    (local $i16 i32)
-    (local $i17 i32)
-    (local $i19 i32)
-    (local $i23 i32)
-    (set_local $i4
+  (func $___stdio_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (set_local $11
       (i32.load
         (i32.const 8)
       )
@@ -7970,27 +7878,27 @@
         (i32.const 48)
       )
     )
-    (set_local $i5
+    (set_local $12
       (i32.add
-        (get_local $i4)
+        (get_local $11)
         (i32.const 16)
       )
     )
-    (set_local $i6
-      (get_local $i4)
+    (set_local $13
+      (get_local $11)
     )
     (i32.store
-      (set_local $i7
+      (set_local $3
         (i32.add
-          (get_local $i4)
+          (get_local $11)
           (i32.const 32)
         )
       )
-      (set_local $i9
+      (set_local $8
         (i32.load
-          (set_local $i8
+          (set_local $9
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -7998,55 +7906,55 @@
       )
     )
     (i32.store offset=4
-      (get_local $i7)
-      (set_local $i11
+      (get_local $3)
+      (set_local $10
         (i32.sub
           (i32.load
-            (set_local $i10
+            (set_local $14
               (i32.add
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $i9)
+          (get_local $8)
         )
       )
     )
     (i32.store offset=8
-      (get_local $i7)
-      (get_local $i2)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $i7)
-      (get_local $i3)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $i2
+    (set_local $1
       (i32.add
-        (get_local $i1)
+        (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $i9
+    (set_local $8
       (i32.add
-        (get_local $i1)
+        (get_local $0)
         (i32.const 44)
       )
     )
-    (set_local $i12
-      (get_local $i7)
+    (set_local $5
+      (get_local $3)
     )
-    (set_local $i7
+    (set_local $3
       (i32.const 2)
     )
-    (set_local $i13
+    (set_local $6
       (i32.add
-        (get_local $i11)
-        (get_local $i3)
+        (get_local $10)
+        (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $i14
+      (set_local $4
         (if
           (i32.load
             (i32.const 8)
@@ -8054,54 +7962,54 @@
           (block
             (call_import $_pthread_cleanup_push
               (i32.const 4)
-              (get_local $i1)
+              (get_local $0)
             )
             (i32.store
-              (get_local $i6)
+              (get_local $13)
               (i32.load
-                (get_local $i2)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $i6)
-              (get_local $i12)
+              (get_local $13)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $i6)
-              (get_local $i7)
+              (get_local $13)
+              (get_local $3)
             )
-            (set_local $i11
+            (set_local $10
               (call $___syscall_ret
                 (call_import $___syscall146
                   (i32.const 146)
-                  (get_local $i6)
+                  (get_local $13)
                 )
               )
             )
             (call_import $_pthread_cleanup_pop
               (i32.const 0)
             )
-            (get_local $i11)
+            (get_local $10)
           )
           (block
             (i32.store
-              (get_local $i5)
+              (get_local $12)
               (i32.load
-                (get_local $i2)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $i5)
-              (get_local $i12)
+              (get_local $12)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $i5)
-              (get_local $i7)
+              (get_local $12)
+              (get_local $3)
             )
             (call $___syscall_ret
               (call_import $___syscall146
                 (i32.const 146)
-                (get_local $i5)
+                (get_local $12)
               )
             )
           )
@@ -8109,11 +8017,11 @@
       )
       (if
         (i32.eq
-          (get_local $i13)
-          (get_local $i14)
+          (get_local $6)
+          (get_local $4)
         )
         (block
-          (set_local $i15
+          (set_local $1
             (i32.const 6)
           )
           (br $while-out$0)
@@ -8121,212 +8029,208 @@
       )
       (if
         (i32.lt_s
-          (get_local $i14)
+          (get_local $4)
           (i32.const 0)
         )
         (block
-          (set_local $i16
-            (get_local $i12)
+          (set_local $17
+            (get_local $5)
           )
-          (set_local $i17
-            (get_local $i7)
+          (set_local $18
+            (get_local $3)
           )
-          (set_local $i15
+          (set_local $1
             (i32.const 8)
           )
           (br $while-out$0)
         )
       )
-      (set_local $i11
+      (set_local $10
         (i32.sub
-          (get_local $i13)
-          (get_local $i14)
+          (get_local $6)
+          (get_local $4)
         )
       )
-      (set_local $i19
+      (set_local $3
         (if
           (i32.le_u
-            (get_local $i14)
-            (set_local $i18
+            (get_local $4)
+            (set_local $6
               (i32.load offset=4
-                (get_local $i12)
+                (get_local $5)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $i7)
+              (get_local $3)
               (i32.const 2)
             )
             (block
               (i32.store
-                (get_local $i8)
+                (get_local $9)
                 (i32.add
                   (i32.load
-                    (get_local $i8)
+                    (get_local $9)
                   )
-                  (get_local $i14)
+                  (get_local $4)
                 )
               )
-              (set_local $i20
-                (get_local $i14)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $i21
-                (get_local $i12)
-              )
-              (set_local $i22
+              (set_local $15
                 (i32.const 2)
               )
-              (get_local $i18)
+              (get_local $6)
             )
             (block
-              (set_local $i20
-                (get_local $i14)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $i21
-                (get_local $i12)
+              (set_local $15
+                (get_local $3)
               )
-              (set_local $i22
-                (get_local $i7)
-              )
-              (get_local $i18)
+              (get_local $6)
             )
           )
           (block
             (i32.store
-              (get_local $i8)
-              (set_local $i23
+              (get_local $9)
+              (set_local $7
                 (i32.load
-                  (get_local $i9)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
-              (get_local $i10)
-              (get_local $i23)
+              (get_local $14)
+              (get_local $7)
             )
-            (set_local $i20
+            (set_local $4
               (i32.sub
-                (get_local $i14)
-                (get_local $i18)
+                (get_local $4)
+                (get_local $6)
               )
             )
-            (set_local $i21
+            (set_local $7
               (i32.add
-                (get_local $i12)
+                (get_local $5)
                 (i32.const 8)
               )
             )
-            (set_local $i22
+            (set_local $15
               (i32.add
-                (get_local $i7)
+                (get_local $3)
                 (i32.const -1)
               )
             )
             (i32.load offset=12
-              (get_local $i12)
+              (get_local $5)
             )
           )
         )
       )
       (i32.store
-        (get_local $i21)
+        (get_local $7)
         (i32.add
           (i32.load
-            (get_local $i21)
+            (get_local $7)
           )
-          (get_local $i20)
+          (get_local $4)
         )
       )
       (i32.store offset=4
-        (get_local $i21)
+        (get_local $7)
         (i32.sub
-          (get_local $i19)
-          (get_local $i20)
+          (get_local $3)
+          (get_local $4)
         )
       )
-      (set_local $i12
-        (get_local $i21)
+      (set_local $5
+        (get_local $7)
       )
-      (set_local $i7
-        (get_local $i22)
+      (set_local $3
+        (get_local $15)
       )
-      (set_local $i13
-        (get_local $i11)
+      (set_local $6
+        (get_local $10)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $i15)
+        (get_local $1)
         (i32.const 6)
       )
       (block
         (i32.store offset=16
-          (get_local $i1)
+          (get_local $0)
           (i32.add
-            (set_local $i13
+            (set_local $6
               (i32.load
-                (get_local $i9)
+                (get_local $8)
               )
             )
             (i32.load offset=48
-              (get_local $i1)
+              (get_local $0)
             )
           )
         )
         (i32.store
-          (get_local $i8)
-          (set_local $i9
-            (get_local $i13)
+          (get_local $9)
+          (set_local $8
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $i10)
-          (get_local $i9)
+          (get_local $14)
+          (get_local $8)
         )
-        (set_local $i24
-          (get_local $i3)
+        (set_local $16
+          (get_local $2)
         )
       )
       (if
         (i32.eq
-          (get_local $i15)
+          (get_local $1)
           (i32.const 8)
         )
         (block
           (i32.store offset=16
-            (get_local $i1)
+            (get_local $0)
             (i32.const 0)
           )
           (i32.store
-            (get_local $i8)
+            (get_local $9)
             (i32.const 0)
           )
           (i32.store
-            (get_local $i10)
+            (get_local $14)
             (i32.const 0)
           )
           (i32.store
-            (get_local $i1)
+            (get_local $0)
             (i32.or
               (i32.load
-                (get_local $i1)
+                (get_local $0)
               )
               (i32.const 32)
             )
           )
-          (set_local $i24
+          (set_local $16
             (if
               (i32.eq
-                (get_local $i17)
+                (get_local $18)
                 (i32.const 2)
               )
               (i32.const 0)
               (i32.sub
-                (get_local $i3)
+                (get_local $2)
                 (i32.load offset=4
-                  (get_local $i16)
+                  (get_local $17)
                 )
               )
             )
@@ -8336,56 +8240,49 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $i4)
+      (get_local $11)
     )
-    (get_local $i24)
+    (get_local $16)
   )
-  (func $___fwritex (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i4 i32)
-    (local $i15 i32)
-    (local $i5 i32)
-    (local $i8 i32)
-    (local $i10 i32)
-    (local $i11 i32)
-    (local $i12 i32)
-    (local $i13 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i9 i32)
-    (local $i14 i32)
+  (func $___fwritex (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
     (if
-      (set_local $i5
+      (set_local $6
         (i32.load
-          (set_local $i4
+          (set_local $3
             (i32.add
-              (get_local $i3)
+              (get_local $2)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $i6
-          (get_local $i5)
+        (set_local $5
+          (get_local $6)
         )
-        (set_local $i7
+        (set_local $4
           (i32.const 5)
         )
       )
       (if
         (call $___towrite
-          (get_local $i3)
+          (get_local $2)
         )
-        (set_local $i8
+        (set_local $7
           (i32.const 0)
         )
         (block
-          (set_local $i6
+          (set_local $5
             (i32.load
-              (get_local $i4)
+              (get_local $3)
             )
           )
-          (set_local $i7
+          (set_local $4
             (i32.const 5)
           )
         )
@@ -8394,16 +8291,16 @@
     (block $label$break$L5
       (if
         (i32.eq
-          (get_local $i7)
+          (get_local $4)
           (i32.const 5)
         )
         (block
-          (set_local $i9
-            (set_local $i4
+          (set_local $4
+            (set_local $3
               (i32.load
-                (set_local $i5
+                (set_local $6
                   (i32.add
-                    (get_local $i3)
+                    (get_local $2)
                     (i32.const 20)
                   )
                 )
@@ -8413,61 +8310,61 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $i6)
-                (get_local $i4)
+                (get_local $5)
+                (get_local $3)
               )
-              (get_local $i2)
+              (get_local $1)
             )
             (block
-              (set_local $i8
+              (set_local $7
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $i3)
+                        (get_local $2)
                       )
                       (i32.const 7)
                     )
                     (i32.const 2)
                   )
-                  (get_local $i3)
-                  (get_local $i1)
-                  (get_local $i2)
+                  (get_local $2)
+                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br $label$break$L5)
             )
           )
-          (set_local $i10
+          (set_local $0
             (block $label$break$L10
               (if
                 (i32.gt_s
                   (i32.load8_s offset=75
-                    (get_local $i3)
+                    (get_local $2)
                   )
                   (i32.const -1)
                 )
                 (block
-                  (set_local $i4
-                    (get_local $i2)
+                  (set_local $3
+                    (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eqz
-                        (get_local $i4)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $i11
-                          (get_local $i1)
+                        (set_local $2
+                          (get_local $0)
                         )
-                        (set_local $i12
-                          (get_local $i9)
+                        (set_local $3
+                          (get_local $4)
                         )
-                        (set_local $i13
+                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$L10
-                          (get_local $i2)
+                          (get_local $1)
                         )
                       )
                     )
@@ -8475,10 +8372,10 @@
                       (i32.eq
                         (i32.load8_s
                           (i32.add
-                            (get_local $i1)
-                            (set_local $i14
+                            (get_local $0)
+                            (set_local $5
                               (i32.add
-                                (get_local $i4)
+                                (get_local $3)
                                 (i32.const -1)
                               )
                             )
@@ -8487,13 +8384,13 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $i15
-                          (get_local $i4)
+                        (set_local $4
+                          (get_local $3)
                         )
                         (br $while-out$2)
                       )
-                      (set_local $i4
-                        (get_local $i14)
+                      (set_local $3
+                        (get_local $5)
                       )
                     )
                     (br $while-in$3)
@@ -8504,134 +8401,130 @@
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $i3)
+                              (get_local $2)
                             )
                             (i32.const 7)
                           )
                           (i32.const 2)
                         )
-                        (get_local $i3)
-                        (get_local $i1)
-                        (get_local $i15)
+                        (get_local $2)
+                        (get_local $0)
+                        (get_local $4)
                       )
-                      (get_local $i15)
+                      (get_local $4)
                     )
                     (block
-                      (set_local $i8
-                        (get_local $i15)
+                      (set_local $7
+                        (get_local $4)
                       )
                       (br $label$break$L5)
                     )
                   )
-                  (set_local $i11
+                  (set_local $2
                     (i32.add
-                      (get_local $i1)
-                      (get_local $i15)
+                      (get_local $0)
+                      (get_local $4)
                     )
                   )
-                  (set_local $i12
+                  (set_local $3
                     (i32.load
-                      (get_local $i5)
+                      (get_local $6)
                     )
                   )
-                  (set_local $i13
-                    (get_local $i15)
+                  (set_local $5
+                    (get_local $4)
                   )
                   (i32.sub
-                    (get_local $i2)
-                    (get_local $i15)
+                    (get_local $1)
+                    (get_local $4)
                   )
                 )
                 (block
-                  (set_local $i11
-                    (get_local $i1)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i12
-                    (get_local $i9)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $i13
+                  (set_local $5
                     (i32.const 0)
                   )
-                  (get_local $i2)
+                  (get_local $1)
                 )
               )
             )
           )
           (call $_memcpy
-            (get_local $i12)
-            (get_local $i11)
-            (get_local $i10)
+            (get_local $3)
+            (get_local $2)
+            (get_local $0)
           )
           (i32.store
-            (get_local $i5)
+            (get_local $6)
             (i32.add
               (i32.load
-                (get_local $i5)
+                (get_local $6)
               )
-              (get_local $i10)
+              (get_local $0)
             )
           )
-          (set_local $i8
+          (set_local $7
             (i32.add
-              (get_local $i13)
-              (get_local $i10)
+              (get_local $5)
+              (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $i8)
+    (get_local $7)
   )
-  (func $_fflush (param $i1 i32) (result i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i5 i32)
-    (local $i6 i32)
-    (local $i8 i32)
-    (local $i7 i32)
+  (func $_fflush (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (block $do-once$0
       (if
-        (get_local $i1)
+        (get_local $0)
         (block
           (if
             (i32.le_s
               (i32.load offset=76
-                (get_local $i1)
+                (get_local $0)
               )
               (i32.const -1)
             )
             (br $do-once$0
               (call $___fflush_unlocked
-                (get_local $i1)
+                (get_local $0)
               )
             )
           )
-          (set_local $i3
+          (set_local $1
             (i32.eq
               (call $___lockfile
-                (get_local $i1)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $i4
+          (set_local $2
             (call $___fflush_unlocked
-              (get_local $i1)
+              (get_local $0)
             )
           )
           (if
-            (get_local $i3)
-            (get_local $i4)
+            (get_local $1)
+            (get_local $2)
             (block
               (call $___unlockfile
-                (get_local $i1)
+                (get_local $0)
               )
-              (get_local $i4)
+              (get_local $2)
             )
           )
         )
         (block
-          (set_local $i5
+          (set_local $0
             (if
               (i32.load
                 (i32.const 56)
@@ -8648,70 +8541,68 @@
             (i32.const 36)
           )
           (if
-            (set_local $i4
+            (set_local $2
               (i32.load
                 (i32.const 32)
               )
             )
             (block
-              (set_local $i3
-                (get_local $i4)
+              (set_local $1
+                (get_local $2)
               )
-              (set_local $i4
-                (get_local $i5)
+              (set_local $2
+                (get_local $0)
               )
               (loop $while-out$2 $while-in$3
-                (set_local $i7
+                (set_local $0
                   (if
                     (i32.gt_s
                       (i32.load offset=76
-                        (get_local $i3)
+                        (get_local $1)
                       )
                       (i32.const -1)
                     )
                     (call $___lockfile
-                      (get_local $i3)
+                      (get_local $1)
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $i8
+                (set_local $2
                   (if
                     (i32.gt_u
                       (i32.load offset=20
-                        (get_local $i3)
+                        (get_local $1)
                       )
                       (i32.load offset=28
-                        (get_local $i3)
+                        (get_local $1)
                       )
                     )
                     (i32.or
                       (call $___fflush_unlocked
-                        (get_local $i3)
+                        (get_local $1)
                       )
-                      (get_local $i4)
+                      (get_local $2)
                     )
-                    (get_local $i4)
+                    (get_local $2)
                   )
                 )
                 (if
-                  (get_local $i7)
+                  (get_local $0)
                   (call $___unlockfile
-                    (get_local $i3)
+                    (get_local $1)
                   )
                 )
                 (if
-                  (set_local $i3
+                  (set_local $1
                     (i32.load offset=56
-                      (get_local $i3)
+                      (get_local $1)
                     )
                   )
-                  (set_local $i4
-                    (get_local $i8)
-                  )
+                  (get_local $2)
                   (block
-                    (set_local $i6
-                      (get_local $i8)
+                    (set_local $0
+                      (get_local $2)
                     )
                     (br $while-out$2)
                   )
@@ -8719,78 +8610,67 @@
                 (br $while-in$3)
               )
             )
-            (set_local $i6
-              (get_local $i5)
-            )
+            (get_local $0)
           )
           (call_import $___unlock
             (i32.const 36)
           )
-          (get_local $i6)
+          (get_local $0)
         )
       )
     )
   )
-  (func $_strlen (param $i1 i32) (result i32)
-    (local $i4 i32)
-    (local $i3 i32)
-    (local $i10 i32)
-    (local $i9 i32)
-    (local $i5 i32)
-    (local $i2 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i8 i32)
-    (local $i11 i32)
+  (func $_strlen (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
     (block $label$break$L1
       (if
         (i32.and
-          (set_local $i2
-            (get_local $i1)
+          (set_local $3
+            (get_local $0)
           )
           (i32.const 3)
         )
         (block
-          (set_local $i5
-            (get_local $i1)
-          )
-          (set_local $i6
-            (get_local $i2)
+          (get_local $0)
+          (set_local $4
+            (get_local $3)
           )
           (loop $while-out$1 $while-in$2
             (if
               (i32.eqz
                 (i32.load8_s
-                  (get_local $i5)
+                  (get_local $0)
                 )
               )
               (block
-                (set_local $i7
-                  (get_local $i6)
+                (set_local $5
+                  (get_local $4)
                 )
                 (br $label$break$L1)
               )
             )
             (if
               (i32.and
-                (set_local $i6
-                  (set_local $i8
+                (set_local $4
+                  (set_local $0
                     (i32.add
-                      (get_local $i5)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
                 (i32.const 3)
               )
-              (set_local $i5
-                (get_local $i8)
-              )
+              (get_local $0)
               (block
-                (set_local $i3
-                  (get_local $i8)
+                (set_local $1
+                  (get_local $0)
                 )
-                (set_local $i4
+                (set_local $2
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8800,10 +8680,10 @@
           )
         )
         (block
-          (set_local $i3
-            (get_local $i1)
+          (set_local $1
+            (get_local $0)
           )
-          (set_local $i4
+          (set_local $2
             (i32.const 4)
           )
         )
@@ -8811,21 +8691,21 @@
     )
     (if
       (i32.eq
-        (get_local $i4)
+        (get_local $2)
         (i32.const 4)
       )
       (block
-        (set_local $i4
-          (get_local $i3)
+        (set_local $2
+          (get_local $1)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $i3
+                  (set_local $1
                     (i32.load
-                      (get_local $i4)
+                      (get_local $2)
                     )
                   )
                   (i32.const -2139062144)
@@ -8833,22 +8713,22 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $i3)
+                (get_local $1)
                 (i32.const -16843009)
               )
             )
             (block
-              (set_local $i9
-                (get_local $i3)
+              (set_local $0
+                (get_local $1)
               )
-              (set_local $i10
-                (get_local $i4)
+              (set_local $1
+                (get_local $2)
               )
               (br $while-out$3)
             )
-            (set_local $i4
+            (set_local $2
               (i32.add
-                (get_local $i4)
+                (get_local $2)
                 (i32.const 4)
               )
             )
@@ -8859,7 +8739,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $i9)
+                (get_local $0)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8867,25 +8747,25 @@
             (i32.const 24)
           )
           (block
-            (set_local $i9
-              (get_local $i10)
+            (set_local $0
+              (get_local $1)
             )
             (loop $while-out$5 $while-in$6
               (if
                 (i32.load8_s
-                  (set_local $i10
+                  (set_local $1
                     (i32.add
-                      (get_local $i9)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $i9
-                  (get_local $i10)
+                (set_local $0
+                  (get_local $1)
                 )
                 (block
-                  (set_local $i11
-                    (get_local $i10)
+                  (set_local $0
+                    (get_local $1)
                   )
                   (br $while-out$5)
                 )
@@ -8893,31 +8773,31 @@
               (br $while-in$6)
             )
           )
-          (set_local $i11
-            (get_local $i10)
+          (set_local $0
+            (get_local $1)
           )
         )
-        (set_local $i7
-          (get_local $i11)
+        (set_local $5
+          (get_local $0)
         )
       )
     )
     (i32.sub
-      (get_local $i7)
-      (get_local $i2)
+      (get_local $5)
+      (get_local $3)
     )
   )
-  (func $___overflow (param $i1 i32) (param $i2 i32) (result i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i10 i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i8 i32)
-    (local $i9 i32)
-    (local $i5 i32)
-    (local $i11 i32)
-    (set_local $i3
+  (func $___overflow (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (set_local $5
       (i32.load
         (i32.const 8)
       )
@@ -8932,49 +8812,49 @@
       )
     )
     (i32.store8
-      (set_local $i4
-        (get_local $i3)
+      (set_local $6
+        (get_local $5)
       )
-      (set_local $i5
+      (set_local $9
         (i32.and
-          (get_local $i2)
+          (get_local $1)
           (i32.const 255)
         )
       )
     )
     (if
-      (set_local $i7
+      (set_local $3
         (i32.load
-          (set_local $i6
+          (set_local $2
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $i8
-          (get_local $i7)
+        (set_local $7
+          (get_local $3)
         )
-        (set_local $i9
+        (set_local $8
           (i32.const 4)
         )
       )
       (if
         (call $___towrite
-          (get_local $i1)
+          (get_local $0)
         )
-        (set_local $i10
+        (set_local $4
           (i32.const -1)
         )
         (block
-          (set_local $i8
+          (set_local $7
             (i32.load
-              (get_local $i6)
+              (get_local $2)
             )
           )
-          (set_local $i9
+          (set_local $8
             (i32.const 4)
           )
         )
@@ -8983,77 +8863,77 @@
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $i9)
+          (get_local $8)
           (i32.const 4)
         )
         (block
           (if
             (if
               (i32.lt_u
-                (set_local $i6
+                (set_local $2
                   (i32.load
-                    (set_local $i7
+                    (set_local $3
                       (i32.add
-                        (get_local $i1)
+                        (get_local $0)
                         (i32.const 20)
                       )
                     )
                   )
                 )
-                (get_local $i8)
+                (get_local $7)
               )
               (i32.ne
-                (set_local $i11
+                (set_local $10
                   (i32.and
-                    (get_local $i2)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.load8_s offset=75
-                  (get_local $i1)
+                  (get_local $0)
                 )
               )
               (i32.const 0)
             )
             (block
               (i32.store
-                (get_local $i7)
+                (get_local $3)
                 (i32.add
-                  (get_local $i6)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store8
-                (get_local $i6)
-                (get_local $i5)
+                (get_local $2)
+                (get_local $9)
               )
-              (set_local $i10
-                (get_local $i11)
+              (set_local $4
+                (get_local $10)
               )
               (br $do-once$0)
             )
           )
-          (set_local $i10
+          (set_local $4
             (if
               (i32.eq
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $i1)
+                        (get_local $0)
                       )
                       (i32.const 7)
                     )
                     (i32.const 2)
                   )
-                  (get_local $i1)
-                  (get_local $i4)
+                  (get_local $0)
+                  (get_local $6)
                   (i32.const 1)
                 )
                 (i32.const 1)
               )
               (i32.load8_u
-                (get_local $i4)
+                (get_local $6)
               )
               (i32.const -1)
             )
@@ -9063,32 +8943,32 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $i3)
+      (get_local $5)
     )
-    (get_local $i10)
+    (get_local $4)
   )
-  (func $___fflush_unlocked (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i3 i32)
-    (local $i5 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i8 i32)
+  (func $___fflush_unlocked (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
     (if
       (if
         (i32.gt_u
           (i32.load
-            (set_local $i2
+            (set_local $1
               (i32.add
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
           (i32.load
-            (set_local $i3
+            (set_local $2
               (i32.add
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 28)
               )
             )
@@ -9099,19 +8979,19 @@
             (i32.add
               (i32.and
                 (i32.load offset=36
-                  (get_local $i1)
+                  (get_local $0)
                 )
                 (i32.const 7)
               )
               (i32.const 2)
             )
-            (get_local $i1)
+            (get_local $0)
             (i32.const 0)
             (i32.const 0)
           )
           (i32.eq
             (i32.load
-              (get_local $i2)
+              (get_local $1)
             )
             (i32.const 0)
           )
@@ -9122,21 +9002,21 @@
       (block
         (if
           (i32.lt_u
-            (set_local $i6
+            (set_local $4
               (i32.load
-                (set_local $i5
+                (set_local $3
                   (i32.add
-                    (get_local $i1)
+                    (get_local $0)
                     (i32.const 4)
                   )
                 )
               )
             )
-            (set_local $i8
+            (set_local $6
               (i32.load
-                (set_local $i7
+                (set_local $5
                   (i32.add
-                    (get_local $i1)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
@@ -9147,70 +9027,70 @@
             (i32.add
               (i32.and
                 (i32.load offset=40
-                  (get_local $i1)
+                  (get_local $0)
                 )
                 (i32.const 7)
               )
               (i32.const 2)
             )
-            (get_local $i1)
+            (get_local $0)
             (i32.sub
-              (get_local $i6)
-              (get_local $i8)
+              (get_local $4)
+              (get_local $6)
             )
             (i32.const 1)
           )
         )
         (i32.store offset=16
-          (get_local $i1)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i3)
+          (get_local $2)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i2)
+          (get_local $1)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i7)
+          (get_local $5)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i5)
+          (get_local $3)
           (i32.const 0)
         )
         (i32.const 0)
       )
     )
   )
-  (func $_memcpy (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i4 i32)
+  (func $_memcpy (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
     (if
       (i32.ge_s
-        (get_local $i3)
+        (get_local $2)
         (i32.const 4096)
       )
       (return
         (call_import $_emscripten_memcpy_big
-          (get_local $i1)
-          (get_local $i2)
-          (get_local $i3)
+          (get_local $0)
+          (get_local $1)
+          (get_local $2)
         )
       )
     )
-    (set_local $i4
-      (get_local $i1)
+    (set_local $3
+      (get_local $0)
     )
     (if
       (i32.eq
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.and
-          (get_local $i2)
+          (get_local $1)
           (i32.const 3)
         )
       )
@@ -9219,40 +9099,40 @@
           (br_if $while-out$0
             (i32.eqz
               (i32.and
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 3)
               )
             )
           )
           (if
             (i32.eqz
-              (get_local $i3)
+              (get_local $2)
             )
             (return
-              (get_local $i4)
+              (get_local $3)
             )
           )
           (i32.store8
-            (get_local $i1)
+            (get_local $0)
             (i32.load8_s
-              (get_local $i2)
+              (get_local $1)
             )
           )
-          (set_local $i1
+          (set_local $0
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 1)
             )
           )
-          (set_local $i2
+          (set_local $1
             (i32.add
-              (get_local $i2)
+              (get_local $1)
               (i32.const 1)
             )
           )
-          (set_local $i3
+          (set_local $2
             (i32.sub
-              (get_local $i3)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -9261,31 +9141,31 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.lt_s
-              (get_local $i3)
+              (get_local $2)
               (i32.const 4)
             )
           )
           (i32.store
-            (get_local $i1)
+            (get_local $0)
             (i32.load
-              (get_local $i2)
+              (get_local $1)
             )
           )
-          (set_local $i1
+          (set_local $0
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 4)
             )
           )
-          (set_local $i2
+          (set_local $1
             (i32.add
-              (get_local $i2)
+              (get_local $1)
               (i32.const 4)
             )
           )
-          (set_local $i3
+          (set_local $2
             (i32.sub
-              (get_local $i3)
+              (get_local $2)
               (i32.const 4)
             )
           )
@@ -9296,87 +9176,87 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.le_s
-          (get_local $i3)
+          (get_local $2)
           (i32.const 0)
         )
       )
       (i32.store8
-        (get_local $i1)
+        (get_local $0)
         (i32.load8_s
-          (get_local $i2)
+          (get_local $1)
         )
       )
-      (set_local $i1
+      (set_local $0
         (i32.add
-          (get_local $i1)
+          (get_local $0)
           (i32.const 1)
         )
       )
-      (set_local $i2
+      (set_local $1
         (i32.add
-          (get_local $i2)
+          (get_local $1)
           (i32.const 1)
         )
       )
-      (set_local $i3
+      (set_local $2
         (i32.sub
-          (get_local $i3)
+          (get_local $2)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
-    (get_local $i4)
+    (get_local $3)
   )
   (func $runPostSets
     (nop)
   )
-  (func $_memset (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i5 i32)
-    (local $i4 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (set_local $i4
+  (func $_memset (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $4
       (i32.add
-        (get_local $i1)
-        (get_local $i3)
+        (get_local $0)
+        (get_local $2)
       )
     )
     (if
       (i32.ge_s
-        (get_local $i3)
+        (get_local $2)
         (i32.const 20)
       )
       (block
-        (set_local $i6
+        (set_local $5
           (i32.or
             (i32.or
               (i32.or
-                (set_local $i2
+                (set_local $1
                   (i32.and
-                    (get_local $i2)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.shl
-                  (get_local $i2)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (i32.shl
-                (get_local $i2)
+                (get_local $1)
                 (i32.const 16)
               )
             )
             (i32.shl
-              (get_local $i2)
+              (get_local $1)
               (i32.const 24)
             )
           )
         )
-        (set_local $i7
+        (set_local $6
           (i32.and
-            (get_local $i4)
+            (get_local $4)
             (i32.xor
               (i32.const 3)
               (i32.const -1)
@@ -9384,36 +9264,36 @@
           )
         )
         (if
-          (set_local $i5
+          (set_local $3
             (i32.and
-              (get_local $i1)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (block
-            (set_local $i5
+            (set_local $3
               (i32.sub
                 (i32.add
-                  (get_local $i1)
+                  (get_local $0)
                   (i32.const 4)
                 )
-                (get_local $i5)
+                (get_local $3)
               )
             )
             (loop $while-out$0 $while-in$1
               (br_if $while-out$0
                 (i32.ge_s
-                  (get_local $i1)
-                  (get_local $i5)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (i32.store8
-                (get_local $i1)
-                (get_local $i2)
+                (get_local $0)
+                (get_local $1)
               )
-              (set_local $i1
+              (set_local $0
                 (i32.add
-                  (get_local $i1)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
@@ -9424,17 +9304,17 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.ge_s
-              (get_local $i1)
-              (get_local $i7)
+              (get_local $0)
+              (get_local $6)
             )
           )
           (i32.store
-            (get_local $i1)
-            (get_local $i6)
+            (get_local $0)
+            (get_local $5)
           )
-          (set_local $i1
+          (set_local $0
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 4)
             )
           )
@@ -9445,38 +9325,37 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.ge_s
-          (get_local $i1)
-          (get_local $i4)
+          (get_local $0)
+          (get_local $4)
         )
       )
       (i32.store8
-        (get_local $i1)
-        (get_local $i2)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $i1
+      (set_local $0
         (i32.add
-          (get_local $i1)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
     (i32.sub
-      (get_local $i1)
-      (get_local $i3)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $_puts (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i6 i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i5 i32)
-    (set_local $i3
+  (func $_puts (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $3
       (if
         (i32.gt_s
           (i32.load offset=76
-            (set_local $i2
+            (set_local $1
               (i32.load
                 (i32.const 52)
               )
@@ -9485,18 +9364,18 @@
           (i32.const -1)
         )
         (call $___lockfile
-          (get_local $i2)
+          (get_local $1)
         )
         (i32.const 0)
       )
     )
-    (set_local $i4
+    (set_local $0
       (block $do-once$0
         (if
           (i32.lt_s
             (call $_fputs
-              (get_local $i1)
-              (get_local $i2)
+              (get_local $0)
+              (get_local $1)
             )
             (i32.const 0)
           )
@@ -9506,37 +9385,37 @@
               (if
                 (i32.ne
                   (i32.load8_s offset=75
-                    (get_local $i2)
+                    (get_local $1)
                   )
                   (i32.const 10)
                 )
                 (i32.lt_u
-                  (set_local $i6
+                  (set_local $2
                     (i32.load
-                      (set_local $i5
+                      (set_local $4
                         (i32.add
-                          (get_local $i2)
+                          (get_local $1)
                           (i32.const 20)
                         )
                       )
                     )
                   )
                   (i32.load offset=16
-                    (get_local $i2)
+                    (get_local $1)
                   )
                 )
                 (i32.const 0)
               )
               (block
                 (i32.store
-                  (get_local $i5)
+                  (get_local $4)
                   (i32.add
-                    (get_local $i6)
+                    (get_local $2)
                     (i32.const 1)
                   )
                 )
                 (i32.store8
-                  (get_local $i6)
+                  (get_local $2)
                   (i32.const 10)
                 )
                 (br $do-once$0
@@ -9546,7 +9425,7 @@
             )
             (i32.lt_s
               (call $___overflow
-                (get_local $i2)
+                (get_local $1)
                 (i32.const 10)
               )
               (i32.const 0)
@@ -9556,25 +9435,23 @@
       )
     )
     (if
-      (get_local $i3)
+      (get_local $3)
       (call $___unlockfile
-        (get_local $i2)
+        (get_local $1)
       )
     )
     (i32.shr_s
       (i32.shl
-        (get_local $i4)
+        (get_local $0)
         (i32.const 31)
       )
       (i32.const 31)
     )
   )
-  (func $___stdio_seek (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i5 i32)
-    (local $i4 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (set_local $i4
+  (func $___stdio_seek (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9589,100 +9466,100 @@
       )
     )
     (i32.store
-      (set_local $i5
-        (get_local $i4)
+      (set_local $3
+        (get_local $4)
       )
       (i32.load offset=60
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store offset=4
-      (get_local $i5)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=8
-      (get_local $i5)
-      (get_local $i2)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $i5)
-      (set_local $i6
+      (get_local $3)
+      (set_local $0
         (i32.add
-          (get_local $i4)
+          (get_local $4)
           (i32.const 20)
         )
       )
     )
     (i32.store offset=16
-      (get_local $i5)
-      (get_local $i3)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $i7
+    (set_local $0
       (if
         (i32.lt_s
           (call $___syscall_ret
             (call_import $___syscall140
               (i32.const 140)
-              (get_local $i5)
+              (get_local $3)
             )
           )
           (i32.const 0)
         )
         (block
           (i32.store
-            (get_local $i6)
+            (get_local $0)
             (i32.const -1)
           )
           (i32.const -1)
         )
         (i32.load
-          (get_local $i6)
+          (get_local $0)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $i4)
+      (get_local $4)
     )
-    (get_local $i7)
+    (get_local $0)
   )
-  (func $___towrite (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i3 i32)
-    (set_local $i3
+  (func $___towrite (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $2
       (i32.load8_s
-        (set_local $i2
+        (set_local $1
           (i32.add
-            (get_local $i1)
+            (get_local $0)
             (i32.const 74)
           )
         )
       )
     )
     (i32.store8
-      (get_local $i2)
+      (get_local $1)
       (i32.or
         (i32.add
-          (get_local $i3)
+          (get_local $2)
           (i32.const 255)
         )
-        (get_local $i3)
+        (get_local $2)
       )
     )
     (if
       (i32.and
-        (set_local $i3
+        (set_local $2
           (i32.load
-            (get_local $i1)
+            (get_local $0)
           )
         )
         (i32.const 8)
       )
       (block
         (i32.store
-          (get_local $i1)
+          (get_local $0)
           (i32.or
-            (get_local $i3)
+            (get_local $2)
             (i32.const 32)
           )
         )
@@ -9690,31 +9567,31 @@
       )
       (block
         (i32.store offset=8
-          (get_local $i1)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=4
-          (get_local $i1)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=28
-          (get_local $i1)
-          (set_local $i2
+          (get_local $0)
+          (set_local $1
             (i32.load offset=44
-              (get_local $i1)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=20
-          (get_local $i1)
-          (get_local $i2)
+          (get_local $0)
+          (get_local $1)
         )
         (i32.store offset=16
-          (get_local $i1)
+          (get_local $0)
           (i32.add
-            (get_local $i2)
+            (get_local $1)
             (i32.load offset=48
-              (get_local $i1)
+              (get_local $0)
             )
           )
         )
@@ -9722,74 +9599,72 @@
       )
     )
   )
-  (func $_fwrite (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (result i32)
-    (local $i5 i32)
-    (local $i7 i32)
-    (local $i6 i32)
-    (local $i8 i32)
-    (set_local $i5
+  (func $_fwrite (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (local $5 i32)
+    (set_local $4
       (i32.mul
-        (get_local $i3)
-        (get_local $i2)
+        (get_local $2)
+        (get_local $1)
       )
     )
     (if
       (i32.eq
-        (set_local $i8
+        (set_local $0
           (if
             (i32.gt_s
               (i32.load offset=76
-                (get_local $i4)
+                (get_local $3)
               )
               (i32.const -1)
             )
             (block
-              (set_local $i6
+              (set_local $5
                 (i32.eq
                   (call $___lockfile
-                    (get_local $i4)
+                    (get_local $3)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $i7
+              (set_local $0
                 (call $___fwritex
-                  (get_local $i1)
-                  (get_local $i5)
-                  (get_local $i4)
+                  (get_local $0)
+                  (get_local $4)
+                  (get_local $3)
                 )
               )
               (if
-                (get_local $i6)
-                (get_local $i7)
+                (get_local $5)
+                (get_local $0)
                 (block
                   (call $___unlockfile
-                    (get_local $i4)
+                    (get_local $3)
                   )
-                  (get_local $i7)
+                  (get_local $0)
                 )
               )
             )
             (call $___fwritex
-              (get_local $i1)
-              (get_local $i5)
-              (get_local $i4)
+              (get_local $0)
+              (get_local $4)
+              (get_local $3)
             )
           )
         )
-        (get_local $i5)
+        (get_local $4)
       )
-      (get_local $i3)
+      (get_local $2)
       (i32.div_u
-        (get_local $i8)
-        (get_local $i2)
+        (get_local $0)
+        (get_local $1)
       )
     )
   )
-  (func $___stdout_write (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i5 i32)
-    (local $i4 i32)
-    (set_local $i4
+  (func $___stdout_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9803,11 +9678,11 @@
         (i32.const 80)
       )
     )
-    (set_local $i5
-      (get_local $i4)
+    (set_local $3
+      (get_local $4)
     )
     (i32.store offset=36
-      (get_local $i1)
+      (get_local $0)
       (i32.const 5)
     )
     (if
@@ -9815,7 +9690,7 @@
         (i32.eq
           (i32.and
             (i32.load
-              (get_local $i1)
+              (get_local $0)
             )
             (i32.const 64)
           )
@@ -9823,26 +9698,26 @@
         )
         (block
           (i32.store
-            (get_local $i5)
+            (get_local $3)
             (i32.load offset=60
-              (get_local $i1)
+              (get_local $0)
             )
           )
           (i32.store offset=4
-            (get_local $i5)
+            (get_local $3)
             (i32.const 21505)
           )
           (i32.store offset=8
-            (get_local $i5)
+            (get_local $3)
             (i32.add
-              (get_local $i4)
+              (get_local $4)
               (i32.const 12)
             )
           )
           (i32.ne
             (call_import $___syscall54
               (i32.const 54)
-              (get_local $i5)
+              (get_local $3)
             )
             (i32.const 0)
           )
@@ -9850,30 +9725,30 @@
         (i32.const 0)
       )
       (i32.store8 offset=75
-        (get_local $i1)
+        (get_local $0)
         (i32.const -1)
       )
     )
-    (set_local $i5
+    (set_local $3
       (call $___stdio_write
-        (get_local $i1)
-        (get_local $i2)
-        (get_local $i3)
+        (get_local $0)
+        (get_local $1)
+        (get_local $2)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $i4)
+      (get_local $4)
     )
-    (get_local $i5)
+    (get_local $3)
   )
-  (func $copyTempDouble (param $i1 i32)
+  (func $copyTempDouble (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -9881,7 +9756,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -9889,7 +9764,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -9897,7 +9772,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=4
@@ -9905,7 +9780,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=4
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=5
@@ -9913,7 +9788,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=5
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=6
@@ -9921,7 +9796,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=6
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=7
@@ -9929,14 +9804,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=7
-        (get_local $i1)
+        (get_local $0)
       )
     )
   )
-  (func $___stdio_close (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i3 i32)
-    (set_local $i2
+  (func $___stdio_close (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -9951,34 +9826,34 @@
       )
     )
     (i32.store
-      (set_local $i3
-        (get_local $i2)
+      (set_local $2
+        (get_local $1)
       )
       (i32.load offset=60
-        (get_local $i1)
+        (get_local $0)
       )
     )
-    (set_local $i1
+    (set_local $0
       (call $___syscall_ret
         (call_import $___syscall6
           (i32.const 6)
-          (get_local $i3)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $i2)
+      (get_local $1)
     )
-    (get_local $i1)
+    (get_local $0)
   )
-  (func $copyTempFloat (param $i1 i32)
+  (func $copyTempFloat (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -9986,7 +9861,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -9994,7 +9869,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -10002,14 +9877,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $i1)
+        (get_local $0)
       )
     )
   )
-  (func $___syscall_ret (param $i1 i32) (result i32)
+  (func $___syscall_ret (param $0 i32) (result i32)
     (if
       (i32.gt_u
-        (get_local $i1)
+        (get_local $0)
         (i32.const -4096)
       )
       (block
@@ -10017,31 +9892,31 @@
           (call $___errno_location)
           (i32.sub
             (i32.const 0)
-            (get_local $i1)
+            (get_local $0)
           )
         )
         (i32.const -1)
       )
-      (get_local $i1)
+      (get_local $0)
     )
   )
-  (func $dynCall_iiii (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (result i32)
+  (func $dynCall_iiii (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call_indirect $FUNCSIG$iiii
       (i32.add
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 2)
       )
-      (get_local $i2)
-      (get_local $i3)
-      (get_local $i4)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
     )
   )
-  (func $stackAlloc (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (set_local $i2
+  (func $stackAlloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -10052,7 +9927,7 @@
         (i32.load
           (i32.const 8)
         )
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store
@@ -10067,7 +9942,7 @@
         (i32.const -16)
       )
     )
-    (get_local $i2)
+    (get_local $1)
   )
   (func $___errno_location (result i32)
     (if
@@ -10080,7 +9955,7 @@
       (i32.const 60)
     )
   )
-  (func $setThrew (param $i1 i32) (param $i2 i32)
+  (func $setThrew (param $0 i32) (param $1 i32)
     (if
       (i32.eqz
         (i32.load
@@ -10090,102 +9965,102 @@
       (block
         (i32.store
           (i32.const 40)
-          (get_local $i1)
+          (get_local $0)
         )
         (i32.store
           (i32.const 48)
-          (get_local $i2)
+          (get_local $1)
         )
       )
     )
   )
-  (func $_fputs (param $i1 i32) (param $i2 i32) (result i32)
+  (func $_fputs (param $0 i32) (param $1 i32) (result i32)
     (i32.add
       (call $_fwrite
-        (get_local $i1)
+        (get_local $0)
         (call $_strlen
-          (get_local $i1)
+          (get_local $0)
         )
         (i32.const 1)
-        (get_local $i2)
+        (get_local $1)
       )
       (i32.const -1)
     )
   )
-  (func $dynCall_ii (param $i1 i32) (param $i2 i32) (result i32)
+  (func $dynCall_ii (param $0 i32) (param $1 i32) (result i32)
     (call_indirect $FUNCSIG$ii
       (i32.add
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 0)
       )
-      (get_local $i2)
+      (get_local $1)
     )
   )
-  (func $_cleanup_418 (param $i1 i32)
+  (func $_cleanup_418 (param $0 i32)
     (if
       (i32.eqz
         (i32.load offset=68
-          (get_local $i1)
+          (get_local $0)
         )
       )
       (call $___unlockfile
-        (get_local $i1)
+        (get_local $0)
       )
     )
   )
-  (func $establishStackSpace (param $i1 i32) (param $i2 i32)
+  (func $establishStackSpace (param $0 i32) (param $1 i32)
     (i32.store
       (i32.const 8)
-      (get_local $i1)
+      (get_local $0)
     )
     (i32.store
       (i32.const 16)
-      (get_local $i2)
+      (get_local $1)
     )
   )
-  (func $dynCall_vi (param $i1 i32) (param $i2 i32)
+  (func $dynCall_vi (param $0 i32) (param $1 i32)
     (call_indirect $FUNCSIG$vi
       (i32.add
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 10)
       )
-      (get_local $i2)
+      (get_local $1)
     )
   )
-  (func $b1 (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
+  (func $b1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (call_import $abort
       (i32.const 1)
     )
     (i32.const 0)
   )
-  (func $stackRestore (param $i1 i32)
+  (func $stackRestore (param $0 i32)
     (i32.store
       (i32.const 8)
-      (get_local $i1)
+      (get_local $0)
     )
   )
-  (func $setTempRet0 (param $i1 i32)
+  (func $setTempRet0 (param $0 i32)
     (i32.store
       (i32.const 160)
-      (get_local $i1)
+      (get_local $0)
     )
   )
-  (func $b0 (param $i1 i32) (result i32)
+  (func $b0 (param $0 i32) (result i32)
     (call_import $abort
       (i32.const 0)
     )
     (i32.const 0)
   )
-  (func $___unlockfile (param $i1 i32)
+  (func $___unlockfile (param $0 i32)
     (nop)
   )
-  (func $___lockfile (param $i1 i32) (result i32)
+  (func $___lockfile (param $0 i32) (result i32)
     (i32.const 0)
   )
   (func $getTempRet0 (result i32)
@@ -10204,7 +10079,7 @@
       (i32.const 8)
     )
   )
-  (func $b2 (param $i1 i32)
+  (func $b2 (param $0 i32)
     (call_import $abort
       (i32.const 2)
     )

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -42,126 +42,90 @@
   (export "dynCall_iiii" $dynCall_iiii)
   (export "dynCall_vi" $dynCall_vi)
   (table $b0 $___stdio_close $b1 $b1 $___stdout_write $___stdio_seek $b1 $___stdio_write $b1 $b1 $b2 $b2 $b2 $b2 $_cleanup_418 $b2 $b2 $b2)
-  (func $_malloc (param $i1 i32) (result i32)
-    (local $i5 i32)
-    (local $i7 i32)
-    (local $i63 i32)
-    (local $i43 i32)
-    (local $i62 i32)
-    (local $i8 i32)
-    (local $i15 i32)
-    (local $i45 i32)
-    (local $i44 i32)
-    (local $i60 i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i50 i32)
-    (local $i14 i32)
-    (local $i36 i32)
-    (local $i2 i32)
-    (local $i53 i32)
-    (local $i61 i32)
-    (local $i12 i32)
-    (local $i52 i32)
-    (local $i17 i32)
-    (local $i31 i32)
-    (local $i58 i32)
-    (local $i55 i32)
-    (local $i22 i32)
-    (local $i10 i32)
-    (local $i57 i32)
-    (local $i59 i32)
-    (local $i54 i32)
-    (local $i11 i32)
-    (local $i24 i32)
-    (local $i56 i32)
-    (local $i72 i32)
-    (local $i16 i32)
-    (local $i9 i32)
-    (local $i79 i32)
-    (local $i38 i32)
-    (local $i51 i32)
-    (local $i21 i32)
-    (local $i25 i32)
-    (local $i46 i32)
-    (local $i73 i32)
-    (local $i37 i32)
-    (local $i71 i32)
-    (local $i23 i32)
-    (local $i26 i32)
-    (local $i35 i32)
-    (local $i39 i32)
-    (local $i47 i32)
-    (local $i68 i32)
-    (local $i74 i32)
-    (local $i82 i32)
-    (local $i89 i32)
-    (local $i18 i32)
-    (local $i20 i32)
-    (local $i30 i32)
-    (local $i32 i32)
-    (local $i33 i32)
-    (local $i34 i32)
-    (local $i40 i32)
-    (local $i41 i32)
-    (local $i81 i32)
-    (local $i83 i32)
-    (local $i88 i32)
-    (local $i90 i32)
-    (local $i6 i32)
-    (local $i19 i32)
-    (local $i28 i32)
-    (local $i29 i32)
-    (local $i49 i32)
-    (local $i70 i32)
-    (local $i76 i32)
-    (local $i77 i32)
-    (local $i80 i32)
-    (local $i84 i32)
-    (local $i86 i32)
-    (local $i87 i32)
-    (local $i91 i32)
-    (local $i27 i32)
-    (local $i42 i32)
-    (local $i48 i32)
-    (local $i64 i32)
-    (local $i65 i32)
-    (local $i66 i32)
-    (local $i67 i32)
-    (local $i69 i32)
-    (local $i75 i32)
-    (local $i85 i32)
-    (local $i92 i32)
+  (func $_malloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 i32)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
+    (local $47 i32)
+    (local $48 i32)
+    (local $49 i32)
+    (local $50 i32)
+    (local $51 i32)
+    (local $52 i32)
+    (local $53 i32)
     (block $do-once$0
       (if
         (i32.lt_u
-          (get_local $i1)
+          (get_local $0)
           (i32.const 245)
         )
         (block
           (if
             (i32.and
-              (set_local $i5
+              (set_local $2
                 (i32.shr_u
-                  (set_local $i4
+                  (set_local $5
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (set_local $i3
+                  (set_local $4
                     (i32.shr_u
-                      (set_local $i2
+                      (set_local $0
                         (select
                           (i32.const 16)
                           (i32.and
                             (i32.add
-                              (get_local $i1)
+                              (get_local $0)
                               (i32.const 11)
                             )
                             (i32.const -8)
                           )
                           (i32.lt_u
-                            (get_local $i1)
+                            (get_local $0)
                             (i32.const 11)
                           )
                         )
@@ -174,29 +138,29 @@
               (i32.const 3)
             )
             (block
-              (set_local $i11
+              (set_local $2
                 (i32.load
-                  (set_local $i10
+                  (set_local $9
                     (i32.add
-                      (set_local $i9
+                      (set_local $4
                         (i32.load
-                          (set_local $i8
+                          (set_local $6
                             (i32.add
-                              (set_local $i7
+                              (set_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $i6
+                                      (set_local $0
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $i5)
+                                              (get_local $2)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $i3)
+                                          (get_local $4)
                                         )
                                       )
                                       (i32.const 1)
@@ -217,13 +181,13 @@
               )
               (if
                 (i32.ne
-                  (get_local $i7)
-                  (get_local $i11)
+                  (get_local $1)
+                  (get_local $2)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i11)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -233,23 +197,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i12
+                        (set_local $8
                           (i32.add
-                            (get_local $i11)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $i9)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
-                        (get_local $i12)
-                        (get_local $i7)
+                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.store
-                        (get_local $i8)
-                        (get_local $i11)
+                        (get_local $6)
+                        (get_local $2)
                       )
                     )
                     (call_import $_abort)
@@ -258,11 +222,11 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $i4)
+                    (get_local $5)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $i6)
+                        (get_local $0)
                       )
                       (i32.const -1)
                     )
@@ -270,11 +234,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $i9)
+                (get_local $4)
                 (i32.or
-                  (set_local $i11
+                  (set_local $2
                     (i32.shl
-                      (get_local $i6)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -282,31 +246,31 @@
                 )
               )
               (i32.store
-                (set_local $i8
+                (set_local $6
                   (i32.add
                     (i32.add
-                      (get_local $i9)
-                      (get_local $i11)
+                      (get_local $4)
+                      (get_local $2)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $i8)
+                    (get_local $6)
                   )
                   (i32.const 1)
                 )
               )
               (return
-                (get_local $i10)
+                (get_local $9)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $i2)
-              (set_local $i8
+              (get_local $0)
+              (set_local $6
                 (i32.load
                   (i32.const 184)
                 )
@@ -314,37 +278,37 @@
             )
             (block
               (if
-                (get_local $i5)
+                (get_local $2)
                 (block
-                  (set_local $i7
+                  (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (set_local $i11
+                        (set_local $2
                           (i32.add
                             (i32.and
-                              (set_local $i7
+                              (set_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $i5)
-                                    (get_local $i3)
+                                    (get_local $2)
+                                    (get_local $4)
                                   )
                                   (i32.or
-                                    (set_local $i11
+                                    (set_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $i3)
+                                        (get_local $4)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $i11)
+                                      (get_local $2)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i7)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -355,32 +319,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $i7
+                  (set_local $1
                     (i32.load
-                      (set_local $i12
+                      (set_local $8
                         (i32.add
-                          (set_local $i14
+                          (set_local $15
                             (i32.load
-                              (set_local $i16
+                              (set_local $18
                                 (i32.add
-                                  (set_local $i15
+                                  (set_local $10
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $i17
+                                          (set_local $19
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $i11
+                                                      (set_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $i12
+                                                            (set_local $8
                                                               (i32.shr_u
-                                                                (get_local $i11)
-                                                                (get_local $i7)
+                                                                (get_local $2)
+                                                                (get_local $1)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -388,15 +352,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $i7)
+                                                      (get_local $1)
                                                     )
-                                                    (set_local $i12
+                                                    (set_local $8
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $i14
+                                                          (set_local $15
                                                             (i32.shr_u
-                                                              (get_local $i12)
-                                                              (get_local $i11)
+                                                              (get_local $8)
+                                                              (get_local $2)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -405,13 +369,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $i14
+                                                  (set_local $15
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $i15
+                                                        (set_local $10
                                                           (i32.shr_u
-                                                            (get_local $i14)
-                                                            (get_local $i12)
+                                                            (get_local $15)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -420,13 +384,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $i15
+                                                (set_local $10
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $i16
+                                                      (set_local $18
                                                         (i32.shr_u
-                                                          (get_local $i15)
-                                                          (get_local $i14)
+                                                          (get_local $10)
+                                                          (get_local $15)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -436,8 +400,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $i16)
-                                                (get_local $i15)
+                                                (get_local $18)
+                                                (get_local $10)
                                               )
                                             )
                                           )
@@ -459,13 +423,13 @@
                   )
                   (if
                     (i32.ne
-                      (get_local $i15)
-                      (get_local $i7)
+                      (get_local $10)
+                      (get_local $1)
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $i7)
+                          (get_local $1)
                           (i32.load
                             (i32.const 192)
                           )
@@ -475,25 +439,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $i11
+                            (set_local $2
                               (i32.add
-                                (get_local $i7)
+                                (get_local $1)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $i14)
+                          (get_local $15)
                         )
                         (block
                           (i32.store
-                            (get_local $i11)
-                            (get_local $i15)
+                            (get_local $2)
+                            (get_local $10)
                           )
                           (i32.store
-                            (get_local $i16)
-                            (get_local $i7)
+                            (get_local $18)
+                            (get_local $1)
                           )
-                          (set_local $i18
+                          (set_local $9
                             (i32.load
                               (i32.const 184)
                             )
@@ -506,43 +470,43 @@
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $i4)
+                          (get_local $5)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i17)
+                              (get_local $19)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $i18
-                        (get_local $i8)
+                      (set_local $9
+                        (get_local $6)
                       )
                     )
                   )
                   (i32.store offset=4
-                    (get_local $i14)
+                    (get_local $15)
                     (i32.or
-                      (get_local $i2)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $i4
+                    (set_local $5
                       (i32.add
-                        (get_local $i14)
-                        (get_local $i2)
+                        (get_local $15)
+                        (get_local $0)
                       )
                     )
                     (i32.or
-                      (set_local $i8
+                      (set_local $6
                         (i32.sub
                           (i32.shl
-                            (get_local $i17)
+                            (get_local $19)
                             (i32.const 3)
                           )
-                          (get_local $i2)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
@@ -550,27 +514,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $i4)
-                      (get_local $i8)
+                      (get_local $5)
+                      (get_local $6)
                     )
-                    (get_local $i8)
+                    (get_local $6)
                   )
                   (if
-                    (get_local $i18)
+                    (get_local $9)
                     (block
-                      (set_local $i7
+                      (set_local $1
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $i15
+                      (set_local $10
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (set_local $i16
+                              (set_local $18
                                 (i32.shr_u
-                                  (get_local $i18)
+                                  (get_local $9)
                                   (i32.const 3)
                                 )
                               )
@@ -582,25 +546,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $i3
+                          (set_local $4
                             (i32.load
                               (i32.const 176)
                             )
                           )
-                          (set_local $i5
+                          (set_local $2
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i16)
+                              (get_local $18)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $i10
+                            (set_local $9
                               (i32.load
-                                (set_local $i16
+                                (set_local $18
                                   (i32.add
-                                    (get_local $i15)
+                                    (get_local $10)
                                     (i32.const 8)
                                   )
                                 )
@@ -612,11 +576,11 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $i19
-                              (get_local $i16)
+                            (set_local $39
+                              (get_local $18)
                             )
-                            (set_local $i20
-                              (get_local $i10)
+                            (set_local $31
+                              (get_local $9)
                             )
                           )
                         )
@@ -624,69 +588,69 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $i3)
-                              (get_local $i5)
+                              (get_local $4)
+                              (get_local $2)
                             )
                           )
-                          (set_local $i19
+                          (set_local $39
                             (i32.add
-                              (get_local $i15)
+                              (get_local $10)
                               (i32.const 8)
                             )
                           )
-                          (set_local $i20
-                            (get_local $i15)
+                          (set_local $31
+                            (get_local $10)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $i19)
-                        (get_local $i7)
+                        (get_local $39)
+                        (get_local $1)
                       )
                       (i32.store offset=12
-                        (get_local $i20)
-                        (get_local $i7)
+                        (get_local $31)
+                        (get_local $1)
                       )
                       (i32.store offset=8
-                        (get_local $i7)
-                        (get_local $i20)
+                        (get_local $1)
+                        (get_local $31)
                       )
                       (i32.store offset=12
-                        (get_local $i7)
-                        (get_local $i15)
+                        (get_local $1)
+                        (get_local $10)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $i8)
+                    (get_local $6)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $i4)
+                    (get_local $5)
                   )
                   (return
-                    (get_local $i12)
+                    (get_local $8)
                   )
                 )
               )
               (if
-                (set_local $i4
+                (set_local $5
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (block
-                  (set_local $i4
+                  (set_local $5
                     (i32.and
                       (i32.shr_u
-                        (set_local $i8
+                        (set_local $6
                           (i32.add
                             (i32.and
-                              (get_local $i4)
+                              (get_local $5)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i4)
+                                (get_local $5)
                               )
                             )
                             (i32.const -1)
@@ -697,11 +661,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $i10
+                          (set_local $9
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -709,13 +673,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $i8
+                                          (set_local $6
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $i15
+                                                (set_local $10
                                                   (i32.shr_u
-                                                    (get_local $i8)
-                                                    (get_local $i4)
+                                                    (get_local $6)
+                                                    (get_local $5)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -723,15 +687,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $i4)
+                                          (get_local $5)
                                         )
-                                        (set_local $i15
+                                        (set_local $10
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $i7
+                                              (set_local $1
                                                 (i32.shr_u
-                                                  (get_local $i15)
-                                                  (get_local $i8)
+                                                  (get_local $10)
+                                                  (get_local $6)
                                                 )
                                               )
                                               (i32.const 2)
@@ -740,13 +704,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $i7
+                                      (set_local $1
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $i5
+                                            (set_local $2
                                               (i32.shr_u
-                                                (get_local $i7)
-                                                (get_local $i15)
+                                                (get_local $1)
+                                                (get_local $10)
                                               )
                                             )
                                             (i32.const 1)
@@ -755,13 +719,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $i5
+                                    (set_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $i3
+                                          (set_local $4
                                             (i32.shr_u
-                                              (get_local $i5)
-                                              (get_local $i7)
+                                              (get_local $2)
+                                              (get_local $1)
                                             )
                                           )
                                           (i32.const 1)
@@ -771,8 +735,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $i3)
-                                    (get_local $i5)
+                                    (get_local $4)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 2)
@@ -782,84 +746,84 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $i2)
+                      (get_local $0)
                     )
                   )
-                  (set_local $i3
-                    (get_local $i10)
+                  (set_local $4
+                    (get_local $9)
                   )
-                  (set_local $i7
-                    (get_local $i10)
+                  (set_local $1
+                    (get_local $9)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $i10
+                      (set_local $9
                         (i32.load offset=16
-                          (get_local $i3)
+                          (get_local $4)
                         )
                       )
-                      (set_local $i23
-                        (get_local $i10)
+                      (set_local $5
+                        (get_local $9)
                       )
                       (if
-                        (set_local $i15
+                        (set_local $10
                           (i32.load offset=20
-                            (get_local $i3)
+                            (get_local $4)
                           )
                         )
-                        (set_local $i23
-                          (get_local $i15)
+                        (set_local $5
+                          (get_local $10)
                         )
                         (block
-                          (set_local $i21
-                            (get_local $i5)
+                          (set_local $5
+                            (get_local $2)
                           )
-                          (set_local $i22
-                            (get_local $i7)
+                          (set_local $6
+                            (get_local $1)
                           )
                           (br $while-out$6)
                         )
                       )
                     )
-                    (set_local $i15
+                    (set_local $10
                       (i32.lt_u
-                        (set_local $i10
+                        (set_local $9
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $i23)
+                                (get_local $5)
                               )
                               (i32.const -8)
                             )
-                            (get_local $i2)
+                            (get_local $0)
                           )
                         )
-                        (get_local $i5)
+                        (get_local $2)
                       )
                     )
-                    (set_local $i5
+                    (set_local $2
                       (select
-                        (get_local $i10)
-                        (get_local $i5)
-                        (get_local $i15)
+                        (get_local $9)
+                        (get_local $2)
+                        (get_local $10)
                       )
                     )
-                    (set_local $i3
-                      (get_local $i23)
+                    (set_local $4
+                      (get_local $5)
                     )
-                    (set_local $i7
+                    (set_local $1
                       (select
-                        (get_local $i23)
-                        (get_local $i7)
-                        (get_local $i15)
+                        (get_local $5)
+                        (get_local $1)
+                        (get_local $10)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i22)
-                      (set_local $i7
+                      (get_local $6)
+                      (set_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -869,72 +833,70 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $i22)
-                      (set_local $i3
+                      (get_local $6)
+                      (set_local $4
                         (i32.add
-                          (get_local $i22)
-                          (get_local $i2)
+                          (get_local $6)
+                          (get_local $0)
                         )
                       )
                     )
                     (call_import $_abort)
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.load offset=24
-                      (get_local $i22)
+                      (get_local $6)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $i12
+                        (set_local $8
                           (i32.load offset=12
-                            (get_local $i22)
+                            (get_local $6)
                           )
                         )
-                        (get_local $i22)
+                        (get_local $6)
                       )
                       (block
                         (if
-                          (set_local $i17
+                          (set_local $19
                             (i32.load
-                              (set_local $i14
+                              (set_local $15
                                 (i32.add
-                                  (get_local $i22)
+                                  (get_local $6)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $i25
-                              (get_local $i17)
+                            (set_local $9
+                              (get_local $19)
                             )
-                            (set_local $i26
-                              (get_local $i14)
+                            (set_local $8
+                              (get_local $15)
                             )
                           )
                           (if
-                            (set_local $i10
+                            (set_local $9
                               (i32.load
-                                (set_local $i15
+                                (set_local $10
                                   (i32.add
-                                    (get_local $i22)
+                                    (get_local $6)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i25
-                                (get_local $i10)
-                              )
-                              (set_local $i26
-                                (get_local $i15)
+                              (get_local $9)
+                              (set_local $8
+                                (get_local $10)
                               )
                             )
                             (block
-                              (set_local $i24
+                              (set_local $18
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -943,52 +905,48 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $i17
+                            (set_local $19
                               (i32.load
-                                (set_local $i14
+                                (set_local $15
                                   (i32.add
-                                    (get_local $i25)
+                                    (get_local $9)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i25
-                                (get_local $i17)
+                              (set_local $9
+                                (get_local $19)
                               )
-                              (set_local $i26
-                                (get_local $i14)
+                              (set_local $8
+                                (get_local $15)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
-                            (set_local $i17
+                            (set_local $19
                               (i32.load
-                                (set_local $i14
+                                (set_local $15
                                   (i32.add
-                                    (get_local $i25)
+                                    (get_local $9)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i25
-                                (get_local $i17)
+                              (set_local $9
+                                (get_local $19)
                               )
-                              (set_local $i26
-                                (get_local $i14)
+                              (set_local $8
+                                (get_local $15)
                               )
                             )
                             (block
-                              (set_local $i27
-                                (get_local $i25)
-                              )
-                              (set_local $i28
-                                (get_local $i26)
-                              )
+                              (get_local $9)
+                              (get_local $8)
                               (br $while-out$10)
                             )
                           )
@@ -996,17 +954,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $i28)
-                            (get_local $i7)
+                            (get_local $8)
+                            (get_local $1)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $i28)
+                              (get_local $8)
                               (i32.const 0)
                             )
-                            (set_local $i24
-                              (get_local $i27)
+                            (set_local $18
+                              (get_local $9)
                             )
                           )
                         )
@@ -1014,52 +972,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $i14
+                            (set_local $15
                               (i32.load offset=8
-                                (get_local $i22)
+                                (get_local $6)
                               )
                             )
-                            (get_local $i7)
+                            (get_local $1)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $i17
+                              (set_local $19
                                 (i32.add
-                                  (get_local $i14)
+                                  (get_local $15)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $i22)
+                            (get_local $6)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $i15
+                              (set_local $10
                                 (i32.add
-                                  (get_local $i12)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $i22)
+                            (get_local $6)
                           )
                           (block
                             (i32.store
-                              (get_local $i17)
-                              (get_local $i12)
+                              (get_local $19)
+                              (get_local $8)
                             )
                             (i32.store
-                              (get_local $i15)
-                              (get_local $i14)
+                              (get_local $10)
+                              (get_local $15)
                             )
-                            (set_local $i24
-                              (get_local $i12)
+                            (set_local $18
+                              (get_local $8)
                             )
                           )
                           (call_import $_abort)
@@ -1069,19 +1027,19 @@
                   )
                   (block $do-once$12
                     (if
-                      (get_local $i5)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
-                            (get_local $i22)
+                            (get_local $6)
                             (i32.load
-                              (set_local $i7
+                              (set_local $1
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (set_local $i12
+                                    (set_local $8
                                       (i32.load offset=28
-                                        (get_local $i22)
+                                        (get_local $6)
                                       )
                                     )
                                     (i32.const 2)
@@ -1092,12 +1050,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $i7)
-                              (get_local $i24)
+                              (get_local $1)
+                              (get_local $18)
                             )
                             (if
                               (i32.eqz
-                                (get_local $i24)
+                                (get_local $18)
                               )
                               (block
                                 (i32.store
@@ -1109,7 +1067,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $i12)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1122,7 +1080,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $i5)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -1132,35 +1090,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $i12
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $i5)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $i22)
+                                (get_local $6)
                               )
                               (i32.store
-                                (get_local $i12)
-                                (get_local $i24)
+                                (get_local $8)
+                                (get_local $18)
                               )
                               (i32.store offset=20
-                                (get_local $i5)
-                                (get_local $i24)
+                                (get_local $2)
+                                (get_local $18)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eqz
-                                (get_local $i24)
+                                (get_local $18)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $i24)
-                            (set_local $i12
+                            (get_local $18)
+                            (set_local $8
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1169,42 +1127,42 @@
                           (call_import $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $i24)
-                          (get_local $i5)
+                          (get_local $18)
+                          (get_local $2)
                         )
                         (if
-                          (set_local $i7
+                          (set_local $1
                             (i32.load offset=16
-                              (get_local $i22)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i7)
-                              (get_local $i12)
+                              (get_local $1)
+                              (get_local $8)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $i24)
-                                (get_local $i7)
+                                (get_local $18)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $i7)
-                                (get_local $i24)
+                                (get_local $1)
+                                (get_local $18)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $i7
+                          (set_local $1
                             (i32.load offset=20
-                              (get_local $i22)
+                              (get_local $6)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i7)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1212,12 +1170,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $i24)
-                                (get_local $i7)
+                                (get_local $18)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $i7)
-                                (get_local $i24)
+                                (get_local $1)
+                                (get_local $18)
                               )
                             )
                           )
@@ -1227,35 +1185,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i21)
+                      (get_local $5)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $i22)
+                        (get_local $6)
                         (i32.or
-                          (set_local $i5
+                          (set_local $2
                             (i32.add
-                              (get_local $i21)
-                              (get_local $i2)
+                              (get_local $5)
+                              (get_local $0)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (set_local $i7
+                        (set_local $1
                           (i32.add
                             (i32.add
-                              (get_local $i22)
-                              (get_local $i5)
+                              (get_local $6)
+                              (get_local $2)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $i7)
+                            (get_local $1)
                           )
                           (i32.const 1)
                         )
@@ -1263,46 +1221,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $i22)
+                        (get_local $6)
                         (i32.or
-                          (get_local $i2)
+                          (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $i3)
+                        (get_local $4)
                         (i32.or
-                          (get_local $i21)
+                          (get_local $5)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $i3)
-                          (get_local $i21)
+                          (get_local $4)
+                          (get_local $5)
                         )
-                        (get_local $i21)
+                        (get_local $5)
                       )
                       (if
-                        (set_local $i7
+                        (set_local $1
                           (i32.load
                             (i32.const 184)
                           )
                         )
                         (block
-                          (set_local $i5
+                          (set_local $2
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $i7
+                          (set_local $1
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $i12
+                                  (set_local $8
                                     (i32.shr_u
-                                      (get_local $i7)
+                                      (get_local $1)
                                       (i32.const 3)
                                     )
                                   )
@@ -1314,25 +1272,25 @@
                           )
                           (if
                             (i32.and
-                              (set_local $i14
+                              (set_local $15
                                 (i32.load
                                   (i32.const 176)
                                 )
                               )
-                              (set_local $i15
+                              (set_local $10
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $i12)
+                                  (get_local $8)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $i17
+                                (set_local $19
                                   (i32.load
-                                    (set_local $i12
+                                    (set_local $8
                                       (i32.add
-                                        (get_local $i7)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
@@ -1344,11 +1302,11 @@
                               )
                               (call_import $_abort)
                               (block
-                                (set_local $i29
-                                  (get_local $i12)
+                                (set_local $40
+                                  (get_local $8)
                                 )
-                                (set_local $i30
-                                  (get_local $i17)
+                                (set_local $32
+                                  (get_local $19)
                                 )
                               )
                             )
@@ -1356,77 +1314,73 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $i14)
-                                  (get_local $i15)
+                                  (get_local $15)
+                                  (get_local $10)
                                 )
                               )
-                              (set_local $i29
+                              (set_local $40
                                 (i32.add
-                                  (get_local $i7)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $i30
-                                (get_local $i7)
+                              (set_local $32
+                                (get_local $1)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $i29)
-                            (get_local $i5)
+                            (get_local $40)
+                            (get_local $2)
                           )
                           (i32.store offset=12
-                            (get_local $i30)
-                            (get_local $i5)
+                            (get_local $32)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $i5)
-                            (get_local $i30)
+                            (get_local $2)
+                            (get_local $32)
                           )
                           (i32.store offset=12
-                            (get_local $i5)
-                            (get_local $i7)
+                            (get_local $2)
+                            (get_local $1)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $i21)
+                        (get_local $5)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $i3)
+                        (get_local $4)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $i22)
+                      (get_local $6)
                       (i32.const 8)
                     )
                   )
                 )
-                (set_local $i31
-                  (get_local $i2)
-                )
+                (get_local $0)
               )
             )
-            (set_local $i31
-              (get_local $i2)
-            )
+            (get_local $0)
           )
         )
         (if
           (i32.le_u
-            (get_local $i1)
+            (get_local $0)
             (i32.const -65)
           )
           (block
-            (set_local $i5
+            (set_local $2
               (i32.and
-                (set_local $i7
+                (set_local $1
                   (i32.add
-                    (get_local $i1)
+                    (get_local $0)
                     (i32.const 11)
                   )
                 )
@@ -1434,60 +1388,60 @@
               )
             )
             (if
-              (set_local $i15
+              (set_local $10
                 (i32.load
                   (i32.const 180)
                 )
               )
               (block
-                (set_local $i14
+                (set_local $15
                   (i32.sub
                     (i32.const 0)
-                    (get_local $i5)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$L123
                   (if
-                    (set_local $i4
+                    (set_local $5
                       (i32.load offset=480
                         (i32.shl
-                          (set_local $i32
+                          (set_local $0
                             (if
-                              (set_local $i17
+                              (set_local $19
                                 (i32.shr_u
-                                  (get_local $i7)
+                                  (get_local $1)
                                   (i32.const 8)
                                 )
                               )
                               (if
                                 (i32.gt_u
-                                  (get_local $i5)
+                                  (get_local $2)
                                   (i32.const 16777215)
                                 )
                                 (i32.const 31)
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $i5)
+                                      (get_local $2)
                                       (i32.add
-                                        (set_local $i4
+                                        (set_local $5
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (set_local $i17
+                                                  (set_local $19
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $i12
+                                                          (set_local $8
                                                             (i32.shl
-                                                              (get_local $i17)
-                                                              (set_local $i7
+                                                              (get_local $19)
+                                                              (set_local $1
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $i17)
+                                                                      (get_local $19)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -1504,16 +1458,16 @@
                                                       (i32.const 4)
                                                     )
                                                   )
-                                                  (get_local $i7)
+                                                  (get_local $1)
                                                 )
-                                                (set_local $i12
+                                                (set_local $8
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $i10
+                                                        (set_local $9
                                                           (i32.shl
-                                                            (get_local $i12)
-                                                            (get_local $i17)
+                                                            (get_local $8)
+                                                            (get_local $19)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -1527,8 +1481,8 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $i10)
-                                                (get_local $i12)
+                                                (get_local $9)
+                                                (get_local $8)
                                               )
                                               (i32.const 15)
                                             )
@@ -1540,7 +1494,7 @@
                                     (i32.const 1)
                                   )
                                   (i32.shl
-                                    (get_local $i4)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
@@ -1553,118 +1507,116 @@
                       )
                     )
                     (block
-                      (set_local $i12
-                        (get_local $i14)
+                      (set_local $8
+                        (get_local $15)
                       )
-                      (set_local $i10
+                      (set_local $9
                         (i32.const 0)
                       )
-                      (set_local $i7
+                      (set_local $1
                         (i32.shl
-                          (get_local $i5)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $i32)
+                                (get_local $0)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $i32)
+                              (get_local $0)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $i17
-                        (get_local $i4)
+                      (set_local $19
+                        (get_local $5)
                       )
-                      (set_local $i8
+                      (set_local $6
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $i9
+                            (set_local $4
                               (i32.sub
-                                (set_local $i16
+                                (set_local $18
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $i17)
+                                      (get_local $19)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $i5)
+                                (get_local $2)
                               )
                             )
-                            (get_local $i12)
+                            (get_local $8)
                           )
                           (if
                             (i32.eq
-                              (get_local $i16)
-                              (get_local $i5)
+                              (get_local $18)
+                              (get_local $2)
                             )
                             (block
-                              (set_local $i37
-                                (get_local $i9)
+                              (set_local $27
+                                (get_local $4)
                               )
-                              (set_local $i38
-                                (get_local $i17)
+                              (set_local $25
+                                (get_local $19)
                               )
-                              (set_local $i39
-                                (get_local $i17)
+                              (set_local $30
+                                (get_local $19)
                               )
-                              (set_local $i36
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $i40
-                                (get_local $i9)
+                              (set_local $5
+                                (get_local $4)
                               )
-                              (set_local $i41
-                                (get_local $i17)
+                              (set_local $6
+                                (get_local $19)
                               )
                             )
                           )
                           (block
-                            (set_local $i40
-                              (get_local $i12)
+                            (set_local $5
+                              (get_local $8)
                             )
-                            (set_local $i41
-                              (get_local $i8)
-                            )
+                            (get_local $6)
                           )
                         )
-                        (set_local $i16
+                        (set_local $18
                           (select
-                            (get_local $i10)
-                            (set_local $i9
+                            (get_local $9)
+                            (set_local $4
                               (i32.load offset=20
-                                (get_local $i17)
+                                (get_local $19)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $i9)
+                                (get_local $4)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $i9)
-                                (set_local $i17
+                                (get_local $4)
+                                (set_local $19
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $i17)
+                                        (get_local $19)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $i7)
+                                          (get_local $1)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1677,65 +1629,63 @@
                           )
                         )
                         (if
-                          (set_local $i9
+                          (set_local $4
                             (i32.eq
-                              (get_local $i17)
+                              (get_local $19)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $i33
-                              (get_local $i40)
+                            (set_local $33
+                              (get_local $5)
                             )
-                            (set_local $i34
-                              (get_local $i16)
+                            (set_local $34
+                              (get_local $18)
                             )
-                            (set_local $i35
-                              (get_local $i41)
+                            (set_local $29
+                              (get_local $6)
                             )
-                            (set_local $i36
+                            (set_local $8
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $i12
-                              (get_local $i40)
+                            (set_local $8
+                              (get_local $5)
                             )
-                            (set_local $i10
-                              (get_local $i16)
+                            (set_local $9
+                              (get_local $18)
                             )
-                            (set_local $i7
+                            (set_local $1
                               (i32.shl
-                                (get_local $i7)
+                                (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $i9)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
                                 )
                               )
                             )
-                            (set_local $i8
-                              (get_local $i41)
-                            )
+                            (get_local $6)
                           )
                         )
                         (br $while-in$18)
                       )
                     )
                     (block
-                      (set_local $i33
-                        (get_local $i14)
+                      (set_local $33
+                        (get_local $15)
                       )
-                      (set_local $i34
+                      (set_local $34
                         (i32.const 0)
                       )
-                      (set_local $i35
+                      (set_local $29
                         (i32.const 0)
                       )
-                      (set_local $i36
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1743,60 +1693,60 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $i36)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
-                    (set_local $i42
+                    (set_local $0
                       (if
                         (i32.and
                           (i32.eq
-                            (get_local $i34)
+                            (get_local $34)
                             (i32.const 0)
                           )
                           (i32.eq
-                            (get_local $i35)
+                            (get_local $29)
                             (i32.const 0)
                           )
                         )
                         (block
                           (if
                             (i32.eqz
-                              (set_local $i14
+                              (set_local $15
                                 (i32.and
-                                  (get_local $i15)
+                                  (get_local $10)
                                   (i32.or
-                                    (set_local $i4
+                                    (set_local $5
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $i32)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $i4)
+                                      (get_local $5)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i31
-                                (get_local $i5)
+                              (set_local $0
+                                (get_local $2)
                               )
                               (br $do-once$0)
                             )
                           )
-                          (set_local $i14
+                          (set_local $15
                             (i32.and
                               (i32.shr_u
-                                (set_local $i4
+                                (set_local $5
                                   (i32.add
                                     (i32.and
-                                      (get_local $i14)
+                                      (get_local $15)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $i14)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.const -1)
@@ -1814,13 +1764,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (set_local $i4
+                                        (set_local $5
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $i2
+                                              (set_local $0
                                                 (i32.shr_u
-                                                  (get_local $i4)
-                                                  (get_local $i14)
+                                                  (get_local $5)
+                                                  (get_local $15)
                                                 )
                                               )
                                               (i32.const 5)
@@ -1828,15 +1778,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $i14)
+                                        (get_local $15)
                                       )
-                                      (set_local $i2
+                                      (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $i3
+                                            (set_local $4
                                               (i32.shr_u
-                                                (get_local $i2)
-                                                (get_local $i4)
+                                                (get_local $0)
+                                                (get_local $5)
                                               )
                                             )
                                             (i32.const 2)
@@ -1845,13 +1795,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $i3
+                                    (set_local $4
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $i8
+                                          (set_local $6
                                             (i32.shr_u
-                                              (get_local $i3)
-                                              (get_local $i2)
+                                              (get_local $4)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -1860,13 +1810,13 @@
                                       )
                                     )
                                   )
-                                  (set_local $i8
+                                  (set_local $6
                                     (i32.and
                                       (i32.shr_u
-                                        (set_local $i7
+                                        (set_local $1
                                           (i32.shr_u
-                                            (get_local $i8)
-                                            (get_local $i3)
+                                            (get_local $6)
+                                            (get_local $4)
                                           )
                                         )
                                         (i32.const 1)
@@ -1876,125 +1826,121 @@
                                   )
                                 )
                                 (i32.shr_u
-                                  (get_local $i7)
-                                  (get_local $i8)
+                                  (get_local $1)
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 2)
                             )
                           )
                         )
-                        (get_local $i34)
+                        (get_local $34)
                       )
                     )
                     (block
-                      (set_local $i37
-                        (get_local $i33)
+                      (set_local $27
+                        (get_local $33)
                       )
-                      (set_local $i38
-                        (get_local $i42)
+                      (set_local $25
+                        (get_local $0)
                       )
-                      (set_local $i39
-                        (get_local $i35)
+                      (set_local $30
+                        (get_local $29)
                       )
-                      (set_local $i36
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $i43
-                        (get_local $i33)
+                      (set_local $7
+                        (get_local $33)
                       )
-                      (set_local $i44
-                        (get_local $i35)
+                      (set_local $12
+                        (get_local $29)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $i36)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $i36
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $i7
+                    (set_local $1
                       (i32.lt_u
-                        (set_local $i8
+                        (set_local $6
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $i38)
+                                (get_local $25)
                               )
                               (i32.const -8)
                             )
-                            (get_local $i5)
+                            (get_local $2)
                           )
                         )
-                        (get_local $i37)
+                        (get_local $27)
                       )
                     )
-                    (set_local $i3
+                    (set_local $4
                       (select
-                        (get_local $i8)
-                        (get_local $i37)
-                        (get_local $i7)
+                        (get_local $6)
+                        (get_local $27)
+                        (get_local $1)
                       )
                     )
-                    (set_local $i8
+                    (set_local $6
                       (select
-                        (get_local $i38)
-                        (get_local $i39)
-                        (get_local $i7)
+                        (get_local $25)
+                        (get_local $30)
+                        (get_local $1)
                       )
                     )
                     (if
-                      (set_local $i7
+                      (set_local $1
                         (i32.load offset=16
-                          (get_local $i38)
+                          (get_local $25)
                         )
                       )
                       (block
-                        (set_local $i37
-                          (get_local $i3)
+                        (set_local $27
+                          (get_local $4)
                         )
-                        (set_local $i38
-                          (get_local $i7)
+                        (set_local $25
+                          (get_local $1)
                         )
-                        (set_local $i39
-                          (get_local $i8)
+                        (set_local $30
+                          (get_local $6)
                         )
-                        (set_local $i36
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                         (br $while-in$20)
                       )
                     )
                     (if
-                      (set_local $i38
+                      (set_local $25
                         (i32.load offset=20
-                          (get_local $i38)
+                          (get_local $25)
                         )
                       )
                       (block
-                        (set_local $i37
-                          (get_local $i3)
+                        (set_local $27
+                          (get_local $4)
                         )
-                        (set_local $i39
-                          (get_local $i8)
+                        (set_local $30
+                          (get_local $6)
                         )
-                        (set_local $i36
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                       )
                       (block
-                        (set_local $i43
-                          (get_local $i3)
+                        (set_local $7
+                          (get_local $4)
                         )
-                        (set_local $i44
-                          (get_local $i8)
+                        (set_local $12
+                          (get_local $6)
                         )
                         (br $while-out$19)
                       )
@@ -2005,25 +1951,25 @@
                 (if
                   (select
                     (i32.lt_u
-                      (get_local $i43)
+                      (get_local $7)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $i5)
+                        (get_local $2)
                       )
                     )
                     (i32.const 0)
                     (i32.ne
-                      (get_local $i44)
+                      (get_local $12)
                       (i32.const 0)
                     )
                   )
                   (block
                     (if
                       (i32.lt_u
-                        (get_local $i44)
-                        (set_local $i15
+                        (get_local $12)
+                        (set_local $10
                           (i32.load
                             (i32.const 192)
                           )
@@ -2033,72 +1979,70 @@
                     )
                     (if
                       (i32.ge_u
-                        (get_local $i44)
-                        (set_local $i8
+                        (get_local $12)
+                        (set_local $6
                           (i32.add
-                            (get_local $i44)
-                            (get_local $i5)
+                            (get_local $12)
+                            (get_local $2)
                           )
                         )
                       )
                       (call_import $_abort)
                     )
-                    (set_local $i3
+                    (set_local $4
                       (i32.load offset=24
-                        (get_local $i44)
+                        (get_local $12)
                       )
                     )
                     (block $do-once$21
                       (if
                         (i32.eq
-                          (set_local $i7
+                          (set_local $1
                             (i32.load offset=12
-                              (get_local $i44)
+                              (get_local $12)
                             )
                           )
-                          (get_local $i44)
+                          (get_local $12)
                         )
                         (block
                           (if
-                            (set_local $i14
+                            (set_local $15
                               (i32.load
-                                (set_local $i2
+                                (set_local $0
                                   (i32.add
-                                    (get_local $i44)
+                                    (get_local $12)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $i46
-                                (get_local $i14)
+                              (set_local $1
+                                (get_local $15)
                               )
-                              (set_local $i47
-                                (get_local $i2)
+                              (set_local $5
+                                (get_local $0)
                               )
                             )
                             (if
-                              (set_local $i10
+                              (set_local $9
                                 (i32.load
-                                  (set_local $i4
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $i44)
+                                      (get_local $12)
                                       (i32.const 16)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $i46
-                                  (get_local $i10)
+                                (set_local $1
+                                  (get_local $9)
                                 )
-                                (set_local $i47
-                                  (get_local $i4)
-                                )
+                                (get_local $5)
                               )
                               (block
-                                (set_local $i45
+                                (set_local $11
                                   (i32.const 0)
                                 )
                                 (br $do-once$21)
@@ -2107,52 +2051,50 @@
                           )
                           (loop $while-out$23 $while-in$24
                             (if
-                              (set_local $i14
+                              (set_local $15
                                 (i32.load
-                                  (set_local $i2
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $i46)
+                                      (get_local $1)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $i46
-                                  (get_local $i14)
+                                (set_local $1
+                                  (get_local $15)
                                 )
-                                (set_local $i47
-                                  (get_local $i2)
+                                (set_local $5
+                                  (get_local $0)
                                 )
                                 (br $while-in$24)
                               )
                             )
                             (if
-                              (set_local $i14
+                              (set_local $15
                                 (i32.load
-                                  (set_local $i2
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $i46)
+                                      (get_local $1)
                                       (i32.const 16)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $i46
-                                  (get_local $i14)
+                                (set_local $1
+                                  (get_local $15)
                                 )
-                                (set_local $i47
-                                  (get_local $i2)
+                                (set_local $5
+                                  (get_local $0)
                                 )
                               )
                               (block
-                                (set_local $i48
-                                  (get_local $i46)
+                                (set_local $0
+                                  (get_local $1)
                                 )
-                                (set_local $i49
-                                  (get_local $i47)
-                                )
+                                (get_local $5)
                                 (br $while-out$23)
                               )
                             )
@@ -2160,17 +2102,17 @@
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i49)
-                              (get_local $i15)
+                              (get_local $5)
+                              (get_local $10)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store
-                                (get_local $i49)
+                                (get_local $5)
                                 (i32.const 0)
                               )
-                              (set_local $i45
-                                (get_local $i48)
+                              (set_local $11
+                                (get_local $0)
                               )
                             )
                           )
@@ -2178,52 +2120,52 @@
                         (block
                           (if
                             (i32.lt_u
-                              (set_local $i2
+                              (set_local $0
                                 (i32.load offset=8
-                                  (get_local $i44)
+                                  (get_local $12)
                                 )
                               )
-                              (get_local $i15)
+                              (get_local $10)
                             )
                             (call_import $_abort)
                           )
                           (if
                             (i32.ne
                               (i32.load
-                                (set_local $i14
+                                (set_local $15
                                   (i32.add
-                                    (get_local $i2)
+                                    (get_local $0)
                                     (i32.const 12)
                                   )
                                 )
                               )
-                              (get_local $i44)
+                              (get_local $12)
                             )
                             (call_import $_abort)
                           )
                           (if
                             (i32.eq
                               (i32.load
-                                (set_local $i4
+                                (set_local $5
                                   (i32.add
-                                    (get_local $i7)
+                                    (get_local $1)
                                     (i32.const 8)
                                   )
                                 )
                               )
-                              (get_local $i44)
+                              (get_local $12)
                             )
                             (block
                               (i32.store
-                                (get_local $i14)
-                                (get_local $i7)
+                                (get_local $15)
+                                (get_local $1)
                               )
                               (i32.store
-                                (get_local $i4)
-                                (get_local $i2)
+                                (get_local $5)
+                                (get_local $0)
                               )
-                              (set_local $i45
-                                (get_local $i7)
+                              (set_local $11
+                                (get_local $1)
                               )
                             )
                             (call_import $_abort)
@@ -2233,19 +2175,19 @@
                     )
                     (block $do-once$25
                       (if
-                        (get_local $i3)
+                        (get_local $4)
                         (block
                           (if
                             (i32.eq
-                              (get_local $i44)
+                              (get_local $12)
                               (i32.load
-                                (set_local $i15
+                                (set_local $10
                                   (i32.add
                                     (i32.const 480)
                                     (i32.shl
-                                      (set_local $i7
+                                      (set_local $1
                                         (i32.load offset=28
-                                          (get_local $i44)
+                                          (get_local $12)
                                         )
                                       )
                                       (i32.const 2)
@@ -2256,12 +2198,12 @@
                             )
                             (block
                               (i32.store
-                                (get_local $i15)
-                                (get_local $i45)
+                                (get_local $10)
+                                (get_local $11)
                               )
                               (if
                                 (i32.eqz
-                                  (get_local $i45)
+                                  (get_local $11)
                                 )
                                 (block
                                   (i32.store
@@ -2273,7 +2215,7 @@
                                       (i32.xor
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $i7)
+                                          (get_local $1)
                                         )
                                         (i32.const -1)
                                       )
@@ -2286,7 +2228,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $i3)
+                                  (get_local $4)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2296,35 +2238,35 @@
                               (if
                                 (i32.eq
                                   (i32.load
-                                    (set_local $i7
+                                    (set_local $1
                                       (i32.add
-                                        (get_local $i3)
+                                        (get_local $4)
                                         (i32.const 16)
                                       )
                                     )
                                   )
-                                  (get_local $i44)
+                                  (get_local $12)
                                 )
                                 (i32.store
-                                  (get_local $i7)
-                                  (get_local $i45)
+                                  (get_local $1)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=20
-                                  (get_local $i3)
-                                  (get_local $i45)
+                                  (get_local $4)
+                                  (get_local $11)
                                 )
                               )
                               (br_if $do-once$25
                                 (i32.eqz
-                                  (get_local $i45)
+                                  (get_local $11)
                                 )
                               )
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i45)
-                              (set_local $i7
+                              (get_local $11)
+                              (set_local $1
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2333,42 +2275,42 @@
                             (call_import $_abort)
                           )
                           (i32.store offset=24
-                            (get_local $i45)
-                            (get_local $i3)
+                            (get_local $11)
+                            (get_local $4)
                           )
                           (if
-                            (set_local $i15
+                            (set_local $10
                               (i32.load offset=16
-                                (get_local $i44)
+                                (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i15)
-                                (get_local $i7)
+                                (get_local $10)
+                                (get_local $1)
                               )
                               (call_import $_abort)
                               (block
                                 (i32.store offset=16
-                                  (get_local $i45)
-                                  (get_local $i15)
+                                  (get_local $11)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i15)
-                                  (get_local $i45)
+                                  (get_local $10)
+                                  (get_local $11)
                                 )
                               )
                             )
                           )
                           (if
-                            (set_local $i15
+                            (set_local $10
                               (i32.load offset=20
-                                (get_local $i44)
+                                (get_local $12)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i15)
+                                (get_local $10)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2376,12 +2318,12 @@
                               (call_import $_abort)
                               (block
                                 (i32.store offset=20
-                                  (get_local $i45)
-                                  (get_local $i15)
+                                  (get_local $11)
+                                  (get_local $10)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i15)
-                                  (get_local $i45)
+                                  (get_local $10)
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -2392,49 +2334,49 @@
                     (block $do-once$29
                       (if
                         (i32.ge_u
-                          (get_local $i43)
+                          (get_local $7)
                           (i32.const 16)
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $i44)
+                            (get_local $12)
                             (i32.or
-                              (get_local $i5)
+                              (get_local $2)
                               (i32.const 3)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $i8)
+                            (get_local $6)
                             (i32.or
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $i8)
-                              (get_local $i43)
+                              (get_local $6)
+                              (get_local $7)
                             )
-                            (get_local $i43)
+                            (get_local $7)
                           )
-                          (set_local $i3
+                          (set_local $4
                             (i32.shr_u
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $i15
+                              (set_local $10
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $i3)
+                                      (get_local $4)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2443,25 +2385,25 @@
                               )
                               (if
                                 (i32.and
-                                  (set_local $i7
+                                  (set_local $1
                                     (i32.load
                                       (i32.const 176)
                                     )
                                   )
-                                  (set_local $i2
+                                  (set_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $i3)
+                                      (get_local $4)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.lt_u
-                                    (set_local $i4
+                                    (set_local $5
                                       (i32.load
-                                        (set_local $i3
+                                        (set_local $4
                                           (i32.add
-                                            (get_local $i15)
+                                            (get_local $10)
                                             (i32.const 8)
                                           )
                                         )
@@ -2473,11 +2415,11 @@
                                   )
                                   (call_import $_abort)
                                   (block
-                                    (set_local $i50
-                                      (get_local $i3)
+                                    (set_local $14
+                                      (get_local $4)
                                     )
-                                    (set_local $i51
-                                      (get_local $i4)
+                                    (set_local $26
+                                      (get_local $5)
                                     )
                                   )
                                 )
@@ -2485,81 +2427,81 @@
                                   (i32.store
                                     (i32.const 176)
                                     (i32.or
-                                      (get_local $i7)
-                                      (get_local $i2)
+                                      (get_local $1)
+                                      (get_local $0)
                                     )
                                   )
-                                  (set_local $i50
+                                  (set_local $14
                                     (i32.add
-                                      (get_local $i15)
+                                      (get_local $10)
                                       (i32.const 8)
                                     )
                                   )
-                                  (set_local $i51
-                                    (get_local $i15)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $i50)
-                                (get_local $i8)
+                                (get_local $14)
+                                (get_local $6)
                               )
                               (i32.store offset=12
-                                (get_local $i51)
-                                (get_local $i8)
+                                (get_local $26)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $i8)
-                                (get_local $i51)
+                                (get_local $6)
+                                (get_local $26)
                               )
                               (i32.store offset=12
-                                (get_local $i8)
-                                (get_local $i15)
+                                (get_local $6)
+                                (get_local $10)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $i3
+                          (set_local $4
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $i52
+                                (set_local $9
                                   (if
-                                    (set_local $i15
+                                    (set_local $10
                                       (i32.shr_u
-                                        (get_local $i43)
+                                        (get_local $7)
                                         (i32.const 8)
                                       )
                                     )
                                     (if
                                       (i32.gt_u
-                                        (get_local $i43)
+                                        (get_local $7)
                                         (i32.const 16777215)
                                       )
                                       (i32.const 31)
                                       (i32.or
                                         (i32.and
                                           (i32.shr_u
-                                            (get_local $i43)
+                                            (get_local $7)
                                             (i32.add
-                                              (set_local $i3
+                                              (set_local $4
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (set_local $i15
+                                                        (set_local $10
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $i7
+                                                                (set_local $1
                                                                   (i32.shl
-                                                                    (get_local $i15)
-                                                                    (set_local $i2
+                                                                    (get_local $10)
+                                                                    (set_local $0
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
-                                                                            (get_local $i15)
+                                                                            (get_local $10)
                                                                             (i32.const 1048320)
                                                                           )
                                                                           (i32.const 16)
@@ -2576,16 +2518,16 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $i2)
+                                                        (get_local $0)
                                                       )
-                                                      (set_local $i7
+                                                      (set_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $i4
+                                                              (set_local $5
                                                                 (i32.shl
-                                                                  (get_local $i7)
-                                                                  (get_local $i15)
+                                                                  (get_local $1)
+                                                                  (get_local $10)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -2599,8 +2541,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $i4)
-                                                      (get_local $i7)
+                                                      (get_local $5)
+                                                      (get_local $1)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -2612,7 +2554,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $i3)
+                                          (get_local $4)
                                           (i32.const 1)
                                         )
                                       )
@@ -2625,34 +2567,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $i8)
-                            (get_local $i52)
+                            (get_local $6)
+                            (get_local $9)
                           )
                           (i32.store offset=4
-                            (set_local $i7
+                            (set_local $1
                               (i32.add
-                                (get_local $i8)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $i7)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $i7
+                                (set_local $1
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $i4
+                                (set_local $5
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $i52)
+                                    (get_local $9)
                                   )
                                 )
                               )
@@ -2661,51 +2603,51 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $i7)
-                                  (get_local $i4)
+                                  (get_local $1)
+                                  (get_local $5)
                                 )
                               )
                               (i32.store
-                                (get_local $i3)
-                                (get_local $i8)
+                                (get_local $4)
+                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $i8)
-                                (get_local $i3)
+                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store offset=12
-                                (get_local $i8)
-                                (get_local $i8)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (i32.store offset=8
-                                (get_local $i8)
-                                (get_local $i8)
+                                (get_local $6)
+                                (get_local $6)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $i4
+                          (set_local $5
                             (i32.shl
-                              (get_local $i43)
+                              (get_local $7)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $i52)
+                                    (get_local $9)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $i52)
+                                  (get_local $9)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $i7
+                          (set_local $1
                             (i32.load
-                              (get_local $i3)
+                              (get_local $4)
                             )
                           )
                           (loop $while-out$31 $while-in$32
@@ -2713,34 +2655,34 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $i7)
+                                    (get_local $1)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $i43)
+                                (get_local $7)
                               )
                               (block
-                                (set_local $i53
-                                  (get_local $i7)
+                                (set_local $16
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 148)
                                 )
                                 (br $while-out$31)
                               )
                             )
                             (if
-                              (set_local $i2
+                              (set_local $0
                                 (i32.load
-                                  (set_local $i3
+                                  (set_local $4
                                     (i32.add
                                       (i32.add
-                                        (get_local $i7)
+                                        (get_local $1)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $i4)
+                                          (get_local $5)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -2750,24 +2692,24 @@
                                 )
                               )
                               (block
-                                (set_local $i4
+                                (set_local $5
                                   (i32.shl
-                                    (get_local $i4)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $i7
-                                  (get_local $i2)
+                                (set_local $1
+                                  (get_local $0)
                                 )
                               )
                               (block
-                                (set_local $i54
-                                  (get_local $i3)
+                                (set_local $23
+                                  (get_local $4)
                                 )
-                                (set_local $i55
-                                  (get_local $i7)
+                                (set_local $21
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 145)
                                 )
                                 (br $while-out$31)
@@ -2777,12 +2719,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $i36)
+                              (get_local $8)
                               (i32.const 145)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i54)
+                                (get_local $23)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -2790,71 +2732,71 @@
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $i54)
-                                  (get_local $i8)
+                                  (get_local $23)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i8)
-                                  (get_local $i55)
+                                  (get_local $6)
+                                  (get_local $21)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i8)
-                                  (get_local $i8)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i8)
-                                  (get_local $i8)
+                                  (get_local $6)
+                                  (get_local $6)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $i36)
+                                (get_local $8)
                                 (i32.const 148)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $i4
+                                    (set_local $5
                                       (i32.load
-                                        (set_local $i7
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $i53)
+                                            (get_local $16)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $i2
+                                    (set_local $0
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $i53)
-                                    (get_local $i2)
+                                    (get_local $16)
+                                    (get_local $0)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $i4)
-                                    (get_local $i8)
+                                    (get_local $5)
+                                    (get_local $6)
                                   )
                                   (i32.store
-                                    (get_local $i7)
-                                    (get_local $i8)
+                                    (get_local $1)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=8
-                                    (get_local $i8)
-                                    (get_local $i4)
+                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=12
-                                    (get_local $i8)
-                                    (get_local $i53)
+                                    (get_local $6)
+                                    (get_local $16)
                                   )
                                   (i32.store offset=24
-                                    (get_local $i8)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -2865,30 +2807,30 @@
                         )
                         (block
                           (i32.store offset=4
-                            (get_local $i44)
+                            (get_local $12)
                             (i32.or
-                              (set_local $i4
+                              (set_local $5
                                 (i32.add
-                                  (get_local $i43)
-                                  (get_local $i5)
+                                  (get_local $7)
+                                  (get_local $2)
                                 )
                               )
                               (i32.const 3)
                             )
                           )
                           (i32.store
-                            (set_local $i7
+                            (set_local $1
                               (i32.add
                                 (i32.add
-                                  (get_local $i44)
-                                  (get_local $i4)
+                                  (get_local $12)
+                                  (get_local $5)
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.or
                               (i32.load
-                                (get_local $i7)
+                                (get_local $1)
                               )
                               (i32.const 1)
                             )
@@ -2898,22 +2840,22 @@
                     )
                     (return
                       (i32.add
-                        (get_local $i44)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
                   )
-                  (set_local $i31
-                    (get_local $i5)
+                  (set_local $0
+                    (get_local $2)
                   )
                 )
               )
-              (set_local $i31
-                (get_local $i5)
+              (set_local $0
+                (get_local $2)
               )
             )
           )
-          (set_local $i31
+          (set_local $0
             (i32.const -1)
           )
         )
@@ -2921,25 +2863,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $i44
+        (set_local $12
           (i32.load
             (i32.const 184)
           )
         )
-        (get_local $i31)
+        (get_local $0)
       )
       (block
-        (set_local $i53
+        (set_local $16
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (set_local $i43
+            (set_local $7
               (i32.sub
-                (get_local $i44)
-                (get_local $i31)
+                (get_local $12)
+                (get_local $0)
               )
             )
             (i32.const 15)
@@ -2947,35 +2889,35 @@
           (block
             (i32.store
               (i32.const 196)
-              (set_local $i55
+              (set_local $21
                 (i32.add
-                  (get_local $i53)
-                  (get_local $i31)
+                  (get_local $16)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $i43)
+              (get_local $7)
             )
             (i32.store offset=4
-              (get_local $i55)
+              (get_local $21)
               (i32.or
-                (get_local $i43)
+                (get_local $7)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $i55)
-                (get_local $i43)
+                (get_local $21)
+                (get_local $7)
               )
-              (get_local $i43)
+              (get_local $7)
             )
             (i32.store offset=4
-              (get_local $i53)
+              (get_local $16)
               (i32.or
-                (get_local $i31)
+                (get_local $0)
                 (i32.const 3)
               )
             )
@@ -2990,25 +2932,25 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $i53)
+              (get_local $16)
               (i32.or
-                (get_local $i44)
+                (get_local $12)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $i43
+              (set_local $7
                 (i32.add
                   (i32.add
-                    (get_local $i53)
-                    (get_local $i44)
+                    (get_local $16)
+                    (get_local $12)
                   )
                   (i32.const 4)
                 )
               )
               (i32.or
                 (i32.load
-                  (get_local $i43)
+                  (get_local $7)
                 )
                 (i32.const 1)
               )
@@ -3017,7 +2959,7 @@
         )
         (return
           (i32.add
-            (get_local $i53)
+            (get_local $16)
             (i32.const 8)
           )
         )
@@ -3025,53 +2967,53 @@
     )
     (if
       (i32.gt_u
-        (set_local $i53
+        (set_local $16
           (i32.load
             (i32.const 188)
           )
         )
-        (get_local $i31)
+        (get_local $0)
       )
       (block
         (i32.store
           (i32.const 188)
-          (set_local $i43
+          (set_local $7
             (i32.sub
-              (get_local $i53)
-              (get_local $i31)
+              (get_local $16)
+              (get_local $0)
             )
           )
         )
         (i32.store
           (i32.const 200)
-          (set_local $i44
+          (set_local $12
             (i32.add
-              (set_local $i53
+              (set_local $16
                 (i32.load
                   (i32.const 200)
                 )
               )
-              (get_local $i31)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=4
-          (get_local $i44)
+          (get_local $12)
           (i32.or
-            (get_local $i43)
+            (get_local $7)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $i53)
+          (get_local $16)
           (i32.or
-            (get_local $i31)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (return
           (i32.add
-            (get_local $i53)
+            (get_local $16)
             (i32.const 8)
           )
         )
@@ -3086,24 +3028,24 @@
       (if
         (i32.and
           (i32.add
-            (set_local $i53
+            (set_local $16
               (call_import $_sysconf
                 (i32.const 30)
               )
             )
             (i32.const -1)
           )
-          (get_local $i53)
+          (get_local $16)
         )
         (call_import $_abort)
         (block
           (i32.store
             (i32.const 656)
-            (get_local $i53)
+            (get_local $16)
           )
           (i32.store
             (i32.const 652)
-            (get_local $i53)
+            (get_local $16)
           )
           (i32.store
             (i32.const 660)
@@ -3136,40 +3078,40 @@
         )
       )
     )
-    (set_local $i53
+    (set_local $16
       (i32.add
-        (get_local $i31)
+        (get_local $0)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $i43
+        (set_local $7
           (i32.and
-            (set_local $i55
+            (set_local $21
               (i32.add
-                (set_local $i43
+                (set_local $7
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (set_local $i44
+                (set_local $12
                   (i32.add
-                    (get_local $i31)
+                    (get_local $0)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $i54
+            (set_local $23
               (i32.sub
                 (i32.const 0)
-                (get_local $i43)
+                (get_local $7)
               )
             )
           )
         )
-        (get_local $i31)
+        (get_local $0)
       )
       (return
         (i32.const 0)
@@ -3178,7 +3120,7 @@
     (if
       (if
         (i32.ne
-          (set_local $i52
+          (set_local $9
             (i32.load
               (i32.const 616)
             )
@@ -3187,21 +3129,21 @@
         )
         (i32.or
           (i32.le_u
-            (set_local $i50
+            (set_local $14
               (i32.add
-                (set_local $i51
+                (set_local $26
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $i43)
+                (get_local $7)
               )
             )
-            (get_local $i51)
+            (get_local $26)
           )
           (i32.gt_u
-            (get_local $i50)
-            (get_local $i52)
+            (get_local $14)
+            (get_local $9)
           )
         )
         (i32.const 0)
@@ -3210,7 +3152,7 @@
         (i32.const 0)
       )
     )
-    (set_local $i36
+    (set_local $8
       (block $label$break$L257
         (if
           (i32.and
@@ -3223,62 +3165,62 @@
           (block
             (block $label$break$L259
               (if
-                (set_local $i52
+                (set_local $9
                   (i32.load
                     (i32.const 200)
                   )
                 )
                 (block
-                  (set_local $i50
+                  (set_local $14
                     (i32.const 624)
                   )
                   (loop $while-out$37 $while-in$38
                     (if
                       (if
                         (i32.le_u
-                          (set_local $i51
+                          (set_local $26
                             (i32.load
-                              (get_local $i50)
+                              (get_local $14)
                             )
                           )
-                          (get_local $i52)
+                          (get_local $9)
                         )
                         (i32.gt_u
                           (i32.add
-                            (get_local $i51)
+                            (get_local $26)
                             (i32.load
-                              (set_local $i45
+                              (set_local $11
                                 (i32.add
-                                  (get_local $i50)
+                                  (get_local $14)
                                   (i32.const 4)
                                 )
                               )
                             )
                           )
-                          (get_local $i52)
+                          (get_local $9)
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $i56
-                          (get_local $i50)
+                        (set_local $4
+                          (get_local $14)
                         )
-                        (set_local $i57
-                          (get_local $i45)
+                        (set_local $5
+                          (get_local $11)
                         )
                         (br $while-out$37)
                       )
                     )
                     (if
                       (i32.eqz
-                        (set_local $i50
+                        (set_local $14
                           (i32.load offset=8
-                            (get_local $i50)
+                            (get_local $14)
                           )
                         )
                       )
                       (block
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 173)
                         )
                         (br $label$break$L259)
@@ -3288,46 +3230,46 @@
                   )
                   (if
                     (i32.lt_u
-                      (set_local $i50
+                      (set_local $14
                         (i32.and
                           (i32.sub
-                            (get_local $i55)
+                            (get_local $21)
                             (i32.load
                               (i32.const 188)
                             )
                           )
-                          (get_local $i54)
+                          (get_local $23)
                         )
                       )
                       (i32.const 2147483647)
                     )
                     (if
                       (i32.eq
-                        (set_local $i45
+                        (set_local $11
                           (call_import $_sbrk
-                            (get_local $i50)
+                            (get_local $14)
                           )
                         )
                         (i32.add
                           (i32.load
-                            (get_local $i56)
+                            (get_local $4)
                           )
                           (i32.load
-                            (get_local $i57)
+                            (get_local $5)
                           )
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $i45)
+                          (get_local $11)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $i58
-                            (get_local $i45)
+                          (set_local $20
+                            (get_local $11)
                           )
-                          (set_local $i59
-                            (get_local $i50)
+                          (set_local $22
+                            (get_local $14)
                           )
                           (br $label$break$L257
                             (i32.const 193)
@@ -3335,20 +3277,20 @@
                         )
                       )
                       (block
-                        (set_local $i60
-                          (get_local $i45)
+                        (set_local $13
+                          (get_local $11)
                         )
-                        (set_local $i61
-                          (get_local $i50)
+                        (set_local $17
+                          (get_local $14)
                         )
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 183)
                         )
                       )
                     )
                   )
                 )
-                (set_local $i36
+                (set_local $8
                   (i32.const 173)
                 )
               )
@@ -3357,11 +3299,11 @@
               (if
                 (if
                   (i32.eq
-                    (get_local $i36)
+                    (get_local $8)
                     (i32.const 173)
                   )
                   (i32.ne
-                    (set_local $i52
+                    (set_local $9
                       (call_import $_sbrk
                         (i32.const 0)
                       )
@@ -3371,12 +3313,12 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $i62
+                  (set_local $1
                     (if
                       (i32.and
-                        (set_local $i45
+                        (set_local $11
                           (i32.add
-                            (set_local $i50
+                            (set_local $14
                               (i32.load
                                 (i32.const 652)
                               )
@@ -3384,47 +3326,47 @@
                             (i32.const -1)
                           )
                         )
-                        (set_local $i5
-                          (get_local $i52)
+                        (set_local $2
+                          (get_local $9)
                         )
                       )
                       (i32.add
                         (i32.sub
-                          (get_local $i43)
-                          (get_local $i5)
+                          (get_local $7)
+                          (get_local $2)
                         )
                         (i32.and
                           (i32.add
-                            (get_local $i45)
-                            (get_local $i5)
+                            (get_local $11)
+                            (get_local $2)
                           )
                           (i32.sub
                             (i32.const 0)
-                            (get_local $i50)
+                            (get_local $14)
                           )
                         )
                       )
-                      (get_local $i43)
+                      (get_local $7)
                     )
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.add
-                      (set_local $i50
+                      (set_local $14
                         (i32.load
                           (i32.const 608)
                         )
                       )
-                      (get_local $i62)
+                      (get_local $1)
                     )
                   )
                   (if
                     (i32.and
                       (i32.gt_u
-                        (get_local $i62)
-                        (get_local $i31)
+                        (get_local $1)
+                        (get_local $0)
                       )
                       (i32.lt_u
-                        (get_local $i62)
+                        (get_local $1)
                         (i32.const 2147483647)
                       )
                     )
@@ -3433,12 +3375,12 @@
                         (select
                           (i32.or
                             (i32.le_u
-                              (get_local $i5)
-                              (get_local $i50)
+                              (get_local $2)
+                              (get_local $14)
                             )
                             (i32.gt_u
-                              (get_local $i5)
-                              (set_local $i45
+                              (get_local $2)
+                              (set_local $11
                                 (i32.load
                                   (i32.const 616)
                                 )
@@ -3447,39 +3389,39 @@
                           )
                           (i32.const 0)
                           (i32.ne
-                            (get_local $i45)
+                            (get_local $11)
                             (i32.const 0)
                           )
                         )
                       )
                       (if
                         (i32.eq
-                          (set_local $i45
+                          (set_local $11
                             (call_import $_sbrk
-                              (get_local $i62)
+                              (get_local $1)
                             )
                           )
-                          (get_local $i52)
+                          (get_local $9)
                         )
                         (block
-                          (set_local $i58
-                            (get_local $i52)
+                          (set_local $20
+                            (get_local $9)
                           )
-                          (set_local $i59
-                            (get_local $i62)
+                          (set_local $22
+                            (get_local $1)
                           )
                           (br $label$break$L257
                             (i32.const 193)
                           )
                         )
                         (block
-                          (set_local $i60
-                            (get_local $i45)
+                          (set_local $13
+                            (get_local $11)
                           )
-                          (set_local $i61
-                            (get_local $i62)
+                          (set_local $17
+                            (get_local $1)
                           )
-                          (set_local $i36
+                          (set_local $8
                             (i32.const 183)
                           )
                         )
@@ -3492,43 +3434,43 @@
             (block $label$break$L279
               (if
                 (i32.eq
-                  (get_local $i36)
+                  (get_local $8)
                   (i32.const 183)
                 )
                 (block
-                  (set_local $i45
+                  (set_local $11
                     (i32.sub
                       (i32.const 0)
-                      (get_local $i61)
+                      (get_local $17)
                     )
                   )
                   (if
                     (if
                       (i32.and
                         (i32.gt_u
-                          (get_local $i53)
-                          (get_local $i61)
+                          (get_local $16)
+                          (get_local $17)
                         )
                         (i32.and
                           (i32.lt_u
-                            (get_local $i61)
+                            (get_local $17)
                             (i32.const 2147483647)
                           )
                           (i32.ne
-                            (get_local $i60)
+                            (get_local $13)
                             (i32.const -1)
                           )
                         )
                       )
                       (i32.lt_u
-                        (set_local $i5
+                        (set_local $2
                           (i32.and
                             (i32.add
                               (i32.sub
-                                (get_local $i44)
-                                (get_local $i61)
+                                (get_local $12)
+                                (get_local $17)
                               )
-                              (set_local $i52
+                              (set_local $9
                                 (i32.load
                                   (i32.const 656)
                                 )
@@ -3536,7 +3478,7 @@
                             )
                             (i32.sub
                               (i32.const 0)
-                              (get_local $i52)
+                              (get_local $9)
                             )
                           )
                         )
@@ -3547,38 +3489,38 @@
                     (if
                       (i32.eq
                         (call_import $_sbrk
-                          (get_local $i5)
+                          (get_local $2)
                         )
                         (i32.const -1)
                       )
                       (block
                         (call_import $_sbrk
-                          (get_local $i45)
+                          (get_local $11)
                         )
                         (br $label$break$L279)
                       )
-                      (set_local $i63
+                      (set_local $3
                         (i32.add
-                          (get_local $i5)
-                          (get_local $i61)
+                          (get_local $2)
+                          (get_local $17)
                         )
                       )
                     )
-                    (set_local $i63
-                      (get_local $i61)
+                    (set_local $3
+                      (get_local $17)
                     )
                   )
                   (if
                     (i32.ne
-                      (get_local $i60)
+                      (get_local $13)
                       (i32.const -1)
                     )
                     (block
-                      (set_local $i58
-                        (get_local $i60)
+                      (set_local $20
+                        (get_local $13)
                       )
-                      (set_local $i59
-                        (get_local $i63)
+                      (set_local $22
+                        (get_local $3)
                       )
                       (br $label$break$L257
                         (i32.const 193)
@@ -3607,23 +3549,23 @@
         (if
           (select
             (i32.lt_u
-              (get_local $i43)
+              (get_local $7)
               (i32.const 2147483647)
             )
             (i32.const 0)
             (i32.eq
-              (get_local $i36)
+              (get_local $8)
               (i32.const 190)
             )
           )
           (i32.and
             (i32.lt_u
-              (set_local $i63
+              (set_local $3
                 (call_import $_sbrk
-                  (get_local $i43)
+                  (get_local $7)
                 )
               )
-              (set_local $i43
+              (set_local $7
                 (call_import $_sbrk
                   (i32.const 0)
                 )
@@ -3631,11 +3573,11 @@
             )
             (i32.and
               (i32.ne
-                (get_local $i63)
+                (get_local $3)
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $i43)
+                (get_local $7)
                 (i32.const -1)
               )
             )
@@ -3643,86 +3585,86 @@
           (i32.const 0)
         )
         (i32.gt_u
-          (set_local $i60
+          (set_local $13
             (i32.sub
-              (get_local $i43)
-              (get_local $i63)
+              (get_local $7)
+              (get_local $3)
             )
           )
           (i32.add
-            (get_local $i31)
+            (get_local $0)
             (i32.const 40)
           )
         )
         (i32.const 0)
       )
       (block
-        (set_local $i58
-          (get_local $i63)
+        (set_local $20
+          (get_local $3)
         )
-        (set_local $i59
-          (get_local $i60)
+        (set_local $22
+          (get_local $13)
         )
-        (set_local $i36
+        (set_local $8
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $i36)
+        (get_local $8)
         (i32.const 193)
       )
       (block
         (i32.store
           (i32.const 608)
-          (set_local $i60
+          (set_local $13
             (i32.add
               (i32.load
                 (i32.const 608)
               )
-              (get_local $i59)
+              (get_local $22)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $i60)
+            (get_local $13)
             (i32.load
               (i32.const 612)
             )
           )
           (i32.store
             (i32.const 612)
-            (get_local $i60)
+            (get_local $13)
           )
         )
         (block $do-once$44
           (if
-            (set_local $i60
+            (set_local $13
               (i32.load
                 (i32.const 200)
               )
             )
             (block
-              (set_local $i63
+              (set_local $3
                 (i32.const 624)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $i58)
+                    (get_local $20)
                     (i32.add
-                      (set_local $i43
+                      (set_local $7
                         (i32.load
-                          (get_local $i63)
+                          (get_local $3)
                         )
                       )
-                      (set_local $i44
+                      (set_local $12
                         (i32.load
-                          (set_local $i61
+                          (set_local $17
                             (i32.add
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 4)
                             )
                           )
@@ -3731,19 +3673,19 @@
                     )
                   )
                   (block
-                    (set_local $i64
-                      (get_local $i43)
+                    (set_local $47
+                      (get_local $7)
                     )
-                    (set_local $i65
-                      (get_local $i61)
+                    (set_local $48
+                      (get_local $17)
                     )
-                    (set_local $i66
-                      (get_local $i44)
+                    (set_local $49
+                      (get_local $12)
                     )
-                    (set_local $i67
-                      (get_local $i63)
+                    (set_local $50
+                      (get_local $3)
                     )
-                    (set_local $i36
+                    (set_local $8
                       (i32.const 203)
                     )
                     (br $do-out$46)
@@ -3751,9 +3693,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $i63
+                    (set_local $3
                       (i32.load offset=8
-                        (get_local $i63)
+                        (get_local $3)
                       )
                     )
                     (i32.const 0)
@@ -3764,12 +3706,12 @@
                 (select
                   (i32.and
                     (i32.lt_u
-                      (get_local $i60)
-                      (get_local $i58)
+                      (get_local $13)
+                      (get_local $20)
                     )
                     (i32.ge_u
-                      (get_local $i60)
-                      (get_local $i64)
+                      (get_local $13)
+                      (get_local $47)
                     )
                   )
                   (i32.const 0)
@@ -3777,7 +3719,7 @@
                     (i32.eq
                       (i32.and
                         (i32.load offset=12
-                          (get_local $i67)
+                          (get_local $50)
                         )
                         (i32.const 8)
                       )
@@ -3785,31 +3727,31 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $i36)
+                      (get_local $8)
                       (i32.const 203)
                     )
                   )
                 )
                 (block
                   (i32.store
-                    (get_local $i65)
+                    (get_local $48)
                     (i32.add
-                      (get_local $i66)
-                      (get_local $i59)
+                      (get_local $49)
+                      (get_local $22)
                     )
                   )
-                  (set_local $i63
+                  (set_local $3
                     (i32.add
-                      (get_local $i60)
-                      (set_local $i44
+                      (get_local $13)
+                      (set_local $12
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $i63
+                              (set_local $3
                                 (i32.add
-                                  (get_local $i60)
+                                  (get_local $13)
                                   (i32.const 8)
                                 )
                               )
@@ -3818,7 +3760,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3827,11 +3769,11 @@
                       )
                     )
                   )
-                  (set_local $i61
+                  (set_local $17
                     (i32.add
                       (i32.sub
-                        (get_local $i59)
-                        (get_local $i44)
+                        (get_local $22)
+                        (get_local $12)
                       )
                       (i32.load
                         (i32.const 188)
@@ -3840,23 +3782,23 @@
                   )
                   (i32.store
                     (i32.const 200)
-                    (get_local $i63)
+                    (get_local $3)
                   )
                   (i32.store
                     (i32.const 188)
-                    (get_local $i61)
+                    (get_local $17)
                   )
                   (i32.store offset=4
-                    (get_local $i63)
+                    (get_local $3)
                     (i32.or
-                      (get_local $i61)
+                      (get_local $17)
                       (i32.const 1)
                     )
                   )
                   (i32.store offset=4
                     (i32.add
-                      (get_local $i63)
-                      (get_local $i61)
+                      (get_local $3)
+                      (get_local $17)
                     )
                     (i32.const 40)
                   )
@@ -3869,11 +3811,11 @@
                   (br $do-once$44)
                 )
               )
-              (set_local $i68
+              (set_local $6
                 (if
                   (i32.lt_u
-                    (get_local $i58)
-                    (set_local $i61
+                    (get_local $20)
+                    (set_local $17
                       (i32.load
                         (i32.const 192)
                       )
@@ -3882,38 +3824,38 @@
                   (block
                     (i32.store
                       (i32.const 192)
-                      (get_local $i58)
+                      (get_local $20)
                     )
-                    (get_local $i58)
+                    (get_local $20)
                   )
-                  (get_local $i61)
+                  (get_local $17)
                 )
               )
-              (set_local $i61
+              (set_local $17
                 (i32.add
-                  (get_local $i58)
-                  (get_local $i59)
+                  (get_local $20)
+                  (get_local $22)
                 )
               )
-              (set_local $i63
+              (set_local $3
                 (i32.const 624)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $i63)
+                      (get_local $3)
                     )
-                    (get_local $i61)
+                    (get_local $17)
                   )
                   (block
-                    (set_local $i69
-                      (get_local $i63)
+                    (set_local $51
+                      (get_local $3)
                     )
-                    (set_local $i70
-                      (get_local $i63)
+                    (set_local $41
+                      (get_local $3)
                     )
-                    (set_local $i36
+                    (set_local $8
                       (i32.const 211)
                     )
                     (br $while-out$48)
@@ -3921,14 +3863,14 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $i63
+                    (set_local $3
                       (i32.load offset=8
-                        (get_local $i63)
+                        (get_local $3)
                       )
                     )
                   )
                   (block
-                    (set_local $i71
+                    (set_local $28
                       (i32.const 624)
                     )
                     (br $while-out$48)
@@ -3938,49 +3880,49 @@
               )
               (if
                 (i32.eq
-                  (get_local $i36)
+                  (get_local $8)
                   (i32.const 211)
                 )
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $i70)
+                      (get_local $41)
                     )
                     (i32.const 8)
                   )
-                  (set_local $i71
+                  (set_local $28
                     (i32.const 624)
                   )
                   (block
                     (i32.store
-                      (get_local $i69)
-                      (get_local $i58)
+                      (get_local $51)
+                      (get_local $20)
                     )
                     (i32.store
-                      (set_local $i63
+                      (set_local $3
                         (i32.add
-                          (get_local $i70)
+                          (get_local $41)
                           (i32.const 4)
                         )
                       )
                       (i32.add
                         (i32.load
-                          (get_local $i63)
+                          (get_local $3)
                         )
-                        (get_local $i59)
+                        (get_local $22)
                       )
                     )
-                    (set_local $i44
+                    (set_local $12
                       (i32.add
-                        (get_local $i58)
+                        (get_local $20)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $i63
+                              (set_local $3
                                 (i32.add
-                                  (get_local $i58)
+                                  (get_local $20)
                                   (i32.const 8)
                                 )
                               )
@@ -3989,7 +3931,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3997,17 +3939,17 @@
                         )
                       )
                     )
-                    (set_local $i43
+                    (set_local $7
                       (i32.add
-                        (get_local $i61)
+                        (get_local $17)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $i63
+                              (set_local $3
                                 (i32.add
-                                  (get_local $i61)
+                                  (get_local $17)
                                   (i32.const 8)
                                 )
                               )
@@ -4016,7 +3958,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $i63)
+                              (get_local $3)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -4024,38 +3966,38 @@
                         )
                       )
                     )
-                    (set_local $i63
+                    (set_local $3
                       (i32.add
-                        (get_local $i44)
-                        (get_local $i31)
+                        (get_local $12)
+                        (get_local $0)
                       )
                     )
-                    (set_local $i53
+                    (set_local $16
                       (i32.sub
                         (i32.sub
-                          (get_local $i43)
-                          (get_local $i44)
+                          (get_local $7)
+                          (get_local $12)
                         )
-                        (get_local $i31)
+                        (get_local $0)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $i44)
+                      (get_local $12)
                       (i32.or
-                        (get_local $i31)
+                        (get_local $0)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$50
                       (if
                         (i32.ne
-                          (get_local $i43)
-                          (get_local $i60)
+                          (get_local $7)
+                          (get_local $13)
                         )
                         (block
                           (if
                             (i32.eq
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.load
                                 (i32.const 196)
                               )
@@ -4063,45 +4005,45 @@
                             (block
                               (i32.store
                                 (i32.const 184)
-                                (set_local $i62
+                                (set_local $1
                                   (i32.add
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $i53)
+                                    (get_local $16)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $i63)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.or
-                                  (get_local $i62)
+                                  (get_local $1)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $i63)
-                                  (get_local $i62)
+                                  (get_local $3)
+                                  (get_local $1)
                                 )
-                                (get_local $i62)
+                                (get_local $1)
                               )
                               (br $do-once$50)
                             )
                           )
                           (i32.store
-                            (set_local $i56
+                            (set_local $4
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $i62
+                                      (set_local $1
                                         (i32.load offset=4
-                                          (get_local $i43)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 3)
@@ -4109,49 +4051,49 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $i57
+                                    (set_local $5
                                       (i32.and
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $i56
+                                    (set_local $4
                                       (i32.shr_u
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$L331
                                       (if
                                         (i32.ge_u
-                                          (get_local $i62)
+                                          (get_local $1)
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $i54
+                                          (set_local $23
                                             (i32.load offset=24
-                                              (get_local $i43)
+                                              (get_local $7)
                                             )
                                           )
                                           (block $do-once$53
                                             (if
                                               (i32.eq
-                                                (set_local $i55
+                                                (set_local $21
                                                   (i32.load offset=12
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                 )
-                                                (get_local $i43)
+                                                (get_local $7)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $i52
+                                                  (set_local $9
                                                     (i32.load
-                                                      (set_local $i5
+                                                      (set_local $2
                                                         (i32.add
-                                                          (set_local $i45
+                                                          (set_local $11
                                                             (i32.add
-                                                              (get_local $i43)
+                                                              (get_local $7)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4161,29 +4103,29 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $i73
-                                                      (get_local $i52)
+                                                    (set_local $0
+                                                      (get_local $9)
                                                     )
-                                                    (set_local $i74
-                                                      (get_local $i5)
+                                                    (set_local $4
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $i50
+                                                    (set_local $14
                                                       (i32.load
-                                                        (get_local $i45)
+                                                        (get_local $11)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i73
-                                                        (get_local $i50)
+                                                      (set_local $0
+                                                        (get_local $14)
                                                       )
-                                                      (set_local $i74
-                                                        (get_local $i45)
+                                                      (set_local $4
+                                                        (get_local $11)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i72
+                                                      (set_local $24
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once$53)
@@ -4192,52 +4134,48 @@
                                                 )
                                                 (loop $while-out$55 $while-in$56
                                                   (if
-                                                    (set_local $i52
+                                                    (set_local $9
                                                       (i32.load
-                                                        (set_local $i5
+                                                        (set_local $2
                                                           (i32.add
-                                                            (get_local $i73)
+                                                            (get_local $0)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i73
-                                                        (get_local $i52)
+                                                      (set_local $0
+                                                        (get_local $9)
                                                       )
-                                                      (set_local $i74
-                                                        (get_local $i5)
+                                                      (set_local $4
+                                                        (get_local $2)
                                                       )
                                                       (br $while-in$56)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $i52
+                                                    (set_local $9
                                                       (i32.load
-                                                        (set_local $i5
+                                                        (set_local $2
                                                           (i32.add
-                                                            (get_local $i73)
+                                                            (get_local $0)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i73
-                                                        (get_local $i52)
+                                                      (set_local $0
+                                                        (get_local $9)
                                                       )
-                                                      (set_local $i74
-                                                        (get_local $i5)
+                                                      (set_local $4
+                                                        (get_local $2)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $i75
-                                                        (get_local $i73)
-                                                      )
-                                                      (set_local $i76
-                                                        (get_local $i74)
-                                                      )
+                                                      (get_local $0)
+                                                      (get_local $4)
                                                       (br $while-out$55)
                                                     )
                                                   )
@@ -4245,17 +4183,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i76)
-                                                    (get_local $i68)
+                                                    (get_local $4)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                   (block
                                                     (i32.store
-                                                      (get_local $i76)
+                                                      (get_local $4)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $i72
-                                                      (get_local $i75)
+                                                    (set_local $24
+                                                      (get_local $0)
                                                     )
                                                   )
                                                 )
@@ -4263,52 +4201,52 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (set_local $i5
+                                                    (set_local $2
                                                       (i32.load offset=8
-                                                        (get_local $i43)
+                                                        (get_local $7)
                                                       )
                                                     )
-                                                    (get_local $i68)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $i52
+                                                      (set_local $9
                                                         (i32.add
-                                                          (get_local $i5)
+                                                          (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $i45
+                                                      (set_local $11
                                                         (i32.add
-                                                          (get_local $i55)
+                                                          (get_local $21)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $i52)
-                                                      (get_local $i55)
+                                                      (get_local $9)
+                                                      (get_local $21)
                                                     )
                                                     (i32.store
-                                                      (get_local $i45)
-                                                      (get_local $i5)
+                                                      (get_local $11)
+                                                      (get_local $2)
                                                     )
-                                                    (set_local $i72
-                                                      (get_local $i55)
+                                                    (set_local $24
+                                                      (get_local $21)
                                                     )
                                                   )
                                                   (call_import $_abort)
@@ -4318,21 +4256,21 @@
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (get_local $i54)
+                                              (get_local $23)
                                             )
                                           )
                                           (block $do-once$57
                                             (if
                                               (i32.ne
-                                                (get_local $i43)
+                                                (get_local $7)
                                                 (i32.load
-                                                  (set_local $i5
+                                                  (set_local $2
                                                     (i32.add
                                                       (i32.const 480)
                                                       (i32.shl
-                                                        (set_local $i55
+                                                        (set_local $21
                                                           (i32.load offset=28
-                                                            (get_local $i43)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4344,7 +4282,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i54)
+                                                    (get_local $23)
                                                     (i32.load
                                                       (i32.const 192)
                                                     )
@@ -4354,37 +4292,37 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $i45
+                                                      (set_local $11
                                                         (i32.add
-                                                          (get_local $i54)
+                                                          (get_local $23)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (i32.store
-                                                    (get_local $i45)
-                                                    (get_local $i72)
+                                                    (get_local $11)
+                                                    (get_local $24)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $i54)
-                                                    (get_local $i72)
+                                                    (get_local $23)
+                                                    (get_local $24)
                                                   )
                                                 )
                                                 (br_if $label$break$L331
                                                   (i32.eqz
-                                                    (get_local $i72)
+                                                    (get_local $24)
                                                   )
                                                 )
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $i5)
-                                                  (get_local $i72)
+                                                  (get_local $2)
+                                                  (get_local $24)
                                                 )
                                                 (br_if $do-once$57
-                                                  (get_local $i72)
+                                                  (get_local $24)
                                                 )
                                                 (i32.store
                                                   (i32.const 180)
@@ -4395,7 +4333,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $i55)
+                                                        (get_local $21)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4407,8 +4345,8 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $i72)
-                                              (set_local $i55
+                                              (get_local $24)
+                                              (set_local $21
                                                 (i32.load
                                                   (i32.const 192)
                                                 )
@@ -4417,15 +4355,15 @@
                                             (call_import $_abort)
                                           )
                                           (i32.store offset=24
-                                            (get_local $i72)
-                                            (get_local $i54)
+                                            (get_local $24)
+                                            (get_local $23)
                                           )
                                           (if
-                                            (set_local $i45
+                                            (set_local $11
                                               (i32.load
-                                                (set_local $i5
+                                                (set_local $2
                                                   (i32.add
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4433,34 +4371,34 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $i45)
-                                                (get_local $i55)
+                                                (get_local $11)
+                                                (get_local $21)
                                               )
                                               (call_import $_abort)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $i72)
-                                                  (get_local $i45)
+                                                  (get_local $24)
+                                                  (get_local $11)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $i45)
-                                                  (get_local $i72)
+                                                  (get_local $11)
+                                                  (get_local $24)
                                                 )
                                               )
                                             )
                                           )
                                           (br_if $label$break$L331
                                             (i32.eqz
-                                              (set_local $i45
+                                              (set_local $11
                                                 (i32.load offset=4
-                                                  (get_local $i5)
+                                                  (get_local $2)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $i45)
+                                              (get_local $11)
                                               (i32.load
                                                 (i32.const 192)
                                               )
@@ -4468,36 +4406,36 @@
                                             (call_import $_abort)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $i72)
-                                                (get_local $i45)
+                                                (get_local $24)
+                                                (get_local $11)
                                               )
                                               (i32.store offset=24
-                                                (get_local $i45)
-                                                (get_local $i72)
+                                                (get_local $11)
+                                                (get_local $24)
                                               )
                                             )
                                           )
                                         )
                                         (block
-                                          (set_local $i55
+                                          (set_local $21
                                             (i32.load offset=12
-                                              (get_local $i43)
+                                              (get_local $7)
                                             )
                                           )
                                           (block $do-once$61
                                             (if
                                               (i32.ne
-                                                (set_local $i45
+                                                (set_local $11
                                                   (i32.load offset=8
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                 )
-                                                (set_local $i54
+                                                (set_local $23
                                                   (i32.add
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $i56)
+                                                        (get_local $4)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4508,17 +4446,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i45)
-                                                    (get_local $i68)
+                                                    (get_local $11)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (br_if $do-once$61
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $i45)
+                                                      (get_local $11)
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                 )
                                                 (call_import $_abort)
@@ -4527,8 +4465,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $i55)
-                                              (get_local $i45)
+                                              (get_local $21)
+                                              (get_local $11)
                                             )
                                             (block
                                               (i32.store
@@ -4540,7 +4478,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $i56)
+                                                      (get_local $4)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4552,38 +4490,38 @@
                                           (block $do-once$63
                                             (if
                                               (i32.eq
-                                                (get_local $i55)
-                                                (get_local $i54)
+                                                (get_local $21)
+                                                (get_local $23)
                                               )
-                                              (set_local $i77
+                                              (set_local $42
                                                 (i32.add
-                                                  (get_local $i55)
+                                                  (get_local $21)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $i55)
-                                                    (get_local $i68)
+                                                    (get_local $21)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $i5
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $i55)
+                                                          (get_local $21)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $i43)
+                                                    (get_local $7)
                                                   )
                                                   (block
-                                                    (set_local $i77
-                                                      (get_local $i5)
+                                                    (set_local $42
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once$63)
                                                   )
@@ -4593,32 +4531,32 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $i45)
-                                            (get_local $i55)
+                                            (get_local $11)
+                                            (get_local $21)
                                           )
                                           (i32.store
-                                            (get_local $i77)
-                                            (get_local $i45)
+                                            (get_local $42)
+                                            (get_local $11)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $i79
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $i57)
-                                        (get_local $i53)
+                                        (get_local $5)
+                                        (get_local $16)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $i43)
-                                      (get_local $i57)
+                                      (get_local $7)
+                                      (get_local $5)
                                     )
                                   )
                                   (block
-                                    (set_local $i79
-                                      (get_local $i53)
+                                    (set_local $0
+                                      (get_local $16)
                                     )
-                                    (get_local $i43)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 4)
@@ -4626,43 +4564,43 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $i56)
+                                (get_local $4)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $i63)
+                            (get_local $3)
                             (i32.or
-                              (get_local $i79)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $i63)
-                              (get_local $i79)
+                              (get_local $3)
+                              (get_local $0)
                             )
-                            (get_local $i79)
+                            (get_local $0)
                           )
-                          (set_local $i56
+                          (set_local $4
                             (i32.shr_u
-                              (get_local $i79)
+                              (get_local $0)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $i79)
+                              (get_local $0)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $i62
+                              (set_local $1
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $i56)
+                                      (get_local $4)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4672,26 +4610,26 @@
                               (block $do-once$65
                                 (if
                                   (i32.and
-                                    (set_local $i54
+                                    (set_local $23
                                       (i32.load
                                         (i32.const 176)
                                       )
                                     )
-                                    (set_local $i5
+                                    (set_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $i56)
+                                        (get_local $4)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $i52
+                                        (set_local $9
                                           (i32.load
-                                            (set_local $i56
+                                            (set_local $4
                                               (i32.add
-                                                (get_local $i62)
+                                                (get_local $1)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4702,11 +4640,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $i80
-                                          (get_local $i56)
+                                        (set_local $43
+                                          (get_local $4)
                                         )
-                                        (set_local $i81
-                                          (get_local $i52)
+                                        (set_local $35
+                                          (get_local $9)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4717,58 +4655,58 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $i54)
-                                        (get_local $i5)
+                                        (get_local $23)
+                                        (get_local $2)
                                       )
                                     )
-                                    (set_local $i80
+                                    (set_local $43
                                       (i32.add
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $i81
-                                      (get_local $i62)
+                                    (set_local $35
+                                      (get_local $1)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $i80)
-                                (get_local $i63)
+                                (get_local $43)
+                                (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $i81)
-                                (get_local $i63)
+                                (get_local $35)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $i63)
-                                (get_local $i81)
+                                (get_local $3)
+                                (get_local $35)
                               )
                               (i32.store offset=12
-                                (get_local $i63)
-                                (get_local $i62)
+                                (get_local $3)
+                                (get_local $1)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $i5
+                          (set_local $2
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $i82
+                                (set_local $4
                                   (block $do-once$67
                                     (if
-                                      (set_local $i5
+                                      (set_local $2
                                         (i32.shr_u
-                                          (get_local $i79)
+                                          (get_local $0)
                                           (i32.const 8)
                                         )
                                       )
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $i79)
+                                            (get_local $0)
                                             (i32.const 16777215)
                                           )
                                           (br $do-once$67
@@ -4778,26 +4716,26 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $i79)
+                                              (get_local $0)
                                               (i32.add
-                                                (set_local $i50
+                                                (set_local $14
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $i52
+                                                          (set_local $9
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $i57
+                                                                  (set_local $5
                                                                     (i32.shl
-                                                                      (get_local $i5)
-                                                                      (set_local $i54
+                                                                      (get_local $2)
+                                                                      (set_local $23
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $i5)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4814,16 +4752,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $i54)
+                                                          (get_local $23)
                                                         )
-                                                        (set_local $i57
+                                                        (set_local $5
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $i56
+                                                                (set_local $4
                                                                   (i32.shl
-                                                                    (get_local $i57)
-                                                                    (get_local $i52)
+                                                                    (get_local $5)
+                                                                    (get_local $9)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4837,8 +4775,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $i56)
-                                                        (get_local $i57)
+                                                        (get_local $4)
+                                                        (get_local $5)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4850,7 +4788,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $i50)
+                                            (get_local $14)
                                             (i32.const 1)
                                           )
                                         )
@@ -4864,34 +4802,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $i63)
-                            (get_local $i82)
+                            (get_local $3)
+                            (get_local $4)
                           )
                           (i32.store offset=4
-                            (set_local $i62
+                            (set_local $1
                               (i32.add
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $i62)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $i62
+                                (set_local $1
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $i50
+                                (set_local $14
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $i82)
+                                    (get_local $4)
                                   )
                                 )
                               )
@@ -4900,51 +4838,51 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $i62)
-                                  (get_local $i50)
+                                  (get_local $1)
+                                  (get_local $14)
                                 )
                               )
                               (i32.store
-                                (get_local $i5)
-                                (get_local $i63)
+                                (get_local $2)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $i63)
-                                (get_local $i5)
+                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $i63)
-                                (get_local $i63)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (i32.store offset=8
-                                (get_local $i63)
-                                (get_local $i63)
+                                (get_local $3)
+                                (get_local $3)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $i50
+                          (set_local $14
                             (i32.shl
-                              (get_local $i79)
+                              (get_local $0)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $i82)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $i82)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $i62
+                          (set_local $1
                             (i32.load
-                              (get_local $i5)
+                              (get_local $2)
                             )
                           )
                           (loop $while-out$69 $while-in$70
@@ -4952,34 +4890,34 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $i62)
+                                    (get_local $1)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $i79)
+                                (get_local $0)
                               )
                               (block
-                                (set_local $i83
-                                  (get_local $i62)
+                                (set_local $36
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 281)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $i57
+                              (set_local $5
                                 (i32.load
-                                  (set_local $i5
+                                  (set_local $2
                                     (i32.add
                                       (i32.add
-                                        (get_local $i62)
+                                        (get_local $1)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $i50)
+                                          (get_local $14)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -4989,24 +4927,24 @@
                                 )
                               )
                               (block
-                                (set_local $i50
+                                (set_local $14
                                   (i32.shl
-                                    (get_local $i50)
+                                    (get_local $14)
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $i62
-                                  (get_local $i57)
+                                (set_local $1
+                                  (get_local $5)
                                 )
                               )
                               (block
-                                (set_local $i84
-                                  (get_local $i5)
+                                (set_local $44
+                                  (get_local $2)
                                 )
-                                (set_local $i85
-                                  (get_local $i62)
+                                (set_local $52
+                                  (get_local $1)
                                 )
-                                (set_local $i36
+                                (set_local $8
                                   (i32.const 278)
                                 )
                                 (br $while-out$69)
@@ -5016,12 +4954,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $i36)
+                              (get_local $8)
                               (i32.const 278)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $i84)
+                                (get_local $44)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -5029,71 +4967,71 @@
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $i84)
-                                  (get_local $i63)
+                                  (get_local $44)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i63)
-                                  (get_local $i85)
+                                  (get_local $3)
+                                  (get_local $52)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i63)
-                                  (get_local $i63)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i63)
-                                  (get_local $i63)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $i36)
+                                (get_local $8)
                                 (i32.const 281)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $i50
+                                    (set_local $14
                                       (i32.load
-                                        (set_local $i62
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $i83)
+                                            (get_local $36)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $i57
+                                    (set_local $5
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $i83)
-                                    (get_local $i57)
+                                    (get_local $36)
+                                    (get_local $5)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $i50)
-                                    (get_local $i63)
+                                    (get_local $14)
+                                    (get_local $3)
                                   )
                                   (i32.store
-                                    (get_local $i62)
-                                    (get_local $i63)
+                                    (get_local $1)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $i63)
-                                    (get_local $i50)
+                                    (get_local $3)
+                                    (get_local $14)
                                   )
                                   (i32.store offset=12
-                                    (get_local $i63)
-                                    (get_local $i83)
+                                    (get_local $3)
+                                    (get_local $36)
                                   )
                                   (i32.store offset=24
-                                    (get_local $i63)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -5105,23 +5043,23 @@
                         (block
                           (i32.store
                             (i32.const 188)
-                            (set_local $i50
+                            (set_local $14
                               (i32.add
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $i53)
+                                (get_local $16)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $i63)
+                            (get_local $3)
                           )
                           (i32.store offset=4
-                            (get_local $i63)
+                            (get_local $3)
                             (i32.or
-                              (get_local $i50)
+                              (get_local $14)
                               (i32.const 1)
                             )
                           )
@@ -5130,7 +5068,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $i44)
+                        (get_local $12)
                         (i32.const 8)
                       )
                     )
@@ -5141,71 +5079,71 @@
                 (if
                   (if
                     (i32.le_u
-                      (set_local $i63
+                      (set_local $3
                         (i32.load
-                          (get_local $i71)
+                          (get_local $28)
                         )
                       )
-                      (get_local $i60)
+                      (get_local $13)
                     )
                     (i32.gt_u
-                      (set_local $i53
+                      (set_local $16
                         (i32.add
-                          (get_local $i63)
+                          (get_local $3)
                           (i32.load offset=4
-                            (get_local $i71)
+                            (get_local $28)
                           )
                         )
                       )
-                      (get_local $i60)
+                      (get_local $13)
                     )
                     (i32.const 0)
                   )
                   (block
-                    (set_local $i86
-                      (get_local $i53)
+                    (set_local $4
+                      (get_local $16)
                     )
                     (br $while-out$71)
                   )
                 )
-                (set_local $i71
+                (set_local $28
                   (i32.load offset=8
-                    (get_local $i71)
+                    (get_local $28)
                   )
                 )
                 (br $while-in$72)
               )
-              (set_local $i53
+              (set_local $16
                 (i32.add
-                  (set_local $i44
+                  (set_local $12
                     (i32.add
-                      (get_local $i86)
+                      (get_local $4)
                       (i32.const -47)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $i63
+              (set_local $3
                 (i32.add
-                  (set_local $i44
+                  (set_local $12
                     (select
-                      (get_local $i60)
-                      (set_local $i63
+                      (get_local $13)
+                      (set_local $3
                         (i32.add
-                          (get_local $i44)
+                          (get_local $12)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i53)
+                                (get_local $16)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $i53)
+                                (get_local $16)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5214,10 +5152,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $i63)
-                        (set_local $i53
+                        (get_local $3)
+                        (set_local $16
                           (i32.add
-                            (get_local $i60)
+                            (get_local $13)
                             (i32.const 16)
                           )
                         )
@@ -5229,18 +5167,18 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $i43
+                (set_local $7
                   (i32.add
-                    (get_local $i58)
-                    (set_local $i61
+                    (get_local $20)
+                    (set_local $17
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $i43
+                            (set_local $7
                               (i32.add
-                                (get_local $i58)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5249,7 +5187,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $i43)
+                            (get_local $7)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5261,27 +5199,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $i50
+                (set_local $14
                   (i32.sub
                     (i32.add
-                      (get_local $i59)
+                      (get_local $22)
                       (i32.const -40)
                     )
-                    (get_local $i61)
+                    (get_local $17)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $i43)
+                (get_local $7)
                 (i32.or
-                  (get_local $i50)
+                  (get_local $14)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $i43)
-                  (get_local $i50)
+                  (get_local $7)
+                  (get_local $14)
                 )
                 (i32.const 40)
               )
@@ -5292,45 +5230,45 @@
                 )
               )
               (i32.store
-                (set_local $i50
+                (set_local $14
                   (i32.add
-                    (get_local $i44)
+                    (get_local $12)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 628)
                 )
               )
               (i32.store offset=8
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 632)
                 )
               )
               (i32.store offset=12
-                (get_local $i63)
+                (get_local $3)
                 (i32.load
                   (i32.const 636)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $i58)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $i59)
+                (get_local $22)
               )
               (i32.store
                 (i32.const 636)
@@ -5338,19 +5276,19 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $i63)
+                (get_local $3)
               )
-              (set_local $i63
+              (set_local $3
                 (i32.add
-                  (get_local $i44)
+                  (get_local $12)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $i63
+                  (set_local $3
                     (i32.add
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 4)
                     )
                   )
@@ -5359,62 +5297,62 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 4)
                     )
-                    (get_local $i86)
+                    (get_local $4)
                   )
                 )
               )
               (if
                 (i32.ne
-                  (get_local $i44)
-                  (get_local $i60)
+                  (get_local $12)
+                  (get_local $13)
                 )
                 (block
                   (i32.store
-                    (get_local $i50)
+                    (get_local $14)
                     (i32.and
                       (i32.load
-                        (get_local $i50)
+                        (get_local $14)
                       )
                       (i32.const -2)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $i60)
+                    (get_local $13)
                     (i32.or
-                      (set_local $i63
+                      (set_local $3
                         (i32.sub
-                          (get_local $i44)
-                          (get_local $i60)
+                          (get_local $12)
+                          (get_local $13)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $i44)
-                    (get_local $i63)
+                    (get_local $12)
+                    (get_local $3)
                   )
-                  (set_local $i43
+                  (set_local $7
                     (i32.shr_u
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i63)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $i61
+                      (set_local $17
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (get_local $i43)
+                              (get_local $7)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5423,25 +5361,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $i62
+                          (set_local $1
                             (i32.load
                               (i32.const 176)
                             )
                           )
-                          (set_local $i57
+                          (set_local $5
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i43)
+                              (get_local $7)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $i5
+                            (set_local $2
                               (i32.load
-                                (set_local $i43
+                                (set_local $7
                                   (i32.add
-                                    (get_local $i61)
+                                    (get_local $17)
                                     (i32.const 8)
                                   )
                                 )
@@ -5453,11 +5391,11 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $i87
-                              (get_local $i43)
+                            (set_local $45
+                              (get_local $7)
                             )
-                            (set_local $i88
-                              (get_local $i5)
+                            (set_local $37
+                              (get_local $2)
                             )
                           )
                         )
@@ -5465,81 +5403,81 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $i62)
-                              (get_local $i57)
+                              (get_local $1)
+                              (get_local $5)
                             )
                           )
-                          (set_local $i87
+                          (set_local $45
                             (i32.add
-                              (get_local $i61)
+                              (get_local $17)
                               (i32.const 8)
                             )
                           )
-                          (set_local $i88
-                            (get_local $i61)
+                          (set_local $37
+                            (get_local $17)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $i87)
-                        (get_local $i60)
+                        (get_local $45)
+                        (get_local $13)
                       )
                       (i32.store offset=12
-                        (get_local $i88)
-                        (get_local $i60)
+                        (get_local $37)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $i60)
-                        (get_local $i88)
+                        (get_local $13)
+                        (get_local $37)
                       )
                       (i32.store offset=12
-                        (get_local $i60)
-                        (get_local $i61)
+                        (get_local $13)
+                        (get_local $17)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $i43
+                  (set_local $7
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (set_local $i89
+                        (set_local $4
                           (if
-                            (set_local $i61
+                            (set_local $17
                               (i32.shr_u
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $i63)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $i63)
+                                    (get_local $3)
                                     (i32.add
-                                      (set_local $i43
+                                      (set_local $7
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $i61
+                                                (set_local $17
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $i62
+                                                        (set_local $1
                                                           (i32.shl
-                                                            (get_local $i61)
-                                                            (set_local $i57
+                                                            (get_local $17)
+                                                            (set_local $5
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $i61)
+                                                                    (get_local $17)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5556,16 +5494,16 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $i57)
+                                                (get_local $5)
                                               )
-                                              (set_local $i62
+                                              (set_local $1
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $i5
+                                                      (set_local $2
                                                         (i32.shl
-                                                          (get_local $i62)
-                                                          (get_local $i61)
+                                                          (get_local $1)
+                                                          (get_local $17)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5579,8 +5517,8 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $i5)
-                                              (get_local $i62)
+                                              (get_local $2)
+                                              (get_local $1)
                                             )
                                             (i32.const 15)
                                           )
@@ -5592,7 +5530,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $i43)
+                                  (get_local $7)
                                   (i32.const 1)
                                 )
                               )
@@ -5605,29 +5543,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $i60)
-                    (get_local $i89)
+                    (get_local $13)
+                    (get_local $4)
                   )
                   (i32.store offset=20
-                    (get_local $i60)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $i53)
+                    (get_local $16)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $i62
+                        (set_local $1
                           (i32.load
                             (i32.const 180)
                           )
                         )
-                        (set_local $i5
+                        (set_local $2
                           (i32.shl
                             (i32.const 1)
-                            (get_local $i89)
+                            (get_local $4)
                           )
                         )
                       )
@@ -5636,51 +5574,51 @@
                       (i32.store
                         (i32.const 180)
                         (i32.or
-                          (get_local $i62)
-                          (get_local $i5)
+                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                       (i32.store
-                        (get_local $i43)
-                        (get_local $i60)
+                        (get_local $7)
+                        (get_local $13)
                       )
                       (i32.store offset=24
-                        (get_local $i60)
-                        (get_local $i43)
+                        (get_local $13)
+                        (get_local $7)
                       )
                       (i32.store offset=12
-                        (get_local $i60)
-                        (get_local $i60)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (i32.store offset=8
-                        (get_local $i60)
-                        (get_local $i60)
+                        (get_local $13)
+                        (get_local $13)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $i5
+                  (set_local $2
                     (i32.shl
-                      (get_local $i63)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $i89)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $i89)
+                          (get_local $4)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $i62
+                  (set_local $1
                     (i32.load
-                      (get_local $i43)
+                      (get_local $7)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5688,34 +5626,34 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $i62)
+                            (get_local $1)
                           )
                           (i32.const -8)
                         )
-                        (get_local $i63)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $i90
-                          (get_local $i62)
+                        (set_local $38
+                          (get_local $1)
                         )
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 307)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $i57
+                      (set_local $5
                         (i32.load
-                          (set_local $i43
+                          (set_local $7
                             (i32.add
                               (i32.add
-                                (get_local $i62)
+                                (get_local $1)
                                 (i32.const 16)
                               )
                               (i32.shl
                                 (i32.shr_u
-                                  (get_local $i5)
+                                  (get_local $2)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5725,24 +5663,24 @@
                         )
                       )
                       (block
-                        (set_local $i5
+                        (set_local $2
                           (i32.shl
-                            (get_local $i5)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
-                        (set_local $i62
-                          (get_local $i57)
+                        (set_local $1
+                          (get_local $5)
                         )
                       )
                       (block
-                        (set_local $i91
-                          (get_local $i43)
+                        (set_local $46
+                          (get_local $7)
                         )
-                        (set_local $i92
-                          (get_local $i62)
+                        (set_local $53
+                          (get_local $1)
                         )
-                        (set_local $i36
+                        (set_local $8
                           (i32.const 304)
                         )
                         (br $while-out$75)
@@ -5752,12 +5690,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $i36)
+                      (get_local $8)
                       (i32.const 304)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i91)
+                        (get_local $46)
                         (i32.load
                           (i32.const 192)
                         )
@@ -5765,71 +5703,71 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $i91)
-                          (get_local $i60)
+                          (get_local $46)
+                          (get_local $13)
                         )
                         (i32.store offset=24
-                          (get_local $i60)
-                          (get_local $i92)
+                          (get_local $13)
+                          (get_local $53)
                         )
                         (i32.store offset=12
-                          (get_local $i60)
-                          (get_local $i60)
+                          (get_local $13)
+                          (get_local $13)
                         )
                         (i32.store offset=8
-                          (get_local $i60)
-                          (get_local $i60)
+                          (get_local $13)
+                          (get_local $13)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $i36)
+                        (get_local $8)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $i5
+                            (set_local $2
                               (i32.load
-                                (set_local $i62
+                                (set_local $1
                                   (i32.add
-                                    (get_local $i90)
+                                    (get_local $38)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $i63
+                            (set_local $3
                               (i32.load
                                 (i32.const 192)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $i90)
-                            (get_local $i63)
+                            (get_local $38)
+                            (get_local $3)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $i5)
-                            (get_local $i60)
+                            (get_local $2)
+                            (get_local $13)
                           )
                           (i32.store
-                            (get_local $i62)
-                            (get_local $i60)
+                            (get_local $1)
+                            (get_local $13)
                           )
                           (i32.store offset=8
-                            (get_local $i60)
-                            (get_local $i5)
+                            (get_local $13)
+                            (get_local $2)
                           )
                           (i32.store offset=12
-                            (get_local $i60)
-                            (get_local $i90)
+                            (get_local $13)
+                            (get_local $38)
                           )
                           (i32.store offset=24
-                            (get_local $i60)
+                            (get_local $13)
                             (i32.const 0)
                           )
                         )
@@ -5844,7 +5782,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $i5
+                    (set_local $2
                       (i32.load
                         (i32.const 192)
                       )
@@ -5852,22 +5790,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $i58)
-                    (get_local $i5)
+                    (get_local $20)
+                    (get_local $2)
                   )
                 )
                 (i32.store
                   (i32.const 192)
-                  (get_local $i58)
+                  (get_local $20)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $i58)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $i59)
+                (get_local $22)
               )
               (i32.store
                 (i32.const 636)
@@ -5883,34 +5821,34 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $i5
+              (set_local $2
                 (i32.const 0)
               )
               (loop $do-out$77 $do-in$78
                 (i32.store offset=12
-                  (set_local $i62
+                  (set_local $1
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $i5)
+                          (get_local $2)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $i62)
+                  (get_local $1)
                 )
                 (i32.store offset=8
-                  (get_local $i62)
-                  (get_local $i62)
+                  (get_local $1)
+                  (get_local $1)
                 )
                 (br_if $do-in$78
                   (i32.ne
-                    (set_local $i5
+                    (set_local $2
                       (i32.add
-                        (get_local $i5)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
@@ -5920,18 +5858,18 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $i5
+                (set_local $2
                   (i32.add
-                    (get_local $i58)
-                    (set_local $i62
+                    (get_local $20)
+                    (set_local $1
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $i5
+                            (set_local $2
                               (i32.add
-                                (get_local $i58)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5940,7 +5878,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $i5)
+                            (get_local $2)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5952,27 +5890,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $i63
+                (set_local $3
                   (i32.sub
                     (i32.add
-                      (get_local $i59)
+                      (get_local $22)
                       (i32.const -40)
                     )
-                    (get_local $i62)
+                    (get_local $1)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $i5)
+                (get_local $2)
                 (i32.or
-                  (get_local $i63)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $i5)
-                  (get_local $i63)
+                  (get_local $2)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -5987,53 +5925,53 @@
         )
         (if
           (i32.gt_u
-            (set_local $i59
+            (set_local $22
               (i32.load
                 (i32.const 188)
               )
             )
-            (get_local $i31)
+            (get_local $0)
           )
           (block
             (i32.store
               (i32.const 188)
-              (set_local $i58
+              (set_local $20
                 (i32.sub
-                  (get_local $i59)
-                  (get_local $i31)
+                  (get_local $22)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (set_local $i60
+              (set_local $13
                 (i32.add
-                  (set_local $i59
+                  (set_local $22
                     (i32.load
                       (i32.const 200)
                     )
                   )
-                  (get_local $i31)
+                  (get_local $0)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $i60)
+              (get_local $13)
               (i32.or
-                (get_local $i58)
+                (get_local $20)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $i59)
+              (get_local $22)
               (i32.or
-                (get_local $i31)
+                (get_local $0)
                 (i32.const 3)
               )
             )
             (return
               (i32.add
-                (get_local $i59)
+                (get_local $22)
                 (i32.const 8)
               )
             )
@@ -6047,58 +5985,41 @@
     )
     (i32.const 0)
   )
-  (func $_free (param $i1 i32)
-    (local $i12 i32)
-    (local $i8 i32)
-    (local $i18 i32)
-    (local $i2 i32)
-    (local $i13 i32)
-    (local $i6 i32)
-    (local $i22 i32)
-    (local $i9 i32)
-    (local $i10 i32)
-    (local $i11 i32)
-    (local $i7 i32)
-    (local $i14 i32)
-    (local $i19 i32)
-    (local $i23 i32)
-    (local $i5 i32)
-    (local $i31 i32)
-    (local $i21 i32)
-    (local $i15 i32)
-    (local $i20 i32)
-    (local $i3 i32)
-    (local $i29 i32)
-    (local $i30 i32)
-    (local $i16 i32)
-    (local $i24 i32)
-    (local $i28 i32)
-    (local $i25 i32)
-    (local $i32 i32)
-    (local $i33 i32)
-    (local $i34 i32)
-    (local $i4 i32)
-    (local $i27 i32)
-    (local $i35 i32)
-    (local $i37 i32)
-    (local $i17 i32)
-    (local $i26 i32)
-    (local $i36 i32)
+  (func $_free (param $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
     (if
       (i32.eqz
-        (get_local $i1)
+        (get_local $0)
       )
       (return)
     )
     (if
       (i32.lt_u
-        (set_local $i2
+        (set_local $1
           (i32.add
-            (get_local $i1)
+            (get_local $0)
             (i32.const -8)
           )
         )
-        (set_local $i3
+        (set_local $12
           (i32.load
             (i32.const 192)
           )
@@ -6108,12 +6029,12 @@
     )
     (if
       (i32.eq
-        (set_local $i1
+        (set_local $0
           (i32.and
-            (set_local $i4
+            (set_local $9
               (i32.load
                 (i32.add
-                  (get_local $i1)
+                  (get_local $0)
                   (i32.const -4)
                 )
               )
@@ -6125,12 +6046,12 @@
       )
       (call_import $_abort)
     )
-    (set_local $i6
+    (set_local $8
       (i32.add
-        (get_local $i2)
-        (set_local $i5
+        (get_local $1)
+        (set_local $3
           (i32.and
-            (get_local $i4)
+            (get_local $9)
             (i32.const -8)
           )
         )
@@ -6139,53 +6060,53 @@
     (block $do-once$0
       (if
         (i32.and
-          (get_local $i4)
+          (get_local $9)
           (i32.const 1)
         )
         (block
-          (set_local $i12
-            (get_local $i2)
+          (set_local $2
+            (get_local $1)
           )
-          (set_local $i13
-            (get_local $i5)
+          (set_local $7
+            (get_local $3)
           )
         )
         (block
-          (set_local $i7
+          (set_local $9
             (i32.load
-              (get_local $i2)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $i1)
+              (get_local $0)
             )
             (return)
           )
-          (set_local $i9
+          (set_local $3
             (i32.add
-              (get_local $i7)
-              (get_local $i5)
+              (get_local $9)
+              (get_local $3)
             )
           )
           (if
             (i32.lt_u
-              (set_local $i8
+              (set_local $0
                 (i32.add
-                  (get_local $i2)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $i7)
+                    (get_local $9)
                   )
                 )
               )
-              (get_local $i3)
+              (get_local $12)
             )
             (call_import $_abort)
           )
           (if
             (i32.eq
-              (get_local $i8)
+              (get_local $0)
               (i32.load
                 (i32.const 196)
               )
@@ -6194,11 +6115,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $i11
+                    (set_local $5
                       (i32.load
-                        (set_local $i10
+                        (set_local $1
                           (i32.add
-                            (get_local $i6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -6209,73 +6130,73 @@
                   (i32.const 3)
                 )
                 (block
-                  (set_local $i12
-                    (get_local $i8)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i13
-                    (get_local $i9)
+                  (set_local $7
+                    (get_local $3)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $i9)
+                (get_local $3)
               )
               (i32.store
-                (get_local $i10)
+                (get_local $1)
                 (i32.and
-                  (get_local $i11)
+                  (get_local $5)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $i8)
+                (get_local $0)
                 (i32.or
-                  (get_local $i9)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $i8)
-                  (get_local $i9)
+                  (get_local $0)
+                  (get_local $3)
                 )
-                (get_local $i9)
+                (get_local $3)
               )
               (return)
             )
           )
-          (set_local $i11
+          (set_local $5
             (i32.shr_u
-              (get_local $i7)
+              (get_local $9)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $i7)
+              (get_local $9)
               (i32.const 256)
             )
             (block
-              (set_local $i10
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $i8)
+                  (get_local $0)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $i7
+                  (set_local $9
                     (i32.load offset=8
-                      (get_local $i8)
+                      (get_local $0)
                     )
                   )
-                  (set_local $i14
+                  (set_local $6
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $i11)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6286,17 +6207,17 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i7)
-                      (get_local $i3)
+                      (get_local $9)
+                      (get_local $12)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $i7)
+                        (get_local $9)
                       )
-                      (get_local $i8)
+                      (get_local $0)
                     )
                     (call_import $_abort)
                   )
@@ -6304,8 +6225,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $i10)
-                  (get_local $i7)
+                  (get_local $1)
+                  (get_local $9)
                 )
                 (block
                   (i32.store
@@ -6317,100 +6238,100 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $i11)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
-                  (set_local $i12
-                    (get_local $i8)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i13
-                    (get_local $i9)
+                  (set_local $7
+                    (get_local $3)
                   )
                   (br $do-once$0)
                 )
               )
               (if
                 (i32.ne
-                  (get_local $i10)
-                  (get_local $i14)
+                  (get_local $1)
+                  (get_local $6)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i10)
-                      (get_local $i3)
+                      (get_local $1)
+                      (get_local $12)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i14
+                        (set_local $6
                           (i32.add
-                            (get_local $i10)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $i8)
+                      (get_local $0)
                     )
-                    (set_local $i15
-                      (get_local $i14)
+                    (set_local $11
+                      (get_local $6)
                     )
                     (call_import $_abort)
                   )
                 )
-                (set_local $i15
+                (set_local $11
                   (i32.add
-                    (get_local $i10)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $i7)
-                (get_local $i10)
+                (get_local $9)
+                (get_local $1)
               )
               (i32.store
-                (get_local $i15)
-                (get_local $i7)
+                (get_local $11)
+                (get_local $9)
               )
-              (set_local $i12
-                (get_local $i8)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $i13
-                (get_local $i9)
+              (set_local $7
+                (get_local $3)
               )
               (br $do-once$0)
             )
           )
-          (set_local $i7
+          (set_local $9
             (i32.load offset=24
-              (get_local $i8)
+              (get_local $0)
             )
           )
           (block $do-once$2
             (if
               (i32.eq
-                (set_local $i10
+                (set_local $1
                   (i32.load offset=12
-                    (get_local $i8)
+                    (get_local $0)
                   )
                 )
-                (get_local $i8)
+                (get_local $0)
               )
               (block
                 (if
-                  (set_local $i16
+                  (set_local $11
                     (i32.load
-                      (set_local $i11
+                      (set_local $5
                         (i32.add
-                          (set_local $i14
+                          (set_local $6
                             (i32.add
-                              (get_local $i8)
+                              (get_local $0)
                               (i32.const 16)
                             )
                           )
@@ -6420,29 +6341,25 @@
                     )
                   )
                   (block
-                    (set_local $i19
-                      (get_local $i16)
+                    (set_local $1
+                      (get_local $11)
                     )
-                    (set_local $i20
-                      (get_local $i11)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                   (if
-                    (set_local $i17
+                    (set_local $1
                       (i32.load
-                        (get_local $i14)
+                        (get_local $6)
                       )
                     )
                     (block
-                      (set_local $i19
-                        (get_local $i17)
-                      )
-                      (set_local $i20
-                        (get_local $i14)
-                      )
+                      (get_local $1)
+                      (get_local $6)
                     )
                     (block
-                      (set_local $i18
+                      (set_local $4
                         (i32.const 0)
                       )
                       (br $do-once$2)
@@ -6451,51 +6368,51 @@
                 )
                 (loop $while-out$4 $while-in$5
                   (if
-                    (set_local $i16
+                    (set_local $11
                       (i32.load
-                        (set_local $i11
+                        (set_local $5
                           (i32.add
-                            (get_local $i19)
+                            (get_local $1)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $i19
-                        (get_local $i16)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $i20
-                        (get_local $i11)
+                      (set_local $6
+                        (get_local $5)
                       )
                       (br $while-in$5)
                     )
                   )
                   (if
-                    (set_local $i16
+                    (set_local $11
                       (i32.load
-                        (set_local $i11
+                        (set_local $5
                           (i32.add
-                            (get_local $i19)
+                            (get_local $1)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $i19
-                        (get_local $i16)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $i20
-                        (get_local $i11)
+                      (set_local $6
+                        (get_local $5)
                       )
                     )
                     (block
-                      (set_local $i21
-                        (get_local $i19)
+                      (set_local $5
+                        (get_local $1)
                       )
-                      (set_local $i22
-                        (get_local $i20)
+                      (set_local $10
+                        (get_local $6)
                       )
                       (br $while-out$4)
                     )
@@ -6504,17 +6421,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $i22)
-                    (get_local $i3)
+                    (get_local $10)
+                    (get_local $12)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store
-                      (get_local $i22)
+                      (get_local $10)
                       (i32.const 0)
                     )
-                    (set_local $i18
-                      (get_local $i21)
+                    (set_local $4
+                      (get_local $5)
                     )
                   )
                 )
@@ -6522,52 +6439,52 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $i11
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $i8)
+                        (get_local $0)
                       )
                     )
-                    (get_local $i3)
+                    (get_local $12)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.ne
                     (i32.load
-                      (set_local $i16
+                      (set_local $11
                         (i32.add
-                          (get_local $i11)
+                          (get_local $5)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $i8)
+                    (get_local $0)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $i14
+                      (set_local $6
                         (i32.add
-                          (get_local $i10)
+                          (get_local $1)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $i8)
+                    (get_local $0)
                   )
                   (block
                     (i32.store
-                      (get_local $i16)
-                      (get_local $i10)
+                      (get_local $11)
+                      (get_local $1)
                     )
                     (i32.store
-                      (get_local $i14)
-                      (get_local $i11)
+                      (get_local $6)
+                      (get_local $5)
                     )
-                    (set_local $i18
-                      (get_local $i10)
+                    (set_local $4
+                      (get_local $1)
                     )
                   )
                   (call_import $_abort)
@@ -6576,19 +6493,19 @@
             )
           )
           (if
-            (get_local $i7)
+            (get_local $9)
             (block
               (if
                 (i32.eq
-                  (get_local $i8)
+                  (get_local $0)
                   (i32.load
-                    (set_local $i11
+                    (set_local $5
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (set_local $i10
+                          (set_local $1
                             (i32.load offset=28
-                              (get_local $i8)
+                              (get_local $0)
                             )
                           )
                           (i32.const 2)
@@ -6599,12 +6516,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $i11)
-                    (get_local $i18)
+                    (get_local $5)
+                    (get_local $4)
                   )
                   (if
                     (i32.eqz
-                      (get_local $i18)
+                      (get_local $4)
                     )
                     (block
                       (i32.store
@@ -6616,17 +6533,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $i10)
+                              (get_local $1)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $i12
-                        (get_local $i8)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $i13
-                        (get_local $i9)
+                      (set_local $7
+                        (get_local $3)
                       )
                       (br $do-once$0)
                     )
@@ -6635,7 +6552,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i7)
+                      (get_local $9)
                       (i32.load
                         (i32.const 192)
                       )
@@ -6645,34 +6562,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i10
+                        (set_local $1
                           (i32.add
-                            (get_local $i7)
+                            (get_local $9)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $i8)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $i10)
-                      (get_local $i18)
+                      (get_local $1)
+                      (get_local $4)
                     )
                     (i32.store offset=20
-                      (get_local $i7)
-                      (get_local $i18)
+                      (get_local $9)
+                      (get_local $4)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $i18)
+                      (get_local $4)
                     )
                     (block
-                      (set_local $i12
-                        (get_local $i8)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $i13
-                        (get_local $i9)
+                      (set_local $7
+                        (get_local $3)
                       )
                       (br $do-once$0)
                     )
@@ -6681,8 +6598,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $i18)
-                  (set_local $i10
+                  (get_local $4)
+                  (set_local $1
                     (i32.load
                       (i32.const 192)
                     )
@@ -6691,15 +6608,15 @@
                 (call_import $_abort)
               )
               (i32.store offset=24
-                (get_local $i18)
-                (get_local $i7)
+                (get_local $4)
+                (get_local $9)
               )
               (if
-                (set_local $i14
+                (set_local $6
                   (i32.load
-                    (set_local $i11
+                    (set_local $5
                       (i32.add
-                        (get_local $i8)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
@@ -6707,31 +6624,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $i14)
-                    (get_local $i10)
+                    (get_local $6)
+                    (get_local $1)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $i18)
-                      (get_local $i14)
+                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $i14)
-                      (get_local $i18)
+                      (get_local $6)
+                      (get_local $4)
                     )
                   )
                 )
               )
               (if
-                (set_local $i14
+                (set_local $6
                   (i32.load offset=4
-                    (get_local $i11)
+                    (get_local $5)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $i14)
+                    (get_local $6)
                     (i32.load
                       (i32.const 192)
                     )
@@ -6739,37 +6656,37 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $i18)
-                      (get_local $i14)
+                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $i14)
-                      (get_local $i18)
+                      (get_local $6)
+                      (get_local $4)
                     )
-                    (set_local $i12
-                      (get_local $i8)
+                    (set_local $2
+                      (get_local $0)
                     )
-                    (set_local $i13
-                      (get_local $i9)
+                    (set_local $7
+                      (get_local $3)
                     )
                   )
                 )
                 (block
-                  (set_local $i12
-                    (get_local $i8)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i13
-                    (get_local $i9)
+                  (set_local $7
+                    (get_local $3)
                   )
                 )
               )
             )
             (block
-              (set_local $i12
-                (get_local $i8)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $i13
-                (get_local $i9)
+              (set_local $7
+                (get_local $3)
               )
             )
           )
@@ -6778,19 +6695,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $i12)
-        (get_local $i6)
+        (get_local $2)
+        (get_local $8)
       )
       (call_import $_abort)
     )
     (if
       (i32.eqz
         (i32.and
-          (set_local $i2
+          (set_local $1
             (i32.load
-              (set_local $i5
+              (set_local $3
                 (i32.add
-                  (get_local $i6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -6803,39 +6720,39 @@
     )
     (if
       (i32.and
-        (get_local $i2)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $i5)
+          (get_local $3)
           (i32.and
-            (get_local $i2)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $i12)
+          (get_local $2)
           (i32.or
-            (get_local $i13)
+            (get_local $7)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $i12)
-            (get_local $i13)
+            (get_local $2)
+            (get_local $7)
           )
-          (get_local $i13)
+          (get_local $7)
         )
-        (set_local $i29
-          (get_local $i13)
+        (set_local $0
+          (get_local $7)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $i6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -6843,29 +6760,29 @@
           (block
             (i32.store
               (i32.const 188)
-              (set_local $i18
+              (set_local $4
                 (i32.add
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $i13)
+                  (get_local $7)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $i12)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $i12)
+              (get_local $2)
               (i32.or
-                (get_local $i18)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (if
               (i32.ne
-                (get_local $i12)
+                (get_local $2)
                 (i32.load
                   (i32.const 196)
                 )
@@ -6885,7 +6802,7 @@
         )
         (if
           (i32.eq
-            (get_local $i6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -6893,82 +6810,82 @@
           (block
             (i32.store
               (i32.const 184)
-              (set_local $i18
+              (set_local $4
                 (i32.add
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $i13)
+                  (get_local $7)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $i12)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $i12)
+              (get_local $2)
               (i32.or
-                (get_local $i18)
+                (get_local $4)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $i12)
-                (get_local $i18)
+                (get_local $2)
+                (get_local $4)
               )
-              (get_local $i18)
+              (get_local $4)
             )
             (return)
           )
         )
-        (set_local $i18
+        (set_local $4
           (i32.add
             (i32.and
-              (get_local $i2)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $i13)
+            (get_local $7)
           )
         )
-        (set_local $i3
+        (set_local $12
           (i32.shr_u
-            (get_local $i2)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once$8
           (if
             (i32.ge_u
-              (get_local $i2)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $i21
+              (set_local $5
                 (i32.load offset=24
-                  (get_local $i6)
+                  (get_local $8)
                 )
               )
               (block $do-once$10
                 (if
                   (i32.eq
-                    (set_local $i22
+                    (set_local $10
                       (i32.load offset=12
-                        (get_local $i6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $i6)
+                    (get_local $8)
                   )
                   (block
                     (if
-                      (set_local $i15
+                      (set_local $11
                         (i32.load
-                          (set_local $i19
+                          (set_local $1
                             (i32.add
-                              (set_local $i20
+                              (set_local $6
                                 (i32.add
-                                  (get_local $i6)
+                                  (get_local $8)
                                   (i32.const 16)
                                 )
                               )
@@ -6978,29 +6895,27 @@
                         )
                       )
                       (block
-                        (set_local $i24
-                          (get_local $i15)
+                        (set_local $0
+                          (get_local $11)
                         )
-                        (set_local $i25
-                          (get_local $i19)
+                        (set_local $12
+                          (get_local $1)
                         )
                       )
                       (if
-                        (set_local $i1
+                        (set_local $0
                           (i32.load
-                            (get_local $i20)
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $i24
-                            (get_local $i1)
-                          )
-                          (set_local $i25
-                            (get_local $i20)
+                          (get_local $0)
+                          (set_local $12
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $i23
+                          (set_local $13
                             (i32.const 0)
                           )
                           (br $do-once$10)
@@ -7009,51 +6924,49 @@
                     )
                     (loop $while-out$12 $while-in$13
                       (if
-                        (set_local $i15
+                        (set_local $11
                           (i32.load
-                            (set_local $i19
+                            (set_local $1
                               (i32.add
-                                (get_local $i24)
+                                (get_local $0)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $i24
-                            (get_local $i15)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $i25
-                            (get_local $i19)
+                          (set_local $12
+                            (get_local $1)
                           )
                           (br $while-in$13)
                         )
                       )
                       (if
-                        (set_local $i15
+                        (set_local $11
                           (i32.load
-                            (set_local $i19
+                            (set_local $1
                               (i32.add
-                                (get_local $i24)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $i24
-                            (get_local $i15)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $i25
-                            (get_local $i19)
+                          (set_local $12
+                            (get_local $1)
                           )
                         )
                         (block
-                          (set_local $i26
-                            (get_local $i24)
-                          )
-                          (set_local $i27
-                            (get_local $i25)
+                          (get_local $0)
+                          (set_local $1
+                            (get_local $12)
                           )
                           (br $while-out$12)
                         )
@@ -7062,7 +6975,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i27)
+                        (get_local $1)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7070,11 +6983,11 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $i27)
+                          (get_local $1)
                           (i32.const 0)
                         )
-                        (set_local $i23
-                          (get_local $i26)
+                        (set_local $13
+                          (get_local $0)
                         )
                       )
                     )
@@ -7082,9 +6995,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (set_local $i19
+                        (set_local $1
                           (i32.load offset=8
-                            (get_local $i6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -7096,40 +7009,40 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $i15
+                          (set_local $11
                             (i32.add
-                              (get_local $i19)
+                              (get_local $1)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $i6)
+                        (get_local $8)
                       )
                       (call_import $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $i20
+                          (set_local $6
                             (i32.add
-                              (get_local $i22)
+                              (get_local $10)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $i6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $i15)
-                          (get_local $i22)
+                          (get_local $11)
+                          (get_local $10)
                         )
                         (i32.store
-                          (get_local $i20)
-                          (get_local $i19)
+                          (get_local $6)
+                          (get_local $1)
                         )
-                        (set_local $i23
-                          (get_local $i22)
+                        (set_local $13
+                          (get_local $10)
                         )
                       )
                       (call_import $_abort)
@@ -7138,19 +7051,19 @@
                 )
               )
               (if
-                (get_local $i21)
+                (get_local $5)
                 (block
                   (if
                     (i32.eq
-                      (get_local $i6)
+                      (get_local $8)
                       (i32.load
-                        (set_local $i9
+                        (set_local $3
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (set_local $i22
+                              (set_local $10
                                 (i32.load offset=28
-                                  (get_local $i6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -7161,12 +7074,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $i9)
-                        (get_local $i23)
+                        (get_local $3)
+                        (get_local $13)
                       )
                       (if
                         (i32.eqz
-                          (get_local $i23)
+                          (get_local $13)
                         )
                         (block
                           (i32.store
@@ -7178,7 +7091,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $i22)
+                                  (get_local $10)
                                 )
                                 (i32.const -1)
                               )
@@ -7191,7 +7104,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $i21)
+                          (get_local $5)
                           (i32.load
                             (i32.const 192)
                           )
@@ -7201,35 +7114,35 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $i22
+                            (set_local $10
                               (i32.add
-                                (get_local $i21)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $i6)
+                          (get_local $8)
                         )
                         (i32.store
-                          (get_local $i22)
-                          (get_local $i23)
+                          (get_local $10)
+                          (get_local $13)
                         )
                         (i32.store offset=20
-                          (get_local $i21)
-                          (get_local $i23)
+                          (get_local $5)
+                          (get_local $13)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eqz
-                          (get_local $i23)
+                          (get_local $13)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $i23)
-                      (set_local $i22
+                      (get_local $13)
+                      (set_local $10
                         (i32.load
                           (i32.const 192)
                         )
@@ -7238,15 +7151,15 @@
                     (call_import $_abort)
                   )
                   (i32.store offset=24
-                    (get_local $i23)
-                    (get_local $i21)
+                    (get_local $13)
+                    (get_local $5)
                   )
                   (if
-                    (set_local $i8
+                    (set_local $0
                       (i32.load
-                        (set_local $i9
+                        (set_local $3
                           (i32.add
-                            (get_local $i6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
@@ -7254,31 +7167,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i8)
-                        (get_local $i22)
+                        (get_local $0)
+                        (get_local $10)
                       )
                       (call_import $_abort)
                       (block
                         (i32.store offset=16
-                          (get_local $i23)
-                          (get_local $i8)
+                          (get_local $13)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $i8)
-                          (get_local $i23)
+                          (get_local $0)
+                          (get_local $13)
                         )
                       )
                     )
                   )
                   (if
-                    (set_local $i8
+                    (set_local $0
                       (i32.load offset=4
-                        (get_local $i9)
+                        (get_local $3)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $i8)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -7286,12 +7199,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=20
-                          (get_local $i23)
-                          (get_local $i8)
+                          (get_local $13)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $i8)
-                          (get_local $i23)
+                          (get_local $0)
+                          (get_local $13)
                         )
                       )
                     )
@@ -7300,24 +7213,24 @@
               )
             )
             (block
-              (set_local $i22
+              (set_local $10
                 (i32.load offset=12
-                  (get_local $i6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $i8
+                  (set_local $0
                     (i32.load offset=8
-                      (get_local $i6)
+                      (get_local $8)
                     )
                   )
-                  (set_local $i21
+                  (set_local $5
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $i3)
+                          (get_local $12)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -7328,7 +7241,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i8)
+                      (get_local $0)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7338,9 +7251,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $i8)
+                        (get_local $0)
                       )
-                      (get_local $i6)
+                      (get_local $8)
                     )
                     (call_import $_abort)
                   )
@@ -7348,8 +7261,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $i22)
-                  (get_local $i8)
+                  (get_local $10)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
@@ -7361,7 +7274,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $i3)
+                          (get_local $12)
                         )
                         (i32.const -1)
                       )
@@ -7372,13 +7285,13 @@
               )
               (if
                 (i32.ne
-                  (get_local $i22)
-                  (get_local $i21)
+                  (get_local $10)
+                  (get_local $5)
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $i22)
+                      (get_local $10)
                       (i32.load
                         (i32.const 192)
                       )
@@ -7388,56 +7301,56 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $i21
+                        (set_local $5
                           (i32.add
-                            (get_local $i22)
+                            (get_local $10)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $i6)
+                      (get_local $8)
                     )
-                    (set_local $i28
-                      (get_local $i21)
+                    (set_local $16
+                      (get_local $5)
                     )
                     (call_import $_abort)
                   )
                 )
-                (set_local $i28
+                (set_local $16
                   (i32.add
-                    (get_local $i22)
+                    (get_local $10)
                     (i32.const 8)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $i8)
-                (get_local $i22)
+                (get_local $0)
+                (get_local $10)
               )
               (i32.store
-                (get_local $i28)
-                (get_local $i8)
+                (get_local $16)
+                (get_local $0)
               )
             )
           )
         )
         (i32.store offset=4
-          (get_local $i12)
+          (get_local $2)
           (i32.or
-            (get_local $i18)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $i12)
-            (get_local $i18)
+            (get_local $2)
+            (get_local $4)
           )
-          (get_local $i18)
+          (get_local $4)
         )
         (if
           (i32.eq
-            (get_local $i12)
+            (get_local $2)
             (i32.load
               (i32.const 196)
             )
@@ -7445,34 +7358,34 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $i18)
+              (get_local $4)
             )
             (return)
           )
-          (set_local $i29
-            (get_local $i18)
+          (set_local $0
+            (get_local $4)
           )
         )
       )
     )
-    (set_local $i13
+    (set_local $7
       (i32.shr_u
-        (get_local $i29)
+        (get_local $0)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $i29)
+        (get_local $0)
         (i32.const 256)
       )
       (block
-        (set_local $i2
+        (set_local $1
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $i13)
+                (get_local $7)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7481,25 +7394,25 @@
         )
         (if
           (i32.and
-            (set_local $i5
+            (set_local $3
               (i32.load
                 (i32.const 176)
               )
             )
-            (set_local $i18
+            (set_local $4
               (i32.shl
                 (i32.const 1)
-                (get_local $i13)
+                (get_local $7)
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $i28
+              (set_local $16
                 (i32.load
-                  (set_local $i13
+                  (set_local $7
                     (i32.add
-                      (get_local $i2)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -7511,11 +7424,11 @@
             )
             (call_import $_abort)
             (block
-              (set_local $i30
-                (get_local $i13)
+              (set_local $15
+                (get_local $7)
               )
-              (set_local $i31
-                (get_local $i28)
+              (set_local $14
+                (get_local $16)
               )
             )
           )
@@ -7523,81 +7436,81 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $i5)
-                (get_local $i18)
+                (get_local $3)
+                (get_local $4)
               )
             )
-            (set_local $i30
+            (set_local $15
               (i32.add
-                (get_local $i2)
+                (get_local $1)
                 (i32.const 8)
               )
             )
-            (set_local $i31
-              (get_local $i2)
+            (set_local $14
+              (get_local $1)
             )
           )
         )
         (i32.store
-          (get_local $i30)
-          (get_local $i12)
+          (get_local $15)
+          (get_local $2)
         )
         (i32.store offset=12
-          (get_local $i31)
-          (get_local $i12)
+          (get_local $14)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $i12)
-          (get_local $i31)
+          (get_local $2)
+          (get_local $14)
         )
         (i32.store offset=12
-          (get_local $i12)
-          (get_local $i2)
+          (get_local $2)
+          (get_local $1)
         )
         (return)
       )
     )
-    (set_local $i5
+    (set_local $3
       (i32.add
         (i32.const 480)
         (i32.shl
-          (set_local $i32
+          (set_local $1
             (if
-              (set_local $i2
+              (set_local $1
                 (i32.shr_u
-                  (get_local $i29)
+                  (get_local $0)
                   (i32.const 8)
                 )
               )
               (if
                 (i32.gt_u
-                  (get_local $i29)
+                  (get_local $0)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $i29)
+                      (get_local $0)
                       (i32.add
-                        (set_local $i5
+                        (set_local $3
                           (i32.add
                             (i32.sub
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (set_local $i2
+                                  (set_local $1
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (set_local $i30
+                                          (set_local $15
                                             (i32.shl
-                                              (get_local $i2)
-                                              (set_local $i31
+                                              (get_local $1)
+                                              (set_local $14
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (get_local $i2)
+                                                      (get_local $1)
                                                       (i32.const 1048320)
                                                     )
                                                     (i32.const 16)
@@ -7614,16 +7527,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $i31)
+                                  (get_local $14)
                                 )
-                                (set_local $i30
+                                (set_local $15
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $i18
+                                        (set_local $4
                                           (i32.shl
-                                            (get_local $i30)
-                                            (get_local $i2)
+                                            (get_local $15)
+                                            (get_local $1)
                                           )
                                         )
                                         (i32.const 245760)
@@ -7637,8 +7550,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $i18)
-                                (get_local $i30)
+                                (get_local $4)
+                                (get_local $15)
                               )
                               (i32.const 15)
                             )
@@ -7650,7 +7563,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $i5)
+                    (get_local $3)
                     (i32.const 1)
                   )
                 )
@@ -7663,54 +7576,54 @@
       )
     )
     (i32.store offset=28
-      (get_local $i12)
-      (get_local $i32)
+      (get_local $2)
+      (get_local $1)
     )
     (i32.store offset=20
-      (get_local $i12)
+      (get_local $2)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $i12)
+      (get_local $2)
       (i32.const 0)
     )
     (if
       (i32.and
-        (set_local $i30
+        (set_local $15
           (i32.load
             (i32.const 180)
           )
         )
-        (set_local $i18
+        (set_local $4
           (i32.shl
             (i32.const 1)
-            (get_local $i32)
+            (get_local $1)
           )
         )
       )
       (block
-        (set_local $i31
+        (set_local $14
           (i32.shl
-            (get_local $i29)
+            (get_local $0)
             (select
               (i32.const 0)
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $i32)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $i32)
+                (get_local $1)
                 (i32.const 31)
               )
             )
           )
         )
-        (set_local $i2
+        (set_local $1
           (i32.load
-            (get_local $i5)
+            (get_local $3)
           )
         )
         (loop $while-out$18 $while-in$19
@@ -7718,34 +7631,34 @@
             (i32.eq
               (i32.and
                 (i32.load offset=4
-                  (get_local $i2)
+                  (get_local $1)
                 )
                 (i32.const -8)
               )
-              (get_local $i29)
+              (get_local $0)
             )
             (block
-              (set_local $i33
-                (get_local $i2)
+              (set_local $17
+                (get_local $1)
               )
-              (set_local $i34
+              (set_local $0
                 (i32.const 130)
               )
               (br $while-out$18)
             )
           )
           (if
-            (set_local $i13
+            (set_local $7
               (i32.load
-                (set_local $i28
+                (set_local $16
                   (i32.add
                     (i32.add
-                      (get_local $i2)
+                      (get_local $1)
                       (i32.const 16)
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $i31)
+                        (get_local $14)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7755,24 +7668,24 @@
               )
             )
             (block
-              (set_local $i31
+              (set_local $14
                 (i32.shl
-                  (get_local $i31)
+                  (get_local $14)
                   (i32.const 1)
                 )
               )
-              (set_local $i2
-                (get_local $i13)
+              (set_local $1
+                (get_local $7)
               )
             )
             (block
-              (set_local $i35
-                (get_local $i28)
+              (set_local $18
+                (get_local $16)
               )
-              (set_local $i36
-                (get_local $i2)
+              (set_local $19
+                (get_local $1)
               )
-              (set_local $i34
+              (set_local $0
                 (i32.const 127)
               )
               (br $while-out$18)
@@ -7782,12 +7695,12 @@
         )
         (if
           (i32.eq
-            (get_local $i34)
+            (get_local $0)
             (i32.const 127)
           )
           (if
             (i32.lt_u
-              (get_local $i35)
+              (get_local $18)
               (i32.load
                 (i32.const 192)
               )
@@ -7795,71 +7708,71 @@
             (call_import $_abort)
             (block
               (i32.store
-                (get_local $i35)
-                (get_local $i12)
+                (get_local $18)
+                (get_local $2)
               )
               (i32.store offset=24
-                (get_local $i12)
-                (get_local $i36)
+                (get_local $2)
+                (get_local $19)
               )
               (i32.store offset=12
-                (get_local $i12)
-                (get_local $i12)
+                (get_local $2)
+                (get_local $2)
               )
               (i32.store offset=8
-                (get_local $i12)
-                (get_local $i12)
+                (get_local $2)
+                (get_local $2)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $i34)
+              (get_local $0)
               (i32.const 130)
             )
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $i31
+                  (set_local $14
                     (i32.load
-                      (set_local $i2
+                      (set_local $1
                         (i32.add
-                          (get_local $i33)
+                          (get_local $17)
                           (i32.const 8)
                         )
                       )
                     )
                   )
-                  (set_local $i9
+                  (set_local $3
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.ge_u
-                  (get_local $i33)
-                  (get_local $i9)
+                  (get_local $17)
+                  (get_local $3)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $i31)
-                  (get_local $i12)
+                  (get_local $14)
+                  (get_local $2)
                 )
                 (i32.store
-                  (get_local $i2)
-                  (get_local $i12)
+                  (get_local $1)
+                  (get_local $2)
                 )
                 (i32.store offset=8
-                  (get_local $i12)
-                  (get_local $i31)
+                  (get_local $2)
+                  (get_local $14)
                 )
                 (i32.store offset=12
-                  (get_local $i12)
-                  (get_local $i33)
+                  (get_local $2)
+                  (get_local $17)
                 )
                 (i32.store offset=24
-                  (get_local $i12)
+                  (get_local $2)
                   (i32.const 0)
                 )
               )
@@ -7872,31 +7785,31 @@
         (i32.store
           (i32.const 180)
           (i32.or
-            (get_local $i30)
-            (get_local $i18)
+            (get_local $15)
+            (get_local $4)
           )
         )
         (i32.store
-          (get_local $i5)
-          (get_local $i12)
+          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=24
-          (get_local $i12)
-          (get_local $i5)
+          (get_local $2)
+          (get_local $3)
         )
         (i32.store offset=12
-          (get_local $i12)
-          (get_local $i12)
+          (get_local $2)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $i12)
-          (get_local $i12)
+          (get_local $2)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 208)
-      (set_local $i12
+      (set_local $2
         (i32.add
           (i32.load
             (i32.const 208)
@@ -7906,22 +7819,22 @@
       )
     )
     (if
-      (get_local $i12)
+      (get_local $2)
       (return)
-      (set_local $i37
+      (set_local $0
         (i32.const 632)
       )
     )
     (loop $while-out$20 $while-in$21
       (if
-        (set_local $i12
+        (set_local $2
           (i32.load
-            (get_local $i37)
+            (get_local $0)
           )
         )
-        (set_local $i37
+        (set_local $0
           (i32.add
-            (get_local $i12)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -7934,29 +7847,24 @@
       (i32.const -1)
     )
   )
-  (func $___stdio_write (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i7 i32)
-    (local $i12 i32)
-    (local $i14 i32)
-    (local $i9 i32)
-    (local $i21 i32)
-    (local $i8 i32)
-    (local $i11 i32)
-    (local $i13 i32)
-    (local $i4 i32)
-    (local $i5 i32)
-    (local $i6 i32)
-    (local $i20 i32)
-    (local $i10 i32)
-    (local $i15 i32)
-    (local $i18 i32)
-    (local $i22 i32)
-    (local $i24 i32)
-    (local $i16 i32)
-    (local $i17 i32)
-    (local $i19 i32)
-    (local $i23 i32)
-    (set_local $i4
+  (func $___stdio_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (set_local $11
       (i32.load
         (i32.const 8)
       )
@@ -7970,27 +7878,27 @@
         (i32.const 48)
       )
     )
-    (set_local $i5
+    (set_local $12
       (i32.add
-        (get_local $i4)
+        (get_local $11)
         (i32.const 16)
       )
     )
-    (set_local $i6
-      (get_local $i4)
+    (set_local $13
+      (get_local $11)
     )
     (i32.store
-      (set_local $i7
+      (set_local $3
         (i32.add
-          (get_local $i4)
+          (get_local $11)
           (i32.const 32)
         )
       )
-      (set_local $i9
+      (set_local $8
         (i32.load
-          (set_local $i8
+          (set_local $9
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -7998,55 +7906,55 @@
       )
     )
     (i32.store offset=4
-      (get_local $i7)
-      (set_local $i11
+      (get_local $3)
+      (set_local $10
         (i32.sub
           (i32.load
-            (set_local $i10
+            (set_local $14
               (i32.add
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $i9)
+          (get_local $8)
         )
       )
     )
     (i32.store offset=8
-      (get_local $i7)
-      (get_local $i2)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $i7)
-      (get_local $i3)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $i2
+    (set_local $1
       (i32.add
-        (get_local $i1)
+        (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $i9
+    (set_local $8
       (i32.add
-        (get_local $i1)
+        (get_local $0)
         (i32.const 44)
       )
     )
-    (set_local $i12
-      (get_local $i7)
+    (set_local $5
+      (get_local $3)
     )
-    (set_local $i7
+    (set_local $3
       (i32.const 2)
     )
-    (set_local $i13
+    (set_local $6
       (i32.add
-        (get_local $i11)
-        (get_local $i3)
+        (get_local $10)
+        (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $i14
+      (set_local $4
         (if
           (i32.load
             (i32.const 8)
@@ -8054,54 +7962,54 @@
           (block
             (call_import $_pthread_cleanup_push
               (i32.const 4)
-              (get_local $i1)
+              (get_local $0)
             )
             (i32.store
-              (get_local $i6)
+              (get_local $13)
               (i32.load
-                (get_local $i2)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $i6)
-              (get_local $i12)
+              (get_local $13)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $i6)
-              (get_local $i7)
+              (get_local $13)
+              (get_local $3)
             )
-            (set_local $i11
+            (set_local $10
               (call $___syscall_ret
                 (call_import $___syscall146
                   (i32.const 146)
-                  (get_local $i6)
+                  (get_local $13)
                 )
               )
             )
             (call_import $_pthread_cleanup_pop
               (i32.const 0)
             )
-            (get_local $i11)
+            (get_local $10)
           )
           (block
             (i32.store
-              (get_local $i5)
+              (get_local $12)
               (i32.load
-                (get_local $i2)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $i5)
-              (get_local $i12)
+              (get_local $12)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $i5)
-              (get_local $i7)
+              (get_local $12)
+              (get_local $3)
             )
             (call $___syscall_ret
               (call_import $___syscall146
                 (i32.const 146)
-                (get_local $i5)
+                (get_local $12)
               )
             )
           )
@@ -8109,11 +8017,11 @@
       )
       (if
         (i32.eq
-          (get_local $i13)
-          (get_local $i14)
+          (get_local $6)
+          (get_local $4)
         )
         (block
-          (set_local $i15
+          (set_local $1
             (i32.const 6)
           )
           (br $while-out$0)
@@ -8121,212 +8029,208 @@
       )
       (if
         (i32.lt_s
-          (get_local $i14)
+          (get_local $4)
           (i32.const 0)
         )
         (block
-          (set_local $i16
-            (get_local $i12)
+          (set_local $17
+            (get_local $5)
           )
-          (set_local $i17
-            (get_local $i7)
+          (set_local $18
+            (get_local $3)
           )
-          (set_local $i15
+          (set_local $1
             (i32.const 8)
           )
           (br $while-out$0)
         )
       )
-      (set_local $i11
+      (set_local $10
         (i32.sub
-          (get_local $i13)
-          (get_local $i14)
+          (get_local $6)
+          (get_local $4)
         )
       )
-      (set_local $i19
+      (set_local $3
         (if
           (i32.le_u
-            (get_local $i14)
-            (set_local $i18
+            (get_local $4)
+            (set_local $6
               (i32.load offset=4
-                (get_local $i12)
+                (get_local $5)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $i7)
+              (get_local $3)
               (i32.const 2)
             )
             (block
               (i32.store
-                (get_local $i8)
+                (get_local $9)
                 (i32.add
                   (i32.load
-                    (get_local $i8)
+                    (get_local $9)
                   )
-                  (get_local $i14)
+                  (get_local $4)
                 )
               )
-              (set_local $i20
-                (get_local $i14)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $i21
-                (get_local $i12)
-              )
-              (set_local $i22
+              (set_local $15
                 (i32.const 2)
               )
-              (get_local $i18)
+              (get_local $6)
             )
             (block
-              (set_local $i20
-                (get_local $i14)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $i21
-                (get_local $i12)
+              (set_local $15
+                (get_local $3)
               )
-              (set_local $i22
-                (get_local $i7)
-              )
-              (get_local $i18)
+              (get_local $6)
             )
           )
           (block
             (i32.store
-              (get_local $i8)
-              (set_local $i23
+              (get_local $9)
+              (set_local $7
                 (i32.load
-                  (get_local $i9)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
-              (get_local $i10)
-              (get_local $i23)
+              (get_local $14)
+              (get_local $7)
             )
-            (set_local $i20
+            (set_local $4
               (i32.sub
-                (get_local $i14)
-                (get_local $i18)
+                (get_local $4)
+                (get_local $6)
               )
             )
-            (set_local $i21
+            (set_local $7
               (i32.add
-                (get_local $i12)
+                (get_local $5)
                 (i32.const 8)
               )
             )
-            (set_local $i22
+            (set_local $15
               (i32.add
-                (get_local $i7)
+                (get_local $3)
                 (i32.const -1)
               )
             )
             (i32.load offset=12
-              (get_local $i12)
+              (get_local $5)
             )
           )
         )
       )
       (i32.store
-        (get_local $i21)
+        (get_local $7)
         (i32.add
           (i32.load
-            (get_local $i21)
+            (get_local $7)
           )
-          (get_local $i20)
+          (get_local $4)
         )
       )
       (i32.store offset=4
-        (get_local $i21)
+        (get_local $7)
         (i32.sub
-          (get_local $i19)
-          (get_local $i20)
+          (get_local $3)
+          (get_local $4)
         )
       )
-      (set_local $i12
-        (get_local $i21)
+      (set_local $5
+        (get_local $7)
       )
-      (set_local $i7
-        (get_local $i22)
+      (set_local $3
+        (get_local $15)
       )
-      (set_local $i13
-        (get_local $i11)
+      (set_local $6
+        (get_local $10)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $i15)
+        (get_local $1)
         (i32.const 6)
       )
       (block
         (i32.store offset=16
-          (get_local $i1)
+          (get_local $0)
           (i32.add
-            (set_local $i13
+            (set_local $6
               (i32.load
-                (get_local $i9)
+                (get_local $8)
               )
             )
             (i32.load offset=48
-              (get_local $i1)
+              (get_local $0)
             )
           )
         )
         (i32.store
-          (get_local $i8)
-          (set_local $i9
-            (get_local $i13)
+          (get_local $9)
+          (set_local $8
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $i10)
-          (get_local $i9)
+          (get_local $14)
+          (get_local $8)
         )
-        (set_local $i24
-          (get_local $i3)
+        (set_local $16
+          (get_local $2)
         )
       )
       (if
         (i32.eq
-          (get_local $i15)
+          (get_local $1)
           (i32.const 8)
         )
         (block
           (i32.store offset=16
-            (get_local $i1)
+            (get_local $0)
             (i32.const 0)
           )
           (i32.store
-            (get_local $i8)
+            (get_local $9)
             (i32.const 0)
           )
           (i32.store
-            (get_local $i10)
+            (get_local $14)
             (i32.const 0)
           )
           (i32.store
-            (get_local $i1)
+            (get_local $0)
             (i32.or
               (i32.load
-                (get_local $i1)
+                (get_local $0)
               )
               (i32.const 32)
             )
           )
-          (set_local $i24
+          (set_local $16
             (if
               (i32.eq
-                (get_local $i17)
+                (get_local $18)
                 (i32.const 2)
               )
               (i32.const 0)
               (i32.sub
-                (get_local $i3)
+                (get_local $2)
                 (i32.load offset=4
-                  (get_local $i16)
+                  (get_local $17)
                 )
               )
             )
@@ -8336,56 +8240,49 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $i4)
+      (get_local $11)
     )
-    (get_local $i24)
+    (get_local $16)
   )
-  (func $___fwritex (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i4 i32)
-    (local $i15 i32)
-    (local $i5 i32)
-    (local $i8 i32)
-    (local $i10 i32)
-    (local $i11 i32)
-    (local $i12 i32)
-    (local $i13 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i9 i32)
-    (local $i14 i32)
+  (func $___fwritex (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
     (if
-      (set_local $i5
+      (set_local $6
         (i32.load
-          (set_local $i4
+          (set_local $3
             (i32.add
-              (get_local $i3)
+              (get_local $2)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $i6
-          (get_local $i5)
+        (set_local $5
+          (get_local $6)
         )
-        (set_local $i7
+        (set_local $4
           (i32.const 5)
         )
       )
       (if
         (call $___towrite
-          (get_local $i3)
+          (get_local $2)
         )
-        (set_local $i8
+        (set_local $7
           (i32.const 0)
         )
         (block
-          (set_local $i6
+          (set_local $5
             (i32.load
-              (get_local $i4)
+              (get_local $3)
             )
           )
-          (set_local $i7
+          (set_local $4
             (i32.const 5)
           )
         )
@@ -8394,16 +8291,16 @@
     (block $label$break$L5
       (if
         (i32.eq
-          (get_local $i7)
+          (get_local $4)
           (i32.const 5)
         )
         (block
-          (set_local $i9
-            (set_local $i4
+          (set_local $4
+            (set_local $3
               (i32.load
-                (set_local $i5
+                (set_local $6
                   (i32.add
-                    (get_local $i3)
+                    (get_local $2)
                     (i32.const 20)
                   )
                 )
@@ -8413,61 +8310,61 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $i6)
-                (get_local $i4)
+                (get_local $5)
+                (get_local $3)
               )
-              (get_local $i2)
+              (get_local $1)
             )
             (block
-              (set_local $i8
+              (set_local $7
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $i3)
+                        (get_local $2)
                       )
                       (i32.const 7)
                     )
                     (i32.const 2)
                   )
-                  (get_local $i3)
-                  (get_local $i1)
-                  (get_local $i2)
+                  (get_local $2)
+                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br $label$break$L5)
             )
           )
-          (set_local $i10
+          (set_local $0
             (block $label$break$L10
               (if
                 (i32.gt_s
                   (i32.load8_s offset=75
-                    (get_local $i3)
+                    (get_local $2)
                   )
                   (i32.const -1)
                 )
                 (block
-                  (set_local $i4
-                    (get_local $i2)
+                  (set_local $3
+                    (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eqz
-                        (get_local $i4)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $i11
-                          (get_local $i1)
+                        (set_local $2
+                          (get_local $0)
                         )
-                        (set_local $i12
-                          (get_local $i9)
+                        (set_local $3
+                          (get_local $4)
                         )
-                        (set_local $i13
+                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$L10
-                          (get_local $i2)
+                          (get_local $1)
                         )
                       )
                     )
@@ -8475,10 +8372,10 @@
                       (i32.eq
                         (i32.load8_s
                           (i32.add
-                            (get_local $i1)
-                            (set_local $i14
+                            (get_local $0)
+                            (set_local $5
                               (i32.add
-                                (get_local $i4)
+                                (get_local $3)
                                 (i32.const -1)
                               )
                             )
@@ -8487,13 +8384,13 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $i15
-                          (get_local $i4)
+                        (set_local $4
+                          (get_local $3)
                         )
                         (br $while-out$2)
                       )
-                      (set_local $i4
-                        (get_local $i14)
+                      (set_local $3
+                        (get_local $5)
                       )
                     )
                     (br $while-in$3)
@@ -8504,134 +8401,130 @@
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $i3)
+                              (get_local $2)
                             )
                             (i32.const 7)
                           )
                           (i32.const 2)
                         )
-                        (get_local $i3)
-                        (get_local $i1)
-                        (get_local $i15)
+                        (get_local $2)
+                        (get_local $0)
+                        (get_local $4)
                       )
-                      (get_local $i15)
+                      (get_local $4)
                     )
                     (block
-                      (set_local $i8
-                        (get_local $i15)
+                      (set_local $7
+                        (get_local $4)
                       )
                       (br $label$break$L5)
                     )
                   )
-                  (set_local $i11
+                  (set_local $2
                     (i32.add
-                      (get_local $i1)
-                      (get_local $i15)
+                      (get_local $0)
+                      (get_local $4)
                     )
                   )
-                  (set_local $i12
+                  (set_local $3
                     (i32.load
-                      (get_local $i5)
+                      (get_local $6)
                     )
                   )
-                  (set_local $i13
-                    (get_local $i15)
+                  (set_local $5
+                    (get_local $4)
                   )
                   (i32.sub
-                    (get_local $i2)
-                    (get_local $i15)
+                    (get_local $1)
+                    (get_local $4)
                   )
                 )
                 (block
-                  (set_local $i11
-                    (get_local $i1)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $i12
-                    (get_local $i9)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $i13
+                  (set_local $5
                     (i32.const 0)
                   )
-                  (get_local $i2)
+                  (get_local $1)
                 )
               )
             )
           )
           (call $_memcpy
-            (get_local $i12)
-            (get_local $i11)
-            (get_local $i10)
+            (get_local $3)
+            (get_local $2)
+            (get_local $0)
           )
           (i32.store
-            (get_local $i5)
+            (get_local $6)
             (i32.add
               (i32.load
-                (get_local $i5)
+                (get_local $6)
               )
-              (get_local $i10)
+              (get_local $0)
             )
           )
-          (set_local $i8
+          (set_local $7
             (i32.add
-              (get_local $i13)
-              (get_local $i10)
+              (get_local $5)
+              (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $i8)
+    (get_local $7)
   )
-  (func $_fflush (param $i1 i32) (result i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i5 i32)
-    (local $i6 i32)
-    (local $i8 i32)
-    (local $i7 i32)
+  (func $_fflush (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (block $do-once$0
       (if
-        (get_local $i1)
+        (get_local $0)
         (block
           (if
             (i32.le_s
               (i32.load offset=76
-                (get_local $i1)
+                (get_local $0)
               )
               (i32.const -1)
             )
             (br $do-once$0
               (call $___fflush_unlocked
-                (get_local $i1)
+                (get_local $0)
               )
             )
           )
-          (set_local $i3
+          (set_local $1
             (i32.eq
               (call $___lockfile
-                (get_local $i1)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $i4
+          (set_local $2
             (call $___fflush_unlocked
-              (get_local $i1)
+              (get_local $0)
             )
           )
           (if
-            (get_local $i3)
-            (get_local $i4)
+            (get_local $1)
+            (get_local $2)
             (block
               (call $___unlockfile
-                (get_local $i1)
+                (get_local $0)
               )
-              (get_local $i4)
+              (get_local $2)
             )
           )
         )
         (block
-          (set_local $i5
+          (set_local $0
             (if
               (i32.load
                 (i32.const 56)
@@ -8648,70 +8541,68 @@
             (i32.const 36)
           )
           (if
-            (set_local $i4
+            (set_local $2
               (i32.load
                 (i32.const 32)
               )
             )
             (block
-              (set_local $i3
-                (get_local $i4)
+              (set_local $1
+                (get_local $2)
               )
-              (set_local $i4
-                (get_local $i5)
+              (set_local $2
+                (get_local $0)
               )
               (loop $while-out$2 $while-in$3
-                (set_local $i7
+                (set_local $0
                   (if
                     (i32.gt_s
                       (i32.load offset=76
-                        (get_local $i3)
+                        (get_local $1)
                       )
                       (i32.const -1)
                     )
                     (call $___lockfile
-                      (get_local $i3)
+                      (get_local $1)
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $i8
+                (set_local $2
                   (if
                     (i32.gt_u
                       (i32.load offset=20
-                        (get_local $i3)
+                        (get_local $1)
                       )
                       (i32.load offset=28
-                        (get_local $i3)
+                        (get_local $1)
                       )
                     )
                     (i32.or
                       (call $___fflush_unlocked
-                        (get_local $i3)
+                        (get_local $1)
                       )
-                      (get_local $i4)
+                      (get_local $2)
                     )
-                    (get_local $i4)
+                    (get_local $2)
                   )
                 )
                 (if
-                  (get_local $i7)
+                  (get_local $0)
                   (call $___unlockfile
-                    (get_local $i3)
+                    (get_local $1)
                   )
                 )
                 (if
-                  (set_local $i3
+                  (set_local $1
                     (i32.load offset=56
-                      (get_local $i3)
+                      (get_local $1)
                     )
                   )
-                  (set_local $i4
-                    (get_local $i8)
-                  )
+                  (get_local $2)
                   (block
-                    (set_local $i6
-                      (get_local $i8)
+                    (set_local $0
+                      (get_local $2)
                     )
                     (br $while-out$2)
                   )
@@ -8719,78 +8610,67 @@
                 (br $while-in$3)
               )
             )
-            (set_local $i6
-              (get_local $i5)
-            )
+            (get_local $0)
           )
           (call_import $___unlock
             (i32.const 36)
           )
-          (get_local $i6)
+          (get_local $0)
         )
       )
     )
   )
-  (func $_strlen (param $i1 i32) (result i32)
-    (local $i4 i32)
-    (local $i3 i32)
-    (local $i10 i32)
-    (local $i9 i32)
-    (local $i5 i32)
-    (local $i2 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i8 i32)
-    (local $i11 i32)
+  (func $_strlen (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
     (block $label$break$L1
       (if
         (i32.and
-          (set_local $i2
-            (get_local $i1)
+          (set_local $3
+            (get_local $0)
           )
           (i32.const 3)
         )
         (block
-          (set_local $i5
-            (get_local $i1)
-          )
-          (set_local $i6
-            (get_local $i2)
+          (get_local $0)
+          (set_local $4
+            (get_local $3)
           )
           (loop $while-out$1 $while-in$2
             (if
               (i32.eqz
                 (i32.load8_s
-                  (get_local $i5)
+                  (get_local $0)
                 )
               )
               (block
-                (set_local $i7
-                  (get_local $i6)
+                (set_local $5
+                  (get_local $4)
                 )
                 (br $label$break$L1)
               )
             )
             (if
               (i32.and
-                (set_local $i6
-                  (set_local $i8
+                (set_local $4
+                  (set_local $0
                     (i32.add
-                      (get_local $i5)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
                 (i32.const 3)
               )
-              (set_local $i5
-                (get_local $i8)
-              )
+              (get_local $0)
               (block
-                (set_local $i3
-                  (get_local $i8)
+                (set_local $1
+                  (get_local $0)
                 )
-                (set_local $i4
+                (set_local $2
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8800,10 +8680,10 @@
           )
         )
         (block
-          (set_local $i3
-            (get_local $i1)
+          (set_local $1
+            (get_local $0)
           )
-          (set_local $i4
+          (set_local $2
             (i32.const 4)
           )
         )
@@ -8811,21 +8691,21 @@
     )
     (if
       (i32.eq
-        (get_local $i4)
+        (get_local $2)
         (i32.const 4)
       )
       (block
-        (set_local $i4
-          (get_local $i3)
+        (set_local $2
+          (get_local $1)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $i3
+                  (set_local $1
                     (i32.load
-                      (get_local $i4)
+                      (get_local $2)
                     )
                   )
                   (i32.const -2139062144)
@@ -8833,22 +8713,22 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $i3)
+                (get_local $1)
                 (i32.const -16843009)
               )
             )
             (block
-              (set_local $i9
-                (get_local $i3)
+              (set_local $0
+                (get_local $1)
               )
-              (set_local $i10
-                (get_local $i4)
+              (set_local $1
+                (get_local $2)
               )
               (br $while-out$3)
             )
-            (set_local $i4
+            (set_local $2
               (i32.add
-                (get_local $i4)
+                (get_local $2)
                 (i32.const 4)
               )
             )
@@ -8859,7 +8739,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $i9)
+                (get_local $0)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8867,25 +8747,25 @@
             (i32.const 24)
           )
           (block
-            (set_local $i9
-              (get_local $i10)
+            (set_local $0
+              (get_local $1)
             )
             (loop $while-out$5 $while-in$6
               (if
                 (i32.load8_s
-                  (set_local $i10
+                  (set_local $1
                     (i32.add
-                      (get_local $i9)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $i9
-                  (get_local $i10)
+                (set_local $0
+                  (get_local $1)
                 )
                 (block
-                  (set_local $i11
-                    (get_local $i10)
+                  (set_local $0
+                    (get_local $1)
                   )
                   (br $while-out$5)
                 )
@@ -8893,31 +8773,31 @@
               (br $while-in$6)
             )
           )
-          (set_local $i11
-            (get_local $i10)
+          (set_local $0
+            (get_local $1)
           )
         )
-        (set_local $i7
-          (get_local $i11)
+        (set_local $5
+          (get_local $0)
         )
       )
     )
     (i32.sub
-      (get_local $i7)
-      (get_local $i2)
+      (get_local $5)
+      (get_local $3)
     )
   )
-  (func $___overflow (param $i1 i32) (param $i2 i32) (result i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i10 i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i8 i32)
-    (local $i9 i32)
-    (local $i5 i32)
-    (local $i11 i32)
-    (set_local $i3
+  (func $___overflow (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (set_local $5
       (i32.load
         (i32.const 8)
       )
@@ -8932,49 +8812,49 @@
       )
     )
     (i32.store8
-      (set_local $i4
-        (get_local $i3)
+      (set_local $6
+        (get_local $5)
       )
-      (set_local $i5
+      (set_local $9
         (i32.and
-          (get_local $i2)
+          (get_local $1)
           (i32.const 255)
         )
       )
     )
     (if
-      (set_local $i7
+      (set_local $3
         (i32.load
-          (set_local $i6
+          (set_local $2
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $i8
-          (get_local $i7)
+        (set_local $7
+          (get_local $3)
         )
-        (set_local $i9
+        (set_local $8
           (i32.const 4)
         )
       )
       (if
         (call $___towrite
-          (get_local $i1)
+          (get_local $0)
         )
-        (set_local $i10
+        (set_local $4
           (i32.const -1)
         )
         (block
-          (set_local $i8
+          (set_local $7
             (i32.load
-              (get_local $i6)
+              (get_local $2)
             )
           )
-          (set_local $i9
+          (set_local $8
             (i32.const 4)
           )
         )
@@ -8983,77 +8863,77 @@
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $i9)
+          (get_local $8)
           (i32.const 4)
         )
         (block
           (if
             (if
               (i32.lt_u
-                (set_local $i6
+                (set_local $2
                   (i32.load
-                    (set_local $i7
+                    (set_local $3
                       (i32.add
-                        (get_local $i1)
+                        (get_local $0)
                         (i32.const 20)
                       )
                     )
                   )
                 )
-                (get_local $i8)
+                (get_local $7)
               )
               (i32.ne
-                (set_local $i11
+                (set_local $10
                   (i32.and
-                    (get_local $i2)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.load8_s offset=75
-                  (get_local $i1)
+                  (get_local $0)
                 )
               )
               (i32.const 0)
             )
             (block
               (i32.store
-                (get_local $i7)
+                (get_local $3)
                 (i32.add
-                  (get_local $i6)
+                  (get_local $2)
                   (i32.const 1)
                 )
               )
               (i32.store8
-                (get_local $i6)
-                (get_local $i5)
+                (get_local $2)
+                (get_local $9)
               )
-              (set_local $i10
-                (get_local $i11)
+              (set_local $4
+                (get_local $10)
               )
               (br $do-once$0)
             )
           )
-          (set_local $i10
+          (set_local $4
             (if
               (i32.eq
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $i1)
+                        (get_local $0)
                       )
                       (i32.const 7)
                     )
                     (i32.const 2)
                   )
-                  (get_local $i1)
-                  (get_local $i4)
+                  (get_local $0)
+                  (get_local $6)
                   (i32.const 1)
                 )
                 (i32.const 1)
               )
               (i32.load8_u
-                (get_local $i4)
+                (get_local $6)
               )
               (i32.const -1)
             )
@@ -9063,32 +8943,32 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $i3)
+      (get_local $5)
     )
-    (get_local $i10)
+    (get_local $4)
   )
-  (func $___fflush_unlocked (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i3 i32)
-    (local $i5 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (local $i8 i32)
+  (func $___fflush_unlocked (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
     (if
       (if
         (i32.gt_u
           (i32.load
-            (set_local $i2
+            (set_local $1
               (i32.add
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
           (i32.load
-            (set_local $i3
+            (set_local $2
               (i32.add
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 28)
               )
             )
@@ -9099,19 +8979,19 @@
             (i32.add
               (i32.and
                 (i32.load offset=36
-                  (get_local $i1)
+                  (get_local $0)
                 )
                 (i32.const 7)
               )
               (i32.const 2)
             )
-            (get_local $i1)
+            (get_local $0)
             (i32.const 0)
             (i32.const 0)
           )
           (i32.eq
             (i32.load
-              (get_local $i2)
+              (get_local $1)
             )
             (i32.const 0)
           )
@@ -9122,21 +9002,21 @@
       (block
         (if
           (i32.lt_u
-            (set_local $i6
+            (set_local $4
               (i32.load
-                (set_local $i5
+                (set_local $3
                   (i32.add
-                    (get_local $i1)
+                    (get_local $0)
                     (i32.const 4)
                   )
                 )
               )
             )
-            (set_local $i8
+            (set_local $6
               (i32.load
-                (set_local $i7
+                (set_local $5
                   (i32.add
-                    (get_local $i1)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
@@ -9147,70 +9027,70 @@
             (i32.add
               (i32.and
                 (i32.load offset=40
-                  (get_local $i1)
+                  (get_local $0)
                 )
                 (i32.const 7)
               )
               (i32.const 2)
             )
-            (get_local $i1)
+            (get_local $0)
             (i32.sub
-              (get_local $i6)
-              (get_local $i8)
+              (get_local $4)
+              (get_local $6)
             )
             (i32.const 1)
           )
         )
         (i32.store offset=16
-          (get_local $i1)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i3)
+          (get_local $2)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i2)
+          (get_local $1)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i7)
+          (get_local $5)
           (i32.const 0)
         )
         (i32.store
-          (get_local $i5)
+          (get_local $3)
           (i32.const 0)
         )
         (i32.const 0)
       )
     )
   )
-  (func $_memcpy (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i4 i32)
+  (func $_memcpy (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
     (if
       (i32.ge_s
-        (get_local $i3)
+        (get_local $2)
         (i32.const 4096)
       )
       (return
         (call_import $_emscripten_memcpy_big
-          (get_local $i1)
-          (get_local $i2)
-          (get_local $i3)
+          (get_local $0)
+          (get_local $1)
+          (get_local $2)
         )
       )
     )
-    (set_local $i4
-      (get_local $i1)
+    (set_local $3
+      (get_local $0)
     )
     (if
       (i32.eq
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.and
-          (get_local $i2)
+          (get_local $1)
           (i32.const 3)
         )
       )
@@ -9219,40 +9099,40 @@
           (br_if $while-out$0
             (i32.eqz
               (i32.and
-                (get_local $i1)
+                (get_local $0)
                 (i32.const 3)
               )
             )
           )
           (if
             (i32.eqz
-              (get_local $i3)
+              (get_local $2)
             )
             (return
-              (get_local $i4)
+              (get_local $3)
             )
           )
           (i32.store8
-            (get_local $i1)
+            (get_local $0)
             (i32.load8_s
-              (get_local $i2)
+              (get_local $1)
             )
           )
-          (set_local $i1
+          (set_local $0
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 1)
             )
           )
-          (set_local $i2
+          (set_local $1
             (i32.add
-              (get_local $i2)
+              (get_local $1)
               (i32.const 1)
             )
           )
-          (set_local $i3
+          (set_local $2
             (i32.sub
-              (get_local $i3)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -9261,31 +9141,31 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.lt_s
-              (get_local $i3)
+              (get_local $2)
               (i32.const 4)
             )
           )
           (i32.store
-            (get_local $i1)
+            (get_local $0)
             (i32.load
-              (get_local $i2)
+              (get_local $1)
             )
           )
-          (set_local $i1
+          (set_local $0
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 4)
             )
           )
-          (set_local $i2
+          (set_local $1
             (i32.add
-              (get_local $i2)
+              (get_local $1)
               (i32.const 4)
             )
           )
-          (set_local $i3
+          (set_local $2
             (i32.sub
-              (get_local $i3)
+              (get_local $2)
               (i32.const 4)
             )
           )
@@ -9296,87 +9176,87 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.le_s
-          (get_local $i3)
+          (get_local $2)
           (i32.const 0)
         )
       )
       (i32.store8
-        (get_local $i1)
+        (get_local $0)
         (i32.load8_s
-          (get_local $i2)
+          (get_local $1)
         )
       )
-      (set_local $i1
+      (set_local $0
         (i32.add
-          (get_local $i1)
+          (get_local $0)
           (i32.const 1)
         )
       )
-      (set_local $i2
+      (set_local $1
         (i32.add
-          (get_local $i2)
+          (get_local $1)
           (i32.const 1)
         )
       )
-      (set_local $i3
+      (set_local $2
         (i32.sub
-          (get_local $i3)
+          (get_local $2)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
-    (get_local $i4)
+    (get_local $3)
   )
   (func $runPostSets
     (nop)
   )
-  (func $_memset (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i5 i32)
-    (local $i4 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (set_local $i4
+  (func $_memset (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $4
       (i32.add
-        (get_local $i1)
-        (get_local $i3)
+        (get_local $0)
+        (get_local $2)
       )
     )
     (if
       (i32.ge_s
-        (get_local $i3)
+        (get_local $2)
         (i32.const 20)
       )
       (block
-        (set_local $i6
+        (set_local $5
           (i32.or
             (i32.or
               (i32.or
-                (set_local $i2
+                (set_local $1
                   (i32.and
-                    (get_local $i2)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.shl
-                  (get_local $i2)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (i32.shl
-                (get_local $i2)
+                (get_local $1)
                 (i32.const 16)
               )
             )
             (i32.shl
-              (get_local $i2)
+              (get_local $1)
               (i32.const 24)
             )
           )
         )
-        (set_local $i7
+        (set_local $6
           (i32.and
-            (get_local $i4)
+            (get_local $4)
             (i32.xor
               (i32.const 3)
               (i32.const -1)
@@ -9384,36 +9264,36 @@
           )
         )
         (if
-          (set_local $i5
+          (set_local $3
             (i32.and
-              (get_local $i1)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (block
-            (set_local $i5
+            (set_local $3
               (i32.sub
                 (i32.add
-                  (get_local $i1)
+                  (get_local $0)
                   (i32.const 4)
                 )
-                (get_local $i5)
+                (get_local $3)
               )
             )
             (loop $while-out$0 $while-in$1
               (br_if $while-out$0
                 (i32.ge_s
-                  (get_local $i1)
-                  (get_local $i5)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (i32.store8
-                (get_local $i1)
-                (get_local $i2)
+                (get_local $0)
+                (get_local $1)
               )
-              (set_local $i1
+              (set_local $0
                 (i32.add
-                  (get_local $i1)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
@@ -9424,17 +9304,17 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.ge_s
-              (get_local $i1)
-              (get_local $i7)
+              (get_local $0)
+              (get_local $6)
             )
           )
           (i32.store
-            (get_local $i1)
-            (get_local $i6)
+            (get_local $0)
+            (get_local $5)
           )
-          (set_local $i1
+          (set_local $0
             (i32.add
-              (get_local $i1)
+              (get_local $0)
               (i32.const 4)
             )
           )
@@ -9445,38 +9325,37 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.ge_s
-          (get_local $i1)
-          (get_local $i4)
+          (get_local $0)
+          (get_local $4)
         )
       )
       (i32.store8
-        (get_local $i1)
-        (get_local $i2)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $i1
+      (set_local $0
         (i32.add
-          (get_local $i1)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
     (i32.sub
-      (get_local $i1)
-      (get_local $i3)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $_puts (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i6 i32)
-    (local $i3 i32)
-    (local $i4 i32)
-    (local $i5 i32)
-    (set_local $i3
+  (func $_puts (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $3
       (if
         (i32.gt_s
           (i32.load offset=76
-            (set_local $i2
+            (set_local $1
               (i32.load
                 (i32.const 52)
               )
@@ -9485,18 +9364,18 @@
           (i32.const -1)
         )
         (call $___lockfile
-          (get_local $i2)
+          (get_local $1)
         )
         (i32.const 0)
       )
     )
-    (set_local $i4
+    (set_local $0
       (block $do-once$0
         (if
           (i32.lt_s
             (call $_fputs
-              (get_local $i1)
-              (get_local $i2)
+              (get_local $0)
+              (get_local $1)
             )
             (i32.const 0)
           )
@@ -9506,37 +9385,37 @@
               (if
                 (i32.ne
                   (i32.load8_s offset=75
-                    (get_local $i2)
+                    (get_local $1)
                   )
                   (i32.const 10)
                 )
                 (i32.lt_u
-                  (set_local $i6
+                  (set_local $2
                     (i32.load
-                      (set_local $i5
+                      (set_local $4
                         (i32.add
-                          (get_local $i2)
+                          (get_local $1)
                           (i32.const 20)
                         )
                       )
                     )
                   )
                   (i32.load offset=16
-                    (get_local $i2)
+                    (get_local $1)
                   )
                 )
                 (i32.const 0)
               )
               (block
                 (i32.store
-                  (get_local $i5)
+                  (get_local $4)
                   (i32.add
-                    (get_local $i6)
+                    (get_local $2)
                     (i32.const 1)
                   )
                 )
                 (i32.store8
-                  (get_local $i6)
+                  (get_local $2)
                   (i32.const 10)
                 )
                 (br $do-once$0
@@ -9546,7 +9425,7 @@
             )
             (i32.lt_s
               (call $___overflow
-                (get_local $i2)
+                (get_local $1)
                 (i32.const 10)
               )
               (i32.const 0)
@@ -9556,25 +9435,23 @@
       )
     )
     (if
-      (get_local $i3)
+      (get_local $3)
       (call $___unlockfile
-        (get_local $i2)
+        (get_local $1)
       )
     )
     (i32.shr_s
       (i32.shl
-        (get_local $i4)
+        (get_local $0)
         (i32.const 31)
       )
       (i32.const 31)
     )
   )
-  (func $___stdio_seek (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i5 i32)
-    (local $i4 i32)
-    (local $i6 i32)
-    (local $i7 i32)
-    (set_local $i4
+  (func $___stdio_seek (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9589,100 +9466,100 @@
       )
     )
     (i32.store
-      (set_local $i5
-        (get_local $i4)
+      (set_local $3
+        (get_local $4)
       )
       (i32.load offset=60
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store offset=4
-      (get_local $i5)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=8
-      (get_local $i5)
-      (get_local $i2)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $i5)
-      (set_local $i6
+      (get_local $3)
+      (set_local $0
         (i32.add
-          (get_local $i4)
+          (get_local $4)
           (i32.const 20)
         )
       )
     )
     (i32.store offset=16
-      (get_local $i5)
-      (get_local $i3)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $i7
+    (set_local $0
       (if
         (i32.lt_s
           (call $___syscall_ret
             (call_import $___syscall140
               (i32.const 140)
-              (get_local $i5)
+              (get_local $3)
             )
           )
           (i32.const 0)
         )
         (block
           (i32.store
-            (get_local $i6)
+            (get_local $0)
             (i32.const -1)
           )
           (i32.const -1)
         )
         (i32.load
-          (get_local $i6)
+          (get_local $0)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $i4)
+      (get_local $4)
     )
-    (get_local $i7)
+    (get_local $0)
   )
-  (func $___towrite (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i3 i32)
-    (set_local $i3
+  (func $___towrite (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $2
       (i32.load8_s
-        (set_local $i2
+        (set_local $1
           (i32.add
-            (get_local $i1)
+            (get_local $0)
             (i32.const 74)
           )
         )
       )
     )
     (i32.store8
-      (get_local $i2)
+      (get_local $1)
       (i32.or
         (i32.add
-          (get_local $i3)
+          (get_local $2)
           (i32.const 255)
         )
-        (get_local $i3)
+        (get_local $2)
       )
     )
     (if
       (i32.and
-        (set_local $i3
+        (set_local $2
           (i32.load
-            (get_local $i1)
+            (get_local $0)
           )
         )
         (i32.const 8)
       )
       (block
         (i32.store
-          (get_local $i1)
+          (get_local $0)
           (i32.or
-            (get_local $i3)
+            (get_local $2)
             (i32.const 32)
           )
         )
@@ -9690,31 +9567,31 @@
       )
       (block
         (i32.store offset=8
-          (get_local $i1)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=4
-          (get_local $i1)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=28
-          (get_local $i1)
-          (set_local $i2
+          (get_local $0)
+          (set_local $1
             (i32.load offset=44
-              (get_local $i1)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=20
-          (get_local $i1)
-          (get_local $i2)
+          (get_local $0)
+          (get_local $1)
         )
         (i32.store offset=16
-          (get_local $i1)
+          (get_local $0)
           (i32.add
-            (get_local $i2)
+            (get_local $1)
             (i32.load offset=48
-              (get_local $i1)
+              (get_local $0)
             )
           )
         )
@@ -9722,74 +9599,72 @@
       )
     )
   )
-  (func $_fwrite (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (result i32)
-    (local $i5 i32)
-    (local $i7 i32)
-    (local $i6 i32)
-    (local $i8 i32)
-    (set_local $i5
+  (func $_fwrite (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (local $5 i32)
+    (set_local $4
       (i32.mul
-        (get_local $i3)
-        (get_local $i2)
+        (get_local $2)
+        (get_local $1)
       )
     )
     (if
       (i32.eq
-        (set_local $i8
+        (set_local $0
           (if
             (i32.gt_s
               (i32.load offset=76
-                (get_local $i4)
+                (get_local $3)
               )
               (i32.const -1)
             )
             (block
-              (set_local $i6
+              (set_local $5
                 (i32.eq
                   (call $___lockfile
-                    (get_local $i4)
+                    (get_local $3)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $i7
+              (set_local $0
                 (call $___fwritex
-                  (get_local $i1)
-                  (get_local $i5)
-                  (get_local $i4)
+                  (get_local $0)
+                  (get_local $4)
+                  (get_local $3)
                 )
               )
               (if
-                (get_local $i6)
-                (get_local $i7)
+                (get_local $5)
+                (get_local $0)
                 (block
                   (call $___unlockfile
-                    (get_local $i4)
+                    (get_local $3)
                   )
-                  (get_local $i7)
+                  (get_local $0)
                 )
               )
             )
             (call $___fwritex
-              (get_local $i1)
-              (get_local $i5)
-              (get_local $i4)
+              (get_local $0)
+              (get_local $4)
+              (get_local $3)
             )
           )
         )
-        (get_local $i5)
+        (get_local $4)
       )
-      (get_local $i3)
+      (get_local $2)
       (i32.div_u
-        (get_local $i8)
-        (get_local $i2)
+        (get_local $0)
+        (get_local $1)
       )
     )
   )
-  (func $___stdout_write (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
-    (local $i5 i32)
-    (local $i4 i32)
-    (set_local $i4
+  (func $___stdout_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9803,11 +9678,11 @@
         (i32.const 80)
       )
     )
-    (set_local $i5
-      (get_local $i4)
+    (set_local $3
+      (get_local $4)
     )
     (i32.store offset=36
-      (get_local $i1)
+      (get_local $0)
       (i32.const 5)
     )
     (if
@@ -9815,7 +9690,7 @@
         (i32.eq
           (i32.and
             (i32.load
-              (get_local $i1)
+              (get_local $0)
             )
             (i32.const 64)
           )
@@ -9823,26 +9698,26 @@
         )
         (block
           (i32.store
-            (get_local $i5)
+            (get_local $3)
             (i32.load offset=60
-              (get_local $i1)
+              (get_local $0)
             )
           )
           (i32.store offset=4
-            (get_local $i5)
+            (get_local $3)
             (i32.const 21505)
           )
           (i32.store offset=8
-            (get_local $i5)
+            (get_local $3)
             (i32.add
-              (get_local $i4)
+              (get_local $4)
               (i32.const 12)
             )
           )
           (i32.ne
             (call_import $___syscall54
               (i32.const 54)
-              (get_local $i5)
+              (get_local $3)
             )
             (i32.const 0)
           )
@@ -9850,30 +9725,30 @@
         (i32.const 0)
       )
       (i32.store8 offset=75
-        (get_local $i1)
+        (get_local $0)
         (i32.const -1)
       )
     )
-    (set_local $i5
+    (set_local $3
       (call $___stdio_write
-        (get_local $i1)
-        (get_local $i2)
-        (get_local $i3)
+        (get_local $0)
+        (get_local $1)
+        (get_local $2)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $i4)
+      (get_local $4)
     )
-    (get_local $i5)
+    (get_local $3)
   )
-  (func $copyTempDouble (param $i1 i32)
+  (func $copyTempDouble (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -9881,7 +9756,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -9889,7 +9764,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -9897,7 +9772,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=4
@@ -9905,7 +9780,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=4
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=5
@@ -9913,7 +9788,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=5
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=6
@@ -9921,7 +9796,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=6
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=7
@@ -9929,14 +9804,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=7
-        (get_local $i1)
+        (get_local $0)
       )
     )
   )
-  (func $___stdio_close (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (local $i3 i32)
-    (set_local $i2
+  (func $___stdio_close (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -9951,34 +9826,34 @@
       )
     )
     (i32.store
-      (set_local $i3
-        (get_local $i2)
+      (set_local $2
+        (get_local $1)
       )
       (i32.load offset=60
-        (get_local $i1)
+        (get_local $0)
       )
     )
-    (set_local $i1
+    (set_local $0
       (call $___syscall_ret
         (call_import $___syscall6
           (i32.const 6)
-          (get_local $i3)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $i2)
+      (get_local $1)
     )
-    (get_local $i1)
+    (get_local $0)
   )
-  (func $copyTempFloat (param $i1 i32)
+  (func $copyTempFloat (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -9986,7 +9861,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -9994,7 +9869,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -10002,14 +9877,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $i1)
+        (get_local $0)
       )
     )
   )
-  (func $___syscall_ret (param $i1 i32) (result i32)
+  (func $___syscall_ret (param $0 i32) (result i32)
     (if
       (i32.gt_u
-        (get_local $i1)
+        (get_local $0)
         (i32.const -4096)
       )
       (block
@@ -10017,31 +9892,31 @@
           (call $___errno_location)
           (i32.sub
             (i32.const 0)
-            (get_local $i1)
+            (get_local $0)
           )
         )
         (i32.const -1)
       )
-      (get_local $i1)
+      (get_local $0)
     )
   )
-  (func $dynCall_iiii (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (result i32)
+  (func $dynCall_iiii (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call_indirect $FUNCSIG$iiii
       (i32.add
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 2)
       )
-      (get_local $i2)
-      (get_local $i3)
-      (get_local $i4)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
     )
   )
-  (func $stackAlloc (param $i1 i32) (result i32)
-    (local $i2 i32)
-    (set_local $i2
+  (func $stackAlloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -10052,7 +9927,7 @@
         (i32.load
           (i32.const 8)
         )
-        (get_local $i1)
+        (get_local $0)
       )
     )
     (i32.store
@@ -10067,7 +9942,7 @@
         (i32.const -16)
       )
     )
-    (get_local $i2)
+    (get_local $1)
   )
   (func $___errno_location (result i32)
     (if
@@ -10080,7 +9955,7 @@
       (i32.const 60)
     )
   )
-  (func $setThrew (param $i1 i32) (param $i2 i32)
+  (func $setThrew (param $0 i32) (param $1 i32)
     (if
       (i32.eqz
         (i32.load
@@ -10090,102 +9965,102 @@
       (block
         (i32.store
           (i32.const 40)
-          (get_local $i1)
+          (get_local $0)
         )
         (i32.store
           (i32.const 48)
-          (get_local $i2)
+          (get_local $1)
         )
       )
     )
   )
-  (func $_fputs (param $i1 i32) (param $i2 i32) (result i32)
+  (func $_fputs (param $0 i32) (param $1 i32) (result i32)
     (i32.add
       (call $_fwrite
-        (get_local $i1)
+        (get_local $0)
         (call $_strlen
-          (get_local $i1)
+          (get_local $0)
         )
         (i32.const 1)
-        (get_local $i2)
+        (get_local $1)
       )
       (i32.const -1)
     )
   )
-  (func $dynCall_ii (param $i1 i32) (param $i2 i32) (result i32)
+  (func $dynCall_ii (param $0 i32) (param $1 i32) (result i32)
     (call_indirect $FUNCSIG$ii
       (i32.add
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 0)
       )
-      (get_local $i2)
+      (get_local $1)
     )
   )
-  (func $_cleanup_418 (param $i1 i32)
+  (func $_cleanup_418 (param $0 i32)
     (if
       (i32.eqz
         (i32.load offset=68
-          (get_local $i1)
+          (get_local $0)
         )
       )
       (call $___unlockfile
-        (get_local $i1)
+        (get_local $0)
       )
     )
   )
-  (func $establishStackSpace (param $i1 i32) (param $i2 i32)
+  (func $establishStackSpace (param $0 i32) (param $1 i32)
     (i32.store
       (i32.const 8)
-      (get_local $i1)
+      (get_local $0)
     )
     (i32.store
       (i32.const 16)
-      (get_local $i2)
+      (get_local $1)
     )
   )
-  (func $dynCall_vi (param $i1 i32) (param $i2 i32)
+  (func $dynCall_vi (param $0 i32) (param $1 i32)
     (call_indirect $FUNCSIG$vi
       (i32.add
         (i32.and
-          (get_local $i1)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 10)
       )
-      (get_local $i2)
+      (get_local $1)
     )
   )
-  (func $b1 (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
+  (func $b1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (call_import $abort
       (i32.const 1)
     )
     (i32.const 0)
   )
-  (func $stackRestore (param $i1 i32)
+  (func $stackRestore (param $0 i32)
     (i32.store
       (i32.const 8)
-      (get_local $i1)
+      (get_local $0)
     )
   )
-  (func $setTempRet0 (param $i1 i32)
+  (func $setTempRet0 (param $0 i32)
     (i32.store
       (i32.const 160)
-      (get_local $i1)
+      (get_local $0)
     )
   )
-  (func $b0 (param $i1 i32) (result i32)
+  (func $b0 (param $0 i32) (result i32)
     (call_import $abort
       (i32.const 0)
     )
     (i32.const 0)
   )
-  (func $___unlockfile (param $i1 i32)
+  (func $___unlockfile (param $0 i32)
     (nop)
   )
-  (func $___lockfile (param $i1 i32) (result i32)
+  (func $___lockfile (param $0 i32) (result i32)
     (i32.const 0)
   )
   (func $getTempRet0 (result i32)
@@ -10204,7 +10079,7 @@
       (i32.const 8)
     )
   )
-  (func $b2 (param $i1 i32)
+  (func $b2 (param $0 i32)
     (call_import $abort
       (i32.const 2)
     )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -52,9 +52,9 @@
   (export "dynCall_vi" $dynCall_vi)
   (export "___udivmoddi4" $___udivmoddi4)
   (table $b0 $___stdio_close $b1 $b1 $___stdout_write $___stdio_seek $___stdio_write $b1 $b1 $b1 $b2 $b2 $b2 $b2 $b2 $_cleanup $b2 $b2)
-  (func $stackAlloc (param $size i32) (result i32)
-    (local $ret i32)
-    (set_local $ret
+  (func $stackAlloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -65,7 +65,7 @@
         (i32.load
           (i32.const 8)
         )
-        (get_local $size)
+        (get_local $0)
       )
     )
     (i32.store
@@ -91,30 +91,30 @@
       )
       (call_import $abort)
     )
-    (get_local $ret)
+    (get_local $1)
   )
   (func $stackSave (result i32)
     (i32.load
       (i32.const 8)
     )
   )
-  (func $stackRestore (param $top i32)
+  (func $stackRestore (param $0 i32)
     (i32.store
       (i32.const 8)
-      (get_local $top)
+      (get_local $0)
     )
   )
-  (func $establishStackSpace (param $stackBase i32) (param $stackMax i32)
+  (func $establishStackSpace (param $0 i32) (param $1 i32)
     (i32.store
       (i32.const 8)
-      (get_local $stackBase)
+      (get_local $0)
     )
     (i32.store
       (i32.const 16)
-      (get_local $stackMax)
+      (get_local $1)
     )
   )
-  (func $setThrew (param $threw i32) (param $value i32)
+  (func $setThrew (param $0 i32) (param $1 i32)
     (if
       (i32.eq
         (i32.load
@@ -125,22 +125,22 @@
       (block
         (i32.store
           (i32.const 48)
-          (get_local $threw)
+          (get_local $0)
         )
         (i32.store
           (i32.const 56)
-          (get_local $value)
+          (get_local $1)
         )
       )
     )
   )
-  (func $copyTempFloat (param $ptr i32)
+  (func $copyTempFloat (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -148,7 +148,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -156,7 +156,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -164,17 +164,17 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $ptr)
+        (get_local $0)
       )
     )
   )
-  (func $copyTempDouble (param $ptr i32)
+  (func $copyTempDouble (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -182,7 +182,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -190,7 +190,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -198,7 +198,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=4
@@ -206,7 +206,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=4
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=5
@@ -214,7 +214,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=5
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=6
@@ -222,7 +222,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=6
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=7
@@ -230,14 +230,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=7
-        (get_local $ptr)
+        (get_local $0)
       )
     )
   )
-  (func $setTempRet0 (param $value i32)
+  (func $setTempRet0 (param $0 i32)
     (i32.store
       (i32.const 168)
-      (get_local $value)
+      (get_local $0)
     )
   )
   (func $getTempRet0 (result i32)
@@ -246,8 +246,8 @@
     )
   )
   (func $_main (result i32)
-    (local $sp i32)
-    (set_local $sp
+    (local $0 i32)
+    (set_local $0
       (i32.load
         (i32.const 8)
       )
@@ -275,21 +275,18 @@
     (i32.const 0)
     (call $_printf
       (i32.const 672)
-      (get_local $sp)
+      (get_local $0)
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $0)
     )
     (i32.const 0)
   )
-  (func $_frexp (param $$x f64) (param $$e i32) (result f64)
-    (local $$x$addr$0 f64)
-    (local $$0 i32)
-    (local $$1 i32)
-    (local $$2 i32)
-    (local $$conv i32)
-    (local $$storemerge i32)
+  (func $_frexp (param $0 f64) (param $1 i32) (result f64)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
     (i32.load
       (i32.const 8)
     )
@@ -297,18 +294,18 @@
       (i32.load
         (i32.const 24)
       )
-      (get_local $$x)
+      (get_local $0)
     )
-    (set_local $$2
+    (set_local $3
       (call $_bitshift64Lshr
-        (set_local $$0
+        (set_local $2
           (i32.load
             (i32.load
               (i32.const 24)
             )
           )
         )
-        (set_local $$1
+        (set_local $4
           (i32.load offset=4
             (i32.load
               (i32.const 24)
@@ -328,9 +325,9 @@
             (block $switch-case$1
               (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
                 (i32.sub
-                  (set_local $$conv
+                  (set_local $3
                     (i32.and
-                      (get_local $$2)
+                      (get_local $3)
                       (i32.const 2047)
                     )
                   )
@@ -338,53 +335,51 @@
                 )
               )
             )
-            (set_local $$storemerge
+            (set_local $2
               (if
                 (f64.ne
-                  (get_local $$x)
+                  (get_local $0)
                   (f64.const 0)
                 )
                 (block
-                  (set_local $$x$addr$0
+                  (set_local $0
                     (call $_frexp
                       (f64.mul
-                        (get_local $$x)
+                        (get_local $0)
                         (f64.const 18446744073709551615)
                       )
-                      (get_local $$e)
+                      (get_local $1)
                     )
                   )
                   (i32.add
                     (i32.load
-                      (get_local $$e)
+                      (get_local $1)
                     )
                     (i32.const -64)
                   )
                 )
                 (block
-                  (set_local $$x$addr$0
-                    (get_local $$x)
-                  )
+                  (get_local $0)
                   (i32.const 0)
                 )
               )
             )
             (i32.store
-              (get_local $$e)
-              (get_local $$storemerge)
+              (get_local $1)
+              (get_local $2)
             )
             (br $switch$0
-              (get_local $$x$addr$0)
+              (get_local $0)
             )
           )
           (br $switch$0
-            (get_local $$x)
+            (get_local $0)
           )
         )
         (i32.store
-          (get_local $$e)
+          (get_local $1)
           (i32.add
-            (get_local $$conv)
+            (get_local $3)
             (i32.const -1022)
           )
         )
@@ -392,7 +387,7 @@
           (i32.load
             (i32.const 24)
           )
-          (get_local $$0)
+          (get_local $2)
         )
         (i32.store offset=4
           (i32.load
@@ -400,7 +395,7 @@
           )
           (i32.or
             (i32.and
-              (get_local $$1)
+              (get_local $4)
               (i32.const -2146435073)
             )
             (i32.const 1071644672)
@@ -414,31 +409,25 @@
       )
     )
   )
-  (func $_frexpl (param $$x f64) (param $$e i32) (result f64)
+  (func $_frexpl (param $0 f64) (param $1 i32) (result f64)
     (i32.load
       (i32.const 8)
     )
     (call $_frexp
-      (get_local $$x)
-      (get_local $$e)
+      (get_local $0)
+      (get_local $1)
     )
   )
-  (func $_strerror (param $$e i32) (result i32)
-    (local $label i32)
-    (local $$i$012 i32)
-    (local $$i$111 i32)
-    (local $$s$010 i32)
-    (local $$s$1 i32)
-    (local $$i$012$lcssa i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr$lcssa i32)
-    (local $$s$0$lcssa i32)
-    (local $$dec i32)
-    (local $$inc i32)
+  (func $_strerror (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$i$012
+    (set_local $1
       (i32.const 0)
     )
     (loop $while-out$0 $while-in$1
@@ -446,17 +435,17 @@
         (i32.eq
           (i32.and
             (i32.load8_s offset=687
-              (get_local $$i$012)
+              (get_local $1)
             )
             (i32.const 255)
           )
-          (get_local $$e)
+          (get_local $0)
         )
         (block
-          (set_local $$i$012$lcssa
-            (get_local $$i$012)
+          (set_local $4
+            (get_local $1)
           )
-          (set_local $label
+          (set_local $0
             (i32.const 2)
           )
           (br $while-out$0)
@@ -464,53 +453,51 @@
       )
       (if
         (i32.eq
-          (set_local $$inc
+          (set_local $1
             (i32.add
-              (get_local $$i$012)
+              (get_local $1)
               (i32.const 1)
             )
           )
           (i32.const 87)
         )
         (block
-          (set_local $$i$111
+          (set_local $2
             (i32.const 87)
           )
-          (set_local $$s$010
+          (set_local $3
             (i32.const 775)
           )
-          (set_local $label
+          (set_local $0
             (i32.const 5)
           )
           (br $while-out$0)
         )
-        (set_local $$i$012
-          (get_local $$inc)
-        )
+        (get_local $1)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $0)
         (i32.const 2)
       )
       (if
         (i32.eq
-          (get_local $$i$012$lcssa)
+          (get_local $4)
           (i32.const 0)
         )
-        (set_local $$s$0$lcssa
+        (set_local $5
           (i32.const 775)
         )
         (block
-          (set_local $$i$111
-            (get_local $$i$012$lcssa)
+          (set_local $2
+            (get_local $4)
           )
-          (set_local $$s$010
+          (set_local $3
             (i32.const 775)
           )
-          (set_local $label
+          (set_local $0
             (i32.const 5)
           )
         )
@@ -518,20 +505,18 @@
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $0)
         (i32.const 5)
       )
       (loop $while-out$2 $while-in$3
-        (set_local $label
-          (i32.const 0)
-        )
-        (set_local $$s$1
-          (get_local $$s$010)
+        (i32.const 0)
+        (set_local $1
+          (get_local $3)
         )
         (loop $while-out$4 $while-in$5
-          (set_local $$incdec$ptr
+          (set_local $0
             (i32.add
-              (get_local $$s$1)
+              (get_local $1)
               (i32.const 1)
             )
           )
@@ -540,7 +525,7 @@
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $$s$1)
+                    (get_local $1)
                   )
                   (i32.const 24)
                 )
@@ -549,49 +534,47 @@
               (i32.const 0)
             )
             (block
-              (set_local $$incdec$ptr$lcssa
-                (get_local $$incdec$ptr)
+              (set_local $1
+                (get_local $0)
               )
               (br $while-out$4)
             )
-            (set_local $$s$1
-              (get_local $$incdec$ptr)
+            (set_local $1
+              (get_local $0)
             )
           )
           (br $while-in$5)
         )
         (if
           (i32.eq
-            (set_local $$dec
+            (set_local $0
               (i32.add
-                (get_local $$i$111)
+                (get_local $2)
                 (i32.const -1)
               )
             )
             (i32.const 0)
           )
           (block
-            (set_local $$s$0$lcssa
-              (get_local $$incdec$ptr$lcssa)
+            (set_local $5
+              (get_local $1)
             )
             (br $while-out$2)
           )
           (block
-            (set_local $$i$111
-              (get_local $$dec)
+            (set_local $2
+              (get_local $0)
             )
-            (set_local $$s$010
-              (get_local $$incdec$ptr$lcssa)
+            (set_local $3
+              (get_local $1)
             )
-            (set_local $label
-              (i32.const 5)
-            )
+            (i32.const 5)
           )
         )
         (br $while-in$3)
       )
     )
-    (get_local $$s$0$lcssa)
+    (get_local $5)
   )
   (func $___errno_location (result i32)
     (i32.load
@@ -610,11 +593,10 @@
       )
     )
   )
-  (func $___stdio_close (param $$f i32) (result i32)
-    (local $sp i32)
-    (local $$call1 i32)
-    (local $$vararg_buffer i32)
-    (set_local $sp
+  (func $___stdio_close (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -640,33 +622,32 @@
       (call_import $abort)
     )
     (i32.store
-      (set_local $$vararg_buffer
-        (get_local $sp)
+      (set_local $2
+        (get_local $1)
       )
       (i32.load offset=60
-        (get_local $$f)
+        (get_local $0)
       )
     )
-    (set_local $$call1
+    (set_local $0
       (call $___syscall_ret
         (call_import $___syscall6
           (i32.const 6)
-          (get_local $$vararg_buffer)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $1)
     )
-    (get_local $$call1)
+    (get_local $0)
   )
-  (func $___stdout_write (param $$f i32) (param $$buf i32) (param $$len i32) (result i32)
-    (local $$vararg_buffer i32)
-    (local $sp i32)
-    (local $$call3 i32)
-    (local $$tio i32)
-    (set_local $sp
+  (func $___stdout_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -691,24 +672,24 @@
       )
       (call_import $abort)
     )
-    (set_local $$vararg_buffer
-      (get_local $sp)
+    (set_local $3
+      (get_local $4)
     )
-    (set_local $$tio
+    (set_local $5
       (i32.add
-        (get_local $sp)
+        (get_local $4)
         (i32.const 12)
       )
     )
     (i32.store offset=36
-      (get_local $$f)
+      (get_local $0)
       (i32.const 4)
     )
     (if
       (i32.eq
         (i32.and
           (i32.load
-            (get_local $$f)
+            (get_local $0)
           )
           (i32.const 64)
         )
@@ -716,53 +697,51 @@
       )
       (block
         (i32.store
-          (get_local $$vararg_buffer)
+          (get_local $3)
           (i32.load offset=60
-            (get_local $$f)
+            (get_local $0)
           )
         )
         (i32.store offset=4
-          (get_local $$vararg_buffer)
+          (get_local $3)
           (i32.const 21505)
         )
         (i32.store offset=8
-          (get_local $$vararg_buffer)
-          (get_local $$tio)
+          (get_local $3)
+          (get_local $5)
         )
         (if
           (i32.ne
             (call_import $___syscall54
               (i32.const 54)
-              (get_local $$vararg_buffer)
+              (get_local $3)
             )
             (i32.const 0)
           )
           (i32.store8 offset=75
-            (get_local $$f)
+            (get_local $0)
             (i32.const -1)
           )
         )
       )
     )
-    (set_local $$call3
+    (set_local $0
       (call $___stdio_write
-        (get_local $$f)
-        (get_local $$buf)
-        (get_local $$len)
+        (get_local $0)
+        (get_local $1)
+        (get_local $2)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $4)
     )
-    (get_local $$call3)
+    (get_local $0)
   )
-  (func $___stdio_seek (param $$f i32) (param $$off i32) (param $$whence i32) (result i32)
-    (local $$vararg_buffer i32)
-    (local $sp i32)
-    (local $$ret i32)
-    (local $$1 i32)
-    (set_local $sp
+  (func $___stdio_seek (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -788,85 +767,77 @@
       (call_import $abort)
     )
     (i32.store
-      (set_local $$vararg_buffer
-        (get_local $sp)
+      (set_local $3
+        (get_local $4)
       )
       (i32.load offset=60
-        (get_local $$f)
+        (get_local $0)
       )
     )
     (i32.store offset=4
-      (get_local $$vararg_buffer)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=8
-      (get_local $$vararg_buffer)
-      (get_local $$off)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $$vararg_buffer)
-      (set_local $$ret
+      (get_local $3)
+      (set_local $0
         (i32.add
-          (get_local $sp)
+          (get_local $4)
           (i32.const 20)
         )
       )
     )
     (i32.store offset=16
-      (get_local $$vararg_buffer)
-      (get_local $$whence)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $$1
+    (set_local $0
       (if
         (i32.lt_s
           (call $___syscall_ret
             (call_import $___syscall140
               (i32.const 140)
-              (get_local $$vararg_buffer)
+              (get_local $3)
             )
           )
           (i32.const 0)
         )
         (block
           (i32.store
-            (get_local $$ret)
+            (get_local $0)
             (i32.const -1)
           )
           (i32.const -1)
         )
         (i32.load
-          (get_local $$ret)
+          (get_local $0)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $4)
     )
-    (get_local $$1)
+    (get_local $0)
   )
-  (func $_fflush (param $$f i32) (result i32)
-    (local $$f$addr$022 i32)
-    (local $$r$021 i32)
-    (local $$call1 i32)
-    (local $$cond10 i32)
-    (local $$r$0$lcssa i32)
-    (local $$r$1 i32)
-    (local $$cond19 i32)
-    (local $$f$addr$0 i32)
-    (local $$f$addr$0$19 i32)
-    (local $$phitmp i32)
+  (func $_fflush (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (i32.load
       (i32.const 8)
     )
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (block
-          (set_local $$cond10
+          (set_local $0
             (if
               (i32.eq
                 (i32.load
@@ -887,88 +858,82 @@
           )
           (if
             (i32.eq
-              (set_local $$f$addr$0$19
+              (set_local $1
                 (i32.load
                   (i32.const 40)
                 )
               )
               (i32.const 0)
             )
-            (set_local $$r$0$lcssa
-              (get_local $$cond10)
-            )
+            (get_local $0)
             (block
-              (set_local $$f$addr$022
-                (get_local $$f$addr$0$19)
-              )
-              (set_local $$r$021
-                (get_local $$cond10)
+              (get_local $1)
+              (set_local $2
+                (get_local $0)
               )
               (loop $while-out$2 $while-in$3
-                (set_local $$cond19
+                (set_local $0
                   (if
                     (i32.gt_s
                       (i32.load offset=76
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                       (i32.const -1)
                     )
                     (call $___lockfile
-                      (get_local $$f$addr$022)
+                      (get_local $1)
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $$r$1
+                (set_local $2
                   (if
                     (i32.gt_u
                       (i32.load offset=20
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                       (i32.load offset=28
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                     )
                     (i32.or
                       (call $___fflush_unlocked
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
-                      (get_local $$r$021)
+                      (get_local $2)
                     )
-                    (get_local $$r$021)
+                    (get_local $2)
                   )
                 )
                 (if
                   (i32.ne
-                    (get_local $$cond19)
+                    (get_local $0)
                     (i32.const 0)
                   )
                   (call $___unlockfile
-                    (get_local $$f$addr$022)
+                    (get_local $1)
                   )
                 )
                 (if
                   (i32.eq
-                    (set_local $$f$addr$0
+                    (set_local $0
                       (i32.load offset=56
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$r$0$lcssa
-                      (get_local $$r$1)
+                    (set_local $0
+                      (get_local $2)
                     )
                     (br $while-out$2)
                   )
                   (block
-                    (set_local $$f$addr$022
-                      (get_local $$f$addr$0)
+                    (set_local $1
+                      (get_local $0)
                     )
-                    (set_local $$r$021
-                      (get_local $$r$1)
-                    )
+                    (get_local $2)
                   )
                 )
                 (br $while-in$3)
@@ -978,54 +943,53 @@
           (call_import $___unlock
             (i32.const 44)
           )
-          (get_local $$r$0$lcssa)
+          (get_local $0)
         )
         (block
           (if
             (i32.le_s
               (i32.load offset=76
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const -1)
             )
             (br $do-once$0
               (call $___fflush_unlocked
-                (get_local $$f)
+                (get_local $0)
               )
             )
           )
-          (set_local $$phitmp
+          (set_local $2
             (i32.eq
               (call $___lockfile
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $$call1
+          (set_local $1
             (call $___fflush_unlocked
-              (get_local $$f)
+              (get_local $0)
             )
           )
           (if
-            (get_local $$phitmp)
-            (get_local $$call1)
+            (get_local $2)
+            (get_local $1)
             (block
               (call $___unlockfile
-                (get_local $$f)
+                (get_local $0)
               )
-              (get_local $$call1)
+              (get_local $1)
             )
           )
         )
       )
     )
   )
-  (func $_printf (param $$fmt i32) (param $$varargs i32) (result i32)
-    (local $sp i32)
-    (local $$ap i32)
-    (local $$call i32)
-    (set_local $sp
+  (func $_printf (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (set_local $2
       (i32.load
         (i32.const 8)
       )
@@ -1051,67 +1015,54 @@
       (call_import $abort)
     )
     (i32.store
-      (set_local $$ap
-        (get_local $sp)
+      (set_local $3
+        (get_local $2)
       )
-      (get_local $$varargs)
+      (get_local $1)
     )
-    (set_local $$call
+    (set_local $0
       (call $_vfprintf
         (i32.load
           (i32.const 8)
         )
-        (get_local $$fmt)
-        (get_local $$ap)
+        (get_local $0)
+        (get_local $3)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $2)
     )
-    (get_local $$call)
+    (get_local $0)
   )
-  (func $___lockfile (param $$f i32) (result i32)
+  (func $___lockfile (param $0 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (i32.const 0)
   )
-  (func $___unlockfile (param $$f i32)
+  (func $___unlockfile (param $0 i32)
     (i32.load
       (i32.const 8)
     )
   )
-  (func $___stdio_write (param $$f i32) (param $$buf i32) (param $$len i32) (result i32)
-    (local $$iov$0 i32)
-    (local $$cnt$0 i32)
-    (local $$iovcnt$0 i32)
-    (local $$iov$1 i32)
-    (local $$wbase i32)
-    (local $$cnt$1 i32)
-    (local $$iovs i32)
-    (local $$vararg_buffer i32)
-    (local $$vararg_buffer3 i32)
-    (local $sp i32)
-    (local $$10 i32)
-    (local $$iovcnt$1 i32)
-    (local $$rem$0 i32)
-    (local $$wpos i32)
-    (local $label i32)
-    (local $$buf31 i32)
-    (local $$fd8 i32)
-    (local $$retval$0 i32)
-    (local $$0 i32)
-    (local $$11 i32)
-    (local $$14 i32)
-    (local $$5 i32)
-    (local $$7 i32)
-    (local $$call7 i32)
-    (local $$iov$0$lcssa57 i32)
-    (local $$iovcnt$0$lcssa58 i32)
-    (local $$sub$ptr$sub i32)
-    (local $$sub26 i32)
-    (set_local $sp
+  (func $___stdio_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (set_local $10
       (i32.load
         (i32.const 8)
       )
@@ -1136,27 +1087,27 @@
       )
       (call_import $abort)
     )
-    (set_local $$vararg_buffer3
+    (set_local $9
       (i32.add
-        (get_local $sp)
+        (get_local $10)
         (i32.const 16)
       )
     )
-    (set_local $$vararg_buffer
-      (get_local $sp)
+    (set_local $8
+      (get_local $10)
     )
     (i32.store
-      (set_local $$iovs
+      (set_local $3
         (i32.add
-          (get_local $sp)
+          (get_local $10)
           (i32.const 32)
         )
       )
-      (set_local $$0
+      (set_local $4
         (i32.load
-          (set_local $$wbase
+          (set_local $7
             (i32.add
-              (get_local $$f)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -1164,55 +1115,55 @@
       )
     )
     (i32.store offset=4
-      (get_local $$iovs)
-      (set_local $$sub$ptr$sub
+      (get_local $3)
+      (set_local $4
         (i32.sub
           (i32.load
-            (set_local $$wpos
+            (set_local $11
               (i32.add
-                (get_local $$f)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $$0)
+          (get_local $4)
         )
       )
     )
     (i32.store offset=8
-      (get_local $$iovs)
-      (get_local $$buf)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $$iovs)
-      (get_local $$len)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $$fd8
+    (set_local $13
       (i32.add
-        (get_local $$f)
+        (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $$buf31
+    (set_local $12
       (i32.add
-        (get_local $$f)
+        (get_local $0)
         (i32.const 44)
       )
     )
-    (set_local $$iov$0
-      (get_local $$iovs)
+    (set_local $5
+      (get_local $3)
     )
-    (set_local $$iovcnt$0
+    (set_local $6
       (i32.const 2)
     )
-    (set_local $$rem$0
+    (set_local $4
       (i32.add
-        (get_local $$sub$ptr$sub)
-        (get_local $$len)
+        (get_local $4)
+        (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $$cnt$0
+      (set_local $3
         (if
           (i32.eq
             (i32.load
@@ -1222,67 +1173,67 @@
           )
           (block
             (i32.store
-              (get_local $$vararg_buffer3)
+              (get_local $9)
               (i32.load
-                (get_local $$fd8)
+                (get_local $13)
               )
             )
             (i32.store offset=4
-              (get_local $$vararg_buffer3)
-              (get_local $$iov$0)
+              (get_local $9)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $$vararg_buffer3)
-              (get_local $$iovcnt$0)
+              (get_local $9)
+              (get_local $6)
             )
             (call $___syscall_ret
               (call_import $___syscall146
                 (i32.const 146)
-                (get_local $$vararg_buffer3)
+                (get_local $9)
               )
             )
           )
           (block
             (call_import $_pthread_cleanup_push
               (i32.const 5)
-              (get_local $$f)
+              (get_local $0)
             )
             (i32.store
-              (get_local $$vararg_buffer)
+              (get_local $8)
               (i32.load
-                (get_local $$fd8)
+                (get_local $13)
               )
             )
             (i32.store offset=4
-              (get_local $$vararg_buffer)
-              (get_local $$iov$0)
+              (get_local $8)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $$vararg_buffer)
-              (get_local $$iovcnt$0)
+              (get_local $8)
+              (get_local $6)
             )
-            (set_local $$call7
+            (set_local $1
               (call $___syscall_ret
                 (call_import $___syscall146
                   (i32.const 146)
-                  (get_local $$vararg_buffer)
+                  (get_local $8)
                 )
               )
             )
             (call_import $_pthread_cleanup_pop
               (i32.const 0)
             )
-            (get_local $$call7)
+            (get_local $1)
           )
         )
       )
       (if
         (i32.eq
-          (get_local $$rem$0)
-          (get_local $$cnt$0)
+          (get_local $4)
+          (get_local $3)
         )
         (block
-          (set_local $label
+          (set_local $1
             (i32.const 6)
           )
           (br $while-out$0)
@@ -1290,212 +1241,208 @@
       )
       (if
         (i32.lt_s
-          (get_local $$cnt$0)
+          (get_local $3)
           (i32.const 0)
         )
         (block
-          (set_local $$iov$0$lcssa57
-            (get_local $$iov$0)
+          (set_local $15
+            (get_local $5)
           )
-          (set_local $$iovcnt$0$lcssa58
-            (get_local $$iovcnt$0)
+          (set_local $16
+            (get_local $6)
           )
-          (set_local $label
+          (set_local $1
             (i32.const 8)
           )
           (br $while-out$0)
         )
       )
-      (set_local $$sub26
+      (set_local $17
         (i32.sub
-          (get_local $$rem$0)
-          (get_local $$cnt$0)
+          (get_local $4)
+          (get_local $3)
         )
       )
-      (set_local $$14
+      (set_local $1
         (if
           (i32.gt_u
-            (get_local $$cnt$0)
-            (set_local $$10
+            (get_local $3)
+            (set_local $1
               (i32.load offset=4
-                (get_local $$iov$0)
+                (get_local $5)
               )
             )
           )
           (block
             (i32.store
-              (get_local $$wbase)
-              (set_local $$11
+              (get_local $7)
+              (set_local $4
                 (i32.load
-                  (get_local $$buf31)
+                  (get_local $12)
                 )
               )
             )
             (i32.store
-              (get_local $$wpos)
-              (get_local $$11)
+              (get_local $11)
+              (get_local $4)
             )
-            (set_local $$cnt$1
+            (set_local $4
               (i32.sub
-                (get_local $$cnt$0)
-                (get_local $$10)
+                (get_local $3)
+                (get_local $1)
               )
             )
-            (set_local $$iov$1
+            (set_local $3
               (i32.add
-                (get_local $$iov$0)
+                (get_local $5)
                 (i32.const 8)
               )
             )
-            (set_local $$iovcnt$1
+            (set_local $6
               (i32.add
-                (get_local $$iovcnt$0)
+                (get_local $6)
                 (i32.const -1)
               )
             )
             (i32.load offset=12
-              (get_local $$iov$0)
+              (get_local $5)
             )
           )
           (if
             (i32.eq
-              (get_local $$iovcnt$0)
+              (get_local $6)
               (i32.const 2)
             )
             (block
               (i32.store
-                (get_local $$wbase)
+                (get_local $7)
                 (i32.add
                   (i32.load
-                    (get_local $$wbase)
+                    (get_local $7)
                   )
-                  (get_local $$cnt$0)
+                  (get_local $3)
                 )
               )
-              (set_local $$cnt$1
-                (get_local $$cnt$0)
+              (set_local $4
+                (get_local $3)
               )
-              (set_local $$iov$1
-                (get_local $$iov$0)
+              (set_local $3
+                (get_local $5)
               )
-              (set_local $$iovcnt$1
+              (set_local $6
                 (i32.const 2)
               )
-              (get_local $$10)
+              (get_local $1)
             )
             (block
-              (set_local $$cnt$1
-                (get_local $$cnt$0)
+              (set_local $4
+                (get_local $3)
               )
-              (set_local $$iov$1
-                (get_local $$iov$0)
+              (set_local $3
+                (get_local $5)
               )
-              (set_local $$iovcnt$1
-                (get_local $$iovcnt$0)
-              )
-              (get_local $$10)
+              (get_local $6)
+              (get_local $1)
             )
           )
         )
       )
       (i32.store
-        (get_local $$iov$1)
+        (get_local $3)
         (i32.add
           (i32.load
-            (get_local $$iov$1)
+            (get_local $3)
           )
-          (get_local $$cnt$1)
+          (get_local $4)
         )
       )
       (i32.store offset=4
-        (get_local $$iov$1)
+        (get_local $3)
         (i32.sub
-          (get_local $$14)
-          (get_local $$cnt$1)
+          (get_local $1)
+          (get_local $4)
         )
       )
-      (set_local $$iov$0
-        (get_local $$iov$1)
+      (set_local $5
+        (get_local $3)
       )
-      (set_local $$iovcnt$0
-        (get_local $$iovcnt$1)
-      )
-      (set_local $$rem$0
-        (get_local $$sub26)
+      (get_local $6)
+      (set_local $4
+        (get_local $17)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $1)
         (i32.const 6)
       )
       (block
         (i32.store offset=16
-          (get_local $$f)
+          (get_local $0)
           (i32.add
-            (set_local $$5
+            (set_local $1
               (i32.load
-                (get_local $$buf31)
+                (get_local $12)
               )
             )
             (i32.load offset=48
-              (get_local $$f)
+              (get_local $0)
             )
           )
         )
         (i32.store
-          (get_local $$wbase)
-          (set_local $$7
-            (get_local $$5)
+          (get_local $7)
+          (set_local $0
+            (get_local $1)
           )
         )
         (i32.store
-          (get_local $$wpos)
-          (get_local $$7)
+          (get_local $11)
+          (get_local $0)
         )
-        (set_local $$retval$0
-          (get_local $$len)
+        (set_local $14
+          (get_local $2)
         )
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $1)
           (i32.const 8)
         )
         (block
           (i32.store offset=16
-            (get_local $$f)
+            (get_local $0)
             (i32.const 0)
           )
           (i32.store
-            (get_local $$wbase)
+            (get_local $7)
             (i32.const 0)
           )
           (i32.store
-            (get_local $$wpos)
+            (get_local $11)
             (i32.const 0)
           )
           (i32.store
-            (get_local $$f)
+            (get_local $0)
             (i32.or
               (i32.load
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 32)
             )
           )
-          (set_local $$retval$0
+          (set_local $14
             (if
               (i32.eq
-                (get_local $$iovcnt$0$lcssa58)
+                (get_local $16)
                 (i32.const 2)
               )
               (i32.const 0)
               (i32.sub
-                (get_local $$len)
+                (get_local $2)
                 (i32.load offset=4
-                  (get_local $$iov$0$lcssa57)
+                  (get_local $15)
                 )
               )
             )
@@ -1505,33 +1452,24 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $10)
     )
-    (get_local $$retval$0)
+    (get_local $14)
   )
-  (func $_vfprintf (param $$f i32) (param $$fmt i32) (param $$ap i32) (result i32)
-    (local $sp i32)
-    (local $$ap2 i32)
-    (local $$internal_buf i32)
-    (local $$nl_arg i32)
-    (local $$nl_type i32)
-    (local $dest i32)
-    (local $$4 i32)
-    (local $$buf i32)
-    (local $$buf_size i32)
-    (local $$call21 i32)
-    (local $$wpos i32)
-    (local $$$call21 i32)
-    (local $$1 i32)
-    (local $$7 i32)
-    (local $$and i32)
-    (local $$cond i32)
-    (local $$ret$1$ i32)
-    (local $$retval$0 i32)
-    (local $$wbase i32)
-    (local $$wend i32)
-    (local $stop i32)
-    (set_local $sp
+  (func $_vfprintf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -1556,27 +1494,27 @@
       )
       (call_import $abort)
     )
-    (set_local $$ap2
+    (set_local $5
       (i32.add
-        (get_local $sp)
+        (get_local $4)
         (i32.const 120)
       )
     )
-    (set_local $$nl_arg
-      (get_local $sp)
+    (set_local $8
+      (get_local $4)
     )
-    (set_local $$internal_buf
+    (set_local $7
       (i32.add
-        (get_local $sp)
+        (get_local $4)
         (i32.const 136)
       )
     )
-    (set_local $stop
+    (set_local $6
       (i32.add
-        (set_local $dest
-          (set_local $$nl_type
+        (set_local $3
+          (set_local $9
             (i32.add
-              (get_local $sp)
+              (get_local $4)
               (i32.const 80)
             )
           )
@@ -1586,60 +1524,60 @@
     )
     (loop $do-out$0 $do-in$1
       (i32.store
-        (get_local $dest)
+        (get_local $3)
         (i32.const 0)
       )
       (br_if $do-in$1
         (i32.lt_s
-          (set_local $dest
+          (set_local $3
             (i32.add
-              (get_local $dest)
+              (get_local $3)
               (i32.const 4)
             )
           )
-          (get_local $stop)
+          (get_local $6)
         )
       )
     )
     (i32.store
-      (get_local $$ap2)
+      (get_local $5)
       (i32.load
-        (get_local $$ap)
+        (get_local $2)
       )
     )
-    (set_local $$retval$0
+    (set_local $0
       (if
         (i32.lt_s
           (call $_printf_core
             (i32.const 0)
-            (get_local $$fmt)
-            (get_local $$ap2)
-            (get_local $$nl_arg)
-            (get_local $$nl_type)
+            (get_local $1)
+            (get_local $5)
+            (get_local $8)
+            (get_local $9)
           )
           (i32.const 0)
         )
         (i32.const -1)
         (block
-          (set_local $$cond
+          (set_local $12
             (if
               (i32.gt_s
                 (i32.load offset=76
-                  (get_local $$f)
+                  (get_local $0)
                 )
                 (i32.const -1)
               )
               (call $___lockfile
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $$and
+          (set_local $3
             (i32.and
-              (set_local $$1
+              (set_local $2
                 (i32.load
-                  (get_local $$f)
+                  (get_local $0)
                 )
               )
               (i32.const 32)
@@ -1650,7 +1588,7 @@
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s offset=74
-                    (get_local $$f)
+                    (get_local $0)
                   )
                   (i32.const 24)
                 )
@@ -1659,21 +1597,21 @@
               (i32.const 1)
             )
             (i32.store
-              (get_local $$f)
+              (get_local $0)
               (i32.and
-                (get_local $$1)
+                (get_local $2)
                 (i32.const -33)
               )
             )
           )
-          (set_local $$ret$1$
+          (set_local $2
             (select
               (if
                 (i32.eq
                   (i32.load
-                    (set_local $$buf_size
+                    (set_local $10
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 48)
                       )
                     )
@@ -1681,134 +1619,134 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$4
+                  (set_local $2
                     (i32.load
-                      (set_local $$buf
+                      (set_local $6
                         (i32.add
-                          (get_local $$f)
+                          (get_local $0)
                           (i32.const 44)
                         )
                       )
                     )
                   )
                   (i32.store
-                    (get_local $$buf)
-                    (get_local $$internal_buf)
+                    (get_local $6)
+                    (get_local $7)
                   )
                   (i32.store
-                    (set_local $$wbase
+                    (set_local $13
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 28)
                       )
                     )
-                    (get_local $$internal_buf)
+                    (get_local $7)
                   )
                   (i32.store
-                    (set_local $$wpos
+                    (set_local $11
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 20)
                       )
                     )
-                    (get_local $$internal_buf)
+                    (get_local $7)
                   )
                   (i32.store
-                    (get_local $$buf_size)
+                    (get_local $10)
                     (i32.const 80)
                   )
                   (i32.store
-                    (set_local $$wend
+                    (set_local $14
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
                     (i32.add
-                      (get_local $$internal_buf)
+                      (get_local $7)
                       (i32.const 80)
                     )
                   )
-                  (set_local $$call21
+                  (set_local $1
                     (call $_printf_core
-                      (get_local $$f)
-                      (get_local $$fmt)
-                      (get_local $$ap2)
-                      (get_local $$nl_arg)
-                      (get_local $$nl_type)
+                      (get_local $0)
+                      (get_local $1)
+                      (get_local $5)
+                      (get_local $8)
+                      (get_local $9)
                     )
                   )
                   (if
                     (i32.eq
-                      (get_local $$4)
+                      (get_local $2)
                       (i32.const 0)
                     )
-                    (get_local $$call21)
+                    (get_local $1)
                     (block
                       (call_indirect $FUNCSIG$iiii
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $$f)
+                              (get_local $0)
                             )
                             (i32.const 7)
                           )
                           (i32.const 2)
                         )
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 0)
                         (i32.const 0)
                       )
-                      (set_local $$$call21
+                      (set_local $1
                         (select
                           (i32.const -1)
-                          (get_local $$call21)
+                          (get_local $1)
                           (i32.eq
                             (i32.load
-                              (get_local $$wpos)
+                              (get_local $11)
                             )
                             (i32.const 0)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $$buf)
-                        (get_local $$4)
+                        (get_local $6)
+                        (get_local $2)
                       )
                       (i32.store
-                        (get_local $$buf_size)
+                        (get_local $10)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $$wend)
+                        (get_local $14)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $$wbase)
+                        (get_local $13)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $$wpos)
+                        (get_local $11)
                         (i32.const 0)
                       )
-                      (get_local $$$call21)
+                      (get_local $1)
                     )
                   )
                 )
                 (call $_printf_core
-                  (get_local $$f)
-                  (get_local $$fmt)
-                  (get_local $$ap2)
-                  (get_local $$nl_arg)
-                  (get_local $$nl_type)
+                  (get_local $0)
+                  (get_local $1)
+                  (get_local $5)
+                  (get_local $8)
+                  (get_local $9)
                 )
               )
               (i32.const -1)
               (i32.eq
                 (i32.and
-                  (set_local $$7
+                  (set_local $1
                     (i32.load
-                      (get_local $$f)
+                      (get_local $0)
                     )
                   )
                   (i32.const 32)
@@ -1818,57 +1756,47 @@
             )
           )
           (i32.store
-            (get_local $$f)
+            (get_local $0)
             (i32.or
-              (get_local $$7)
-              (get_local $$and)
+              (get_local $1)
+              (get_local $3)
             )
           )
           (if
             (i32.ne
-              (get_local $$cond)
+              (get_local $12)
               (i32.const 0)
             )
             (call $___unlockfile
-              (get_local $$f)
+              (get_local $0)
             )
           )
-          (get_local $$ret$1$)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $4)
     )
-    (get_local $$retval$0)
+    (get_local $0)
   )
-  (func $___fwritex (param $$s i32) (param $$l i32) (param $$f i32) (result i32)
-    (local $$i$0$lcssa36 i32)
-    (local $$l$addr$0 i32)
-    (local $$i$0 i32)
-    (local $$retval$0 i32)
-    (local $$i$1 i32)
-    (local $$s$addr$0 i32)
-    (local $$wpos i32)
-    (local $$3 i32)
-    (local $$4 i32)
-    (local $label i32)
-    (local $$0 i32)
-    (local $$2 i32)
-    (local $$cmp i32)
-    (local $$sub i32)
-    (local $$wend i32)
+  (func $___fwritex (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
-        (set_local $$0
+        (set_local $3
           (i32.load
-            (set_local $$wend
+            (set_local $6
               (i32.add
-                (get_local $$f)
+                (get_local $2)
                 (i32.const 16)
               )
             )
@@ -1879,29 +1807,29 @@
       (if
         (i32.eq
           (call $___towrite
-            (get_local $$f)
+            (get_local $2)
           )
           (i32.const 0)
         )
         (block
-          (set_local $$3
+          (set_local $4
             (i32.load
-              (get_local $$wend)
+              (get_local $6)
             )
           )
-          (set_local $label
+          (set_local $7
             (i32.const 5)
           )
         )
-        (set_local $$retval$0
+        (set_local $5
           (i32.const 0)
         )
       )
       (block
-        (set_local $$3
-          (get_local $$0)
+        (set_local $4
+          (get_local $3)
         )
-        (set_local $label
+        (set_local $7
           (i32.const 5)
         )
       )
@@ -1909,48 +1837,46 @@
     (block $label$break$L5
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $7)
           (i32.const 5)
         )
         (block
-          (set_local $$cmp
+          (set_local $4
             (i32.lt_u
               (i32.sub
-                (get_local $$3)
-                (set_local $$2
+                (get_local $4)
+                (set_local $3
                   (i32.load
-                    (set_local $$wpos
+                    (set_local $6
                       (i32.add
-                        (get_local $$f)
+                        (get_local $2)
                         (i32.const 20)
                       )
                     )
                   )
                 )
               )
-              (get_local $$l)
+              (get_local $1)
             )
           )
-          (set_local $$4
-            (get_local $$2)
-          )
+          (get_local $3)
           (if
-            (get_local $$cmp)
+            (get_local $4)
             (block
-              (set_local $$retval$0
+              (set_local $5
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $$f)
+                        (get_local $2)
                       )
                       (i32.const 7)
                     )
                     (i32.const 2)
                   )
-                  (get_local $$f)
-                  (get_local $$s)
-                  (get_local $$l)
+                  (get_local $2)
+                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br $label$break$L5)
@@ -1963,7 +1889,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s offset=75
-                        (get_local $$f)
+                        (get_local $2)
                       )
                       (i32.const 24)
                     )
@@ -1972,27 +1898,23 @@
                   (i32.const -1)
                 )
                 (block
-                  (set_local $$i$0
-                    (get_local $$l)
+                  (set_local $4
+                    (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eq
-                        (get_local $$i$0)
+                        (get_local $4)
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$i$1
+                        (set_local $2
                           (i32.const 0)
                         )
-                        (set_local $$l$addr$0
-                          (get_local $$l)
-                        )
-                        (set_local $$s$addr$0
-                          (get_local $$s)
-                        )
+                        (get_local $1)
+                        (get_local $0)
                         (br $label$break$L10
-                          (get_local $$4)
+                          (get_local $3)
                         )
                       )
                     )
@@ -2002,10 +1924,10 @@
                           (i32.shl
                             (i32.load8_s
                               (i32.add
-                                (get_local $$s)
-                                (set_local $$sub
+                                (get_local $0)
+                                (set_local $5
                                   (i32.add
-                                    (get_local $$i$0)
+                                    (get_local $4)
                                     (i32.const -1)
                                   )
                                 )
@@ -2018,13 +1940,13 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $$i$0$lcssa36
-                          (get_local $$i$0)
+                        (set_local $3
+                          (get_local $4)
                         )
                         (br $while-out$2)
                       )
-                      (set_local $$i$0
-                        (get_local $$sub)
+                      (set_local $4
+                        (get_local $5)
                       )
                     )
                     (br $while-in$3)
@@ -2035,101 +1957,94 @@
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $$f)
+                              (get_local $2)
                             )
                             (i32.const 7)
                           )
                           (i32.const 2)
                         )
-                        (get_local $$f)
-                        (get_local $$s)
-                        (get_local $$i$0$lcssa36)
+                        (get_local $2)
+                        (get_local $0)
+                        (get_local $3)
                       )
-                      (get_local $$i$0$lcssa36)
+                      (get_local $3)
                     )
                     (block
-                      (set_local $$retval$0
-                        (get_local $$i$0$lcssa36)
+                      (set_local $5
+                        (get_local $3)
                       )
                       (br $label$break$L5)
                     )
                   )
-                  (set_local $$i$1
-                    (get_local $$i$0$lcssa36)
+                  (set_local $2
+                    (get_local $3)
                   )
-                  (set_local $$l$addr$0
+                  (set_local $1
                     (i32.sub
-                      (get_local $$l)
-                      (get_local $$i$0$lcssa36)
+                      (get_local $1)
+                      (get_local $3)
                     )
                   )
-                  (set_local $$s$addr$0
+                  (set_local $0
                     (i32.add
-                      (get_local $$s)
-                      (get_local $$i$0$lcssa36)
+                      (get_local $0)
+                      (get_local $3)
                     )
                   )
                   (i32.load
-                    (get_local $$wpos)
+                    (get_local $6)
                   )
                 )
                 (block
-                  (set_local $$i$1
+                  (set_local $2
                     (i32.const 0)
                   )
-                  (set_local $$l$addr$0
-                    (get_local $$l)
-                  )
-                  (set_local $$s$addr$0
-                    (get_local $$s)
-                  )
-                  (get_local $$4)
+                  (get_local $1)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
             )
-            (get_local $$s$addr$0)
-            (get_local $$l$addr$0)
+            (get_local $0)
+            (get_local $1)
           )
           (i32.store
-            (get_local $$wpos)
+            (get_local $6)
             (i32.add
               (i32.load
-                (get_local $$wpos)
+                (get_local $6)
               )
-              (get_local $$l$addr$0)
+              (get_local $1)
             )
           )
-          (set_local $$retval$0
+          (set_local $5
             (i32.add
-              (get_local $$i$1)
-              (get_local $$l$addr$0)
+              (get_local $2)
+              (get_local $1)
             )
           )
         )
       )
     )
-    (get_local $$retval$0)
+    (get_local $5)
   )
-  (func $___towrite (param $$f i32) (result i32)
-    (local $$2 i32)
-    (local $$1 i32)
-    (local $$conv i32)
-    (local $$conv3 i32)
-    (local $$mode i32)
+  (func $___towrite (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$conv3
+    (set_local $1
       (i32.and
         (i32.or
           (i32.add
-            (set_local $$conv
+            (set_local $1
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (set_local $$mode
+                    (set_local $2
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 74)
                       )
                     )
@@ -2141,21 +2056,21 @@
             )
             (i32.const 255)
           )
-          (get_local $$conv)
+          (get_local $1)
         )
         (i32.const 255)
       )
     )
     (i32.store8
-      (get_local $$mode)
-      (get_local $$conv3)
+      (get_local $2)
+      (get_local $1)
     )
     (if
       (i32.eq
         (i32.and
-          (set_local $$1
+          (set_local $1
             (i32.load
-              (get_local $$f)
+              (get_local $0)
             )
           )
           (i32.const 8)
@@ -2164,31 +2079,31 @@
       )
       (block
         (i32.store offset=8
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=4
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=28
-          (get_local $$f)
-          (set_local $$2
+          (get_local $0)
+          (set_local $1
             (i32.load offset=44
-              (get_local $$f)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=20
-          (get_local $$f)
-          (get_local $$2)
+          (get_local $0)
+          (get_local $1)
         )
         (i32.store offset=16
-          (get_local $$f)
+          (get_local $0)
           (i32.add
-            (get_local $$2)
+            (get_local $1)
             (i32.load offset=48
-              (get_local $$f)
+              (get_local $0)
             )
           )
         )
@@ -2196,9 +2111,9 @@
       )
       (block
         (i32.store
-          (get_local $$f)
+          (get_local $0)
           (i32.or
-            (get_local $$1)
+            (get_local $1)
             (i32.const 32)
           )
         )
@@ -2206,28 +2121,28 @@
       )
     )
   )
-  (func $_wcrtomb (param $$s i32) (param $$wc i32) (param $$st i32) (result i32)
+  (func $_wcrtomb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $$s)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.const 1)
         (block
           (if
             (i32.lt_u
-              (get_local $$wc)
+              (get_local $1)
               (i32.const 128)
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
-                  (get_local $$wc)
+                  (get_local $1)
                   (i32.const 255)
                 )
               )
@@ -2238,16 +2153,16 @@
           )
           (if
             (i32.lt_u
-              (get_local $$wc)
+              (get_local $1)
               (i32.const 2048)
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.shr_u
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 6)
                     )
                     (i32.const 192)
@@ -2256,11 +2171,11 @@
                 )
               )
               (i32.store8 offset=1
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 63)
                     )
                     (i32.const 128)
@@ -2276,12 +2191,12 @@
           (if
             (i32.or
               (i32.lt_u
-                (get_local $$wc)
+                (get_local $1)
                 (i32.const 55296)
               )
               (i32.eq
                 (i32.and
-                  (get_local $$wc)
+                  (get_local $1)
                   (i32.const -8192)
                 )
                 (i32.const 57344)
@@ -2289,11 +2204,11 @@
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.shr_u
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 12)
                     )
                     (i32.const 224)
@@ -2302,12 +2217,12 @@
                 )
               )
               (i32.store8 offset=1
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$wc)
+                        (get_local $1)
                         (i32.const 6)
                       )
                       (i32.const 63)
@@ -2318,11 +2233,11 @@
                 )
               )
               (i32.store8 offset=2
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 63)
                     )
                     (i32.const 128)
@@ -2338,18 +2253,18 @@
           (if
             (i32.lt_u
               (i32.add
-                (get_local $$wc)
+                (get_local $1)
                 (i32.const -65536)
               )
               (i32.const 1048576)
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.shr_u
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 18)
                     )
                     (i32.const 240)
@@ -2358,12 +2273,12 @@
                 )
               )
               (i32.store8 offset=1
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$wc)
+                        (get_local $1)
                         (i32.const 12)
                       )
                       (i32.const 63)
@@ -2374,12 +2289,12 @@
                 )
               )
               (i32.store8 offset=2
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$wc)
+                        (get_local $1)
                         (i32.const 6)
                       )
                       (i32.const 63)
@@ -2390,11 +2305,11 @@
                 )
               )
               (i32.store8 offset=3
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 63)
                     )
                     (i32.const 128)
@@ -2416,94 +2331,76 @@
       )
     )
   )
-  (func $_wctomb (param $$s i32) (param $$wc i32) (result i32)
+  (func $_wctomb (param $0 i32) (param $1 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
-        (get_local $$s)
+        (get_local $0)
         (i32.const 0)
       )
       (i32.const 0)
       (call $_wcrtomb
-        (get_local $$s)
-        (get_local $$wc)
+        (get_local $0)
+        (get_local $1)
         (i32.const 0)
       )
     )
   )
-  (func $_memchr (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
-    (local $label i32)
-    (local $$n$addr$0$lcssa61 i32)
-    (local $$n$addr$3 i32)
-    (local $$s$0$lcssa60 i32)
-    (local $$s$128 i32)
-    (local $$s$2 i32)
-    (local $$n$addr$227 i32)
-    (local $$s$044 i32)
-    (local $$w$034 i32)
-    (local $$n$addr$043 i32)
-    (local $$n$addr$1$lcssa i32)
-    (local $$n$addr$133 i32)
-    (local $$s$0$lcssa i32)
-    (local $$w$0$lcssa i32)
-    (local $$dec i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr21 i32)
-    (local $$incdec$ptr33 i32)
-    (local $$n$addr$0$lcssa i32)
-    (local $$sub22 i32)
-    (local $$tobool2$lcssa i32)
-    (local $$1 i32)
-    (local $$5 i32)
-    (local $$conv1 i32)
-    (local $$dec34 i32)
-    (local $$mul i32)
-    (local $$n$addr$133$lcssa i32)
-    (local $$sub i32)
-    (local $$tobool2 i32)
-    (local $$tobool2$41 i32)
-    (local $$w$034$lcssa i32)
-    (local $$xor i32)
+  (func $_memchr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$conv1
+    (set_local $5
       (i32.and
-        (get_local $$c)
+        (get_local $1)
         (i32.const 255)
       )
     )
     (block $label$break$L1
       (if
         (i32.and
-          (set_local $$tobool2$41
+          (set_local $4
             (i32.ne
-              (get_local $$n)
+              (get_local $2)
               (i32.const 0)
             )
           )
           (i32.ne
             (i32.and
-              (get_local $$src)
+              (get_local $0)
               (i32.const 3)
             )
             (i32.const 0)
           )
         )
         (block
-          (set_local $$1
+          (set_local $4
             (i32.and
-              (get_local $$c)
+              (get_local $1)
               (i32.const 255)
             )
           )
-          (set_local $$n$addr$043
-            (get_local $$n)
+          (set_local $3
+            (get_local $2)
           )
-          (set_local $$s$044
-            (get_local $$src)
+          (set_local $2
+            (get_local $0)
           )
           (loop $while-out$1 $while-in$2
             (if
@@ -2511,7 +2408,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $$s$044)
+                      (get_local $2)
                     )
                     (i32.const 24)
                   )
@@ -2519,20 +2416,20 @@
                 )
                 (i32.shr_s
                   (i32.shl
-                    (get_local $$1)
+                    (get_local $4)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
               (block
-                (set_local $$n$addr$0$lcssa61
-                  (get_local $$n$addr$043)
+                (set_local $6
+                  (get_local $3)
                 )
-                (set_local $$s$0$lcssa60
-                  (get_local $$s$044)
+                (set_local $8
+                  (get_local $2)
                 )
-                (set_local $label
+                (set_local $3
                   (i32.const 6)
                 )
                 (br $label$break$L1)
@@ -2540,11 +2437,11 @@
             )
             (if
               (i32.and
-                (set_local $$tobool2
+                (set_local $3
                   (i32.ne
-                    (set_local $$dec
+                    (set_local $0
                       (i32.add
-                        (get_local $$n$addr$043)
+                        (get_local $3)
                         (i32.const -1)
                       )
                     )
@@ -2553,9 +2450,9 @@
                 )
                 (i32.ne
                   (i32.and
-                    (set_local $$incdec$ptr
+                    (set_local $2
                       (i32.add
-                        (get_local $$s$044)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
@@ -2565,24 +2462,22 @@
                 )
               )
               (block
-                (set_local $$n$addr$043
-                  (get_local $$dec)
+                (set_local $3
+                  (get_local $0)
                 )
-                (set_local $$s$044
-                  (get_local $$incdec$ptr)
-                )
+                (get_local $2)
               )
               (block
-                (set_local $$n$addr$0$lcssa
-                  (get_local $$dec)
+                (set_local $11
+                  (get_local $0)
                 )
-                (set_local $$s$0$lcssa
-                  (get_local $$incdec$ptr)
+                (set_local $14
+                  (get_local $2)
                 )
-                (set_local $$tobool2$lcssa
-                  (get_local $$tobool2)
+                (set_local $16
+                  (get_local $3)
                 )
-                (set_local $label
+                (set_local $3
                   (i32.const 5)
                 )
                 (br $while-out$1)
@@ -2592,16 +2487,16 @@
           )
         )
         (block
-          (set_local $$n$addr$0$lcssa
-            (get_local $$n)
+          (set_local $11
+            (get_local $2)
           )
-          (set_local $$s$0$lcssa
-            (get_local $$src)
+          (set_local $14
+            (get_local $0)
           )
-          (set_local $$tobool2$lcssa
-            (get_local $$tobool2$41)
+          (set_local $16
+            (get_local $4)
           )
-          (set_local $label
+          (set_local $3
             (i32.const 5)
           )
         )
@@ -2609,28 +2504,28 @@
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $3)
         (i32.const 5)
       )
       (if
-        (get_local $$tobool2$lcssa)
+        (get_local $16)
         (block
-          (set_local $$n$addr$0$lcssa61
-            (get_local $$n$addr$0$lcssa)
+          (set_local $6
+            (get_local $11)
           )
-          (set_local $$s$0$lcssa60
-            (get_local $$s$0$lcssa)
+          (set_local $8
+            (get_local $14)
           )
-          (set_local $label
+          (set_local $3
             (i32.const 6)
           )
         )
         (block
-          (set_local $$n$addr$3
+          (set_local $7
             (i32.const 0)
           )
-          (set_local $$s$2
-            (get_local $$s$0$lcssa)
+          (set_local $10
+            (get_local $14)
           )
         )
       )
@@ -2638,7 +2533,7 @@
     (block $label$break$L8
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $3)
           (i32.const 6)
         )
         (if
@@ -2646,7 +2541,7 @@
             (i32.shr_s
               (i32.shl
                 (i32.load8_s
-                  (get_local $$s$0$lcssa60)
+                  (get_local $8)
                 )
                 (i32.const 24)
               )
@@ -2654,9 +2549,9 @@
             )
             (i32.shr_s
               (i32.shl
-                (set_local $$5
+                (set_local $0
                   (i32.and
-                    (get_local $$c)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
@@ -2666,42 +2561,42 @@
             )
           )
           (block
-            (set_local $$n$addr$3
-              (get_local $$n$addr$0$lcssa61)
+            (set_local $7
+              (get_local $6)
             )
-            (set_local $$s$2
-              (get_local $$s$0$lcssa60)
+            (set_local $10
+              (get_local $8)
             )
           )
           (block
-            (set_local $$mul
+            (set_local $2
               (i32.mul
-                (get_local $$conv1)
+                (get_local $5)
                 (i32.const 16843009)
               )
             )
             (block $label$break$L11
               (if
                 (i32.gt_u
-                  (get_local $$n$addr$0$lcssa61)
+                  (get_local $6)
                   (i32.const 3)
                 )
                 (block
-                  (set_local $$n$addr$133
-                    (get_local $$n$addr$0$lcssa61)
+                  (set_local $4
+                    (get_local $6)
                   )
-                  (set_local $$w$034
-                    (get_local $$s$0$lcssa60)
+                  (set_local $5
+                    (get_local $8)
                   )
                   (loop $while-out$5 $while-in$6
-                    (set_local $$sub
+                    (set_local $1
                       (i32.add
-                        (set_local $$xor
+                        (set_local $11
                           (i32.xor
                             (i32.load
-                              (get_local $$w$034)
+                              (get_local $5)
                             )
-                            (get_local $$mul)
+                            (get_local $2)
                           )
                         )
                         (i32.const -16843009)
@@ -2712,57 +2607,55 @@
                         (i32.and
                           (i32.xor
                             (i32.and
-                              (get_local $$xor)
+                              (get_local $11)
                               (i32.const -2139062144)
                             )
                             (i32.const -2139062144)
                           )
-                          (get_local $$sub)
+                          (get_local $1)
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$n$addr$133$lcssa
-                          (get_local $$n$addr$133)
+                        (set_local $1
+                          (get_local $4)
                         )
-                        (set_local $$w$034$lcssa
-                          (get_local $$w$034)
+                        (set_local $2
+                          (get_local $5)
                         )
                         (br $while-out$5)
                       )
                     )
-                    (set_local $$incdec$ptr21
+                    (set_local $1
                       (i32.add
-                        (get_local $$w$034)
+                        (get_local $5)
                         (i32.const 4)
                       )
                     )
                     (if
                       (i32.gt_u
-                        (set_local $$sub22
+                        (set_local $4
                           (i32.add
-                            (get_local $$n$addr$133)
+                            (get_local $4)
                             (i32.const -4)
                           )
                         )
                         (i32.const 3)
                       )
                       (block
-                        (set_local $$n$addr$133
-                          (get_local $$sub22)
-                        )
-                        (set_local $$w$034
-                          (get_local $$incdec$ptr21)
+                        (get_local $4)
+                        (set_local $5
+                          (get_local $1)
                         )
                       )
                       (block
-                        (set_local $$n$addr$1$lcssa
-                          (get_local $$sub22)
+                        (set_local $13
+                          (get_local $4)
                         )
-                        (set_local $$w$0$lcssa
-                          (get_local $$incdec$ptr21)
+                        (set_local $15
+                          (get_local $1)
                         )
-                        (set_local $label
+                        (set_local $3
                           (i32.const 11)
                         )
                         (br $label$break$L11)
@@ -2770,21 +2663,21 @@
                     )
                     (br $while-in$6)
                   )
-                  (set_local $$n$addr$227
-                    (get_local $$n$addr$133$lcssa)
+                  (set_local $12
+                    (get_local $1)
                   )
-                  (set_local $$s$128
-                    (get_local $$w$034$lcssa)
+                  (set_local $9
+                    (get_local $2)
                   )
                 )
                 (block
-                  (set_local $$n$addr$1$lcssa
-                    (get_local $$n$addr$0$lcssa61)
+                  (set_local $13
+                    (get_local $6)
                   )
-                  (set_local $$w$0$lcssa
-                    (get_local $$s$0$lcssa60)
+                  (set_local $15
+                    (get_local $8)
                   )
-                  (set_local $label
+                  (set_local $3
                     (i32.const 11)
                   )
                 )
@@ -2792,29 +2685,29 @@
             )
             (if
               (i32.eq
-                (get_local $label)
+                (get_local $3)
                 (i32.const 11)
               )
               (if
                 (i32.eq
-                  (get_local $$n$addr$1$lcssa)
+                  (get_local $13)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$n$addr$3
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $$s$2
-                    (get_local $$w$0$lcssa)
+                  (set_local $10
+                    (get_local $15)
                   )
                   (br $label$break$L8)
                 )
                 (block
-                  (set_local $$n$addr$227
-                    (get_local $$n$addr$1$lcssa)
+                  (set_local $12
+                    (get_local $13)
                   )
-                  (set_local $$s$128
-                    (get_local $$w$0$lcssa)
+                  (set_local $9
+                    (get_local $15)
                   )
                 )
               )
@@ -2825,7 +2718,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s
-                        (get_local $$s$128)
+                        (get_local $9)
                       )
                       (i32.const 24)
                     )
@@ -2833,53 +2726,53 @@
                   )
                   (i32.shr_s
                     (i32.shl
-                      (get_local $$5)
+                      (get_local $0)
                       (i32.const 24)
                     )
                     (i32.const 24)
                   )
                 )
                 (block
-                  (set_local $$n$addr$3
-                    (get_local $$n$addr$227)
+                  (set_local $7
+                    (get_local $12)
                   )
-                  (set_local $$s$2
-                    (get_local $$s$128)
+                  (set_local $10
+                    (get_local $9)
                   )
                   (br $label$break$L8)
                 )
               )
-              (set_local $$incdec$ptr33
+              (set_local $2
                 (i32.add
-                  (get_local $$s$128)
+                  (get_local $9)
                   (i32.const 1)
                 )
               )
               (if
                 (i32.eq
-                  (set_local $$dec34
+                  (set_local $1
                     (i32.add
-                      (get_local $$n$addr$227)
+                      (get_local $12)
                       (i32.const -1)
                     )
                   )
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$n$addr$3
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $$s$2
-                    (get_local $$incdec$ptr33)
+                  (set_local $10
+                    (get_local $2)
                   )
                   (br $while-out$7)
                 )
                 (block
-                  (set_local $$n$addr$227
-                    (get_local $$dec34)
+                  (set_local $12
+                    (get_local $1)
                   )
-                  (set_local $$s$128
-                    (get_local $$incdec$ptr33)
+                  (set_local $9
+                    (get_local $2)
                   )
                 )
               )
@@ -2890,21 +2783,21 @@
       )
     )
     (select
-      (get_local $$s$2)
+      (get_local $10)
       (i32.const 0)
       (i32.ne
-        (get_local $$n$addr$3)
+        (get_local $7)
         (i32.const 0)
       )
     )
   )
-  (func $___syscall_ret (param $$r i32) (result i32)
+  (func $___syscall_ret (param $0 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.gt_u
-        (get_local $$r)
+        (get_local $0)
         (i32.const -4096)
       )
       (block
@@ -2912,40 +2805,38 @@
           (call $___errno_location)
           (i32.sub
             (i32.const 0)
-            (get_local $$r)
+            (get_local $0)
           )
         )
         (i32.const -1)
       )
-      (get_local $$r)
+      (get_local $0)
     )
   )
-  (func $___fflush_unlocked (param $$f i32) (result i32)
-    (local $$retval$0 i32)
-    (local $$wpos i32)
-    (local $label i32)
-    (local $$4 i32)
-    (local $$5 i32)
-    (local $$rend i32)
-    (local $$rpos i32)
-    (local $$wbase i32)
+  (func $___fflush_unlocked (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.gt_u
         (i32.load
-          (set_local $$wpos
+          (set_local $3
             (i32.add
-              (get_local $$f)
+              (get_local $0)
               (i32.const 20)
             )
           )
         )
         (i32.load
-          (set_local $$wbase
+          (set_local $6
             (i32.add
-              (get_local $$f)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -2956,58 +2847,58 @@
           (i32.add
             (i32.and
               (i32.load offset=36
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 7)
             )
             (i32.const 2)
           )
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
           (i32.const 0)
         )
         (if
           (i32.eq
             (i32.load
-              (get_local $$wpos)
+              (get_local $3)
             )
             (i32.const 0)
           )
-          (set_local $$retval$0
+          (set_local $1
             (i32.const -1)
           )
-          (set_local $label
+          (set_local $2
             (i32.const 3)
           )
         )
       )
-      (set_local $label
+      (set_local $2
         (i32.const 3)
       )
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $2)
         (i32.const 3)
       )
       (block
         (if
           (i32.lt_u
-            (set_local $$4
+            (set_local $1
               (i32.load
-                (set_local $$rpos
+                (set_local $5
                   (i32.add
-                    (get_local $$f)
+                    (get_local $0)
                     (i32.const 4)
                   )
                 )
               )
             )
-            (set_local $$5
+            (set_local $2
               (i32.load
-                (set_local $$rend
+                (set_local $4
                   (i32.add
-                    (get_local $$f)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
@@ -3018,517 +2909,144 @@
             (i32.add
               (i32.and
                 (i32.load offset=40
-                  (get_local $$f)
+                  (get_local $0)
                 )
                 (i32.const 7)
               )
               (i32.const 2)
             )
-            (get_local $$f)
+            (get_local $0)
             (i32.sub
-              (get_local $$4)
-              (get_local $$5)
+              (get_local $1)
+              (get_local $2)
             )
             (i32.const 1)
           )
         )
         (i32.store offset=16
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$wbase)
+          (get_local $6)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$wpos)
+          (get_local $3)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$rend)
+          (get_local $4)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$rpos)
+          (get_local $5)
           (i32.const 0)
         )
-        (set_local $$retval$0
+        (set_local $1
           (i32.const 0)
         )
       )
     )
-    (get_local $$retval$0)
+    (get_local $1)
   )
-  (func $_cleanup (param $$p i32)
+  (func $_cleanup (param $0 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
         (i32.load offset=68
-          (get_local $$p)
+          (get_local $0)
         )
         (i32.const 0)
       )
       (call $___unlockfile
-        (get_local $$p)
+        (get_local $0)
       )
     )
   )
-  (func $_printf_core (param $$f i32) (param $$fmt i32) (param $$ap i32) (param $$nl_arg i32) (param $$nl_type i32) (result i32)
-    (local $label i32)
-    (local $$p$0 i32)
-    (local $$w$1 i32)
-    (local $$fl$1$and219 i32)
-    (local $$arg i32)
-    (local $$cnt$1 i32)
-    (local $$incdec$ptr169275 i32)
-    (local $$cnt$0 i32)
-    (local $$l10n$0 i32)
-    (local $$l10n$3 i32)
-    (local $$l$0 i32)
-    (local $$retval$0 i32)
-    (local $$e2$i i32)
-    (local $$incdec$ptr169$lcssa i32)
-    (local $$e$5$ph$i i32)
-    (local $$p$addr$3$i i32)
-    (local $$sub$ptr$sub i32)
-    (local $$add$ptr205 i32)
-    (local $$buf$i i32)
-    (local $$incdec$ptr169269 i32)
-    (local $$a$3$lcssa$i i32)
-    (local $$a$3539$i i32)
-    (local $$i$0$lcssa i32)
-    (local $$p$2 i32)
-    (local $sp i32)
-    (local $$add$ptr358$i i32)
-    (local $$arraydecay208$add$ptr213$i i32)
-    (local $$t$0 i32)
-    (local $$fl$0284 i32)
-    (local $$fl$4 i32)
-    (local $$fl$6 i32)
-    (local $$i$0$lcssa368 i32)
-    (local $$pl$1 i32)
-    (local $$prefix$0$i i32)
-    (local $$prefix$1 i32)
-    (local $$storemerge$186282 i32)
-    (local $$z$3$lcssa$i i32)
-    (local $$z$3538$i i32)
-    (local $$a$1549$i i32)
-    (local $$a$9$ph$i i32)
-    (local $$e$1$i i32)
-    (local $$fl$1 i32)
-    (local $$incdec$ptr169274 i32)
-    (local $$incdec$ptr169276$lcssa i32)
-    (local $$p$5 i32)
-    (local $$pl$2 i32)
-    (local $$s753$2$i i32)
-    (local $$sub$ptr$lhs$cast160$i i32)
-    (local $$y$addr$0$i f64)
-    (local $$z$7$i$lcssa i32)
-    (local $$$p$i i32)
-    (local $$249 i32)
-    (local $$a$1 i32)
-    (local $$a$2 i32)
-    (local $$a$5$lcssa$i i32)
-    (local $$add$ptr671$i i32)
-    (local $$call384 i32)
-    (local $$fl$3 i32)
-    (local $$i$0316 i32)
-    (local $$i$1$lcssa$i i32)
-    (local $$i$2299 i32)
-    (local $$j$2$i i32)
-    (local $$mul$i$240 f64)
-    (local $$p$addr$2$i i32)
-    (local $$p$addr$4489$i i32)
-    (local $$p$addr$5501$i i32)
-    (local $$pl$0$i i32)
-    (local $$prefix$2 i32)
-    (local $$s668$1$i i32)
-    (local $$s753$0$i i32)
-    (local $$t$addr$0$i i32)
-    (local $$t$addr$1$i i32)
-    (local $$tobool25 i32)
-    (local $$z$2 i32)
-    (local $$z$2$i i32)
-    (local $$z$7$i i32)
-    (local $$12 i32)
-    (local $$149 i32)
-    (local $$181 f64)
-    (local $$7 i32)
-    (local $$a$0 i32)
-    (local $$a$5521$i i32)
-    (local $$a$8$i i32)
-    (local $$add165$i i32)
-    (local $$add441 i32)
-    (local $$add653$i i32)
-    (local $$arrayidx$i$236 i32)
-    (local $$cond271$i i32)
-    (local $$d$0545$i i32)
-    (local $$d$1534$i i32)
-    (local $$d$4$i i32)
-    (local $$d$5494$i i32)
-    (local $$d$7500$i i32)
-    (local $$e$4$i i32)
-    (local $$incdec$ptr115$i i32)
-    (local $$incdec$ptr169271 i32)
-    (local $$incdec$ptr169276301 i32)
-    (local $$incdec$ptr419$i i32)
-    (local $$incdec$ptr689$i i32)
-    (local $$l10n$1 i32)
-    (local $$mul80$i$lcssa f64)
-    (local $$p$1 i32)
-    (local $$pl$0 i32)
-    (local $$prefix$0 i32)
-    (local $$s$0$i i32)
-    (local $$s$addr$0$lcssa$i$229 i32)
-    (local $$sub$ptr$rhs$cast345$i i32)
-    (local $$w$0 i32)
-    (local $$z$0$lcssa i32)
-    (local $$z$4$i i32)
-    (local $$$396$i f64)
-    (local $$$pr477$i i32)
-    (local $$126 i32)
-    (local $$137 i32)
-    (local $$140 i32)
-    (local $$148 i32)
-    (local $$198 i32)
-    (local $$211 i32)
-    (local $$9 i32)
-    (local $$99 i32)
-    (local $$a$1$lcssa$i i32)
-    (local $$a$2$ph$i i32)
-    (local $$add$i$239 i32)
-    (local $$and219 i32)
-    (local $$argpos$0 i32)
-    (local $$arrayidx119 i32)
-    (local $$arrayidx68 i32)
-    (local $$cmp450$lcssa$i i32)
-    (local $$d$2$lcssa$i i32)
-    (local $$d$2520$i i32)
-    (local $$d$6488$i i32)
-    (local $$estr$1$lcssa$i i32)
-    (local $$fl$0310 i32)
-    (local $$i$3296 i32)
-    (local $$incdec$ptr122$i i32)
-    (local $$incdec$ptr292$a$3573$i i32)
-    (local $$incdec$ptr639$i i32)
-    (local $$incdec$ptr681$i i32)
-    (local $$incdec$ptr725$i i32)
-    (local $$incdec$ptr773$i i32)
-    (local $$incdec$ptr776$i i32)
-    (local $$l$2 i32)
-    (local $$l10n$2 i32)
-    (local $$mb i32)
-    (local $$mul125$i f64)
-    (local $$or$i$241 i32)
-    (local $$p$4365 i32)
-    (local $$rem370$i i32)
-    (local $$small$0$i f64)
-    (local $$small$1$i f64)
-    (local $$st$0 i32)
-    (local $$storemerge i32)
-    (local $$storemerge$186309 i32)
-    (local $$storemerge$191 i32)
-    (local $$sub$ptr$rhs$cast$i i32)
-    (local $$sub$ptr$sub433 i32)
-    (local $$sub$ptr$sub789$i i32)
-    (local $$sub256$i i32)
-    (local $$t$1 i32)
-    (local $$w$2 i32)
-    (local $$ws$0317 i32)
-    (local $$ws$1326 i32)
-    (local $$y$addr$2$i f64)
-    (local $$y$addr$4$i f64)
-    (local $$z$0$i i32)
-    (local $$z$0302 i32)
-    (local $$z$1$lcssa$i i32)
-    (local $$z$1548$i i32)
-    (local $$z$2$i$lcssa i32)
-    (local $$$lcssa i32)
-    (local $$$p$inc468$i i32)
-    (local $$$pr$i i32)
-    (local $$$pre566$i i32)
-    (local $$1 i32)
-    (local $$10 i32)
-    (local $$101 i32)
-    (local $$129 i32)
-    (local $$142 i32)
-    (local $$143 i32)
-    (local $$219 i32)
-    (local $$223 i32)
-    (local $$231 i32)
-    (local $$237 i32)
-    (local $$243 i32)
-    (local $$255 i32)
-    (local $$29 i32)
-    (local $$49 i32)
-    (local $$a$6$i i32)
-    (local $$add$i i32)
-    (local $$add$i$203 i32)
-    (local $$add$i$lcssa i32)
-    (local $$add$ptr i32)
-    (local $$add$ptr311$z$4$i i32)
-    (local $$add$ptr340 i32)
-    (local $$add275$i i32)
-    (local $$add313$i i32)
-    (local $$add395 i32)
-    (local $$add412 i32)
-    (local $$add67$i i32)
-    (local $$and309$fl$4 i32)
-    (local $$and610$pre$phi$iZ2D i32)
-    (local $$arrayidx114 i32)
-    (local $$arrayidx31 i32)
-    (local $$call356 i32)
-    (local $$carry$0544$i i32)
-    (local $$carry262$0535$i i32)
-    (local $$cmp184 i32)
-    (local $$cmp37 i32)
-    (local $$cond233$i i32)
-    (local $$conv174 i32)
-    (local $$conv174$lcssa i32)
-    (local $$conv207 i32)
-    (local $$conv242$i$lcssa i32)
-    (local $$conv48311 i32)
-    (local $$e$0531$i i32)
-    (local $$e$2517$i i32)
-    (local $$estr$1507$i i32)
-    (local $$estr$2$i i32)
-    (local $$i$0530$i i32)
-    (local $$i$07$i i32)
-    (local $$i$07$i$201 i32)
-    (local $$i$1325 i32)
-    (local $$i$1526$i i32)
-    (local $$i$2299$lcssa i32)
-    (local $$i$2516$i i32)
-    (local $$i$3512$i i32)
-    (local $$inc$i i32)
-    (local $$inc438$i i32)
-    (local $$inc488 i32)
-    (local $$inc500$i i32)
-    (local $$incdec$ptr$i i32)
-    (local $$incdec$ptr$i$204 i32)
-    (local $$incdec$ptr$i$212 i32)
-    (local $$incdec$ptr$i$212$lcssa i32)
-    (local $$incdec$ptr$i$225 i32)
-    (local $$incdec$ptr106$i i32)
-    (local $$incdec$ptr169 i32)
-    (local $$incdec$ptr217$i i32)
-    (local $$incdec$ptr217$i$lcssa i32)
-    (local $$incdec$ptr23 i32)
-    (local $$incdec$ptr292$a$3$i i32)
-    (local $$incdec$ptr62 i32)
-    (local $$incdec$ptr647$i i32)
-    (local $$incdec$ptr698$i i32)
-    (local $$incdec$ptr698$i$lcssa i32)
-    (local $$isdigittmp8$i i32)
-    (local $$isdigittmp8$i$200 i32)
-    (local $$j$0527$i i32)
-    (local $$j$1513$i i32)
-    (local $$l$1315 i32)
-    (local $$mul286$i i32)
-    (local $$mul286$i$lcssa i32)
-    (local $$mul322$i i32)
-    (local $$mul367$i i32)
-    (local $$mul431$i i32)
-    (local $$mul513$i i32)
-    (local $$mul80$i f64)
-    (local $$or i32)
-    (local $$p$addr$4$lcssa$i i32)
-    (local $$p$addr$5$lcssa$i i32)
-    (local $$pl$1$i i32)
-    (local $$prefix$0$add$ptr65$i i32)
-    (local $$re$1482$i i32)
-    (local $$round$0481$i f64)
-    (local $$round377$1$i f64)
-    (local $$s$1$i i32)
-    (local $$s$addr$06$i i32)
-    (local $$s$addr$06$i$221 i32)
-    (local $$s668$0492$i i32)
-    (local $$s715$0$lcssa$i i32)
-    (local $$s715$0484$i i32)
-    (local $$s753$1496$i i32)
-    (local $$st$0$lcssa415 i32)
-    (local $$sub$ptr$lhs$cast317 i32)
-    (local $$sub$ptr$lhs$cast694$i i32)
-    (local $$sub$ptr$sub172$i i32)
-    (local $$sub$ptr$sub650$pn$i i32)
-    (local $$sub735$i i32)
-    (local $$sub806$i i32)
-    (local $$tobool357 i32)
-    (local $$wc i32)
-    (local $$y$addr$3$i f64)
-    (local $$z$7$ph$i i32)
-    (local $$$ i32)
-    (local $$$sub514$i i32)
-    (local $$$sub562$i i32)
-    (local $$0 i32)
-    (local $$102 i32)
-    (local $$103 i32)
-    (local $$107 i32)
-    (local $$116 i32)
-    (local $$118 i32)
-    (local $$121 i32)
-    (local $$130 i32)
-    (local $$131 i32)
-    (local $$135 i32)
-    (local $$144 i32)
-    (local $$151 i32)
-    (local $$159 i32)
-    (local $$16 i32)
-    (local $$161 i32)
-    (local $$163 i32)
-    (local $$169 i32)
-    (local $$170 i32)
-    (local $$172 i32)
-    (local $$177 i32)
-    (local $$179 i32)
-    (local $$18 i32)
-    (local $$187 i32)
-    (local $$193 i32)
-    (local $$200 i32)
-    (local $$201 i32)
-    (local $$210 i32)
-    (local $$215 i32)
-    (local $$216 i32)
-    (local $$217 i32)
-    (local $$225 i32)
-    (local $$228 i32)
-    (local $$234 i32)
-    (local $$239 i32)
-    (local $$242 i32)
-    (local $$259 i32)
-    (local $$267 i32)
-    (local $$27 i32)
-    (local $$28 i32)
-    (local $$32 i32)
-    (local $$36 i32)
-    (local $$38 i32)
-    (local $$47 i32)
-    (local $$48 i32)
-    (local $$5 i32)
-    (local $$52 i32)
-    (local $$54 i32)
-    (local $$56 i32)
-    (local $$59 i32)
-    (local $$60 i32)
-    (local $$65 i32)
-    (local $$76 i32)
-    (local $$86 i32)
-    (local $$90 i32)
-    (local $$92 i32)
-    (local $$95 i32)
-    (local $$add$ptr213$i i32)
-    (local $$add$ptr43$arrayidx31 i32)
-    (local $$add$ptr442$i i32)
-    (local $$add269 i32)
-    (local $$add322 i32)
-    (local $$add355$i i32)
-    (local $$add414$i i32)
-    (local $$and12$i i32)
-    (local $$and249 i32)
-    (local $$and282$i i32)
-    (local $$and294 i32)
-    (local $$and483$i i32)
-    (local $$and62$i i32)
-    (local $$arrayidx251$i i32)
-    (local $$arrayidx370 i32)
-    (local $$arrayidx453$i i32)
-    (local $$big$i i32)
-    (local $$buf i32)
-    (local $$call411 i32)
-    (local $$cmp265$i i32)
-    (local $$cmp270 i32)
-    (local $$cmp299$i i32)
-    (local $$cmp308$i i32)
-    (local $$cmp323 i32)
-    (local $$cmp338$i i32)
-    (local $$cmp374$i i32)
-    (local $$cmp38$i i32)
-    (local $$cmp434 i32)
-    (local $$cmp442 i32)
-    (local $$cmp443$i i32)
-    (local $$cmp515$i i32)
-    (local $$cmp528$i i32)
-    (local $$cmp563$i i32)
-    (local $$cmp577$i i32)
-    (local $$cmp614$i i32)
-    (local $$cmp94$i i32)
-    (local $$cnt$1$lcssa i32)
-    (local $$cond$i i32)
-    (local $$cond100$i i32)
-    (local $$cond304$i i32)
-    (local $$cond629$i i32)
-    (local $$conv116$i i32)
-    (local $$conv216$i i32)
-    (local $$conv48 i32)
-    (local $$conv48$307 i32)
-    (local $$d$0$542$i i32)
-    (local $$d$0$i i32)
-    (local $$dec78$i i32)
-    (local $$div384$i i32)
-    (local $$ebuf0$i i32)
-    (local $$estr$0$i i32)
-    (local $$inc i32)
-    (local $$inc425$i i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr$i$lcssa i32)
-    (local $$incdec$ptr169271$lcssa414 i32)
-    (local $$incdec$ptr246$i i32)
-    (local $$incdec$ptr288$i i32)
-    (local $$incdec$ptr383 i32)
-    (local $$incdec$ptr410 i32)
-    (local $$incdec$ptr423$i i32)
-    (local $$incdec$ptr734$i i32)
-    (local $$incdec$ptr808$i i32)
-    (local $$isdigittmp i32)
-    (local $$isdigittmp$5$i i32)
-    (local $$isdigittmp$5$i$198 i32)
-    (local $$isdigittmp$i i32)
-    (local $$isdigittmp$i$206 i32)
-    (local $$isdigittmp187 i32)
-    (local $$isdigittmp189 i32)
-    (local $$j$0$524$i i32)
-    (local $$j$0$i i32)
-    (local $$l$0$i i32)
-    (local $$l10n$0$lcssa i32)
-    (local $$lor$ext$i i32)
-    (local $$mul220$i f64)
-    (local $$mul328$i i32)
-    (local $$mul437$i i32)
-    (local $$mul499$i i32)
-    (local $$notrhs$i i32)
-    (local $$or$cond192 i32)
-    (local $$or$cond384 i32)
-    (local $$r$0$a$9$i i32)
-    (local $$retval$0$i i32)
-    (local $$s$1$i$lcssa i32)
-    (local $$s35$0$i i32)
-    (local $$shr285$i i32)
-    (local $$sub$ptr$sub145$i i32)
-    (local $$sub$ptr$sub153$i i32)
-    (local $$sub$ptr$sub159$i i32)
-    (local $$sub$ptr$sub175$i i32)
-    (local $$sub$ptr$sub433$p$5 i32)
-    (local $$sub164 i32)
-    (local $$sub203$i i32)
-    (local $$sub264$i i32)
-    (local $$sub281$i i32)
-    (local $$sub343$i i32)
-    (local $$sub409$i i32)
-    (local $$sub514$i i32)
-    (local $$sub562$i i32)
-    (local $$sub626$le$i i32)
-    (local $$sub74$i i32)
-    (local $$tobool135$i i32)
-    (local $$tobool341$i i32)
-    (local $$tobool349 i32)
-    (local $$tobool37$i i32)
-    (local $$tobool56$i i32)
-    (local $$tobool781$i i32)
-    (local $$y$addr$1$i f64)
-    (local $$z$7$add$ptr742$i i32)
-    (set_local $sp
+  (func $_printf_core (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 f64)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 f64)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
+    (local $47 i32)
+    (local $48 i32)
+    (local $49 i32)
+    (local $50 i32)
+    (local $51 i32)
+    (local $52 i32)
+    (local $53 i32)
+    (local $54 i32)
+    (local $55 i32)
+    (local $56 i32)
+    (local $57 i32)
+    (local $58 i32)
+    (local $59 i32)
+    (local $60 i32)
+    (local $61 i32)
+    (local $62 i32)
+    (local $63 i32)
+    (local $64 i32)
+    (local $65 i32)
+    (local $66 i32)
+    (local $67 i32)
+    (local $68 i32)
+    (local $69 i32)
+    (local $70 i32)
+    (local $71 i32)
+    (local $72 i32)
+    (local $73 i32)
+    (local $74 i32)
+    (local $75 i32)
+    (local $76 i32)
+    (local $77 i32)
+    (local $78 i32)
+    (local $79 i32)
+    (local $80 i32)
+    (local $81 i32)
+    (local $82 i32)
+    (local $83 i32)
+    (set_local $32
       (i32.load
         (i32.const 8)
       )
@@ -3553,33 +3071,33 @@
       )
       (call_import $abort)
     )
-    (set_local $$e2$i
+    (set_local $25
       (i32.add
-        (get_local $sp)
+        (get_local $32)
         (i32.const 16)
       )
     )
-    (set_local $$arg
-      (get_local $sp)
+    (set_local $18
+      (get_local $32)
     )
-    (set_local $$mb
+    (set_local $64
       (i32.add
-        (get_local $sp)
+        (get_local $32)
         (i32.const 528)
       )
     )
-    (set_local $$tobool25
+    (set_local $52
       (i32.ne
-        (get_local $$f)
+        (get_local $0)
         (i32.const 0)
       )
     )
-    (set_local $$sub$ptr$lhs$cast317
-      (set_local $$add$ptr205
+    (set_local $73
+      (set_local $28
         (i32.add
-          (set_local $$buf
+          (set_local $5
             (i32.add
-              (get_local $sp)
+              (get_local $32)
               (i32.const 536)
             )
           )
@@ -3587,117 +3105,117 @@
         )
       )
     )
-    (set_local $$add$ptr340
+    (set_local $71
       (i32.add
-        (get_local $$buf)
+        (get_local $5)
         (i32.const 39)
       )
     )
-    (set_local $$arrayidx370
+    (set_local $77
       (i32.add
-        (set_local $$wc
+        (set_local $75
           (i32.add
-            (get_local $sp)
+            (get_local $32)
             (i32.const 8)
           )
         )
         (i32.const 4)
       )
     )
-    (set_local $$arrayidx$i$236
+    (set_local $55
       (i32.add
-        (set_local $$ebuf0$i
+        (set_local $5
           (i32.add
-            (get_local $sp)
+            (get_local $32)
             (i32.const 576)
           )
         )
         (i32.const 12)
       )
     )
-    (set_local $$incdec$ptr106$i
+    (set_local $72
       (i32.add
-        (get_local $$ebuf0$i)
+        (get_local $5)
         (i32.const 11)
       )
     )
-    (set_local $$sub$ptr$sub159$i
+    (set_local $83
       (i32.sub
-        (set_local $$sub$ptr$lhs$cast160$i
-          (get_local $$arrayidx$i$236)
+        (set_local $44
+          (get_local $55)
         )
-        (set_local $$sub$ptr$rhs$cast$i
-          (set_local $$buf$i
+        (set_local $67
+          (set_local $29
             (i32.add
-              (get_local $sp)
+              (get_local $32)
               (i32.const 588)
             )
           )
         )
       )
     )
-    (set_local $$sub$ptr$sub145$i
+    (set_local $81
       (i32.sub
         (i32.const -2)
-        (get_local $$sub$ptr$rhs$cast$i)
+        (get_local $67)
       )
     )
-    (set_local $$sub$ptr$sub153$i
+    (set_local $82
       (i32.add
-        (get_local $$sub$ptr$lhs$cast160$i)
+        (get_local $44)
         (i32.const 2)
       )
     )
-    (set_local $$add$ptr213$i
+    (set_local $76
       (i32.add
-        (set_local $$big$i
+        (set_local $78
           (i32.add
-            (get_local $sp)
+            (get_local $32)
             (i32.const 24)
           )
         )
         (i32.const 288)
       )
     )
-    (set_local $$sub$ptr$lhs$cast694$i
-      (set_local $$add$ptr671$i
+    (set_local $74
+      (set_local $48
         (i32.add
-          (get_local $$buf$i)
+          (get_local $29)
           (i32.const 9)
         )
       )
     )
-    (set_local $$incdec$ptr689$i
+    (set_local $57
       (i32.add
-        (get_local $$buf$i)
+        (get_local $29)
         (i32.const 8)
       )
     )
-    (set_local $$cnt$0
+    (set_local $5
       (i32.const 0)
     )
-    (set_local $$incdec$ptr169275
-      (get_local $$fmt)
+    (set_local $12
+      (get_local $1)
     )
-    (set_local $$l$0
+    (set_local $1
       (i32.const 0)
     )
-    (set_local $$l10n$0
+    (set_local $8
       (i32.const 0)
     )
     (loop $label$break$L1 $label$continue$L1
-      (set_local $$cnt$1
+      (set_local $19
         (if
           (i32.gt_s
-            (get_local $$cnt$0)
+            (get_local $5)
             (i32.const -1)
           )
           (if
             (i32.gt_s
-              (get_local $$l$0)
+              (get_local $1)
               (i32.sub
                 (i32.const 2147483647)
-                (get_local $$cnt$0)
+                (get_local $5)
               )
             )
             (block
@@ -3708,20 +3226,20 @@
               (i32.const -1)
             )
             (i32.add
-              (get_local $$l$0)
-              (get_local $$cnt$0)
+              (get_local $1)
+              (get_local $5)
             )
           )
-          (get_local $$cnt$0)
+          (get_local $5)
         )
       )
       (if
         (i32.eq
           (i32.shr_s
             (i32.shl
-              (set_local $$0
+              (set_local $1
                 (i32.load8_s
-                  (get_local $$incdec$ptr169275)
+                  (get_local $12)
                 )
               )
               (i32.const 24)
@@ -3731,23 +3249,21 @@
           (i32.const 0)
         )
         (block
-          (set_local $$cnt$1$lcssa
-            (get_local $$cnt$1)
+          (set_local $79
+            (get_local $19)
           )
-          (set_local $$l10n$0$lcssa
-            (get_local $$l10n$0)
+          (set_local $80
+            (get_local $8)
           )
-          (set_local $label
+          (set_local $13
             (i32.const 242)
           )
           (br $label$break$L1)
         )
         (block
-          (set_local $$1
-            (get_local $$0)
-          )
-          (set_local $$incdec$ptr169274
-            (get_local $$incdec$ptr169275)
+          (get_local $1)
+          (set_local $5
+            (get_local $12)
           )
         )
       )
@@ -3761,7 +3277,7 @@
                     (i32.sub
                       (i32.shr_s
                         (i32.shl
-                          (get_local $$1)
+                          (get_local $1)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -3770,50 +3286,48 @@
                     )
                   )
                 )
-                (set_local $$incdec$ptr169276301
-                  (get_local $$incdec$ptr169274)
+                (set_local $56
+                  (get_local $5)
                 )
-                (set_local $$z$0302
-                  (get_local $$incdec$ptr169274)
+                (set_local $70
+                  (get_local $5)
                 )
-                (set_local $label
+                (set_local $13
                   (i32.const 9)
                 )
                 (br $label$break$L9)
               )
-              (set_local $$incdec$ptr169276$lcssa
-                (get_local $$incdec$ptr169274)
+              (set_local $41
+                (get_local $5)
               )
-              (set_local $$z$0$lcssa
-                (get_local $$incdec$ptr169274)
+              (set_local $62
+                (get_local $5)
               )
               (br $label$break$L9)
             )
           )
         )
-        (set_local $$1
+        (set_local $1
           (i32.load8_s
-            (set_local $$incdec$ptr
+            (set_local $5
               (i32.add
-                (get_local $$incdec$ptr169274)
+                (get_local $5)
                 (i32.const 1)
               )
             )
           )
         )
-        (set_local $$incdec$ptr169274
-          (get_local $$incdec$ptr)
-        )
+        (get_local $5)
         (br $label$continue$L9)
       )
       (block $label$break$L12
         (if
           (i32.eq
-            (get_local $label)
+            (get_local $13)
             (i32.const 9)
           )
           (loop $while-out$7 $while-in$8
-            (set_local $label
+            (set_local $13
               (i32.const 0)
             )
             (if
@@ -3821,7 +3335,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s offset=1
-                      (get_local $$incdec$ptr169276301)
+                      (get_local $56)
                     )
                     (i32.const 24)
                   )
@@ -3830,18 +3344,18 @@
                 (i32.const 37)
               )
               (block
-                (set_local $$incdec$ptr169276$lcssa
-                  (get_local $$incdec$ptr169276301)
+                (set_local $41
+                  (get_local $56)
                 )
-                (set_local $$z$0$lcssa
-                  (get_local $$z$0302)
+                (set_local $62
+                  (get_local $70)
                 )
                 (br $label$break$L12)
               )
             )
-            (set_local $$incdec$ptr23
+            (set_local $5
               (i32.add
-                (get_local $$z$0302)
+                (get_local $70)
                 (i32.const 1)
               )
             )
@@ -3850,9 +3364,9 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (set_local $$add$ptr
+                      (set_local $1
                         (i32.add
-                          (get_local $$incdec$ptr169276301)
+                          (get_local $56)
                           (i32.const 2)
                         )
                       )
@@ -3864,22 +3378,20 @@
                 (i32.const 37)
               )
               (block
-                (set_local $$incdec$ptr169276301
-                  (get_local $$add$ptr)
+                (set_local $56
+                  (get_local $1)
                 )
-                (set_local $$z$0302
-                  (get_local $$incdec$ptr23)
+                (set_local $70
+                  (get_local $5)
                 )
-                (set_local $label
-                  (i32.const 9)
-                )
+                (i32.const 9)
               )
               (block
-                (set_local $$incdec$ptr169276$lcssa
-                  (get_local $$add$ptr)
+                (set_local $41
+                  (get_local $1)
                 )
-                (set_local $$z$0$lcssa
-                  (get_local $$incdec$ptr23)
+                (set_local $62
+                  (get_local $5)
                 )
                 (br $while-out$7)
               )
@@ -3888,64 +3400,62 @@
           )
         )
       )
-      (set_local $$sub$ptr$sub
+      (set_local $15
         (i32.sub
-          (get_local $$z$0$lcssa)
-          (get_local $$incdec$ptr169275)
+          (get_local $62)
+          (get_local $12)
         )
       )
       (if
-        (get_local $$tobool25)
+        (get_local $52)
         (if
           (i32.eq
             (i32.and
               (i32.load
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 32)
             )
             (i32.const 0)
           )
           (call $___fwritex
-            (get_local $$incdec$ptr169275)
-            (get_local $$sub$ptr$sub)
-            (get_local $$f)
+            (get_local $12)
+            (get_local $15)
+            (get_local $0)
           )
         )
       )
       (if
         (i32.ne
-          (get_local $$z$0$lcssa)
-          (get_local $$incdec$ptr169275)
+          (get_local $62)
+          (get_local $12)
         )
         (block
-          (set_local $$cnt$0
-            (get_local $$cnt$1)
+          (set_local $5
+            (get_local $19)
           )
-          (set_local $$incdec$ptr169275
-            (get_local $$incdec$ptr169276$lcssa)
+          (set_local $12
+            (get_local $41)
           )
-          (set_local $$l$0
-            (get_local $$sub$ptr$sub)
+          (set_local $1
+            (get_local $15)
           )
-          (set_local $$l10n$0
-            (get_local $$l10n$0)
-          )
+          (get_local $8)
           (br $label$continue$L1)
         )
       )
-      (set_local $$argpos$0
+      (set_local $7
         (if
           (i32.lt_u
-            (set_local $$isdigittmp
+            (set_local $6
               (i32.add
                 (i32.shr_s
                   (i32.shl
-                    (set_local $$5
+                    (set_local $1
                       (i32.load8_s
-                        (set_local $$arrayidx31
+                        (set_local $5
                           (i32.add
-                            (get_local $$incdec$ptr169276$lcssa)
+                            (get_local $41)
                             (i32.const 1)
                           )
                         )
@@ -3961,21 +3471,21 @@
             (i32.const 10)
           )
           (block
-            (set_local $$7
+            (set_local $1
               (i32.load8_s
-                (set_local $$add$ptr43$arrayidx31
+                (set_local $5
                   (select
                     (i32.add
-                      (get_local $$incdec$ptr169276$lcssa)
+                      (get_local $41)
                       (i32.const 3)
                     )
-                    (get_local $$arrayidx31)
-                    (set_local $$cmp37
+                    (get_local $5)
+                    (set_local $7
                       (i32.eq
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s offset=2
-                              (get_local $$incdec$ptr169276$lcssa)
+                              (get_local $41)
                             )
                             (i32.const 24)
                           )
@@ -3988,31 +3498,29 @@
                 )
               )
             )
-            (set_local $$l10n$1
+            (set_local $11
               (select
                 (i32.const 1)
-                (get_local $$l10n$0)
-                (get_local $$cmp37)
+                (get_local $8)
+                (get_local $7)
               )
             )
-            (set_local $$storemerge
-              (get_local $$add$ptr43$arrayidx31)
+            (set_local $10
+              (get_local $5)
             )
             (select
-              (get_local $$isdigittmp)
+              (get_local $6)
               (i32.const -1)
-              (get_local $$cmp37)
+              (get_local $7)
             )
           )
           (block
-            (set_local $$7
-              (get_local $$5)
+            (get_local $1)
+            (set_local $11
+              (get_local $8)
             )
-            (set_local $$l10n$1
-              (get_local $$l10n$0)
-            )
-            (set_local $$storemerge
-              (get_local $$arrayidx31)
+            (set_local $10
+              (get_local $5)
             )
             (i32.const -1)
           )
@@ -4022,10 +3530,10 @@
         (if
           (i32.eq
             (i32.and
-              (set_local $$conv48$307
+              (set_local $5
                 (i32.shr_s
                   (i32.shl
-                    (get_local $$7)
+                    (get_local $1)
                     (i32.const 24)
                   )
                   (i32.const 24)
@@ -4036,18 +3544,12 @@
             (i32.const 32)
           )
           (block
-            (set_local $$9
-              (get_local $$7)
-            )
-            (set_local $$conv48311
-              (get_local $$conv48$307)
-            )
-            (set_local $$fl$0310
+            (get_local $1)
+            (get_local $5)
+            (set_local $6
               (i32.const 0)
             )
-            (set_local $$storemerge$186309
-              (get_local $$storemerge)
-            )
+            (get_local $10)
             (loop $while-out$10 $while-in$11
               (if
                 (i32.eq
@@ -4055,7 +3557,7 @@
                     (i32.shl
                       (i32.const 1)
                       (i32.add
-                        (get_local $$conv48311)
+                        (get_local $5)
                         (i32.const -32)
                       )
                     )
@@ -4064,26 +3566,22 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$12
-                    (get_local $$9)
+                  (get_local $1)
+                  (set_local $8
+                    (get_local $6)
                   )
-                  (set_local $$fl$0284
-                    (get_local $$fl$0310)
-                  )
-                  (set_local $$storemerge$186282
-                    (get_local $$storemerge$186309)
-                  )
+                  (get_local $10)
                   (br $label$break$L25)
                 )
               )
-              (set_local $$or
+              (set_local $6
                 (i32.or
                   (i32.shl
                     (i32.const 1)
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (get_local $$9)
+                          (get_local $1)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -4091,20 +3589,20 @@
                       (i32.const -32)
                     )
                   )
-                  (get_local $$fl$0310)
+                  (get_local $6)
                 )
               )
               (if
                 (i32.eq
                   (i32.and
-                    (set_local $$conv48
+                    (set_local $5
                       (i32.shr_s
                         (i32.shl
-                          (set_local $$10
+                          (set_local $1
                             (i32.load8_s
-                              (set_local $$incdec$ptr62
+                              (set_local $10
                                 (i32.add
-                                  (get_local $$storemerge$186309)
+                                  (get_local $10)
                                   (i32.const 1)
                                 )
                               )
@@ -4120,29 +3618,17 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $$9
-                    (get_local $$10)
-                  )
-                  (set_local $$conv48311
-                    (get_local $$conv48)
-                  )
-                  (set_local $$fl$0310
-                    (get_local $$or)
-                  )
-                  (set_local $$storemerge$186309
-                    (get_local $$incdec$ptr62)
-                  )
+                  (get_local $1)
+                  (get_local $5)
+                  (get_local $6)
+                  (get_local $10)
                 )
                 (block
-                  (set_local $$12
-                    (get_local $$10)
+                  (get_local $1)
+                  (set_local $8
+                    (get_local $6)
                   )
-                  (set_local $$fl$0284
-                    (get_local $$or)
-                  )
-                  (set_local $$storemerge$186282
-                    (get_local $$incdec$ptr62)
-                  )
+                  (get_local $10)
                   (br $while-out$10)
                 )
               )
@@ -4150,15 +3636,11 @@
             )
           )
           (block
-            (set_local $$12
-              (get_local $$7)
-            )
-            (set_local $$fl$0284
+            (get_local $1)
+            (set_local $8
               (i32.const 0)
             )
-            (set_local $$storemerge$186282
-              (get_local $$storemerge)
-            )
+            (get_local $10)
           )
         )
       )
@@ -4167,7 +3649,7 @@
           (i32.eq
             (i32.shr_s
               (i32.shl
-                (get_local $$12)
+                (get_local $1)
                 (i32.const 24)
               )
               (i32.const 24)
@@ -4177,14 +3659,14 @@
           (block
             (if
               (i32.lt_u
-                (set_local $$isdigittmp189
+                (set_local $1
                   (i32.add
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s
-                          (set_local $$arrayidx68
+                          (set_local $6
                             (i32.add
-                              (get_local $$storemerge$186282)
+                              (get_local $10)
                               (i32.const 1)
                             )
                           )
@@ -4203,7 +3685,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s offset=2
-                        (get_local $$storemerge$186282)
+                        (get_local $10)
                       )
                       (i32.const 24)
                     )
@@ -4214,25 +3696,25 @@
                 (block
                   (i32.store
                     (i32.add
-                      (get_local $$nl_type)
+                      (get_local $4)
                       (i32.shl
-                        (get_local $$isdigittmp189)
+                        (get_local $1)
                         (i32.const 2)
                       )
                     )
                     (i32.const 10)
                   )
-                  (set_local $$18
+                  (set_local $5
                     (i32.load
-                      (set_local $$16
+                      (set_local $1
                         (i32.add
-                          (get_local $$nl_arg)
+                          (get_local $3)
                           (i32.shl
                             (i32.add
                               (i32.shr_s
                                 (i32.shl
                                   (i32.load8_s
-                                    (get_local $$arrayidx68)
+                                    (get_local $6)
                                   )
                                   (i32.const 24)
                                 )
@@ -4247,45 +3729,45 @@
                     )
                   )
                   (i32.load offset=4
-                    (get_local $$16)
+                    (get_local $1)
                   )
-                  (set_local $$l10n$2
+                  (set_local $63
                     (i32.const 1)
                   )
-                  (set_local $$storemerge$191
+                  (set_local $66
                     (i32.add
-                      (get_local $$storemerge$186282)
+                      (get_local $10)
                       (i32.const 3)
                     )
                   )
-                  (set_local $$w$0
-                    (get_local $$18)
+                  (set_local $61
+                    (get_local $5)
                   )
                 )
-                (set_local $label
+                (set_local $13
                   (i32.const 24)
                 )
               )
-              (set_local $label
+              (set_local $13
                 (i32.const 24)
               )
             )
             (if
               (i32.eq
-                (get_local $label)
+                (get_local $13)
                 (i32.const 24)
               )
               (block
-                (set_local $label
+                (set_local $13
                   (i32.const 0)
                 )
                 (if
                   (i32.ne
-                    (get_local $$l10n$1)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$retval$0
+                    (set_local $23
                       (i32.const -1)
                     )
                     (br $label$break$L1)
@@ -4293,31 +3775,29 @@
                 )
                 (if
                   (i32.eqz
-                    (get_local $$tobool25)
+                    (get_local $52)
                   )
                   (block
-                    (set_local $$fl$1
-                      (get_local $$fl$0284)
+                    (get_local $8)
+                    (set_local $10
+                      (get_local $6)
                     )
-                    (set_local $$incdec$ptr169269
-                      (get_local $$arrayidx68)
-                    )
-                    (set_local $$l10n$3
+                    (set_local $20
                       (i32.const 0)
                     )
-                    (set_local $$w$1
+                    (set_local $16
                       (i32.const 0)
                     )
                     (br $do-once$12)
                   )
                 )
-                (set_local $$28
+                (set_local $5
                   (i32.load
-                    (set_local $$27
+                    (set_local $1
                       (i32.and
                         (i32.add
                           (i32.load
-                            (get_local $$ap)
+                            (get_local $2)
                           )
                           (i32.sub
                             (i32.add
@@ -4342,69 +3822,69 @@
                   )
                 )
                 (i32.store
-                  (get_local $$ap)
+                  (get_local $2)
                   (i32.add
-                    (get_local $$27)
+                    (get_local $1)
                     (i32.const 4)
                   )
                 )
-                (set_local $$l10n$2
+                (set_local $63
                   (i32.const 0)
                 )
-                (set_local $$storemerge$191
-                  (get_local $$arrayidx68)
+                (set_local $66
+                  (get_local $6)
                 )
-                (set_local $$w$0
-                  (get_local $$28)
+                (set_local $61
+                  (get_local $5)
                 )
               )
             )
-            (set_local $$fl$1
+            (set_local $8
               (if
                 (i32.lt_s
-                  (get_local $$w$0)
+                  (get_local $61)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$incdec$ptr169269
-                    (get_local $$storemerge$191)
+                  (set_local $10
+                    (get_local $66)
                   )
-                  (set_local $$l10n$3
-                    (get_local $$l10n$2)
+                  (set_local $20
+                    (get_local $63)
                   )
-                  (set_local $$w$1
+                  (set_local $16
                     (i32.sub
                       (i32.const 0)
-                      (get_local $$w$0)
+                      (get_local $61)
                     )
                   )
                   (i32.or
-                    (get_local $$fl$0284)
+                    (get_local $8)
                     (i32.const 8192)
                   )
                 )
                 (block
-                  (set_local $$incdec$ptr169269
-                    (get_local $$storemerge$191)
+                  (set_local $10
+                    (get_local $66)
                   )
-                  (set_local $$l10n$3
-                    (get_local $$l10n$2)
+                  (set_local $20
+                    (get_local $63)
                   )
-                  (set_local $$w$1
-                    (get_local $$w$0)
+                  (set_local $16
+                    (get_local $61)
                   )
-                  (get_local $$fl$0284)
+                  (get_local $8)
                 )
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $$isdigittmp$5$i
+              (set_local $6
                 (i32.add
                   (i32.shr_s
                     (i32.shl
-                      (get_local $$12)
+                      (get_local $1)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -4415,35 +3895,33 @@
               (i32.const 10)
             )
             (block
-              (set_local $$29
-                (get_local $$storemerge$186282)
+              (set_local $1
+                (get_local $10)
               )
-              (set_local $$i$07$i
+              (set_local $5
                 (i32.const 0)
               )
-              (set_local $$isdigittmp8$i
-                (get_local $$isdigittmp$5$i)
-              )
+              (get_local $6)
               (loop $while-out$14 $while-in$15
-                (set_local $$add$i
+                (set_local $5
                   (i32.add
                     (i32.mul
-                      (get_local $$i$07$i)
+                      (get_local $5)
                       (i32.const 10)
                     )
-                    (get_local $$isdigittmp8$i)
+                    (get_local $6)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (set_local $$isdigittmp$i
+                    (set_local $10
                       (i32.add
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s
-                              (set_local $$incdec$ptr$i
+                              (set_local $6
                                 (i32.add
-                                  (get_local $$29)
+                                  (get_local $1)
                                   (i32.const 1)
                                 )
                               )
@@ -4458,22 +3936,20 @@
                     (i32.const 10)
                   )
                   (block
-                    (set_local $$29
-                      (get_local $$incdec$ptr$i)
+                    (set_local $1
+                      (get_local $6)
                     )
-                    (set_local $$i$07$i
-                      (get_local $$add$i)
-                    )
-                    (set_local $$isdigittmp8$i
-                      (get_local $$isdigittmp$i)
+                    (get_local $5)
+                    (set_local $6
+                      (get_local $10)
                     )
                   )
                   (block
-                    (set_local $$add$i$lcssa
-                      (get_local $$add$i)
+                    (set_local $1
+                      (get_local $5)
                     )
-                    (set_local $$incdec$ptr$i$lcssa
-                      (get_local $$incdec$ptr$i)
+                    (set_local $5
+                      (get_local $6)
                     )
                     (br $while-out$14)
                   )
@@ -4482,56 +3958,50 @@
               )
               (if
                 (i32.lt_s
-                  (get_local $$add$i$lcssa)
+                  (get_local $1)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$retval$0
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
                 (block
-                  (set_local $$fl$1
-                    (get_local $$fl$0284)
+                  (get_local $8)
+                  (set_local $10
+                    (get_local $5)
                   )
-                  (set_local $$incdec$ptr169269
-                    (get_local $$incdec$ptr$i$lcssa)
+                  (set_local $20
+                    (get_local $11)
                   )
-                  (set_local $$l10n$3
-                    (get_local $$l10n$1)
-                  )
-                  (set_local $$w$1
-                    (get_local $$add$i$lcssa)
+                  (set_local $16
+                    (get_local $1)
                   )
                 )
               )
             )
             (block
-              (set_local $$fl$1
-                (get_local $$fl$0284)
+              (get_local $8)
+              (get_local $10)
+              (set_local $20
+                (get_local $11)
               )
-              (set_local $$incdec$ptr169269
-                (get_local $$storemerge$186282)
-              )
-              (set_local $$l10n$3
-                (get_local $$l10n$1)
-              )
-              (set_local $$w$1
+              (set_local $16
                 (i32.const 0)
               )
             )
           )
         )
       )
-      (set_local $$incdec$ptr169271
+      (set_local $11
         (block $label$break$L46
           (if
             (i32.eq
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $$incdec$ptr169269)
+                    (get_local $10)
                   )
                   (i32.const 24)
                 )
@@ -4544,11 +4014,11 @@
                 (i32.ne
                   (i32.shr_s
                     (i32.shl
-                      (set_local $$32
+                      (set_local $1
                         (i32.load8_s
-                          (set_local $$arrayidx114
+                          (set_local $5
                             (i32.add
-                              (get_local $$incdec$ptr169269)
+                              (get_local $10)
                               (i32.const 1)
                             )
                           )
@@ -4563,11 +4033,11 @@
                 (block
                   (if
                     (i32.lt_u
-                      (set_local $$isdigittmp$5$i$198
+                      (set_local $6
                         (i32.add
                           (i32.shr_s
                             (i32.shl
-                              (get_local $$32)
+                              (get_local $1)
                               (i32.const 24)
                             )
                             (i32.const 24)
@@ -4578,45 +4048,43 @@
                       (i32.const 10)
                     )
                     (block
-                      (set_local $$49
-                        (get_local $$arrayidx114)
+                      (set_local $1
+                        (get_local $5)
                       )
-                      (set_local $$i$07$i$201
+                      (set_local $5
                         (i32.const 0)
                       )
-                      (set_local $$isdigittmp8$i$200
-                        (get_local $$isdigittmp$5$i$198)
-                      )
+                      (get_local $6)
                     )
                     (block
-                      (set_local $$p$0
+                      (set_local $9
                         (i32.const 0)
                       )
                       (br $label$break$L46
-                        (get_local $$arrayidx114)
+                        (get_local $5)
                       )
                     )
                   )
                   (loop $while-out$17 $while-in$18
-                    (set_local $$add$i$203
+                    (set_local $5
                       (i32.add
                         (i32.mul
-                          (get_local $$i$07$i$201)
+                          (get_local $5)
                           (i32.const 10)
                         )
-                        (get_local $$isdigittmp8$i$200)
+                        (get_local $6)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (set_local $$isdigittmp$i$206
+                        (set_local $6
                           (i32.add
                             (i32.shr_s
                               (i32.shl
                                 (i32.load8_s
-                                  (set_local $$incdec$ptr$i$204
+                                  (set_local $1
                                     (i32.add
-                                      (get_local $$49)
+                                      (get_local $1)
                                       (i32.const 1)
                                     )
                                   )
@@ -4631,22 +4099,16 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $$49
-                          (get_local $$incdec$ptr$i$204)
-                        )
-                        (set_local $$i$07$i$201
-                          (get_local $$add$i$203)
-                        )
-                        (set_local $$isdigittmp8$i$200
-                          (get_local $$isdigittmp$i$206)
-                        )
+                        (get_local $1)
+                        (get_local $5)
+                        (get_local $6)
                       )
                       (block
-                        (set_local $$p$0
-                          (get_local $$add$i$203)
+                        (set_local $9
+                          (get_local $5)
                         )
                         (br $label$break$L46
-                          (get_local $$incdec$ptr$i$204)
+                          (get_local $1)
                         )
                       )
                     )
@@ -4656,14 +4118,14 @@
               )
               (if
                 (i32.lt_u
-                  (set_local $$isdigittmp187
+                  (set_local $1
                     (i32.add
                       (i32.shr_s
                         (i32.shl
                           (i32.load8_s
-                            (set_local $$arrayidx119
+                            (set_local $6
                               (i32.add
-                                (get_local $$incdec$ptr169269)
+                                (get_local $10)
                                 (i32.const 2)
                               )
                             )
@@ -4682,7 +4144,7 @@
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s offset=3
-                          (get_local $$incdec$ptr169269)
+                          (get_local $10)
                         )
                         (i32.const 24)
                       )
@@ -4693,25 +4155,25 @@
                   (block
                     (i32.store
                       (i32.add
-                        (get_local $$nl_type)
+                        (get_local $4)
                         (i32.shl
-                          (get_local $$isdigittmp187)
+                          (get_local $1)
                           (i32.const 2)
                         )
                       )
                       (i32.const 10)
                     )
-                    (set_local $$38
+                    (set_local $5
                       (i32.load
-                        (set_local $$36
+                        (set_local $1
                           (i32.add
-                            (get_local $$nl_arg)
+                            (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.load8_s
-                                      (get_local $$arrayidx119)
+                                      (get_local $6)
                                     )
                                     (i32.const 24)
                                   )
@@ -4726,14 +4188,14 @@
                       )
                     )
                     (i32.load offset=4
-                      (get_local $$36)
+                      (get_local $1)
                     )
-                    (set_local $$p$0
-                      (get_local $$38)
+                    (set_local $9
+                      (get_local $5)
                     )
                     (br $label$break$L46
                       (i32.add
-                        (get_local $$incdec$ptr169269)
+                        (get_local $10)
                         (i32.const 4)
                       )
                     )
@@ -4742,26 +4204,26 @@
               )
               (if
                 (i32.ne
-                  (get_local $$l10n$3)
+                  (get_local $20)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$retval$0
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
               )
               (if
-                (get_local $$tobool25)
+                (get_local $52)
                 (block
-                  (set_local $$48
+                  (set_local $5
                     (i32.load
-                      (set_local $$47
+                      (set_local $1
                         (i32.and
                           (i32.add
                             (i32.load
-                              (get_local $$ap)
+                              (get_local $2)
                             )
                             (i32.sub
                               (i32.add
@@ -4786,46 +4248,46 @@
                     )
                   )
                   (i32.store
-                    (get_local $$ap)
+                    (get_local $2)
                     (i32.add
-                      (get_local $$47)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
-                  (set_local $$p$0
-                    (get_local $$48)
+                  (set_local $9
+                    (get_local $5)
                   )
-                  (get_local $$arrayidx119)
+                  (get_local $6)
                 )
                 (block
-                  (set_local $$p$0
+                  (set_local $9
                     (i32.const 0)
                   )
-                  (get_local $$arrayidx119)
+                  (get_local $6)
                 )
               )
             )
             (block
-              (set_local $$p$0
+              (set_local $9
                 (i32.const -1)
               )
-              (get_local $$incdec$ptr169269)
+              (get_local $10)
             )
           )
         )
       )
-      (set_local $$st$0
+      (set_local $21
         (i32.const 0)
       )
       (loop $while-out$19 $while-in$20
         (if
           (i32.gt_u
-            (set_local $$sub164
+            (set_local $1
               (i32.add
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $$incdec$ptr169271)
+                      (get_local $11)
                     )
                     (i32.const 24)
                   )
@@ -4837,34 +4299,34 @@
             (i32.const 57)
           )
           (block
-            (set_local $$retval$0
+            (set_local $23
               (i32.const -1)
             )
             (br $label$break$L1)
           )
         )
-        (set_local $$incdec$ptr169
+        (set_local $10
           (i32.add
-            (get_local $$incdec$ptr169271)
+            (get_local $11)
             (i32.const 1)
           )
         )
         (if
           (i32.lt_u
             (i32.add
-              (set_local $$conv174
+              (set_local $5
                 (i32.and
-                  (set_local $$52
+                  (set_local $1
                     (i32.load8_s
                       (i32.add
                         (i32.add
                           (i32.const 3611)
                           (i32.mul
-                            (get_local $$st$0)
+                            (get_local $21)
                             (i32.const 58)
                           )
                         )
-                        (get_local $$sub164)
+                        (get_local $1)
                       )
                     )
                   )
@@ -4876,28 +4338,26 @@
             (i32.const 8)
           )
           (block
-            (set_local $$incdec$ptr169271
-              (get_local $$incdec$ptr169)
+            (set_local $11
+              (get_local $10)
             )
-            (set_local $$st$0
-              (get_local $$conv174)
+            (set_local $21
+              (get_local $5)
             )
           )
           (block
-            (set_local $$$lcssa
-              (get_local $$52)
+            (get_local $1)
+            (set_local $6
+              (get_local $5)
             )
-            (set_local $$conv174$lcssa
-              (get_local $$conv174)
+            (set_local $26
+              (get_local $10)
             )
-            (set_local $$incdec$ptr169$lcssa
-              (get_local $$incdec$ptr169)
+            (set_local $10
+              (get_local $11)
             )
-            (set_local $$incdec$ptr169271$lcssa414
-              (get_local $$incdec$ptr169271)
-            )
-            (set_local $$st$0$lcssa415
-              (get_local $$st$0)
+            (set_local $11
+              (get_local $21)
             )
             (br $while-out$19)
           )
@@ -4908,7 +4368,7 @@
         (i32.eq
           (i32.shr_s
             (i32.shl
-              (get_local $$$lcssa)
+              (get_local $1)
               (i32.const 24)
             )
             (i32.const 24)
@@ -4916,15 +4376,15 @@
           (i32.const 0)
         )
         (block
-          (set_local $$retval$0
+          (set_local $23
             (i32.const -1)
           )
           (br $label$break$L1)
         )
       )
-      (set_local $$cmp184
+      (set_local $5
         (i32.gt_s
-          (get_local $$argpos$0)
+          (get_local $7)
           (i32.const -1)
         )
       )
@@ -4933,7 +4393,7 @@
           (i32.eq
             (i32.shr_s
               (i32.shl
-                (get_local $$$lcssa)
+                (get_local $1)
                 (i32.const 24)
               )
               (i32.const 24)
@@ -4941,60 +4401,60 @@
             (i32.const 19)
           )
           (if
-            (get_local $$cmp184)
+            (get_local $5)
             (block
-              (set_local $$retval$0
+              (set_local $23
                 (i32.const -1)
               )
               (br $label$break$L1)
             )
-            (set_local $label
+            (set_local $13
               (i32.const 52)
             )
           )
           (block
             (if
-              (get_local $$cmp184)
+              (get_local $5)
               (block
                 (i32.store
                   (i32.add
-                    (get_local $$nl_type)
+                    (get_local $4)
                     (i32.shl
-                      (get_local $$argpos$0)
+                      (get_local $7)
                       (i32.const 2)
                     )
                   )
-                  (get_local $$conv174$lcssa)
+                  (get_local $6)
                 )
-                (set_local $$56
+                (set_local $5
                   (i32.load
-                    (set_local $$54
+                    (set_local $1
                       (i32.add
-                        (get_local $$nl_arg)
+                        (get_local $3)
                         (i32.shl
-                          (get_local $$argpos$0)
+                          (get_local $7)
                           (i32.const 3)
                         )
                       )
                     )
                   )
                 )
-                (set_local $$59
+                (set_local $1
                   (i32.load offset=4
-                    (get_local $$54)
+                    (get_local $1)
                   )
                 )
                 (i32.store
-                  (set_local $$60
-                    (get_local $$arg)
+                  (set_local $7
+                    (get_local $18)
                   )
-                  (get_local $$56)
+                  (get_local $5)
                 )
                 (i32.store offset=4
-                  (get_local $$60)
-                  (get_local $$59)
+                  (get_local $7)
+                  (get_local $1)
                 )
-                (set_local $label
+                (set_local $13
                   (i32.const 52)
                 )
                 (br $do-once$21)
@@ -5002,67 +4462,67 @@
             )
             (if
               (i32.eqz
-                (get_local $$tobool25)
+                (get_local $52)
               )
               (block
-                (set_local $$retval$0
+                (set_local $23
                   (i32.const 0)
                 )
                 (br $label$break$L1)
               )
             )
             (call $_pop_arg_336
-              (get_local $$arg)
-              (get_local $$conv174$lcssa)
-              (get_local $$ap)
+              (get_local $18)
+              (get_local $6)
+              (get_local $2)
             )
           )
         )
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 52)
         )
         (block
-          (set_local $label
+          (set_local $13
             (i32.const 0)
           )
           (if
             (i32.eqz
-              (get_local $$tobool25)
+              (get_local $52)
             )
             (block
-              (set_local $$cnt$0
-                (get_local $$cnt$1)
+              (set_local $5
+                (get_local $19)
               )
-              (set_local $$incdec$ptr169275
-                (get_local $$incdec$ptr169$lcssa)
+              (set_local $12
+                (get_local $26)
               )
-              (set_local $$l$0
-                (get_local $$sub$ptr$sub)
+              (set_local $1
+                (get_local $15)
               )
-              (set_local $$l10n$0
-                (get_local $$l10n$3)
+              (set_local $8
+                (get_local $20)
               )
               (br $label$continue$L1)
             )
           )
         )
       )
-      (set_local $$or$cond192
+      (set_local $5
         (i32.and
           (i32.ne
-            (get_local $$st$0$lcssa415)
+            (get_local $11)
             (i32.const 0)
           )
           (i32.eq
             (i32.and
-              (set_local $$conv207
+              (set_local $1
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $$incdec$ptr169271$lcssa414)
+                      (get_local $10)
                     )
                     (i32.const 24)
                   )
@@ -5075,18 +4535,18 @@
           )
         )
       )
-      (set_local $$fl$1$and219
+      (set_local $17
         (select
-          (get_local $$fl$1)
-          (set_local $$and219
+          (get_local $8)
+          (set_local $6
             (i32.and
-              (get_local $$fl$1)
+              (get_local $8)
               (i32.const -65537)
             )
           )
           (i32.eq
             (i32.and
-              (get_local $$fl$1)
+              (get_local $8)
               (i32.const 8192)
             )
             (i32.const 0)
@@ -5120,14 +4580,14 @@
                                                       (block $switch-case$34
                                                         (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
                                                           (i32.sub
-                                                            (set_local $$t$0
+                                                            (set_local $33
                                                               (select
                                                                 (i32.and
-                                                                  (get_local $$conv207)
+                                                                  (get_local $1)
                                                                   (i32.const -33)
                                                                 )
-                                                                (get_local $$conv207)
-                                                                (get_local $$or$cond192)
+                                                                (get_local $1)
+                                                                (get_local $5)
                                                               )
                                                             )
                                                             (i32.const 65)
@@ -5146,65 +4606,65 @@
                                                                         (block $switch-case$26
                                                                           (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
                                                                             (i32.sub
-                                                                              (get_local $$st$0$lcssa415)
+                                                                              (get_local $11)
                                                                               (i32.const 0)
                                                                             )
                                                                           )
                                                                         )
                                                                         (i32.store
                                                                           (i32.load
-                                                                            (get_local $$arg)
+                                                                            (get_local $18)
                                                                           )
-                                                                          (get_local $$cnt$1)
+                                                                          (get_local $19)
                                                                         )
-                                                                        (set_local $$cnt$0
-                                                                          (get_local $$cnt$1)
+                                                                        (set_local $5
+                                                                          (get_local $19)
                                                                         )
-                                                                        (set_local $$incdec$ptr169275
-                                                                          (get_local $$incdec$ptr169$lcssa)
+                                                                        (set_local $12
+                                                                          (get_local $26)
                                                                         )
-                                                                        (set_local $$l$0
-                                                                          (get_local $$sub$ptr$sub)
+                                                                        (set_local $1
+                                                                          (get_local $15)
                                                                         )
-                                                                        (set_local $$l10n$0
-                                                                          (get_local $$l10n$3)
+                                                                        (set_local $8
+                                                                          (get_local $20)
                                                                         )
                                                                         (br $label$continue$L1)
                                                                       )
                                                                       (i32.store
                                                                         (i32.load
-                                                                          (get_local $$arg)
+                                                                          (get_local $18)
                                                                         )
-                                                                        (get_local $$cnt$1)
+                                                                        (get_local $19)
                                                                       )
-                                                                      (set_local $$cnt$0
-                                                                        (get_local $$cnt$1)
+                                                                      (set_local $5
+                                                                        (get_local $19)
                                                                       )
-                                                                      (set_local $$incdec$ptr169275
-                                                                        (get_local $$incdec$ptr169$lcssa)
+                                                                      (set_local $12
+                                                                        (get_local $26)
                                                                       )
-                                                                      (set_local $$l$0
-                                                                        (get_local $$sub$ptr$sub)
+                                                                      (set_local $1
+                                                                        (get_local $15)
                                                                       )
-                                                                      (set_local $$l10n$0
-                                                                        (get_local $$l10n$3)
+                                                                      (set_local $8
+                                                                        (get_local $20)
                                                                       )
                                                                       (br $label$continue$L1)
                                                                     )
                                                                     (i32.store
-                                                                      (set_local $$76
+                                                                      (set_local $1
                                                                         (i32.load
-                                                                          (get_local $$arg)
+                                                                          (get_local $18)
                                                                         )
                                                                       )
-                                                                      (get_local $$cnt$1)
+                                                                      (get_local $19)
                                                                     )
                                                                     (i32.store offset=4
-                                                                      (get_local $$76)
+                                                                      (get_local $1)
                                                                       (i32.shr_s
                                                                         (i32.shl
                                                                           (i32.lt_s
-                                                                            (get_local $$cnt$1)
+                                                                            (get_local $19)
                                                                             (i32.const 0)
                                                                           )
                                                                           (i32.const 31)
@@ -5212,100 +4672,100 @@
                                                                         (i32.const 31)
                                                                       )
                                                                     )
-                                                                    (set_local $$cnt$0
-                                                                      (get_local $$cnt$1)
+                                                                    (set_local $5
+                                                                      (get_local $19)
                                                                     )
-                                                                    (set_local $$incdec$ptr169275
-                                                                      (get_local $$incdec$ptr169$lcssa)
+                                                                    (set_local $12
+                                                                      (get_local $26)
                                                                     )
-                                                                    (set_local $$l$0
-                                                                      (get_local $$sub$ptr$sub)
+                                                                    (set_local $1
+                                                                      (get_local $15)
                                                                     )
-                                                                    (set_local $$l10n$0
-                                                                      (get_local $$l10n$3)
+                                                                    (set_local $8
+                                                                      (get_local $20)
                                                                     )
                                                                     (br $label$continue$L1)
                                                                   )
                                                                   (i32.store16
                                                                     (i32.load
-                                                                      (get_local $$arg)
+                                                                      (get_local $18)
                                                                     )
                                                                     (i32.and
-                                                                      (get_local $$cnt$1)
+                                                                      (get_local $19)
                                                                       (i32.const 65535)
                                                                     )
                                                                   )
-                                                                  (set_local $$cnt$0
-                                                                    (get_local $$cnt$1)
+                                                                  (set_local $5
+                                                                    (get_local $19)
                                                                   )
-                                                                  (set_local $$incdec$ptr169275
-                                                                    (get_local $$incdec$ptr169$lcssa)
+                                                                  (set_local $12
+                                                                    (get_local $26)
                                                                   )
-                                                                  (set_local $$l$0
-                                                                    (get_local $$sub$ptr$sub)
+                                                                  (set_local $1
+                                                                    (get_local $15)
                                                                   )
-                                                                  (set_local $$l10n$0
-                                                                    (get_local $$l10n$3)
+                                                                  (set_local $8
+                                                                    (get_local $20)
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
                                                                 (i32.store8
                                                                   (i32.load
-                                                                    (get_local $$arg)
+                                                                    (get_local $18)
                                                                   )
                                                                   (i32.and
-                                                                    (get_local $$cnt$1)
+                                                                    (get_local $19)
                                                                     (i32.const 255)
                                                                   )
                                                                 )
-                                                                (set_local $$cnt$0
-                                                                  (get_local $$cnt$1)
+                                                                (set_local $5
+                                                                  (get_local $19)
                                                                 )
-                                                                (set_local $$incdec$ptr169275
-                                                                  (get_local $$incdec$ptr169$lcssa)
+                                                                (set_local $12
+                                                                  (get_local $26)
                                                                 )
-                                                                (set_local $$l$0
-                                                                  (get_local $$sub$ptr$sub)
+                                                                (set_local $1
+                                                                  (get_local $15)
                                                                 )
-                                                                (set_local $$l10n$0
-                                                                  (get_local $$l10n$3)
+                                                                (set_local $8
+                                                                  (get_local $20)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
                                                               (i32.store
                                                                 (i32.load
-                                                                  (get_local $$arg)
+                                                                  (get_local $18)
                                                                 )
-                                                                (get_local $$cnt$1)
+                                                                (get_local $19)
                                                               )
-                                                              (set_local $$cnt$0
-                                                                (get_local $$cnt$1)
+                                                              (set_local $5
+                                                                (get_local $19)
                                                               )
-                                                              (set_local $$incdec$ptr169275
-                                                                (get_local $$incdec$ptr169$lcssa)
+                                                              (set_local $12
+                                                                (get_local $26)
                                                               )
-                                                              (set_local $$l$0
-                                                                (get_local $$sub$ptr$sub)
+                                                              (set_local $1
+                                                                (get_local $15)
                                                               )
-                                                              (set_local $$l10n$0
-                                                                (get_local $$l10n$3)
+                                                              (set_local $8
+                                                                (get_local $20)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
                                                             (i32.store
-                                                              (set_local $$86
+                                                              (set_local $1
                                                                 (i32.load
-                                                                  (get_local $$arg)
+                                                                  (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $$cnt$1)
+                                                              (get_local $19)
                                                             )
                                                             (i32.store offset=4
-                                                              (get_local $$86)
+                                                              (get_local $1)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $$cnt$1)
+                                                                    (get_local $19)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -5313,72 +4773,72 @@
                                                                 (i32.const 31)
                                                               )
                                                             )
-                                                            (set_local $$cnt$0
-                                                              (get_local $$cnt$1)
+                                                            (set_local $5
+                                                              (get_local $19)
                                                             )
-                                                            (set_local $$incdec$ptr169275
-                                                              (get_local $$incdec$ptr169$lcssa)
+                                                            (set_local $12
+                                                              (get_local $26)
                                                             )
-                                                            (set_local $$l$0
-                                                              (get_local $$sub$ptr$sub)
+                                                            (set_local $1
+                                                              (get_local $15)
                                                             )
-                                                            (set_local $$l10n$0
-                                                              (get_local $$l10n$3)
+                                                            (set_local $8
+                                                              (get_local $20)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
-                                                          (set_local $$cnt$0
-                                                            (get_local $$cnt$1)
+                                                          (set_local $5
+                                                            (get_local $19)
                                                           )
-                                                          (set_local $$incdec$ptr169275
-                                                            (get_local $$incdec$ptr169$lcssa)
+                                                          (set_local $12
+                                                            (get_local $26)
                                                           )
-                                                          (set_local $$l$0
-                                                            (get_local $$sub$ptr$sub)
+                                                          (set_local $1
+                                                            (get_local $15)
                                                           )
-                                                          (set_local $$l10n$0
-                                                            (get_local $$l10n$3)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
                                                       )
                                                       (br $switch$24)
                                                     )
-                                                    (set_local $$fl$3
+                                                    (set_local $49
                                                       (i32.or
-                                                        (get_local $$fl$1$and219)
+                                                        (get_local $17)
                                                         (i32.const 8)
                                                       )
                                                     )
-                                                    (set_local $$p$1
+                                                    (set_local $58
                                                       (select
-                                                        (get_local $$p$0)
+                                                        (get_local $9)
                                                         (i32.const 8)
                                                         (i32.gt_u
-                                                          (get_local $$p$0)
+                                                          (get_local $9)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (set_local $$t$1
+                                                    (set_local $69
                                                       (i32.const 120)
                                                     )
-                                                    (set_local $label
+                                                    (set_local $13
                                                       (i32.const 64)
                                                     )
                                                     (br $switch$24)
                                                   )
                                                 )
-                                                (set_local $$fl$3
-                                                  (get_local $$fl$1$and219)
+                                                (set_local $49
+                                                  (get_local $17)
                                                 )
-                                                (set_local $$p$1
-                                                  (get_local $$p$0)
+                                                (set_local $58
+                                                  (get_local $9)
                                                 )
-                                                (set_local $$t$1
-                                                  (get_local $$t$0)
+                                                (set_local $69
+                                                  (get_local $33)
                                                 )
-                                                (set_local $label
+                                                (set_local $13
                                                   (i32.const 64)
                                                 )
                                                 (br $switch$24)
@@ -5386,49 +4846,45 @@
                                               (if
                                                 (i32.and
                                                   (i32.eq
-                                                    (set_local $$118
+                                                    (set_local $5
                                                       (i32.load
-                                                        (set_local $$116
-                                                          (get_local $$arg)
+                                                        (set_local $1
+                                                          (get_local $18)
                                                         )
                                                       )
                                                     )
                                                     (i32.const 0)
                                                   )
                                                   (i32.eq
-                                                    (set_local $$121
+                                                    (set_local $1
                                                       (i32.load offset=4
-                                                        (get_local $$116)
+                                                        (get_local $1)
                                                       )
                                                     )
                                                     (i32.const 0)
                                                   )
                                                 )
-                                                (set_local $$s$addr$0$lcssa$i$229
-                                                  (get_local $$add$ptr205)
+                                                (set_local $7
+                                                  (get_local $28)
                                                 )
                                                 (block
-                                                  (set_local $$126
-                                                    (get_local $$118)
-                                                  )
-                                                  (set_local $$129
-                                                    (get_local $$121)
-                                                  )
-                                                  (set_local $$s$addr$06$i$221
-                                                    (get_local $$add$ptr205)
+                                                  (get_local $5)
+                                                  (get_local $1)
+                                                  (set_local $7
+                                                    (get_local $28)
                                                   )
                                                   (loop $while-out$38 $while-in$39
                                                     (i32.store8
-                                                      (set_local $$incdec$ptr$i$225
+                                                      (set_local $34
                                                         (i32.add
-                                                          (get_local $$s$addr$06$i$221)
+                                                          (get_local $7)
                                                           (i32.const -1)
                                                         )
                                                       )
                                                       (i32.and
                                                         (i32.or
                                                           (i32.and
-                                                            (get_local $$126)
+                                                            (get_local $5)
                                                             (i32.const 7)
                                                           )
                                                           (i32.const 48)
@@ -5439,17 +4895,17 @@
                                                     (if
                                                       (i32.and
                                                         (i32.eq
-                                                          (set_local $$130
+                                                          (set_local $1
                                                             (call $_bitshift64Lshr
-                                                              (get_local $$126)
-                                                              (get_local $$129)
+                                                              (get_local $5)
+                                                              (get_local $1)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                           (i32.const 0)
                                                         )
                                                         (i32.eq
-                                                          (set_local $$131
+                                                          (set_local $7
                                                             (i32.load
                                                               (i32.const 168)
                                                             )
@@ -5458,20 +4914,20 @@
                                                         )
                                                       )
                                                       (block
-                                                        (set_local $$s$addr$0$lcssa$i$229
-                                                          (get_local $$incdec$ptr$i$225)
+                                                        (set_local $7
+                                                          (get_local $34)
                                                         )
                                                         (br $while-out$38)
                                                       )
                                                       (block
-                                                        (set_local $$126
-                                                          (get_local $$130)
+                                                        (set_local $5
+                                                          (get_local $1)
                                                         )
-                                                        (set_local $$129
-                                                          (get_local $$131)
+                                                        (set_local $1
+                                                          (get_local $7)
                                                         )
-                                                        (set_local $$s$addr$06$i$221
-                                                          (get_local $$incdec$ptr$i$225)
+                                                        (set_local $7
+                                                          (get_local $34)
                                                         )
                                                       )
                                                     )
@@ -5479,150 +4935,150 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $$a$0
+                                              (set_local $34
                                                 (if
                                                   (i32.eq
                                                     (i32.and
-                                                      (get_local $$fl$1$and219)
+                                                      (get_local $17)
                                                       (i32.const 8)
                                                     )
                                                     (i32.const 0)
                                                   )
                                                   (block
-                                                    (set_local $$fl$4
-                                                      (get_local $$fl$1$and219)
+                                                    (set_local $35
+                                                      (get_local $17)
                                                     )
-                                                    (set_local $$p$2
-                                                      (get_local $$p$0)
+                                                    (set_local $31
+                                                      (get_local $9)
                                                     )
-                                                    (set_local $$pl$1
+                                                    (set_local $38
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $$prefix$1
+                                                    (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $label
+                                                    (set_local $13
                                                       (i32.const 77)
                                                     )
-                                                    (get_local $$s$addr$0$lcssa$i$229)
+                                                    (get_local $7)
                                                   )
                                                   (block
-                                                    (set_local $$cmp270
+                                                    (set_local $5
                                                       (i32.lt_s
-                                                        (get_local $$p$0)
-                                                        (set_local $$add269
+                                                        (get_local $9)
+                                                        (set_local $1
                                                           (i32.add
                                                             (i32.sub
-                                                              (get_local $$sub$ptr$lhs$cast317)
-                                                              (get_local $$s$addr$0$lcssa$i$229)
+                                                              (get_local $73)
+                                                              (get_local $7)
                                                             )
                                                             (i32.const 1)
                                                           )
                                                         )
                                                       )
                                                     )
-                                                    (set_local $$fl$4
-                                                      (get_local $$fl$1$and219)
+                                                    (set_local $35
+                                                      (get_local $17)
                                                     )
-                                                    (set_local $$p$2
+                                                    (set_local $31
                                                       (select
-                                                        (get_local $$add269)
-                                                        (get_local $$p$0)
-                                                        (get_local $$cmp270)
+                                                        (get_local $1)
+                                                        (get_local $9)
+                                                        (get_local $5)
                                                       )
                                                     )
-                                                    (set_local $$pl$1
+                                                    (set_local $38
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $$prefix$1
+                                                    (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $label
+                                                    (set_local $13
                                                       (i32.const 77)
                                                     )
-                                                    (get_local $$s$addr$0$lcssa$i$229)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
                                               (br $switch$24)
                                             )
                                           )
-                                          (set_local $$137
+                                          (set_local $5
                                             (i32.load
-                                              (set_local $$135
-                                                (get_local $$arg)
+                                              (set_local $1
+                                                (get_local $18)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (set_local $$140
+                                              (set_local $7
                                                 (i32.load offset=4
-                                                  (get_local $$135)
+                                                  (get_local $1)
                                                 )
                                               )
                                               (i32.const 0)
                                             )
                                             (block
-                                              (set_local $$142
+                                              (set_local $1
                                                 (call $_i64Subtract
                                                   (i32.const 0)
                                                   (i32.const 0)
-                                                  (get_local $$137)
-                                                  (get_local $$140)
+                                                  (get_local $5)
+                                                  (get_local $7)
                                                 )
                                               )
-                                              (set_local $$143
+                                              (set_local $5
                                                 (i32.load
                                                   (i32.const 168)
                                                 )
                                               )
                                               (i32.store
-                                                (set_local $$144
-                                                  (get_local $$arg)
+                                                (set_local $7
+                                                  (get_local $18)
                                                 )
-                                                (get_local $$142)
+                                                (get_local $1)
                                               )
                                               (i32.store offset=4
-                                                (get_local $$144)
-                                                (get_local $$143)
+                                                (get_local $7)
+                                                (get_local $5)
                                               )
-                                              (set_local $$148
-                                                (get_local $$142)
+                                              (set_local $45
+                                                (get_local $1)
                                               )
-                                              (set_local $$149
-                                                (get_local $$143)
+                                              (set_local $54
+                                                (get_local $5)
                                               )
-                                              (set_local $$pl$0
+                                              (set_local $59
                                                 (i32.const 1)
                                               )
-                                              (set_local $$prefix$0
+                                              (set_local $60
                                                 (i32.const 4091)
                                               )
-                                              (set_local $label
+                                              (set_local $13
                                                 (i32.const 76)
                                               )
                                               (br $label$break$L75)
                                             )
                                           )
-                                          (set_local $$148
+                                          (set_local $45
                                             (if
                                               (i32.eq
                                                 (i32.and
-                                                  (get_local $$fl$1$and219)
+                                                  (get_local $17)
                                                   (i32.const 2048)
                                                 )
                                                 (i32.const 0)
                                               )
                                               (block
-                                                (set_local $$$
+                                                (set_local $1
                                                   (select
                                                     (i32.const 4091)
                                                     (i32.const 4093)
                                                     (i32.eq
-                                                      (set_local $$and294
+                                                      (set_local $45
                                                         (i32.and
-                                                          (get_local $$fl$1$and219)
+                                                          (get_local $17)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -5630,185 +5086,185 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $$149
-                                                  (get_local $$140)
+                                                (set_local $54
+                                                  (get_local $7)
                                                 )
-                                                (set_local $$pl$0
-                                                  (get_local $$and294)
+                                                (set_local $59
+                                                  (get_local $45)
                                                 )
-                                                (set_local $$prefix$0
-                                                  (get_local $$$)
+                                                (set_local $60
+                                                  (get_local $1)
                                                 )
-                                                (set_local $label
+                                                (set_local $13
                                                   (i32.const 76)
                                                 )
-                                                (get_local $$137)
+                                                (get_local $5)
                                               )
                                               (block
-                                                (set_local $$149
-                                                  (get_local $$140)
+                                                (set_local $54
+                                                  (get_local $7)
                                                 )
-                                                (set_local $$pl$0
+                                                (set_local $59
                                                   (i32.const 1)
                                                 )
-                                                (set_local $$prefix$0
+                                                (set_local $60
                                                   (i32.const 4092)
                                                 )
-                                                (set_local $label
+                                                (set_local $13
                                                   (i32.const 76)
                                                 )
-                                                (get_local $$137)
+                                                (get_local $5)
                                               )
                                             )
                                           )
                                           (br $switch$24)
                                         )
-                                        (set_local $$148
+                                        (set_local $45
                                           (i32.load
-                                            (set_local $$65
-                                              (get_local $$arg)
+                                            (set_local $1
+                                              (get_local $18)
                                             )
                                           )
                                         )
-                                        (set_local $$149
+                                        (set_local $54
                                           (i32.load offset=4
-                                            (get_local $$65)
+                                            (get_local $1)
                                           )
                                         )
-                                        (set_local $$pl$0
+                                        (set_local $59
                                           (i32.const 0)
                                         )
-                                        (set_local $$prefix$0
+                                        (set_local $60
                                           (i32.const 4091)
                                         )
-                                        (set_local $label
+                                        (set_local $13
                                           (i32.const 76)
                                         )
                                         (br $switch$24)
                                       )
-                                      (set_local $$163
+                                      (set_local $5
                                         (i32.load
-                                          (set_local $$161
-                                            (get_local $$arg)
+                                          (set_local $1
+                                            (get_local $18)
                                           )
                                         )
                                       )
                                       (i32.load offset=4
-                                        (get_local $$161)
+                                        (get_local $1)
                                       )
                                       (i32.store8
-                                        (get_local $$add$ptr340)
+                                        (get_local $71)
                                         (i32.and
-                                          (get_local $$163)
+                                          (get_local $5)
                                           (i32.const 255)
                                         )
                                       )
-                                      (set_local $$a$2
-                                        (get_local $$add$ptr340)
+                                      (set_local $47
+                                        (get_local $71)
                                       )
-                                      (set_local $$fl$6
-                                        (get_local $$and219)
+                                      (set_local $36
+                                        (get_local $6)
                                       )
-                                      (set_local $$p$5
+                                      (set_local $42
                                         (i32.const 1)
                                       )
-                                      (set_local $$pl$2
+                                      (set_local $43
                                         (i32.const 0)
                                       )
-                                      (set_local $$prefix$2
+                                      (set_local $51
                                         (i32.const 4091)
                                       )
-                                      (set_local $$z$2
-                                        (get_local $$add$ptr205)
+                                      (set_local $53
+                                        (get_local $28)
                                       )
                                       (br $switch$24)
                                     )
-                                    (set_local $$a$1
+                                    (set_local $46
                                       (call $_strerror
                                         (i32.load
                                           (call $___errno_location)
                                         )
                                       )
                                     )
-                                    (set_local $label
+                                    (set_local $13
                                       (i32.const 82)
                                     )
                                     (br $switch$24)
                                   )
-                                  (set_local $$tobool349
+                                  (set_local $5
                                     (i32.ne
-                                      (set_local $$169
+                                      (set_local $1
                                         (i32.load
-                                          (get_local $$arg)
+                                          (get_local $18)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $$a$1
+                                  (set_local $46
                                     (select
-                                      (get_local $$169)
+                                      (get_local $1)
                                       (i32.const 4101)
-                                      (get_local $$tobool349)
+                                      (get_local $5)
                                     )
                                   )
-                                  (set_local $label
+                                  (set_local $13
                                     (i32.const 82)
                                   )
                                   (br $switch$24)
                                 )
-                                (set_local $$172
+                                (set_local $5
                                   (i32.load
-                                    (set_local $$170
-                                      (get_local $$arg)
+                                    (set_local $1
+                                      (get_local $18)
                                     )
                                   )
                                 )
                                 (i32.load offset=4
-                                  (get_local $$170)
+                                  (get_local $1)
                                 )
                                 (i32.store
-                                  (get_local $$wc)
-                                  (get_local $$172)
+                                  (get_local $75)
+                                  (get_local $5)
                                 )
                                 (i32.store
-                                  (get_local $$arrayidx370)
+                                  (get_local $77)
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $$arg)
-                                  (get_local $$wc)
+                                  (get_local $18)
+                                  (get_local $75)
                                 )
-                                (set_local $$p$4365
+                                (set_local $65
                                   (i32.const -1)
                                 )
-                                (set_local $label
+                                (set_local $13
                                   (i32.const 86)
                                 )
                                 (br $switch$24)
                               )
-                              (set_local $label
+                              (set_local $13
                                 (if
                                   (i32.eq
-                                    (get_local $$p$0)
+                                    (get_local $9)
                                     (i32.const 0)
                                   )
                                   (block
                                     (call $_pad
-                                      (get_local $$f)
+                                      (get_local $0)
                                       (i32.const 32)
-                                      (get_local $$w$1)
+                                      (get_local $16)
                                       (i32.const 0)
-                                      (get_local $$fl$1$and219)
+                                      (get_local $17)
                                     )
-                                    (set_local $$i$0$lcssa368
+                                    (set_local $37
                                       (i32.const 0)
                                     )
                                     (i32.const 98)
                                   )
                                   (block
-                                    (set_local $$p$4365
-                                      (get_local $$p$0)
+                                    (set_local $65
+                                      (get_local $9)
                                     )
                                     (i32.const 86)
                                   )
@@ -5823,27 +5279,27 @@
                   )
                 )
               )
-              (set_local $$181
+              (set_local $14
                 (f64.load
-                  (get_local $$arg)
+                  (get_local $18)
                 )
               )
               (i32.store
-                (get_local $$e2$i)
+                (get_local $25)
                 (i32.const 0)
               )
               (f64.store
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $$181)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
               )
-              (set_local $$pl$0$i
+              (set_local $50
                 (if
                   (i32.lt_s
                     (i32.load offset=4
@@ -5854,12 +5310,12 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$prefix$0$i
+                    (set_local $39
                       (i32.const 4108)
                     )
-                    (set_local $$y$addr$0$i
+                    (set_local $14
                       (f64.neg
-                        (get_local $$181)
+                        (get_local $14)
                       )
                     )
                     (i32.const 1)
@@ -5867,20 +5323,20 @@
                   (if
                     (i32.eq
                       (i32.and
-                        (get_local $$fl$1$and219)
+                        (get_local $17)
                         (i32.const 2048)
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$prefix$0$i
+                      (set_local $39
                         (select
                           (i32.const 4109)
                           (i32.const 4114)
                           (i32.eq
-                            (set_local $$and12$i
+                            (set_local $1
                               (i32.and
-                                (get_local $$fl$1$and219)
+                                (get_local $17)
                                 (i32.const 1)
                               )
                             )
@@ -5888,18 +5344,14 @@
                           )
                         )
                       )
-                      (set_local $$y$addr$0$i
-                        (get_local $$181)
-                      )
-                      (get_local $$and12$i)
+                      (get_local $14)
+                      (get_local $1)
                     )
                     (block
-                      (set_local $$prefix$0$i
+                      (set_local $39
                         (i32.const 4111)
                       )
-                      (set_local $$y$addr$0$i
-                        (get_local $$181)
-                      )
+                      (get_local $14)
                       (i32.const 1)
                     )
                   )
@@ -5909,19 +5361,19 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $$y$addr$0$i)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
               )
-              (set_local $$retval$0$i
+              (set_local $1
                 (block $do-once$56
                   (if
                     (i32.or
                       (i32.lt_u
-                        (set_local $$187
+                        (set_local $1
                           (i32.and
                             (i32.load offset=4
                               (i32.load
@@ -5935,7 +5387,7 @@
                       )
                       (i32.and
                         (i32.eq
-                          (get_local $$187)
+                          (get_local $1)
                           (i32.const 2146435072)
                         )
                         (i32.lt_s
@@ -5946,13 +5398,13 @@
                     )
                     (block
                       (if
-                        (set_local $$tobool56$i
+                        (set_local $5
                           (f64.ne
-                            (set_local $$mul$i$240
+                            (set_local $14
                               (f64.mul
                                 (call $_frexpl
-                                  (get_local $$y$addr$0$i)
-                                  (get_local $$e2$i)
+                                  (get_local $14)
+                                  (get_local $25)
                                 )
                                 (f64.const 2)
                               )
@@ -5961,10 +5413,10 @@
                           )
                         )
                         (i32.store
-                          (get_local $$e2$i)
+                          (get_local $25)
                           (i32.add
                             (i32.load
-                              (get_local $$e2$i)
+                              (get_local $25)
                             )
                             (i32.const -1)
                           )
@@ -5972,26 +5424,26 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $$or$i$241
+                          (set_local $15
                             (i32.or
-                              (get_local $$t$0)
+                              (get_local $33)
                               (i32.const 32)
                             )
                           )
                           (i32.const 97)
                         )
                         (block
-                          (set_local $$prefix$0$add$ptr65$i
+                          (set_local $10
                             (select
-                              (get_local $$prefix$0$i)
+                              (get_local $39)
                               (i32.add
-                                (get_local $$prefix$0$i)
+                                (get_local $39)
                                 (i32.const 9)
                               )
                               (i32.eq
-                                (set_local $$and62$i
+                                (set_local $6
                                   (i32.and
-                                    (get_local $$t$0)
+                                    (get_local $33)
                                     (i32.const 32)
                                   )
                                 )
@@ -5999,67 +5451,59 @@
                               )
                             )
                           )
-                          (set_local $$add67$i
+                          (set_local $7
                             (i32.or
-                              (get_local $$pl$0$i)
+                              (get_local $50)
                               (i32.const 2)
                             )
                           )
-                          (set_local $$y$addr$1$i
+                          (set_local $14
                             (if
                               (i32.or
                                 (i32.gt_u
-                                  (get_local $$p$0)
+                                  (get_local $9)
                                   (i32.const 11)
                                 )
                                 (i32.eq
-                                  (set_local $$sub74$i
+                                  (set_local $1
                                     (i32.sub
                                       (i32.const 12)
-                                      (get_local $$p$0)
+                                      (get_local $9)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                               )
-                              (get_local $$mul$i$240)
+                              (get_local $14)
                               (block
-                                (set_local $$re$1482$i
-                                  (get_local $$sub74$i)
-                                )
-                                (set_local $$round$0481$i
+                                (get_local $1)
+                                (set_local $22
                                   (f64.const 8)
                                 )
                                 (loop $while-out$60 $while-in$61
-                                  (set_local $$mul80$i
+                                  (set_local $22
                                     (f64.mul
-                                      (get_local $$round$0481$i)
+                                      (get_local $22)
                                       (f64.const 16)
                                     )
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $$dec78$i
+                                      (set_local $1
                                         (i32.add
-                                          (get_local $$re$1482$i)
+                                          (get_local $1)
                                           (i32.const -1)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                     (block
-                                      (set_local $$mul80$i$lcssa
-                                        (get_local $$mul80$i)
-                                      )
+                                      (get_local $22)
                                       (br $while-out$60)
                                     )
                                     (block
-                                      (set_local $$re$1482$i
-                                        (get_local $$dec78$i)
-                                      )
-                                      (set_local $$round$0481$i
-                                        (get_local $$mul80$i)
-                                      )
+                                      (get_local $1)
+                                      (get_local $22)
                                     )
                                   )
                                   (br $while-in$61)
@@ -6069,7 +5513,7 @@
                                     (i32.shr_s
                                       (i32.shl
                                         (i32.load8_s
-                                          (get_local $$prefix$0$add$ptr65$i)
+                                          (get_local $10)
                                         )
                                         (i32.const 24)
                                       )
@@ -6079,48 +5523,48 @@
                                   )
                                   (f64.neg
                                     (f64.add
-                                      (get_local $$mul80$i$lcssa)
+                                      (get_local $22)
                                       (f64.sub
                                         (f64.neg
-                                          (get_local $$mul$i$240)
+                                          (get_local $14)
                                         )
-                                        (get_local $$mul80$i$lcssa)
+                                        (get_local $22)
                                       )
                                     )
                                   )
                                   (f64.sub
                                     (f64.add
-                                      (get_local $$mul$i$240)
-                                      (get_local $$mul80$i$lcssa)
+                                      (get_local $14)
+                                      (get_local $22)
                                     )
-                                    (get_local $$mul80$i$lcssa)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $$cmp94$i
+                          (set_local $5
                             (i32.lt_s
-                              (set_local $$198
+                              (set_local $1
                                 (i32.load
-                                  (get_local $$e2$i)
+                                  (get_local $25)
                                 )
                               )
                               (i32.const 0)
                             )
                           )
-                          (set_local $$200
+                          (set_local $5
                             (i32.shr_s
                               (i32.shl
                                 (i32.lt_s
-                                  (set_local $$cond100$i
+                                  (set_local $8
                                     (select
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $$198)
+                                        (get_local $1)
                                       )
-                                      (get_local $$198)
-                                      (get_local $$cmp94$i)
+                                      (get_local $1)
+                                      (get_local $5)
                                     )
                                   )
                                   (i32.const 0)
@@ -6132,26 +5576,26 @@
                           )
                           (i32.store8
                             (i32.add
-                              (set_local $$estr$0$i
+                              (set_local $5
                                 (if
                                   (i32.eq
-                                    (set_local $$201
+                                    (set_local $5
                                       (call $_fmt_u
-                                        (get_local $$cond100$i)
-                                        (get_local $$200)
-                                        (get_local $$arrayidx$i$236)
+                                        (get_local $8)
+                                        (get_local $5)
+                                        (get_local $55)
                                       )
                                     )
-                                    (get_local $$arrayidx$i$236)
+                                    (get_local $55)
                                   )
                                   (block
                                     (i32.store8
-                                      (get_local $$incdec$ptr106$i)
+                                      (get_local $72)
                                       (i32.const 48)
                                     )
-                                    (get_local $$incdec$ptr106$i)
+                                    (get_local $72)
                                   )
-                                  (get_local $$201)
+                                  (get_local $5)
                                 )
                               )
                               (i32.const -1)
@@ -6160,7 +5604,7 @@
                               (i32.add
                                 (i32.and
                                   (i32.shr_s
-                                    (get_local $$198)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -6171,52 +5615,50 @@
                             )
                           )
                           (i32.store8
-                            (set_local $$incdec$ptr115$i
+                            (set_local $8
                               (i32.add
-                                (get_local $$estr$0$i)
+                                (get_local $5)
                                 (i32.const -2)
                               )
                             )
                             (i32.and
                               (i32.add
-                                (get_local $$t$0)
+                                (get_local $33)
                                 (i32.const 15)
                               )
                               (i32.const 255)
                             )
                           )
-                          (set_local $$notrhs$i
+                          (set_local $5
                             (i32.lt_s
-                              (get_local $$p$0)
+                              (get_local $9)
                               (i32.const 1)
                             )
                           )
-                          (set_local $$tobool135$i
+                          (set_local $12
                             (i32.eq
                               (i32.and
-                                (get_local $$fl$1$and219)
+                                (get_local $17)
                                 (i32.const 8)
                               )
                               (i32.const 0)
                             )
                           )
-                          (set_local $$s$0$i
-                            (get_local $$buf$i)
+                          (set_local $11
+                            (get_local $29)
                           )
-                          (set_local $$y$addr$2$i
-                            (get_local $$y$addr$1$i)
-                          )
+                          (get_local $14)
                           (loop $while-out$62 $while-in$63
                             (i32.store8
-                              (get_local $$s$0$i)
+                              (get_local $11)
                               (i32.and
                                 (i32.or
                                   (i32.and
                                     (i32.load8_s
                                       (i32.add
-                                        (set_local $$conv116$i
+                                        (set_local $1
                                           (call_import $f64-to-int
-                                            (get_local $$y$addr$2$i)
+                                            (get_local $14)
                                           )
                                         )
                                         (i32.const 4075)
@@ -6224,194 +5666,188 @@
                                     )
                                     (i32.const 255)
                                   )
-                                  (get_local $$and62$i)
+                                  (get_local $6)
                                 )
                                 (i32.const 255)
                               )
                             )
-                            (set_local $$mul125$i
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $$y$addr$2$i)
+                                  (get_local $14)
                                   (f64.convert_s/i32
-                                    (get_local $$conv116$i)
+                                    (get_local $1)
                                   )
                                 )
                                 (f64.const 16)
                               )
                             )
-                            (set_local $$s$1$i
+                            (set_local $1
                               (block $do-once$64
                                 (if
                                   (i32.eq
                                     (i32.sub
-                                      (set_local $$incdec$ptr122$i
+                                      (set_local $1
                                         (i32.add
-                                          (get_local $$s$0$i)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
-                                      (get_local $$sub$ptr$rhs$cast$i)
+                                      (get_local $67)
                                     )
                                     (i32.const 1)
                                   )
                                   (block
                                     (if
                                       (i32.and
-                                        (get_local $$tobool135$i)
+                                        (get_local $12)
                                         (i32.and
-                                          (get_local $$notrhs$i)
+                                          (get_local $5)
                                           (f64.eq
-                                            (get_local $$mul125$i)
+                                            (get_local $14)
                                             (f64.const 0)
                                           )
                                         )
                                       )
                                       (br $do-once$64
-                                        (get_local $$incdec$ptr122$i)
+                                        (get_local $1)
                                       )
                                     )
                                     (i32.store8
-                                      (get_local $$incdec$ptr122$i)
+                                      (get_local $1)
                                       (i32.const 46)
                                     )
                                     (i32.add
-                                      (get_local $$s$0$i)
+                                      (get_local $11)
                                       (i32.const 2)
                                     )
                                   )
-                                  (get_local $$incdec$ptr122$i)
+                                  (get_local $1)
                                 )
                               )
                             )
                             (if
                               (f64.ne
-                                (get_local $$mul125$i)
+                                (get_local $14)
                                 (f64.const 0)
                               )
                               (block
-                                (set_local $$s$0$i
-                                  (get_local $$s$1$i)
+                                (set_local $11
+                                  (get_local $1)
                                 )
-                                (set_local $$y$addr$2$i
-                                  (get_local $$mul125$i)
-                                )
+                                (get_local $14)
                               )
                               (block
-                                (set_local $$s$1$i$lcssa
-                                  (get_local $$s$1$i)
-                                )
+                                (get_local $1)
                                 (br $while-out$62)
                               )
                             )
                             (br $while-in$63)
                           )
-                          (set_local $$or$cond384
+                          (set_local $5
                             (i32.and
                               (i32.ne
-                                (get_local $$p$0)
+                                (get_local $9)
                                 (i32.const 0)
                               )
                               (i32.lt_s
                                 (i32.add
-                                  (get_local $$sub$ptr$sub145$i)
-                                  (set_local $$$pre566$i
-                                    (get_local $$s$1$i$lcssa)
-                                  )
+                                  (get_local $81)
+                                  (get_local $1)
                                 )
-                                (get_local $$p$0)
+                                (get_local $9)
                               )
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 32)
-                            (get_local $$w$1)
-                            (set_local $$add165$i
+                            (get_local $16)
+                            (set_local $5
                               (i32.add
-                                (set_local $$l$0$i
+                                (set_local $6
                                   (select
                                     (i32.sub
                                       (i32.add
-                                        (get_local $$sub$ptr$sub153$i)
-                                        (get_local $$p$0)
+                                        (get_local $82)
+                                        (get_local $9)
                                       )
-                                      (get_local $$incdec$ptr115$i)
+                                      (get_local $8)
                                     )
                                     (i32.add
                                       (i32.sub
-                                        (get_local $$sub$ptr$sub159$i)
-                                        (get_local $$incdec$ptr115$i)
+                                        (get_local $83)
+                                        (get_local $8)
                                       )
-                                      (get_local $$$pre566$i)
+                                      (get_local $1)
                                     )
-                                    (get_local $$or$cond384)
+                                    (get_local $5)
                                   )
                                 )
-                                (get_local $$add67$i)
+                                (get_local $7)
                               )
                             )
-                            (get_local $$fl$1$and219)
+                            (get_local $17)
                           )
                           (if
                             (i32.eq
                               (i32.and
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $$prefix$0$add$ptr65$i)
-                              (get_local $$add67$i)
-                              (get_local $$f)
+                              (get_local $10)
+                              (get_local $7)
+                              (get_local $0)
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 48)
-                            (get_local $$w$1)
-                            (get_local $$add165$i)
+                            (get_local $16)
+                            (get_local $5)
                             (i32.xor
-                              (get_local $$fl$1$and219)
+                              (get_local $17)
                               (i32.const 65536)
                             )
                           )
-                          (set_local $$sub$ptr$sub172$i
+                          (set_local $1
                             (i32.sub
-                              (get_local $$$pre566$i)
-                              (get_local $$sub$ptr$rhs$cast$i)
+                              (get_local $1)
+                              (get_local $67)
                             )
                           )
                           (if
                             (i32.eq
                               (i32.and
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $$buf$i)
-                              (get_local $$sub$ptr$sub172$i)
-                              (get_local $$f)
+                              (get_local $29)
+                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 48)
                             (i32.sub
-                              (get_local $$l$0$i)
+                              (get_local $6)
                               (i32.add
-                                (get_local $$sub$ptr$sub172$i)
-                                (set_local $$sub$ptr$sub175$i
+                                (get_local $1)
+                                (set_local $1
                                   (i32.sub
-                                    (get_local $$sub$ptr$lhs$cast160$i)
-                                    (get_local $$incdec$ptr115$i)
+                                    (get_local $44)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -6423,124 +5859,120 @@
                             (i32.eq
                               (i32.and
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $$incdec$ptr115$i)
-                              (get_local $$sub$ptr$sub175$i)
-                              (get_local $$f)
+                              (get_local $8)
+                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 32)
-                            (get_local $$w$1)
-                            (get_local $$add165$i)
+                            (get_local $16)
+                            (get_local $5)
                             (i32.xor
-                              (get_local $$fl$1$and219)
+                              (get_local $17)
                               (i32.const 8192)
                             )
                           )
                           (br $do-once$56
                             (select
-                              (get_local $$w$1)
-                              (get_local $$add165$i)
+                              (get_local $16)
+                              (get_local $5)
                               (i32.lt_s
-                                (get_local $$add165$i)
-                                (get_local $$w$1)
+                                (get_local $5)
+                                (get_local $16)
                               )
                             )
                           )
                         )
                       )
-                      (set_local $$$p$i
+                      (set_local $1
                         (select
                           (i32.const 6)
-                          (get_local $$p$0)
+                          (get_local $9)
                           (i32.lt_s
-                            (get_local $$p$0)
+                            (get_local $9)
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $$210
+                      (set_local $5
                         (if
-                          (get_local $$tobool56$i)
+                          (get_local $5)
                           (block
                             (i32.store
-                              (get_local $$e2$i)
-                              (set_local $$sub203$i
+                              (get_local $25)
+                              (set_local $5
                                 (i32.add
                                   (i32.load
-                                    (get_local $$e2$i)
+                                    (get_local $25)
                                   )
                                   (i32.const -28)
                                 )
                               )
                             )
-                            (set_local $$y$addr$3$i
+                            (set_local $14
                               (f64.mul
-                                (get_local $$mul$i$240)
+                                (get_local $14)
                                 (f64.const 268435456)
                               )
                             )
-                            (get_local $$sub203$i)
+                            (get_local $5)
                           )
                           (block
-                            (set_local $$y$addr$3$i
-                              (get_local $$mul$i$240)
-                            )
+                            (get_local $14)
                             (i32.load
-                              (get_local $$e2$i)
+                              (get_local $25)
                             )
                           )
                         )
                       )
-                      (set_local $$sub$ptr$rhs$cast345$i
-                        (set_local $$arraydecay208$add$ptr213$i
+                      (set_local $30
+                        (set_local $10
                           (select
-                            (get_local $$big$i)
-                            (get_local $$add$ptr213$i)
+                            (get_local $78)
+                            (get_local $76)
                             (i32.lt_s
-                              (get_local $$210)
+                              (get_local $5)
                               (i32.const 0)
                             )
                           )
                         )
                       )
-                      (set_local $$y$addr$4$i
-                        (get_local $$y$addr$3$i)
-                      )
-                      (set_local $$z$0$i
-                        (get_local $$arraydecay208$add$ptr213$i)
+                      (get_local $14)
+                      (set_local $7
+                        (get_local $10)
                       )
                       (loop $while-out$66 $while-in$67
                         (i32.store
-                          (get_local $$z$0$i)
-                          (set_local $$conv216$i
+                          (get_local $7)
+                          (set_local $5
                             (call_import $f64-to-int
-                              (get_local $$y$addr$4$i)
+                              (get_local $14)
                             )
                           )
                         )
-                        (set_local $$incdec$ptr217$i
+                        (set_local $7
                           (i32.add
-                            (get_local $$z$0$i)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (if
                           (f64.ne
-                            (set_local $$mul220$i
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $$y$addr$4$i)
+                                  (get_local $14)
                                   (f64.convert_u/i32
-                                    (get_local $$conv216$i)
+                                    (get_local $5)
                                   )
                                 )
                                 (f64.const 1e9)
@@ -6549,16 +5981,12 @@
                             (f64.const 0)
                           )
                           (block
-                            (set_local $$y$addr$4$i
-                              (get_local $$mul220$i)
-                            )
-                            (set_local $$z$0$i
-                              (get_local $$incdec$ptr217$i)
-                            )
+                            (get_local $14)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$incdec$ptr217$i$lcssa
-                              (get_local $$incdec$ptr217$i)
+                            (set_local $6
+                              (get_local $7)
                             )
                             (br $while-out$66)
                           )
@@ -6567,74 +5995,72 @@
                       )
                       (if
                         (i32.gt_s
-                          (set_local $$$pr$i
+                          (set_local $5
                             (i32.load
-                              (get_local $$e2$i)
+                              (get_local $25)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$211
-                            (get_local $$$pr$i)
+                          (get_local $5)
+                          (set_local $8
+                            (get_local $10)
                           )
-                          (set_local $$a$1549$i
-                            (get_local $$arraydecay208$add$ptr213$i)
-                          )
-                          (set_local $$z$1548$i
-                            (get_local $$incdec$ptr217$i$lcssa)
+                          (set_local $9
+                            (get_local $6)
                           )
                           (loop $while-out$68 $while-in$69
-                            (set_local $$cond233$i
+                            (set_local $11
                               (select
                                 (i32.const 29)
-                                (get_local $$211)
+                                (get_local $5)
                                 (i32.gt_s
-                                  (get_local $$211)
+                                  (get_local $5)
                                   (i32.const 29)
                                 )
                               )
                             )
-                            (set_local $$a$2$ph$i
+                            (set_local $7
                               (block $do-once$70
                                 (if
                                   (i32.lt_u
-                                    (set_local $$d$0$542$i
+                                    (set_local $7
                                       (i32.add
-                                        (get_local $$z$1548$i)
+                                        (get_local $9)
                                         (i32.const -4)
                                       )
                                     )
-                                    (get_local $$a$1549$i)
+                                    (get_local $8)
                                   )
-                                  (get_local $$a$1549$i)
+                                  (get_local $8)
                                   (block
-                                    (set_local $$carry$0544$i
+                                    (set_local $5
                                       (i32.const 0)
                                     )
-                                    (set_local $$d$0545$i
-                                      (get_local $$d$0$542$i)
+                                    (set_local $12
+                                      (get_local $7)
                                     )
                                     (loop $while-out$72 $while-in$73
-                                      (set_local $$217
+                                      (set_local $6
                                         (call $___uremdi3
-                                          (set_local $$215
+                                          (set_local $5
                                             (call $_i64Add
                                               (call $_bitshift64Shl
                                                 (i32.load
-                                                  (get_local $$d$0545$i)
+                                                  (get_local $12)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $$cond233$i)
+                                                (get_local $11)
                                               )
                                               (i32.load
                                                 (i32.const 168)
                                               )
-                                              (get_local $$carry$0544$i)
+                                              (get_local $5)
                                               (i32.const 0)
                                             )
                                           )
-                                          (set_local $$216
+                                          (set_local $7
                                             (i32.load
                                               (i32.const 168)
                                             )
@@ -6647,13 +6073,13 @@
                                         (i32.const 168)
                                       )
                                       (i32.store
-                                        (get_local $$d$0545$i)
-                                        (get_local $$217)
+                                        (get_local $12)
+                                        (get_local $6)
                                       )
-                                      (set_local $$219
+                                      (set_local $5
                                         (call $___udivdi3
-                                          (get_local $$215)
-                                          (get_local $$216)
+                                          (get_local $5)
+                                          (get_local $7)
                                           (i32.const 1000000000)
                                           (i32.const 0)
                                         )
@@ -6663,26 +6089,22 @@
                                       )
                                       (if
                                         (i32.lt_u
-                                          (set_local $$d$0$i
+                                          (set_local $7
                                             (i32.add
-                                              (get_local $$d$0545$i)
+                                              (get_local $12)
                                               (i32.const -4)
                                             )
                                           )
-                                          (get_local $$a$1549$i)
+                                          (get_local $8)
                                         )
                                         (block
-                                          (set_local $$conv242$i$lcssa
-                                            (get_local $$219)
-                                          )
+                                          (get_local $5)
                                           (br $while-out$72)
                                         )
                                         (block
-                                          (set_local $$carry$0544$i
-                                            (get_local $$219)
-                                          )
-                                          (set_local $$d$0545$i
-                                            (get_local $$d$0$i)
+                                          (get_local $5)
+                                          (set_local $12
+                                            (get_local $7)
                                           )
                                         )
                                       )
@@ -6690,104 +6112,92 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (get_local $$conv242$i$lcssa)
+                                        (get_local $5)
                                         (i32.const 0)
                                       )
                                       (br $do-once$70
-                                        (get_local $$a$1549$i)
+                                        (get_local $8)
                                       )
                                     )
                                     (i32.store
-                                      (set_local $$incdec$ptr246$i
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $$a$1549$i)
+                                          (get_local $8)
                                           (i32.const -4)
                                         )
                                       )
-                                      (get_local $$conv242$i$lcssa)
+                                      (get_local $5)
                                     )
-                                    (get_local $$incdec$ptr246$i)
+                                    (get_local $7)
                                   )
                                 )
                               )
                             )
-                            (set_local $$z$2$i
-                              (get_local $$z$1548$i)
+                            (set_local $6
+                              (get_local $9)
                             )
                             (loop $while-out$74 $while-in$75
                               (if
                                 (i32.le_u
-                                  (get_local $$z$2$i)
-                                  (get_local $$a$2$ph$i)
+                                  (get_local $6)
+                                  (get_local $7)
                                 )
                                 (block
-                                  (set_local $$z$2$i$lcssa
-                                    (get_local $$z$2$i)
-                                  )
+                                  (get_local $6)
                                   (br $while-out$74)
                                 )
                               )
                               (if
                                 (i32.eq
                                   (i32.load
-                                    (set_local $$arrayidx251$i
+                                    (set_local $5
                                       (i32.add
-                                        (get_local $$z$2$i)
+                                        (get_local $6)
                                         (i32.const -4)
                                       )
                                     )
                                   )
                                   (i32.const 0)
                                 )
-                                (set_local $$z$2$i
-                                  (get_local $$arrayidx251$i)
+                                (set_local $6
+                                  (get_local $5)
                                 )
                                 (block
-                                  (set_local $$z$2$i$lcssa
-                                    (get_local $$z$2$i)
-                                  )
+                                  (get_local $6)
                                   (br $while-out$74)
                                 )
                               )
                               (br $while-in$75)
                             )
                             (i32.store
-                              (get_local $$e2$i)
-                              (set_local $$sub256$i
+                              (get_local $25)
+                              (set_local $5
                                 (i32.sub
                                   (i32.load
-                                    (get_local $$e2$i)
+                                    (get_local $25)
                                   )
-                                  (get_local $$cond233$i)
+                                  (get_local $11)
                                 )
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $$sub256$i)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$211
-                                  (get_local $$sub256$i)
+                                (get_local $5)
+                                (set_local $8
+                                  (get_local $7)
                                 )
-                                (set_local $$a$1549$i
-                                  (get_local $$a$2$ph$i)
-                                )
-                                (set_local $$z$1548$i
-                                  (get_local $$z$2$i$lcssa)
+                                (set_local $9
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $$$pr477$i
-                                  (get_local $$sub256$i)
-                                )
-                                (set_local $$a$1$lcssa$i
-                                  (get_local $$a$2$ph$i)
-                                )
-                                (set_local $$z$1$lcssa$i
-                                  (get_local $$z$2$i$lcssa)
-                                )
+                                (get_local $5)
+                                (get_local $7)
+                                (get_local $6)
                                 (br $while-out$68)
                               )
                             )
@@ -6795,29 +6205,25 @@
                           )
                         )
                         (block
-                          (set_local $$$pr477$i
-                            (get_local $$$pr$i)
+                          (get_local $5)
+                          (set_local $7
+                            (get_local $10)
                           )
-                          (set_local $$a$1$lcssa$i
-                            (get_local $$arraydecay208$add$ptr213$i)
-                          )
-                          (set_local $$z$1$lcssa$i
-                            (get_local $$incdec$ptr217$i$lcssa)
-                          )
+                          (get_local $6)
                         )
                       )
                       (if
                         (i32.lt_s
-                          (get_local $$$pr477$i)
+                          (get_local $5)
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$add275$i
+                          (set_local $8
                             (i32.add
                               (i32.and
                                 (i32.div_s
                                   (i32.add
-                                    (get_local $$$p$i)
+                                    (get_local $1)
                                     (i32.const 25)
                                   )
                                   (i32.const 9)
@@ -6827,133 +6233,127 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $$cmp299$i
+                          (set_local $12
                             (i32.eq
-                              (get_local $$or$i$241)
+                              (get_local $15)
                               (i32.const 102)
                             )
                           )
-                          (set_local $$223
-                            (get_local $$$pr477$i)
-                          )
-                          (set_local $$a$3539$i
-                            (get_local $$a$1$lcssa$i)
-                          )
-                          (set_local $$z$3538$i
-                            (get_local $$z$1$lcssa$i)
+                          (get_local $5)
+                          (get_local $7)
+                          (set_local $24
+                            (get_local $6)
                           )
                           (loop $while-out$76 $while-in$77
-                            (set_local $$cmp265$i
+                            (set_local $5
                               (i32.gt_s
-                                (set_local $$sub264$i
+                                (set_local $6
                                   (i32.sub
                                     (i32.const 0)
-                                    (get_local $$223)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 9)
                               )
                             )
-                            (set_local $$cond271$i
+                            (set_local $9
                               (select
                                 (i32.const 9)
-                                (get_local $$sub264$i)
-                                (get_local $$cmp265$i)
+                                (get_local $6)
+                                (get_local $5)
                               )
                             )
-                            (set_local $$incdec$ptr292$a$3573$i
+                            (set_local $11
                               (block $do-once$78
                                 (if
                                   (i32.lt_u
-                                    (get_local $$a$3539$i)
-                                    (get_local $$z$3538$i)
+                                    (get_local $7)
+                                    (get_local $24)
                                   )
                                   (block
-                                    (set_local $$sub281$i
+                                    (set_local $68
                                       (i32.add
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $$cond271$i)
+                                          (get_local $9)
                                         )
                                         (i32.const -1)
                                       )
                                     )
-                                    (set_local $$shr285$i
+                                    (set_local $27
                                       (i32.shr_u
                                         (i32.const 1000000000)
-                                        (get_local $$cond271$i)
+                                        (get_local $9)
                                       )
                                     )
-                                    (set_local $$carry262$0535$i
+                                    (set_local $11
                                       (i32.const 0)
                                     )
-                                    (set_local $$d$1534$i
-                                      (get_local $$a$3539$i)
+                                    (set_local $21
+                                      (get_local $7)
                                     )
                                     (loop $while-out$80 $while-in$81
-                                      (set_local $$and282$i
+                                      (set_local $6
                                         (i32.and
-                                          (set_local $$225
+                                          (set_local $5
                                             (i32.load
-                                              (get_local $$d$1534$i)
+                                              (get_local $21)
                                             )
                                           )
-                                          (get_local $$sub281$i)
+                                          (get_local $68)
                                         )
                                       )
                                       (i32.store
-                                        (get_local $$d$1534$i)
+                                        (get_local $21)
                                         (i32.add
                                           (i32.shr_u
-                                            (get_local $$225)
-                                            (get_local $$cond271$i)
+                                            (get_local $5)
+                                            (get_local $9)
                                           )
-                                          (get_local $$carry262$0535$i)
+                                          (get_local $11)
                                         )
                                       )
-                                      (set_local $$mul286$i
+                                      (set_local $6
                                         (i32.mul
-                                          (get_local $$and282$i)
-                                          (get_local $$shr285$i)
+                                          (get_local $6)
+                                          (get_local $27)
                                         )
                                       )
                                       (if
                                         (i32.lt_u
-                                          (set_local $$incdec$ptr288$i
+                                          (set_local $5
                                             (i32.add
-                                              (get_local $$d$1534$i)
+                                              (get_local $21)
                                               (i32.const 4)
                                             )
                                           )
-                                          (get_local $$z$3538$i)
+                                          (get_local $24)
                                         )
                                         (block
-                                          (set_local $$carry262$0535$i
-                                            (get_local $$mul286$i)
+                                          (set_local $11
+                                            (get_local $6)
                                           )
-                                          (set_local $$d$1534$i
-                                            (get_local $$incdec$ptr288$i)
+                                          (set_local $21
+                                            (get_local $5)
                                           )
                                         )
                                         (block
-                                          (set_local $$mul286$i$lcssa
-                                            (get_local $$mul286$i)
-                                          )
+                                          (get_local $6)
                                           (br $while-out$80)
                                         )
                                       )
                                       (br $while-in$81)
                                     )
-                                    (set_local $$incdec$ptr292$a$3$i
+                                    (set_local $5
                                       (select
                                         (i32.add
-                                          (get_local $$a$3539$i)
+                                          (get_local $7)
                                           (i32.const 4)
                                         )
-                                        (get_local $$a$3539$i)
+                                        (get_local $7)
                                         (i32.eq
                                           (i32.load
-                                            (get_local $$a$3539$i)
+                                            (get_local $7)
                                           )
                                           (i32.const 0)
                                         )
@@ -6961,43 +6361,43 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (get_local $$mul286$i$lcssa)
+                                        (get_local $6)
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $$z$4$i
-                                          (get_local $$z$3538$i)
+                                        (set_local $6
+                                          (get_local $24)
                                         )
                                         (br $do-once$78
-                                          (get_local $$incdec$ptr292$a$3$i)
+                                          (get_local $5)
                                         )
                                       )
                                     )
                                     (i32.store
-                                      (get_local $$z$3538$i)
-                                      (get_local $$mul286$i$lcssa)
+                                      (get_local $24)
+                                      (get_local $6)
                                     )
-                                    (set_local $$z$4$i
+                                    (set_local $6
                                       (i32.add
-                                        (get_local $$z$3538$i)
+                                        (get_local $24)
                                         (i32.const 4)
                                       )
                                     )
-                                    (get_local $$incdec$ptr292$a$3$i)
+                                    (get_local $5)
                                   )
                                   (block
-                                    (set_local $$z$4$i
-                                      (get_local $$z$3538$i)
+                                    (set_local $6
+                                      (get_local $24)
                                     )
                                     (select
                                       (i32.add
-                                        (get_local $$a$3539$i)
+                                        (get_local $7)
                                         (i32.const 4)
                                       )
-                                      (get_local $$a$3539$i)
+                                      (get_local $7)
                                       (i32.eq
                                         (i32.load
-                                          (get_local $$a$3539$i)
+                                          (get_local $7)
                                         )
                                         (i32.const 0)
                                       )
@@ -7006,70 +6406,68 @@
                                 )
                               )
                             )
-                            (set_local $$cmp308$i
+                            (set_local $5
                               (i32.gt_s
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $$z$4$i)
-                                    (set_local $$cond304$i
+                                    (get_local $6)
+                                    (set_local $7
                                       (select
-                                        (get_local $$arraydecay208$add$ptr213$i)
-                                        (get_local $$incdec$ptr292$a$3573$i)
-                                        (get_local $$cmp299$i)
+                                        (get_local $10)
+                                        (get_local $11)
+                                        (get_local $12)
                                       )
                                     )
                                   )
                                   (i32.const 2)
                                 )
-                                (get_local $$add275$i)
+                                (get_local $8)
                               )
                             )
-                            (set_local $$add$ptr311$z$4$i
+                            (set_local $6
                               (select
                                 (i32.add
-                                  (get_local $$cond304$i)
+                                  (get_local $7)
                                   (i32.shl
-                                    (get_local $$add275$i)
+                                    (get_local $8)
                                     (i32.const 2)
                                   )
                                 )
-                                (get_local $$z$4$i)
-                                (get_local $$cmp308$i)
+                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                             (i32.store
-                              (get_local $$e2$i)
-                              (set_local $$add313$i
+                              (get_local $25)
+                              (set_local $5
                                 (i32.add
                                   (i32.load
-                                    (get_local $$e2$i)
+                                    (get_local $25)
                                   )
-                                  (get_local $$cond271$i)
+                                  (get_local $9)
                                 )
                               )
                             )
                             (if
                               (i32.lt_s
-                                (get_local $$add313$i)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$223
-                                  (get_local $$add313$i)
+                                (get_local $5)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $$a$3539$i
-                                  (get_local $$incdec$ptr292$a$3573$i)
-                                )
-                                (set_local $$z$3538$i
-                                  (get_local $$add$ptr311$z$4$i)
+                                (set_local $24
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $$a$3$lcssa$i
-                                  (get_local $$incdec$ptr292$a$3573$i)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $$z$3$lcssa$i
-                                  (get_local $$add$ptr311$z$4$i)
+                                (set_local $27
+                                  (get_local $6)
                                 )
                                 (br $while-out$76)
                               )
@@ -7078,27 +6476,25 @@
                           )
                         )
                         (block
-                          (set_local $$a$3$lcssa$i
-                            (get_local $$a$1$lcssa$i)
-                          )
-                          (set_local $$z$3$lcssa$i
-                            (get_local $$z$1$lcssa$i)
+                          (get_local $7)
+                          (set_local $27
+                            (get_local $6)
                           )
                         )
                       )
                       (block $do-once$82
                         (if
                           (i32.lt_u
-                            (get_local $$a$3$lcssa$i)
-                            (get_local $$z$3$lcssa$i)
+                            (get_local $7)
+                            (get_local $27)
                           )
                           (block
-                            (set_local $$mul322$i
+                            (set_local $6
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $$sub$ptr$rhs$cast345$i)
-                                    (get_local $$a$3$lcssa$i)
+                                    (get_local $30)
+                                    (get_local $7)
                                   )
                                   (i32.const 2)
                                 )
@@ -7107,80 +6503,74 @@
                             )
                             (if
                               (i32.lt_u
-                                (set_local $$228
+                                (set_local $5
                                   (i32.load
-                                    (get_local $$a$3$lcssa$i)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 10)
                               )
                               (block
-                                (set_local $$e$1$i
-                                  (get_local $$mul322$i)
+                                (set_local $9
+                                  (get_local $6)
                                 )
                                 (br $do-once$82)
                               )
                               (block
-                                (set_local $$e$0531$i
-                                  (get_local $$mul322$i)
-                                )
-                                (set_local $$i$0530$i
+                                (get_local $6)
+                                (set_local $8
                                   (i32.const 10)
                                 )
                               )
                             )
                             (loop $while-out$84 $while-in$85
-                              (set_local $$inc$i
+                              (set_local $6
                                 (i32.add
-                                  (get_local $$e$0531$i)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$228)
-                                  (set_local $$mul328$i
+                                  (get_local $5)
+                                  (set_local $8
                                     (i32.mul
-                                      (get_local $$i$0530$i)
+                                      (get_local $8)
                                       (i32.const 10)
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $$e$1$i
-                                    (get_local $$inc$i)
+                                  (set_local $9
+                                    (get_local $6)
                                   )
                                   (br $while-out$84)
                                 )
                                 (block
-                                  (set_local $$e$0531$i
-                                    (get_local $$inc$i)
-                                  )
-                                  (set_local $$i$0530$i
-                                    (get_local $$mul328$i)
-                                  )
+                                  (get_local $6)
+                                  (get_local $8)
                                 )
                               )
                               (br $while-in$85)
                             )
                           )
-                          (set_local $$e$1$i
+                          (set_local $9
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $$a$9$ph$i
+                      (set_local $7
                         (if
                           (i32.lt_s
-                            (set_local $$sub343$i
+                            (set_local $5
                               (i32.add
                                 (i32.sub
-                                  (get_local $$$p$i)
+                                  (get_local $1)
                                   (select
-                                    (get_local $$e$1$i)
+                                    (get_local $9)
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $$or$i$241)
+                                      (get_local $15)
                                       (i32.const 102)
                                     )
                                   )
@@ -7188,15 +6578,15 @@
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.and
-                                      (set_local $$tobool341$i
+                                      (set_local $68
                                         (i32.ne
-                                          (get_local $$$p$i)
+                                          (get_local $1)
                                           (i32.const 0)
                                         )
                                       )
-                                      (set_local $$cmp338$i
+                                      (set_local $8
                                         (i32.eq
-                                          (get_local $$or$i$241)
+                                          (get_local $15)
                                           (i32.const 103)
                                         )
                                       )
@@ -7211,8 +6601,8 @@
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $$z$3$lcssa$i)
-                                    (get_local $$sub$ptr$rhs$cast345$i)
+                                    (get_local $27)
+                                    (get_local $30)
                                   )
                                   (i32.const 2)
                                 )
@@ -7222,19 +6612,19 @@
                             )
                           )
                           (block
-                            (set_local $$add$ptr358$i
+                            (set_local $6
                               (i32.add
                                 (i32.add
-                                  (get_local $$arraydecay208$add$ptr213$i)
+                                  (get_local $10)
                                   (i32.const 4)
                                 )
                                 (i32.shl
                                   (i32.add
                                     (i32.and
                                       (i32.div_s
-                                        (set_local $$add355$i
+                                        (set_local $5
                                           (i32.add
-                                            (get_local $$sub343$i)
+                                            (get_local $5)
                                             (i32.const 9216)
                                           )
                                         )
@@ -7250,11 +6640,11 @@
                             )
                             (if
                               (i32.lt_s
-                                (set_local $$j$0$524$i
+                                (set_local $11
                                   (i32.add
                                     (i32.and
                                       (i32.rem_s
-                                        (get_local $$add355$i)
+                                        (get_local $5)
                                         (i32.const 9)
                                       )
                                       (i32.const -1)
@@ -7265,73 +6655,67 @@
                                 (i32.const 9)
                               )
                               (block
-                                (set_local $$i$1526$i
+                                (set_local $5
                                   (i32.const 10)
                                 )
-                                (set_local $$j$0527$i
-                                  (get_local $$j$0$524$i)
-                                )
+                                (get_local $11)
                                 (loop $while-out$86 $while-in$87
-                                  (set_local $$mul367$i
+                                  (set_local $5
                                     (i32.mul
-                                      (get_local $$i$1526$i)
+                                      (get_local $5)
                                       (i32.const 10)
                                     )
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $$j$0$i
+                                      (set_local $11
                                         (i32.add
-                                          (get_local $$j$0527$i)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
                                       (i32.const 9)
                                     )
                                     (block
-                                      (set_local $$i$1$lcssa$i
-                                        (get_local $$mul367$i)
+                                      (set_local $21
+                                        (get_local $5)
                                       )
                                       (br $while-out$86)
                                     )
                                     (block
-                                      (set_local $$i$1526$i
-                                        (get_local $$mul367$i)
-                                      )
-                                      (set_local $$j$0527$i
-                                        (get_local $$j$0$i)
-                                      )
+                                      (get_local $5)
+                                      (get_local $11)
                                     )
                                   )
                                   (br $while-in$87)
                                 )
                               )
-                              (set_local $$i$1$lcssa$i
+                              (set_local $21
                                 (i32.const 10)
                               )
                             )
                             (block $do-once$88
                               (if
                                 (i32.and
-                                  (set_local $$cmp374$i
+                                  (set_local $11
                                     (i32.eq
                                       (i32.add
-                                        (get_local $$add$ptr358$i)
+                                        (get_local $6)
                                         (i32.const 4)
                                       )
-                                      (get_local $$z$3$lcssa$i)
+                                      (get_local $27)
                                     )
                                   )
                                   (i32.eq
-                                    (set_local $$rem370$i
+                                    (set_local $15
                                       (i32.and
                                         (i32.rem_u
-                                          (set_local $$231
+                                          (set_local $5
                                             (i32.load
-                                              (get_local $$add$ptr358$i)
+                                              (get_local $6)
                                             )
                                           )
-                                          (get_local $$i$1$lcssa$i)
+                                          (get_local $21)
                                         )
                                         (i32.const -1)
                                       )
@@ -7340,18 +6724,18 @@
                                   )
                                 )
                                 (block
-                                  (set_local $$a$8$i
-                                    (get_local $$a$3$lcssa$i)
+                                  (set_local $5
+                                    (get_local $7)
                                   )
-                                  (set_local $$d$4$i
-                                    (get_local $$add$ptr358$i)
+                                  (set_local $7
+                                    (get_local $6)
                                   )
-                                  (set_local $$e$4$i
-                                    (get_local $$e$1$i)
+                                  (set_local $11
+                                    (get_local $9)
                                   )
                                 )
                                 (block
-                                  (set_local $$$396$i
+                                  (set_local $14
                                     (select
                                       (f64.const 9007199254740992)
                                       (f64.const 9007199254740994)
@@ -7359,8 +6743,8 @@
                                         (i32.and
                                           (i32.and
                                             (i32.div_u
-                                              (get_local $$231)
-                                              (get_local $$i$1$lcssa$i)
+                                              (get_local $5)
+                                              (get_local $21)
                                             )
                                             (i32.const -1)
                                           )
@@ -7370,14 +6754,14 @@
                                       )
                                     )
                                   )
-                                  (set_local $$small$0$i
+                                  (set_local $22
                                     (if
                                       (i32.lt_u
-                                        (get_local $$rem370$i)
-                                        (set_local $$div384$i
+                                        (get_local $15)
+                                        (set_local $12
                                           (i32.and
                                             (i32.div_s
-                                              (get_local $$i$1$lcssa$i)
+                                              (get_local $21)
                                               (i32.const 2)
                                             )
                                             (i32.const -1)
@@ -7389,27 +6773,25 @@
                                         (f64.const 1)
                                         (f64.const 1.5)
                                         (i32.and
-                                          (get_local $$cmp374$i)
+                                          (get_local $11)
                                           (i32.eq
-                                            (get_local $$rem370$i)
-                                            (get_local $$div384$i)
+                                            (get_local $15)
+                                            (get_local $12)
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $$round377$1$i
+                                  (set_local $14
                                     (block $do-once$90
                                       (if
                                         (i32.eq
-                                          (get_local $$pl$0$i)
+                                          (get_local $50)
                                           (i32.const 0)
                                         )
                                         (block
-                                          (set_local $$small$1$i
-                                            (get_local $$small$0$i)
-                                          )
-                                          (get_local $$$396$i)
+                                          (get_local $22)
+                                          (get_local $14)
                                         )
                                         (block
                                           (if
@@ -7417,7 +6799,7 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.load8_s
-                                                    (get_local $$prefix$0$i)
+                                                    (get_local $39)
                                                   )
                                                   (i32.const 24)
                                                 )
@@ -7426,114 +6808,112 @@
                                               (i32.const 45)
                                             )
                                             (block
-                                              (set_local $$small$1$i
-                                                (get_local $$small$0$i)
-                                              )
+                                              (get_local $22)
                                               (br $do-once$90
-                                                (get_local $$$396$i)
+                                                (get_local $14)
                                               )
                                             )
                                           )
-                                          (set_local $$small$1$i
+                                          (set_local $22
                                             (f64.neg
-                                              (get_local $$small$0$i)
+                                              (get_local $22)
                                             )
                                           )
                                           (f64.neg
-                                            (get_local $$$396$i)
+                                            (get_local $14)
                                           )
                                         )
                                       )
                                     )
                                   )
                                   (i32.store
-                                    (get_local $$add$ptr358$i)
-                                    (set_local $$sub409$i
+                                    (get_local $6)
+                                    (set_local $5
                                       (i32.sub
-                                        (get_local $$231)
-                                        (get_local $$rem370$i)
+                                        (get_local $5)
+                                        (get_local $15)
                                       )
                                     )
                                   )
                                   (if
                                     (f64.eq
                                       (f64.add
-                                        (get_local $$round377$1$i)
-                                        (get_local $$small$1$i)
+                                        (get_local $14)
+                                        (get_local $22)
                                       )
-                                      (get_local $$round377$1$i)
+                                      (get_local $14)
                                     )
                                     (block
-                                      (set_local $$a$8$i
-                                        (get_local $$a$3$lcssa$i)
+                                      (set_local $5
+                                        (get_local $7)
                                       )
-                                      (set_local $$d$4$i
-                                        (get_local $$add$ptr358$i)
+                                      (set_local $7
+                                        (get_local $6)
                                       )
-                                      (set_local $$e$4$i
-                                        (get_local $$e$1$i)
+                                      (set_local $11
+                                        (get_local $9)
                                       )
                                       (br $do-once$88)
                                     )
                                   )
                                   (i32.store
-                                    (get_local $$add$ptr358$i)
-                                    (set_local $$add414$i
+                                    (get_local $6)
+                                    (set_local $5
                                       (i32.add
-                                        (get_local $$sub409$i)
-                                        (get_local $$i$1$lcssa$i)
+                                        (get_local $5)
+                                        (get_local $21)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.gt_u
-                                      (get_local $$add414$i)
+                                      (get_local $5)
                                       (i32.const 999999999)
                                     )
                                     (block
-                                      (set_local $$a$5521$i
-                                        (get_local $$a$3$lcssa$i)
+                                      (set_local $5
+                                        (get_local $7)
                                       )
-                                      (set_local $$d$2520$i
-                                        (get_local $$add$ptr358$i)
+                                      (set_local $7
+                                        (get_local $6)
                                       )
                                       (loop $while-out$92 $while-in$93
                                         (i32.store
-                                          (get_local $$d$2520$i)
+                                          (get_local $7)
                                           (i32.const 0)
                                         )
-                                        (set_local $$a$6$i
+                                        (set_local $5
                                           (if
                                             (i32.lt_u
-                                              (set_local $$incdec$ptr419$i
+                                              (set_local $6
                                                 (i32.add
-                                                  (get_local $$d$2520$i)
+                                                  (get_local $7)
                                                   (i32.const -4)
                                                 )
                                               )
-                                              (get_local $$a$5521$i)
+                                              (get_local $5)
                                             )
                                             (block
                                               (i32.store
-                                                (set_local $$incdec$ptr423$i
+                                                (set_local $5
                                                   (i32.add
-                                                    (get_local $$a$5521$i)
+                                                    (get_local $5)
                                                     (i32.const -4)
                                                   )
                                                 )
                                                 (i32.const 0)
                                               )
-                                              (get_local $$incdec$ptr423$i)
+                                              (get_local $5)
                                             )
-                                            (get_local $$a$5521$i)
+                                            (get_local $5)
                                           )
                                         )
                                         (i32.store
-                                          (get_local $$incdec$ptr419$i)
-                                          (set_local $$inc425$i
+                                          (get_local $6)
+                                          (set_local $7
                                             (i32.add
                                               (i32.load
-                                                (get_local $$incdec$ptr419$i)
+                                                (get_local $6)
                                               )
                                               (i32.const 1)
                                             )
@@ -7541,24 +6921,20 @@
                                         )
                                         (if
                                           (i32.gt_u
-                                            (get_local $$inc425$i)
+                                            (get_local $7)
                                             (i32.const 999999999)
                                           )
                                           (block
-                                            (set_local $$a$5521$i
-                                              (get_local $$a$6$i)
-                                            )
-                                            (set_local $$d$2520$i
-                                              (get_local $$incdec$ptr419$i)
+                                            (get_local $5)
+                                            (set_local $7
+                                              (get_local $6)
                                             )
                                           )
                                           (block
-                                            (set_local $$a$5$lcssa$i
-                                              (get_local $$a$6$i)
+                                            (set_local $7
+                                              (get_local $5)
                                             )
-                                            (set_local $$d$2$lcssa$i
-                                              (get_local $$incdec$ptr419$i)
-                                            )
+                                            (get_local $6)
                                             (br $while-out$92)
                                           )
                                         )
@@ -7566,20 +6942,16 @@
                                       )
                                     )
                                     (block
-                                      (set_local $$a$5$lcssa$i
-                                        (get_local $$a$3$lcssa$i)
-                                      )
-                                      (set_local $$d$2$lcssa$i
-                                        (get_local $$add$ptr358$i)
-                                      )
+                                      (get_local $7)
+                                      (get_local $6)
                                     )
                                   )
-                                  (set_local $$mul431$i
+                                  (set_local $11
                                     (i32.mul
                                       (i32.shr_s
                                         (i32.sub
-                                          (get_local $$sub$ptr$rhs$cast345$i)
-                                          (get_local $$a$5$lcssa$i)
+                                          (get_local $30)
+                                          (get_local $7)
                                         )
                                         (i32.const 2)
                                       )
@@ -7588,70 +6960,60 @@
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $$234
+                                      (set_local $5
                                         (i32.load
-                                          (get_local $$a$5$lcssa$i)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 10)
                                     )
                                     (block
-                                      (set_local $$a$8$i
-                                        (get_local $$a$5$lcssa$i)
+                                      (set_local $5
+                                        (get_local $7)
                                       )
-                                      (set_local $$d$4$i
-                                        (get_local $$d$2$lcssa$i)
+                                      (set_local $7
+                                        (get_local $6)
                                       )
-                                      (set_local $$e$4$i
-                                        (get_local $$mul431$i)
-                                      )
+                                      (get_local $11)
                                       (br $do-once$88)
                                     )
                                     (block
-                                      (set_local $$e$2517$i
-                                        (get_local $$mul431$i)
-                                      )
-                                      (set_local $$i$2516$i
+                                      (get_local $11)
+                                      (set_local $12
                                         (i32.const 10)
                                       )
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
-                                    (set_local $$inc438$i
+                                    (set_local $11
                                       (i32.add
-                                        (get_local $$e$2517$i)
+                                        (get_local $11)
                                         (i32.const 1)
                                       )
                                     )
                                     (if
                                       (i32.lt_u
-                                        (get_local $$234)
-                                        (set_local $$mul437$i
+                                        (get_local $5)
+                                        (set_local $12
                                           (i32.mul
-                                            (get_local $$i$2516$i)
+                                            (get_local $12)
                                             (i32.const 10)
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $$a$8$i
-                                          (get_local $$a$5$lcssa$i)
+                                        (set_local $5
+                                          (get_local $7)
                                         )
-                                        (set_local $$d$4$i
-                                          (get_local $$d$2$lcssa$i)
+                                        (set_local $7
+                                          (get_local $6)
                                         )
-                                        (set_local $$e$4$i
-                                          (get_local $$inc438$i)
-                                        )
+                                        (get_local $11)
                                         (br $while-out$94)
                                       )
                                       (block
-                                        (set_local $$e$2517$i
-                                          (get_local $$inc438$i)
-                                        )
-                                        (set_local $$i$2516$i
-                                          (get_local $$mul437$i)
-                                        )
+                                        (get_local $11)
+                                        (get_local $12)
                                       )
                                     )
                                     (br $while-in$95)
@@ -7659,61 +7021,57 @@
                                 )
                               )
                             )
-                            (set_local $$cmp443$i
+                            (set_local $6
                               (i32.gt_u
-                                (get_local $$z$3$lcssa$i)
-                                (set_local $$add$ptr442$i
+                                (get_local $27)
+                                (set_local $7
                                   (i32.add
-                                    (get_local $$d$4$i)
+                                    (get_local $7)
                                     (i32.const 4)
                                   )
                                 )
                               )
                             )
-                            (set_local $$e$5$ph$i
-                              (get_local $$e$4$i)
+                            (set_local $9
+                              (get_local $11)
                             )
-                            (set_local $$z$7$ph$i
+                            (set_local $6
                               (select
-                                (get_local $$add$ptr442$i)
-                                (get_local $$z$3$lcssa$i)
-                                (get_local $$cmp443$i)
+                                (get_local $7)
+                                (get_local $27)
+                                (get_local $6)
                               )
                             )
-                            (get_local $$a$8$i)
+                            (get_local $5)
                           )
                           (block
-                            (set_local $$e$5$ph$i
-                              (get_local $$e$1$i)
+                            (get_local $9)
+                            (set_local $6
+                              (get_local $27)
                             )
-                            (set_local $$z$7$ph$i
-                              (get_local $$z$3$lcssa$i)
-                            )
-                            (get_local $$a$3$lcssa$i)
+                            (get_local $7)
                           )
                         )
                       )
-                      (set_local $$sub626$le$i
+                      (set_local $27
                         (i32.sub
                           (i32.const 0)
-                          (get_local $$e$5$ph$i)
+                          (get_local $9)
                         )
                       )
-                      (set_local $$z$7$i
-                        (get_local $$z$7$ph$i)
-                      )
+                      (get_local $6)
                       (loop $while-out$96 $while-in$97
                         (if
                           (i32.le_u
-                            (get_local $$z$7$i)
-                            (get_local $$a$9$ph$i)
+                            (get_local $6)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$cmp450$lcssa$i
+                            (set_local $11
                               (i32.const 0)
                             )
-                            (set_local $$z$7$i$lcssa
-                              (get_local $$z$7$i)
+                            (set_local $24
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
@@ -7721,82 +7079,82 @@
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $$arrayidx453$i
+                              (set_local $5
                                 (i32.add
-                                  (get_local $$z$7$i)
+                                  (get_local $6)
                                   (i32.const -4)
                                 )
                               )
                             )
                             (i32.const 0)
                           )
-                          (set_local $$z$7$i
-                            (get_local $$arrayidx453$i)
+                          (set_local $6
+                            (get_local $5)
                           )
                           (block
-                            (set_local $$cmp450$lcssa$i
+                            (set_local $11
                               (i32.const 1)
                             )
-                            (set_local $$z$7$i$lcssa
-                              (get_local $$z$7$i)
+                            (set_local $24
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
                         )
                         (br $while-in$97)
                       )
-                      (set_local $$and610$pre$phi$iZ2D
+                      (set_local $8
                         (block $do-once$98
                           (if
-                            (get_local $$cmp338$i)
+                            (get_local $8)
                             (block
-                              (set_local $$p$addr$2$i
+                              (set_local $8
                                 (if
                                   (i32.and
                                     (i32.gt_s
-                                      (set_local $$$p$inc468$i
+                                      (set_local $1
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $$tobool341$i)
+                                              (get_local $68)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $$$p$i)
+                                          (get_local $1)
                                         )
                                       )
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                     )
                                     (i32.gt_s
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                       (i32.const -5)
                                     )
                                   )
                                   (block
-                                    (set_local $$t$addr$0$i
+                                    (set_local $12
                                       (i32.add
-                                        (get_local $$t$0)
+                                        (get_local $33)
                                         (i32.const -1)
                                       )
                                     )
                                     (i32.sub
                                       (i32.add
-                                        (get_local $$$p$inc468$i)
+                                        (get_local $1)
                                         (i32.const -1)
                                       )
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                     )
                                   )
                                   (block
-                                    (set_local $$t$addr$0$i
+                                    (set_local $12
                                       (i32.add
-                                        (get_local $$t$0)
+                                        (get_local $33)
                                         (i32.const -2)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $$$p$inc468$i)
+                                      (get_local $1)
                                       (i32.const -1)
                                     )
                                   )
@@ -7804,36 +7162,36 @@
                               )
                               (if
                                 (i32.ne
-                                  (set_local $$and483$i
+                                  (set_local $1
                                     (i32.and
-                                      (get_local $$fl$1$and219)
+                                      (get_local $17)
                                       (i32.const 8)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$p$addr$3$i
-                                    (get_local $$p$addr$2$i)
+                                  (set_local $15
+                                    (get_local $8)
                                   )
-                                  (set_local $$t$addr$1$i
-                                    (get_local $$t$addr$0$i)
+                                  (set_local $30
+                                    (get_local $12)
                                   )
                                   (br $do-once$98
-                                    (get_local $$and483$i)
+                                    (get_local $1)
                                   )
                                 )
                               )
                               (block $do-once$100
                                 (if
-                                  (get_local $$cmp450$lcssa$i)
+                                  (get_local $11)
                                   (block
                                     (if
                                       (i32.eq
-                                        (set_local $$237
+                                        (set_local $1
                                           (i32.load
                                             (i32.add
-                                              (get_local $$z$7$i$lcssa)
+                                              (get_local $24)
                                               (i32.const -4)
                                             )
                                           )
@@ -7841,7 +7199,7 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $$j$2$i
+                                        (set_local $1
                                           (i32.const 9)
                                         )
                                         (br $do-once$100)
@@ -7851,7 +7209,7 @@
                                       (i32.eq
                                         (i32.and
                                           (i32.rem_u
-                                            (get_local $$237)
+                                            (get_local $1)
                                             (i32.const 10)
                                           )
                                           (i32.const -1)
@@ -7859,24 +7217,24 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $$i$3512$i
+                                        (set_local $5
                                           (i32.const 10)
                                         )
-                                        (set_local $$j$1513$i
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                       )
                                       (block
-                                        (set_local $$j$2$i
+                                        (set_local $1
                                           (i32.const 0)
                                         )
                                         (br $do-once$100)
                                       )
                                     )
                                     (loop $while-out$102 $while-in$103
-                                      (set_local $$inc500$i
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $$j$1513$i)
+                                          (get_local $6)
                                           (i32.const 1)
                                         )
                                       )
@@ -7884,10 +7242,10 @@
                                         (i32.eq
                                           (i32.and
                                             (i32.rem_u
-                                              (get_local $$237)
-                                              (set_local $$mul499$i
+                                              (get_local $1)
+                                              (set_local $5
                                                 (i32.mul
-                                                  (get_local $$i$3512$i)
+                                                  (get_local $5)
                                                   (i32.const 10)
                                                 )
                                               )
@@ -7897,16 +7255,12 @@
                                           (i32.const 0)
                                         )
                                         (block
-                                          (set_local $$i$3512$i
-                                            (get_local $$mul499$i)
-                                          )
-                                          (set_local $$j$1513$i
-                                            (get_local $$inc500$i)
-                                          )
+                                          (get_local $5)
+                                          (get_local $6)
                                         )
                                         (block
-                                          (set_local $$j$2$i
-                                            (get_local $$inc500$i)
+                                          (set_local $1
+                                            (get_local $6)
                                           )
                                           (br $while-out$102)
                                         )
@@ -7914,18 +7268,18 @@
                                       (br $while-in$103)
                                     )
                                   )
-                                  (set_local $$j$2$i
+                                  (set_local $1
                                     (i32.const 9)
                                   )
                                 )
                               )
-                              (set_local $$mul513$i
+                              (set_local $5
                                 (i32.add
                                   (i32.mul
                                     (i32.shr_s
                                       (i32.sub
-                                        (get_local $$z$7$i$lcssa)
-                                        (get_local $$sub$ptr$rhs$cast345$i)
+                                        (get_local $24)
+                                        (get_local $30)
                                       )
                                       (i32.const 2)
                                     )
@@ -7937,110 +7291,110 @@
                               (if
                                 (i32.eq
                                   (i32.or
-                                    (get_local $$t$addr$0$i)
+                                    (get_local $12)
                                     (i32.const 32)
                                   )
                                   (i32.const 102)
                                 )
                                 (block
-                                  (set_local $$cmp515$i
+                                  (set_local $1
                                     (i32.lt_s
-                                      (set_local $$sub514$i
+                                      (set_local $5
                                         (i32.sub
-                                          (get_local $$mul513$i)
-                                          (get_local $$j$2$i)
+                                          (get_local $5)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $$cmp528$i
+                                  (set_local $5
                                     (i32.lt_s
-                                      (get_local $$p$addr$2$i)
-                                      (set_local $$$sub514$i
+                                      (get_local $8)
+                                      (set_local $1
                                         (select
                                           (i32.const 0)
-                                          (get_local $$sub514$i)
-                                          (get_local $$cmp515$i)
+                                          (get_local $5)
+                                          (get_local $1)
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $$p$addr$3$i
+                                  (set_local $15
                                     (select
-                                      (get_local $$p$addr$2$i)
-                                      (get_local $$$sub514$i)
-                                      (get_local $$cmp528$i)
+                                      (get_local $8)
+                                      (get_local $1)
+                                      (get_local $5)
                                     )
                                   )
-                                  (set_local $$t$addr$1$i
-                                    (get_local $$t$addr$0$i)
+                                  (set_local $30
+                                    (get_local $12)
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$cmp563$i
+                                  (set_local $1
                                     (i32.lt_s
-                                      (set_local $$sub562$i
+                                      (set_local $5
                                         (i32.sub
                                           (i32.add
-                                            (get_local $$mul513$i)
-                                            (get_local $$e$5$ph$i)
+                                            (get_local $5)
+                                            (get_local $9)
                                           )
-                                          (get_local $$j$2$i)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $$cmp577$i
+                                  (set_local $5
                                     (i32.lt_s
-                                      (get_local $$p$addr$2$i)
-                                      (set_local $$$sub562$i
+                                      (get_local $8)
+                                      (set_local $1
                                         (select
                                           (i32.const 0)
-                                          (get_local $$sub562$i)
-                                          (get_local $$cmp563$i)
+                                          (get_local $5)
+                                          (get_local $1)
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $$p$addr$3$i
+                                  (set_local $15
                                     (select
-                                      (get_local $$p$addr$2$i)
-                                      (get_local $$$sub562$i)
-                                      (get_local $$cmp577$i)
+                                      (get_local $8)
+                                      (get_local $1)
+                                      (get_local $5)
                                     )
                                   )
-                                  (set_local $$t$addr$1$i
-                                    (get_local $$t$addr$0$i)
+                                  (set_local $30
+                                    (get_local $12)
                                   )
                                   (i32.const 0)
                                 )
                               )
                             )
                             (block
-                              (set_local $$p$addr$3$i
-                                (get_local $$$p$i)
+                              (set_local $15
+                                (get_local $1)
                               )
-                              (set_local $$t$addr$1$i
-                                (get_local $$t$0)
+                              (set_local $30
+                                (get_local $33)
                               )
                               (i32.and
-                                (get_local $$fl$1$and219)
+                                (get_local $17)
                                 (i32.const 8)
                               )
                             )
                           )
                         )
                       )
-                      (set_local $$lor$ext$i
+                      (set_local $21
                         (i32.and
                           (i32.ne
-                            (set_local $$239
+                            (set_local $1
                               (i32.or
-                                (get_local $$p$addr$3$i)
-                                (get_local $$and610$pre$phi$iZ2D)
+                                (get_local $15)
+                                (get_local $8)
                               )
                             )
                             (i32.const 0)
@@ -8048,24 +7402,24 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $$estr$2$i
+                      (set_local $9
                         (if
-                          (set_local $$cmp614$i
+                          (set_local $12
                             (i32.eq
                               (i32.or
-                                (get_local $$t$addr$1$i)
+                                (get_local $30)
                                 (i32.const 32)
                               )
                               (i32.const 102)
                             )
                           )
                           (block
-                            (set_local $$sub$ptr$sub650$pn$i
+                            (set_local $6
                               (select
-                                (get_local $$e$5$ph$i)
+                                (get_local $9)
                                 (i32.const 0)
                                 (i32.gt_s
-                                  (get_local $$e$5$ph$i)
+                                  (get_local $9)
                                   (i32.const 0)
                                 )
                               )
@@ -8073,16 +7427,16 @@
                             (i32.const 0)
                           )
                           (block
-                            (set_local $$242
+                            (set_local $5
                               (i32.shr_s
                                 (i32.shl
                                   (i32.lt_s
-                                    (set_local $$cond629$i
+                                    (set_local $6
                                       (select
-                                        (get_local $$sub626$le$i)
-                                        (get_local $$e$5$ph$i)
+                                        (get_local $27)
+                                        (get_local $9)
                                         (i32.lt_s
-                                          (get_local $$e$5$ph$i)
+                                          (get_local $9)
                                           (i32.const 0)
                                         )
                                       )
@@ -8097,26 +7451,24 @@
                             (if
                               (i32.lt_s
                                 (i32.sub
-                                  (get_local $$sub$ptr$lhs$cast160$i)
-                                  (set_local $$243
+                                  (get_local $44)
+                                  (set_local $5
                                     (call $_fmt_u
-                                      (get_local $$cond629$i)
-                                      (get_local $$242)
-                                      (get_local $$arrayidx$i$236)
+                                      (get_local $6)
+                                      (get_local $5)
+                                      (get_local $55)
                                     )
                                   )
                                 )
                                 (i32.const 2)
                               )
                               (block
-                                (set_local $$estr$1507$i
-                                  (get_local $$243)
-                                )
+                                (get_local $5)
                                 (loop $while-out$104 $while-in$105
                                   (i32.store8
-                                    (set_local $$incdec$ptr639$i
+                                    (set_local $5
                                       (i32.add
-                                        (get_local $$estr$1507$i)
+                                        (get_local $5)
                                         (i32.const -1)
                                       )
                                     )
@@ -8125,38 +7477,32 @@
                                   (if
                                     (i32.lt_s
                                       (i32.sub
-                                        (get_local $$sub$ptr$lhs$cast160$i)
-                                        (get_local $$incdec$ptr639$i)
+                                        (get_local $44)
+                                        (get_local $5)
                                       )
                                       (i32.const 2)
                                     )
-                                    (set_local $$estr$1507$i
-                                      (get_local $$incdec$ptr639$i)
-                                    )
+                                    (get_local $5)
                                     (block
-                                      (set_local $$estr$1$lcssa$i
-                                        (get_local $$incdec$ptr639$i)
-                                      )
+                                      (get_local $5)
                                       (br $while-out$104)
                                     )
                                   )
                                   (br $while-in$105)
                                 )
                               )
-                              (set_local $$estr$1$lcssa$i
-                                (get_local $$243)
-                              )
+                              (get_local $5)
                             )
                             (i32.store8
                               (i32.add
-                                (get_local $$estr$1$lcssa$i)
+                                (get_local $5)
                                 (i32.const -1)
                               )
                               (i32.and
                                 (i32.add
                                   (i32.and
                                     (i32.shr_s
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                       (i32.const 31)
                                     )
                                     (i32.const 2)
@@ -8167,148 +7513,142 @@
                               )
                             )
                             (i32.store8
-                              (set_local $$incdec$ptr647$i
+                              (set_local $5
                                 (i32.add
-                                  (get_local $$estr$1$lcssa$i)
+                                  (get_local $5)
                                   (i32.const -2)
                                 )
                               )
                               (i32.and
-                                (get_local $$t$addr$1$i)
+                                (get_local $30)
                                 (i32.const 255)
                               )
                             )
-                            (set_local $$sub$ptr$sub650$pn$i
+                            (set_local $6
                               (i32.sub
-                                (get_local $$sub$ptr$lhs$cast160$i)
-                                (get_local $$incdec$ptr647$i)
+                                (get_local $44)
+                                (get_local $5)
                               )
                             )
-                            (get_local $$incdec$ptr647$i)
+                            (get_local $5)
                           )
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (set_local $$add653$i
+                        (get_local $16)
+                        (set_local $6
                           (i32.add
                             (i32.add
                               (i32.add
                                 (i32.add
-                                  (get_local $$pl$0$i)
+                                  (get_local $50)
                                   (i32.const 1)
                                 )
-                                (get_local $$p$addr$3$i)
+                                (get_local $15)
                               )
-                              (get_local $$lor$ext$i)
+                              (get_local $21)
                             )
-                            (get_local $$sub$ptr$sub650$pn$i)
+                            (get_local $6)
                           )
                         )
-                        (get_local $$fl$1$and219)
+                        (get_local $17)
                       )
                       (if
                         (i32.eq
                           (i32.and
                             (i32.load
-                              (get_local $$f)
+                              (get_local $0)
                             )
                             (i32.const 32)
                           )
                           (i32.const 0)
                         )
                         (call $___fwritex
-                          (get_local $$prefix$0$i)
-                          (get_local $$pl$0$i)
-                          (get_local $$f)
+                          (get_local $39)
+                          (get_local $50)
+                          (get_local $0)
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 48)
-                        (get_local $$w$1)
-                        (get_local $$add653$i)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $$fl$1$and219)
+                          (get_local $17)
                           (i32.const 65536)
                         )
                       )
                       (block $do-once$106
                         (if
-                          (get_local $$cmp614$i)
+                          (get_local $12)
                           (block
-                            (set_local $$d$5494$i
-                              (set_local $$r$0$a$9$i
+                            (set_local $7
+                              (set_local $8
                                 (select
-                                  (get_local $$arraydecay208$add$ptr213$i)
-                                  (get_local $$a$9$ph$i)
+                                  (get_local $10)
+                                  (get_local $7)
                                   (i32.gt_u
-                                    (get_local $$a$9$ph$i)
-                                    (get_local $$arraydecay208$add$ptr213$i)
+                                    (get_local $7)
+                                    (get_local $10)
                                   )
                                 )
                               )
                             )
                             (loop $while-out$108 $while-in$109
-                              (set_local $$249
+                              (set_local $5
                                 (call $_fmt_u
                                   (i32.load
-                                    (get_local $$d$5494$i)
+                                    (get_local $7)
                                   )
                                   (i32.const 0)
-                                  (get_local $$add$ptr671$i)
+                                  (get_local $48)
                                 )
                               )
                               (block $do-once$110
                                 (if
                                   (i32.eq
-                                    (get_local $$d$5494$i)
-                                    (get_local $$r$0$a$9$i)
+                                    (get_local $7)
+                                    (get_local $8)
                                   )
                                   (block
                                     (if
                                       (i32.ne
-                                        (get_local $$249)
-                                        (get_local $$add$ptr671$i)
+                                        (get_local $5)
+                                        (get_local $48)
                                       )
                                       (block
-                                        (set_local $$s668$1$i
-                                          (get_local $$249)
-                                        )
+                                        (get_local $5)
                                         (br $do-once$110)
                                       )
                                     )
                                     (i32.store8
-                                      (get_local $$incdec$ptr689$i)
+                                      (get_local $57)
                                       (i32.const 48)
                                     )
-                                    (set_local $$s668$1$i
-                                      (get_local $$incdec$ptr689$i)
+                                    (set_local $5
+                                      (get_local $57)
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.gt_u
-                                        (get_local $$249)
-                                        (get_local $$buf$i)
+                                        (get_local $5)
+                                        (get_local $29)
                                       )
-                                      (set_local $$s668$0492$i
-                                        (get_local $$249)
-                                      )
+                                      (get_local $5)
                                       (block
-                                        (set_local $$s668$1$i
-                                          (get_local $$249)
-                                        )
+                                        (get_local $5)
                                         (br $do-once$110)
                                       )
                                     )
                                     (loop $while-out$112 $while-in$113
                                       (i32.store8
-                                        (set_local $$incdec$ptr681$i
+                                        (set_local $5
                                           (i32.add
-                                            (get_local $$s668$0492$i)
+                                            (get_local $5)
                                             (i32.const -1)
                                           )
                                         )
@@ -8316,16 +7656,12 @@
                                       )
                                       (if
                                         (i32.gt_u
-                                          (get_local $$incdec$ptr681$i)
-                                          (get_local $$buf$i)
+                                          (get_local $5)
+                                          (get_local $29)
                                         )
-                                        (set_local $$s668$0492$i
-                                          (get_local $$incdec$ptr681$i)
-                                        )
+                                        (get_local $5)
                                         (block
-                                          (set_local $$s668$1$i
-                                            (get_local $$incdec$ptr681$i)
-                                          )
+                                          (get_local $5)
                                           (br $while-out$112)
                                         )
                                       )
@@ -8338,39 +7674,37 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                     (i32.const 32)
                                   )
                                   (i32.const 0)
                                 )
                                 (call $___fwritex
-                                  (get_local $$s668$1$i)
+                                  (get_local $5)
                                   (i32.sub
-                                    (get_local $$sub$ptr$lhs$cast694$i)
-                                    (get_local $$s668$1$i)
+                                    (get_local $74)
+                                    (get_local $5)
                                   )
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                               )
                               (if
                                 (i32.gt_u
-                                  (set_local $$incdec$ptr698$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$d$5494$i)
+                                      (get_local $7)
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $$arraydecay208$add$ptr213$i)
+                                  (get_local $10)
                                 )
                                 (block
-                                  (set_local $$incdec$ptr698$i$lcssa
-                                    (get_local $$incdec$ptr698$i)
-                                  )
+                                  (get_local $5)
                                   (br $while-out$108)
                                 )
-                                (set_local $$d$5494$i
-                                  (get_local $$incdec$ptr698$i)
+                                (set_local $7
+                                  (get_local $5)
                                 )
                               )
                               (br $while-in$109)
@@ -8378,7 +7712,7 @@
                             (block $do-once$114
                               (if
                                 (i32.ne
-                                  (get_local $$239)
+                                  (get_local $1)
                                   (i32.const 0)
                                 )
                                 (block
@@ -8386,7 +7720,7 @@
                                     (i32.ne
                                       (i32.and
                                         (i32.load
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
                                         (i32.const 32)
                                       )
@@ -8396,7 +7730,7 @@
                                   (call $___fwritex
                                     (i32.const 4143)
                                     (i32.const 1)
-                                    (get_local $$f)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -8404,44 +7738,40 @@
                             (if
                               (i32.and
                                 (i32.gt_s
-                                  (get_local $$p$addr$3$i)
+                                  (get_local $15)
                                   (i32.const 0)
                                 )
                                 (i32.lt_u
-                                  (get_local $$incdec$ptr698$i$lcssa)
-                                  (get_local $$z$7$i$lcssa)
+                                  (get_local $5)
+                                  (get_local $24)
                                 )
                               )
                               (block
-                                (set_local $$d$6488$i
-                                  (get_local $$incdec$ptr698$i$lcssa)
-                                )
-                                (set_local $$p$addr$4489$i
-                                  (get_local $$p$addr$3$i)
+                                (get_local $5)
+                                (set_local $7
+                                  (get_local $15)
                                 )
                                 (loop $while-out$116 $while-in$117
                                   (if
                                     (i32.gt_u
-                                      (set_local $$255
+                                      (set_local $1
                                         (call $_fmt_u
                                           (i32.load
-                                            (get_local $$d$6488$i)
+                                            (get_local $5)
                                           )
                                           (i32.const 0)
-                                          (get_local $$add$ptr671$i)
+                                          (get_local $48)
                                         )
                                       )
-                                      (get_local $$buf$i)
+                                      (get_local $29)
                                     )
                                     (block
-                                      (set_local $$s715$0484$i
-                                        (get_local $$255)
-                                      )
+                                      (get_local $1)
                                       (loop $while-out$118 $while-in$119
                                         (i32.store8
-                                          (set_local $$incdec$ptr725$i
+                                          (set_local $1
                                             (i32.add
-                                              (get_local $$s715$0484$i)
+                                              (get_local $1)
                                               (i32.const -1)
                                             )
                                           )
@@ -8449,82 +7779,76 @@
                                         )
                                         (if
                                           (i32.gt_u
-                                            (get_local $$incdec$ptr725$i)
-                                            (get_local $$buf$i)
+                                            (get_local $1)
+                                            (get_local $29)
                                           )
-                                          (set_local $$s715$0484$i
-                                            (get_local $$incdec$ptr725$i)
-                                          )
+                                          (get_local $1)
                                           (block
-                                            (set_local $$s715$0$lcssa$i
-                                              (get_local $$incdec$ptr725$i)
-                                            )
+                                            (get_local $1)
                                             (br $while-out$118)
                                           )
                                         )
                                         (br $while-in$119)
                                       )
                                     )
-                                    (set_local $$s715$0$lcssa$i
-                                      (get_local $$255)
-                                    )
+                                    (get_local $1)
                                   )
                                   (if
                                     (i32.eq
                                       (i32.and
                                         (i32.load
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
                                         (i32.const 32)
                                       )
                                       (i32.const 0)
                                     )
                                     (call $___fwritex
-                                      (get_local $$s715$0$lcssa$i)
+                                      (get_local $1)
                                       (select
                                         (i32.const 9)
-                                        (get_local $$p$addr$4489$i)
+                                        (get_local $7)
                                         (i32.gt_s
-                                          (get_local $$p$addr$4489$i)
+                                          (get_local $7)
                                           (i32.const 9)
                                         )
                                       )
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                   )
-                                  (set_local $$sub735$i
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $$p$addr$4489$i)
+                                      (get_local $7)
                                       (i32.const -9)
                                     )
                                   )
                                   (if
                                     (i32.and
                                       (i32.gt_s
-                                        (get_local $$p$addr$4489$i)
+                                        (get_local $7)
                                         (i32.const 9)
                                       )
                                       (i32.lt_u
-                                        (set_local $$incdec$ptr734$i
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $$d$6488$i)
+                                            (get_local $5)
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $$z$7$i$lcssa)
+                                        (get_local $24)
                                       )
                                     )
                                     (block
-                                      (set_local $$d$6488$i
-                                        (get_local $$incdec$ptr734$i)
+                                      (set_local $5
+                                        (get_local $1)
                                       )
-                                      (set_local $$p$addr$4489$i
-                                        (get_local $$sub735$i)
+                                      (set_local $7
+                                        (get_local $8)
                                       )
                                     )
                                     (block
-                                      (set_local $$p$addr$4$lcssa$i
-                                        (get_local $$sub735$i)
+                                      (set_local $1
+                                        (get_local $8)
                                       )
                                       (br $while-out$116)
                                     )
@@ -8532,15 +7856,15 @@
                                   (br $while-in$117)
                                 )
                               )
-                              (set_local $$p$addr$4$lcssa$i
-                                (get_local $$p$addr$3$i)
+                              (set_local $1
+                                (get_local $15)
                               )
                             )
                             (call $_pad
-                              (get_local $$f)
+                              (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $$p$addr$4$lcssa$i)
+                                (get_local $1)
                                 (i32.const 9)
                               )
                               (i32.const 9)
@@ -8548,69 +7872,69 @@
                             )
                           )
                           (block
-                            (set_local $$z$7$add$ptr742$i
+                            (set_local $12
                               (select
-                                (get_local $$z$7$i$lcssa)
+                                (get_local $24)
                                 (i32.add
-                                  (get_local $$a$9$ph$i)
+                                  (get_local $7)
                                   (i32.const 4)
                                 )
-                                (get_local $$cmp450$lcssa$i)
+                                (get_local $11)
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $$p$addr$3$i)
+                                (get_local $15)
                                 (i32.const -1)
                               )
                               (block
-                                (set_local $$tobool781$i
+                                (set_local $11
                                   (i32.eq
-                                    (get_local $$and610$pre$phi$iZ2D)
+                                    (get_local $8)
                                     (i32.const 0)
                                   )
                                 )
-                                (set_local $$d$7500$i
-                                  (get_local $$a$9$ph$i)
+                                (set_local $5
+                                  (get_local $7)
                                 )
-                                (set_local $$p$addr$5501$i
-                                  (get_local $$p$addr$3$i)
+                                (set_local $8
+                                  (get_local $15)
                                 )
                                 (loop $while-out$120 $while-in$121
-                                  (set_local $$s753$0$i
+                                  (set_local $10
                                     (if
                                       (i32.eq
-                                        (set_local $$259
+                                        (set_local $1
                                           (call $_fmt_u
                                             (i32.load
-                                              (get_local $$d$7500$i)
+                                              (get_local $5)
                                             )
                                             (i32.const 0)
-                                            (get_local $$add$ptr671$i)
+                                            (get_local $48)
                                           )
                                         )
-                                        (get_local $$add$ptr671$i)
+                                        (get_local $48)
                                       )
                                       (block
                                         (i32.store8
-                                          (get_local $$incdec$ptr689$i)
+                                          (get_local $57)
                                           (i32.const 48)
                                         )
-                                        (get_local $$incdec$ptr689$i)
+                                        (get_local $57)
                                       )
-                                      (get_local $$259)
+                                      (get_local $1)
                                     )
                                   )
                                   (block $do-once$122
                                     (if
                                       (i32.eq
-                                        (get_local $$d$7500$i)
-                                        (get_local $$a$9$ph$i)
+                                        (get_local $5)
+                                        (get_local $7)
                                       )
                                       (block
-                                        (set_local $$incdec$ptr776$i
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $$s753$0$i)
+                                            (get_local $10)
                                             (i32.const 1)
                                           )
                                         )
@@ -8618,30 +7942,28 @@
                                           (i32.eq
                                             (i32.and
                                               (i32.load
-                                                (get_local $$f)
+                                                (get_local $0)
                                               )
                                               (i32.const 32)
                                             )
                                             (i32.const 0)
                                           )
                                           (call $___fwritex
-                                            (get_local $$s753$0$i)
+                                            (get_local $10)
                                             (i32.const 1)
-                                            (get_local $$f)
+                                            (get_local $0)
                                           )
                                         )
                                         (if
                                           (i32.and
-                                            (get_local $$tobool781$i)
+                                            (get_local $11)
                                             (i32.lt_s
-                                              (get_local $$p$addr$5501$i)
+                                              (get_local $8)
                                               (i32.const 1)
                                             )
                                           )
                                           (block
-                                            (set_local $$s753$2$i
-                                              (get_local $$incdec$ptr776$i)
-                                            )
+                                            (get_local $1)
                                             (br $do-once$122)
                                           )
                                         )
@@ -8649,49 +7971,45 @@
                                           (i32.ne
                                             (i32.and
                                               (i32.load
-                                                (get_local $$f)
+                                                (get_local $0)
                                               )
                                               (i32.const 32)
                                             )
                                             (i32.const 0)
                                           )
                                           (block
-                                            (set_local $$s753$2$i
-                                              (get_local $$incdec$ptr776$i)
-                                            )
+                                            (get_local $1)
                                             (br $do-once$122)
                                           )
                                         )
                                         (call $___fwritex
                                           (i32.const 4143)
                                           (i32.const 1)
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
-                                        (set_local $$s753$2$i
-                                          (get_local $$incdec$ptr776$i)
-                                        )
+                                        (get_local $1)
                                       )
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $$s753$0$i)
-                                            (get_local $$buf$i)
+                                            (get_local $10)
+                                            (get_local $29)
                                           )
-                                          (set_local $$s753$1496$i
-                                            (get_local $$s753$0$i)
+                                          (set_local $1
+                                            (get_local $10)
                                           )
                                           (block
-                                            (set_local $$s753$2$i
-                                              (get_local $$s753$0$i)
+                                            (set_local $1
+                                              (get_local $10)
                                             )
                                             (br $do-once$122)
                                           )
                                         )
                                         (loop $while-out$124 $while-in$125
                                           (i32.store8
-                                            (set_local $$incdec$ptr773$i
+                                            (set_local $1
                                               (i32.add
-                                                (get_local $$s753$1496$i)
+                                                (get_local $1)
                                                 (i32.const -1)
                                               )
                                             )
@@ -8699,16 +8017,12 @@
                                           )
                                           (if
                                             (i32.gt_u
-                                              (get_local $$incdec$ptr773$i)
-                                              (get_local $$buf$i)
+                                              (get_local $1)
+                                              (get_local $29)
                                             )
-                                            (set_local $$s753$1496$i
-                                              (get_local $$incdec$ptr773$i)
-                                            )
+                                            (get_local $1)
                                             (block
-                                              (set_local $$s753$2$i
-                                                (get_local $$incdec$ptr773$i)
-                                              )
+                                              (get_local $1)
                                               (br $while-out$124)
                                             )
                                           )
@@ -8717,67 +8031,65 @@
                                       )
                                     )
                                   )
-                                  (set_local $$sub$ptr$sub789$i
+                                  (set_local $10
                                     (i32.sub
-                                      (get_local $$sub$ptr$lhs$cast694$i)
-                                      (get_local $$s753$2$i)
+                                      (get_local $74)
+                                      (get_local $1)
                                     )
                                   )
                                   (if
                                     (i32.eq
                                       (i32.and
                                         (i32.load
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
                                         (i32.const 32)
                                       )
                                       (i32.const 0)
                                     )
                                     (call $___fwritex
-                                      (get_local $$s753$2$i)
+                                      (get_local $1)
                                       (select
-                                        (get_local $$sub$ptr$sub789$i)
-                                        (get_local $$p$addr$5501$i)
+                                        (get_local $10)
+                                        (get_local $8)
                                         (i32.gt_s
-                                          (get_local $$p$addr$5501$i)
-                                          (get_local $$sub$ptr$sub789$i)
+                                          (get_local $8)
+                                          (get_local $10)
                                         )
                                       )
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                   )
                                   (if
                                     (i32.and
                                       (i32.lt_u
-                                        (set_local $$incdec$ptr808$i
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $$d$7500$i)
+                                            (get_local $5)
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $$z$7$add$ptr742$i)
+                                        (get_local $12)
                                       )
                                       (i32.gt_s
-                                        (set_local $$sub806$i
+                                        (set_local $8
                                           (i32.sub
-                                            (get_local $$p$addr$5501$i)
-                                            (get_local $$sub$ptr$sub789$i)
+                                            (get_local $8)
+                                            (get_local $10)
                                           )
                                         )
                                         (i32.const -1)
                                       )
                                     )
                                     (block
-                                      (set_local $$d$7500$i
-                                        (get_local $$incdec$ptr808$i)
+                                      (set_local $5
+                                        (get_local $1)
                                       )
-                                      (set_local $$p$addr$5501$i
-                                        (get_local $$sub806$i)
-                                      )
+                                      (get_local $8)
                                     )
                                     (block
-                                      (set_local $$p$addr$5$lcssa$i
-                                        (get_local $$sub806$i)
+                                      (set_local $1
+                                        (get_local $8)
                                       )
                                       (br $while-out$120)
                                     )
@@ -8785,15 +8097,15 @@
                                   (br $while-in$121)
                                 )
                               )
-                              (set_local $$p$addr$5$lcssa$i
-                                (get_local $$p$addr$3$i)
+                              (set_local $1
+                                (get_local $15)
                               )
                             )
                             (call $_pad
-                              (get_local $$f)
+                              (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $$p$addr$5$lcssa$i)
+                                (get_local $1)
                                 (i32.const 18)
                               )
                               (i32.const 18)
@@ -8803,7 +8115,7 @@
                               (i32.ne
                                 (i32.and
                                   (i32.load
-                                    (get_local $$f)
+                                    (get_local $0)
                                   )
                                   (i32.const 32)
                                 )
@@ -8811,44 +8123,44 @@
                               )
                             )
                             (call $___fwritex
-                              (get_local $$estr$2$i)
+                              (get_local $9)
                               (i32.sub
-                                (get_local $$sub$ptr$lhs$cast160$i)
-                                (get_local $$estr$2$i)
+                                (get_local $44)
+                                (get_local $9)
                               )
-                              (get_local $$f)
+                              (get_local $0)
                             )
                           )
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (get_local $$add653$i)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $$fl$1$and219)
+                          (get_local $17)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $$w$1)
-                        (get_local $$add653$i)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.lt_s
-                          (get_local $$add653$i)
-                          (get_local $$w$1)
+                          (get_local $6)
+                          (get_local $16)
                         )
                       )
                     )
                     (block
-                      (set_local $$cond$i
+                      (set_local $5
                         (select
                           (i32.const 4127)
                           (i32.const 4131)
-                          (set_local $$tobool37$i
+                          (set_local $8
                             (i32.ne
                               (i32.and
-                                (get_local $$t$0)
+                                (get_local $33)
                                 (i32.const 32)
                               )
                               (i32.const 0)
@@ -8856,15 +8168,15 @@
                           )
                         )
                       )
-                      (set_local $$pl$1$i
+                      (set_local $7
                         (select
                           (i32.const 0)
-                          (get_local $$pl$0$i)
-                          (set_local $$cmp38$i
+                          (get_local $50)
+                          (set_local $1
                             (i32.or
                               (f64.ne
-                                (get_local $$y$addr$0$i)
-                                (get_local $$y$addr$0$i)
+                                (get_local $14)
+                                (get_local $14)
                               )
                               (f64.ne
                                 (f64.const 0)
@@ -8874,28 +8186,28 @@
                           )
                         )
                       )
-                      (set_local $$s35$0$i
+                      (set_local $8
                         (select
                           (select
                             (i32.const 4135)
                             (i32.const 4139)
-                            (get_local $$tobool37$i)
+                            (get_local $8)
                           )
-                          (get_local $$cond$i)
-                          (get_local $$cmp38$i)
+                          (get_local $5)
+                          (get_local $1)
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (set_local $$add$i$239
+                        (get_local $16)
+                        (set_local $5
                           (i32.add
-                            (get_local $$pl$1$i)
+                            (get_local $7)
                             (i32.const 3)
                           )
                         )
-                        (get_local $$and219)
+                        (get_local $6)
                       )
                       (if
                         (i32.eq
@@ -8903,9 +8215,9 @@
                             (if
                               (i32.eq
                                 (i32.and
-                                  (set_local $$193
+                                  (set_local $1
                                     (i32.load
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                   )
                                   (i32.const 32)
@@ -8914,79 +8226,77 @@
                               )
                               (block
                                 (call $___fwritex
-                                  (get_local $$prefix$0$i)
-                                  (get_local $$pl$1$i)
-                                  (get_local $$f)
+                                  (get_local $39)
+                                  (get_local $7)
+                                  (get_local $0)
                                 )
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                               )
-                              (get_local $$193)
+                              (get_local $1)
                             )
                             (i32.const 32)
                           )
                           (i32.const 0)
                         )
                         (call $___fwritex
-                          (get_local $$s35$0$i)
+                          (get_local $8)
                           (i32.const 3)
-                          (get_local $$f)
+                          (get_local $0)
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (get_local $$add$i$239)
+                        (get_local $16)
+                        (get_local $5)
                         (i32.xor
-                          (get_local $$fl$1$and219)
+                          (get_local $17)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $$w$1)
-                        (get_local $$add$i$239)
+                        (get_local $16)
+                        (get_local $5)
                         (i32.lt_s
-                          (get_local $$add$i$239)
-                          (get_local $$w$1)
+                          (get_local $5)
+                          (get_local $16)
                         )
                       )
                     )
                   )
                 )
               )
-              (set_local $$cnt$0
-                (get_local $$cnt$1)
+              (set_local $5
+                (get_local $19)
               )
-              (set_local $$incdec$ptr169275
-                (get_local $$incdec$ptr169$lcssa)
+              (set_local $12
+                (get_local $26)
               )
-              (set_local $$l$0
-                (get_local $$retval$0$i)
-              )
-              (set_local $$l10n$0
-                (get_local $$l10n$3)
+              (get_local $1)
+              (set_local $8
+                (get_local $20)
               )
               (br $label$continue$L1)
             )
-            (set_local $$a$2
-              (get_local $$incdec$ptr169275)
+            (set_local $47
+              (get_local $12)
             )
-            (set_local $$fl$6
-              (get_local $$fl$1$and219)
+            (set_local $36
+              (get_local $17)
             )
-            (set_local $$p$5
-              (get_local $$p$0)
+            (set_local $42
+              (get_local $9)
             )
-            (set_local $$pl$2
+            (set_local $43
               (i32.const 0)
             )
-            (set_local $$prefix$2
+            (set_local $51
               (i32.const 4091)
             )
-            (set_local $$z$2
-              (get_local $$add$ptr205)
+            (set_local $53
+              (get_local $28)
             )
           )
         )
@@ -8994,74 +8304,68 @@
       (block $label$break$L308
         (if
           (i32.eq
-            (get_local $label)
+            (get_local $13)
             (i32.const 64)
           )
           (block
-            (set_local $label
-              (i32.const 0)
-            )
-            (set_local $$and249
+            (i32.const 0)
+            (set_local $7
               (i32.and
-                (get_local $$t$1)
+                (get_local $69)
                 (i32.const 32)
               )
             )
-            (set_local $$a$0
+            (set_local $34
               (if
                 (i32.and
                   (i32.eq
-                    (set_local $$92
+                    (set_local $5
                       (i32.load
-                        (set_local $$90
-                          (get_local $$arg)
+                        (set_local $1
+                          (get_local $18)
                         )
                       )
                     )
                     (i32.const 0)
                   )
                   (i32.eq
-                    (set_local $$95
+                    (set_local $1
                       (i32.load offset=4
-                        (get_local $$90)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                   )
                 )
                 (block
-                  (set_local $$fl$4
-                    (get_local $$fl$3)
+                  (set_local $35
+                    (get_local $49)
                   )
-                  (set_local $$p$2
-                    (get_local $$p$1)
+                  (set_local $31
+                    (get_local $58)
                   )
-                  (set_local $$pl$1
+                  (set_local $38
                     (i32.const 0)
                   )
-                  (set_local $$prefix$1
+                  (set_local $40
                     (i32.const 4091)
                   )
-                  (set_local $label
+                  (set_local $13
                     (i32.const 77)
                   )
-                  (get_local $$add$ptr205)
+                  (get_local $28)
                 )
                 (block
-                  (set_local $$101
-                    (get_local $$95)
-                  )
-                  (set_local $$99
-                    (get_local $$92)
-                  )
-                  (set_local $$s$addr$06$i
-                    (get_local $$add$ptr205)
+                  (get_local $1)
+                  (get_local $5)
+                  (set_local $6
+                    (get_local $28)
                   )
                   (loop $while-out$129 $while-in$130
                     (i32.store8
-                      (set_local $$incdec$ptr$i$212
+                      (set_local $6
                         (i32.add
-                          (get_local $$s$addr$06$i)
+                          (get_local $6)
                           (i32.const -1)
                         )
                       )
@@ -9071,7 +8375,7 @@
                             (i32.load8_s
                               (i32.add
                                 (i32.and
-                                  (get_local $$99)
+                                  (get_local $5)
                                   (i32.const 15)
                                 )
                                 (i32.const 4075)
@@ -9079,7 +8383,7 @@
                             )
                             (i32.const 255)
                           )
-                          (get_local $$and249)
+                          (get_local $7)
                         )
                         (i32.const 255)
                       )
@@ -9087,17 +8391,17 @@
                     (if
                       (i32.and
                         (i32.eq
-                          (set_local $$102
+                          (set_local $5
                             (call $_bitshift64Lshr
-                              (get_local $$99)
-                              (get_local $$101)
+                              (get_local $5)
+                              (get_local $1)
                               (i32.const 4)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.eq
-                          (set_local $$103
+                          (set_local $1
                             (i32.load
                               (i32.const 168)
                             )
@@ -9106,21 +8410,15 @@
                         )
                       )
                       (block
-                        (set_local $$incdec$ptr$i$212$lcssa
-                          (get_local $$incdec$ptr$i$212)
+                        (set_local $5
+                          (get_local $6)
                         )
                         (br $while-out$129)
                       )
                       (block
-                        (set_local $$101
-                          (get_local $$103)
-                        )
-                        (set_local $$99
-                          (get_local $$102)
-                        )
-                        (set_local $$s$addr$06$i
-                          (get_local $$incdec$ptr$i$212)
-                        )
+                        (get_local $1)
+                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                     (br $while-in$130)
@@ -9129,7 +8427,7 @@
                     (i32.or
                       (i32.eq
                         (i32.and
-                          (get_local $$fl$3)
+                          (get_local $49)
                           (i32.const 8)
                         )
                         (i32.const 0)
@@ -9137,61 +8435,61 @@
                       (i32.and
                         (i32.eq
                           (i32.load
-                            (set_local $$107
-                              (get_local $$arg)
+                            (set_local $1
+                              (get_local $18)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.eq
                           (i32.load offset=4
-                            (get_local $$107)
+                            (get_local $1)
                           )
                           (i32.const 0)
                         )
                       )
                     )
                     (block
-                      (set_local $$fl$4
-                        (get_local $$fl$3)
+                      (set_local $35
+                        (get_local $49)
                       )
-                      (set_local $$p$2
-                        (get_local $$p$1)
+                      (set_local $31
+                        (get_local $58)
                       )
-                      (set_local $$pl$1
+                      (set_local $38
                         (i32.const 0)
                       )
-                      (set_local $$prefix$1
+                      (set_local $40
                         (i32.const 4091)
                       )
-                      (set_local $label
+                      (set_local $13
                         (i32.const 77)
                       )
-                      (get_local $$incdec$ptr$i$212$lcssa)
+                      (get_local $5)
                     )
                     (block
-                      (set_local $$fl$4
-                        (get_local $$fl$3)
+                      (set_local $35
+                        (get_local $49)
                       )
-                      (set_local $$p$2
-                        (get_local $$p$1)
+                      (set_local $31
+                        (get_local $58)
                       )
-                      (set_local $$pl$1
+                      (set_local $38
                         (i32.const 2)
                       )
-                      (set_local $$prefix$1
+                      (set_local $40
                         (i32.add
                           (i32.const 4091)
                           (i32.shr_s
-                            (get_local $$t$1)
+                            (get_local $69)
                             (i32.const 4)
                           )
                         )
                       )
-                      (set_local $label
+                      (set_local $13
                         (i32.const 77)
                       )
-                      (get_local $$incdec$ptr$i$212$lcssa)
+                      (get_local $5)
                     )
                   )
                 )
@@ -9200,124 +8498,122 @@
           )
           (if
             (i32.eq
-              (get_local $label)
+              (get_local $13)
               (i32.const 76)
             )
             (block
               (i32.const 0)
-              (set_local $$a$0
+              (set_local $34
                 (call $_fmt_u
-                  (get_local $$148)
-                  (get_local $$149)
-                  (get_local $$add$ptr205)
+                  (get_local $45)
+                  (get_local $54)
+                  (get_local $28)
                 )
               )
-              (set_local $$fl$4
-                (get_local $$fl$1$and219)
+              (set_local $35
+                (get_local $17)
               )
-              (set_local $$p$2
-                (get_local $$p$0)
+              (set_local $31
+                (get_local $9)
               )
-              (set_local $$pl$1
-                (get_local $$pl$0)
+              (set_local $38
+                (get_local $59)
               )
-              (set_local $$prefix$1
-                (get_local $$prefix$0)
+              (set_local $40
+                (get_local $60)
               )
-              (set_local $label
+              (set_local $13
                 (i32.const 77)
               )
             )
             (if
               (i32.eq
-                (get_local $label)
+                (get_local $13)
                 (i32.const 82)
               )
               (block
-                (set_local $label
+                (set_local $13
                   (i32.const 0)
                 )
-                (set_local $$tobool357
+                (set_local $5
                   (i32.eq
-                    (set_local $$call356
+                    (set_local $1
                       (call $_memchr
-                        (get_local $$a$1)
+                        (get_local $46)
                         (i32.const 0)
-                        (get_local $$p$0)
+                        (get_local $9)
                       )
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $$a$2
-                  (get_local $$a$1)
+                (set_local $47
+                  (get_local $46)
                 )
-                (set_local $$fl$6
-                  (get_local $$and219)
+                (set_local $36
+                  (get_local $6)
                 )
-                (set_local $$p$5
+                (set_local $42
                   (select
-                    (get_local $$p$0)
+                    (get_local $9)
                     (i32.sub
-                      (get_local $$call356)
-                      (get_local $$a$1)
+                      (get_local $1)
+                      (get_local $46)
                     )
-                    (get_local $$tobool357)
+                    (get_local $5)
                   )
                 )
-                (set_local $$pl$2
+                (set_local $43
                   (i32.const 0)
                 )
-                (set_local $$prefix$2
+                (set_local $51
                   (i32.const 4091)
                 )
-                (set_local $$z$2
+                (set_local $53
                   (select
                     (i32.add
-                      (get_local $$a$1)
-                      (get_local $$p$0)
+                      (get_local $46)
+                      (get_local $9)
                     )
-                    (get_local $$call356)
-                    (get_local $$tobool357)
+                    (get_local $1)
+                    (get_local $5)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (get_local $label)
+                  (get_local $13)
                   (i32.const 86)
                 )
                 (block
-                  (set_local $label
+                  (set_local $13
                     (i32.const 0)
                   )
-                  (set_local $$i$0316
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $$l$1315
+                  (set_local $5
                     (i32.const 0)
                   )
-                  (set_local $$ws$0317
+                  (set_local $6
                     (i32.load
-                      (get_local $$arg)
+                      (get_local $18)
                     )
                   )
                   (loop $while-out$131 $while-in$132
                     (if
                       (i32.eq
-                        (set_local $$177
+                        (set_local $1
                           (i32.load
-                            (get_local $$ws$0317)
+                            (get_local $6)
                           )
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$i$0$lcssa
-                          (get_local $$i$0316)
-                        )
-                        (set_local $$l$2
-                          (get_local $$l$1315)
+                        (get_local $7)
+                        (set_local $1
+                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
@@ -9325,65 +8621,59 @@
                     (if
                       (i32.or
                         (i32.lt_s
-                          (set_local $$call384
+                          (set_local $5
                             (call $_wctomb
-                              (get_local $$mb)
-                              (get_local $$177)
+                              (get_local $64)
+                              (get_local $1)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.gt_u
-                          (get_local $$call384)
+                          (get_local $5)
                           (i32.sub
-                            (get_local $$p$4365)
-                            (get_local $$i$0316)
+                            (get_local $65)
+                            (get_local $7)
                           )
                         )
                       )
                       (block
-                        (set_local $$i$0$lcssa
-                          (get_local $$i$0316)
-                        )
-                        (set_local $$l$2
-                          (get_local $$call384)
+                        (get_local $7)
+                        (set_local $1
+                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
                     )
-                    (set_local $$incdec$ptr383
+                    (set_local $6
                       (i32.add
-                        (get_local $$ws$0317)
+                        (get_local $6)
                         (i32.const 4)
                       )
                     )
                     (if
                       (i32.gt_u
-                        (get_local $$p$4365)
-                        (set_local $$add395
+                        (get_local $65)
+                        (set_local $1
                           (i32.add
-                            (get_local $$call384)
-                            (get_local $$i$0316)
+                            (get_local $5)
+                            (get_local $7)
                           )
                         )
                       )
                       (block
-                        (set_local $$i$0316
-                          (get_local $$add395)
+                        (set_local $7
+                          (get_local $1)
                         )
-                        (set_local $$l$1315
-                          (get_local $$call384)
-                        )
-                        (set_local $$ws$0317
-                          (get_local $$incdec$ptr383)
-                        )
+                        (get_local $5)
+                        (get_local $6)
                       )
                       (block
-                        (set_local $$i$0$lcssa
-                          (get_local $$add395)
+                        (set_local $7
+                          (get_local $1)
                         )
-                        (set_local $$l$2
-                          (get_local $$call384)
+                        (set_local $1
+                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
@@ -9392,91 +8682,91 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $$l$2)
+                      (get_local $1)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$retval$0
+                      (set_local $23
                         (i32.const -1)
                       )
                       (br $label$break$L1)
                     )
                   )
                   (call $_pad
-                    (get_local $$f)
+                    (get_local $0)
                     (i32.const 32)
-                    (get_local $$w$1)
-                    (get_local $$i$0$lcssa)
-                    (get_local $$fl$1$and219)
+                    (get_local $16)
+                    (get_local $7)
+                    (get_local $17)
                   )
                   (if
                     (i32.eq
-                      (get_local $$i$0$lcssa)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$i$0$lcssa368
+                      (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $label
+                      (set_local $13
                         (i32.const 98)
                       )
                     )
                     (block
-                      (set_local $$i$1325
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $$ws$1326
+                      (set_local $5
                         (i32.load
-                          (get_local $$arg)
+                          (get_local $18)
                         )
                       )
                       (loop $while-out$133 $while-in$134
                         (if
                           (i32.eq
-                            (set_local $$179
+                            (set_local $1
                               (i32.load
-                                (get_local $$ws$1326)
+                                (get_local $5)
                               )
                             )
                             (i32.const 0)
                           )
                           (block
-                            (set_local $$i$0$lcssa368
-                              (get_local $$i$0$lcssa)
+                            (set_local $37
+                              (get_local $7)
                             )
-                            (set_local $label
+                            (set_local $13
                               (i32.const 98)
                             )
                             (br $label$break$L308)
                           )
                         )
-                        (set_local $$incdec$ptr410
+                        (set_local $8
                           (i32.add
-                            (get_local $$ws$1326)
+                            (get_local $5)
                             (i32.const 4)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (set_local $$add412
+                            (set_local $1
                               (i32.add
-                                (set_local $$call411
+                                (set_local $5
                                   (call $_wctomb
-                                    (get_local $$mb)
-                                    (get_local $$179)
+                                    (get_local $64)
+                                    (get_local $1)
                                   )
                                 )
-                                (get_local $$i$1325)
+                                (get_local $6)
                               )
                             )
-                            (get_local $$i$0$lcssa)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$i$0$lcssa368
-                              (get_local $$i$0$lcssa)
+                            (set_local $37
+                              (get_local $7)
                             )
-                            (set_local $label
+                            (set_local $13
                               (i32.const 98)
                             )
                             (br $label$break$L308)
@@ -9486,36 +8776,36 @@
                           (i32.eq
                             (i32.and
                               (i32.load
-                                (get_local $$f)
+                                (get_local $0)
                               )
                               (i32.const 32)
                             )
                             (i32.const 0)
                           )
                           (call $___fwritex
-                            (get_local $$mb)
-                            (get_local $$call411)
-                            (get_local $$f)
+                            (get_local $64)
+                            (get_local $5)
+                            (get_local $0)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $$add412)
-                            (get_local $$i$0$lcssa)
+                            (get_local $1)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$i$1325
-                              (get_local $$add412)
+                            (set_local $6
+                              (get_local $1)
                             )
-                            (set_local $$ws$1326
-                              (get_local $$incdec$ptr410)
+                            (set_local $5
+                              (get_local $8)
                             )
                           )
                           (block
-                            (set_local $$i$0$lcssa368
-                              (get_local $$i$0$lcssa)
+                            (set_local $37
+                              (get_local $7)
                             )
-                            (set_local $label
+                            (set_local $13
                               (i32.const 98)
                             )
                             (br $while-out$133)
@@ -9533,87 +8823,87 @@
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 98)
         )
         (block
-          (set_local $label
+          (set_local $13
             (i32.const 0)
           )
           (call $_pad
-            (get_local $$f)
+            (get_local $0)
             (i32.const 32)
-            (get_local $$w$1)
-            (get_local $$i$0$lcssa368)
+            (get_local $16)
+            (get_local $37)
             (i32.xor
-              (get_local $$fl$1$and219)
+              (get_local $17)
               (i32.const 8192)
             )
           )
-          (set_local $$cnt$0
-            (get_local $$cnt$1)
+          (set_local $5
+            (get_local $19)
           )
-          (set_local $$incdec$ptr169275
-            (get_local $$incdec$ptr169$lcssa)
+          (set_local $12
+            (get_local $26)
           )
-          (set_local $$l$0
+          (set_local $1
             (select
-              (get_local $$w$1)
-              (get_local $$i$0$lcssa368)
+              (get_local $16)
+              (get_local $37)
               (i32.gt_s
-                (get_local $$w$1)
-                (get_local $$i$0$lcssa368)
+                (get_local $16)
+                (get_local $37)
               )
             )
           )
-          (set_local $$l10n$0
-            (get_local $$l10n$3)
+          (set_local $8
+            (get_local $20)
           )
           (br $label$continue$L1)
         )
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 77)
         )
         (block
-          (set_local $label
+          (set_local $13
             (i32.const 0)
           )
-          (set_local $$and309$fl$4
+          (set_local $5
             (select
               (i32.and
-                (get_local $$fl$4)
+                (get_local $35)
                 (i32.const -65537)
               )
-              (get_local $$fl$4)
+              (get_local $35)
               (i32.gt_s
-                (get_local $$p$2)
+                (get_local $31)
                 (i32.const -1)
               )
             )
           )
-          (set_local $$a$2
+          (set_local $47
             (if
               (i32.or
                 (i32.ne
-                  (get_local $$p$2)
+                  (get_local $31)
                   (i32.const 0)
                 )
-                (set_local $$159
+                (set_local $1
                   (i32.or
                     (i32.ne
                       (i32.load
-                        (set_local $$151
-                          (get_local $$arg)
+                        (set_local $1
+                          (get_local $18)
                         )
                       )
                       (i32.const 0)
                     )
                     (i32.ne
                       (i32.load offset=4
-                        (get_local $$151)
+                        (get_local $1)
                       )
                       (i32.const 0)
                     )
@@ -9621,91 +8911,91 @@
                 )
               )
               (block
-                (set_local $$cmp323
+                (set_local $7
                   (i32.gt_s
-                    (get_local $$p$2)
-                    (set_local $$add322
+                    (get_local $31)
+                    (set_local $1
                       (i32.add
                         (i32.xor
                           (i32.and
-                            (get_local $$159)
+                            (get_local $1)
                             (i32.const 1)
                           )
                           (i32.const 1)
                         )
                         (i32.sub
-                          (get_local $$sub$ptr$lhs$cast317)
-                          (get_local $$a$0)
+                          (get_local $73)
+                          (get_local $34)
                         )
                       )
                     )
                   )
                 )
-                (set_local $$fl$6
-                  (get_local $$and309$fl$4)
+                (set_local $36
+                  (get_local $5)
                 )
-                (set_local $$p$5
+                (set_local $42
                   (select
-                    (get_local $$p$2)
-                    (get_local $$add322)
-                    (get_local $$cmp323)
+                    (get_local $31)
+                    (get_local $1)
+                    (get_local $7)
                   )
                 )
-                (set_local $$pl$2
-                  (get_local $$pl$1)
+                (set_local $43
+                  (get_local $38)
                 )
-                (set_local $$prefix$2
-                  (get_local $$prefix$1)
+                (set_local $51
+                  (get_local $40)
                 )
-                (set_local $$z$2
-                  (get_local $$add$ptr205)
+                (set_local $53
+                  (get_local $28)
                 )
-                (get_local $$a$0)
+                (get_local $34)
               )
               (block
-                (set_local $$fl$6
-                  (get_local $$and309$fl$4)
+                (set_local $36
+                  (get_local $5)
                 )
-                (set_local $$p$5
+                (set_local $42
                   (i32.const 0)
                 )
-                (set_local $$pl$2
-                  (get_local $$pl$1)
+                (set_local $43
+                  (get_local $38)
                 )
-                (set_local $$prefix$2
-                  (get_local $$prefix$1)
+                (set_local $51
+                  (get_local $40)
                 )
-                (set_local $$z$2
-                  (get_local $$add$ptr205)
+                (set_local $53
+                  (get_local $28)
                 )
-                (get_local $$add$ptr205)
+                (get_local $28)
               )
             )
           )
         )
       )
-      (set_local $$cmp434
+      (set_local $1
         (i32.lt_s
-          (get_local $$p$5)
-          (set_local $$sub$ptr$sub433
+          (get_local $42)
+          (set_local $7
             (i32.sub
-              (get_local $$z$2)
-              (get_local $$a$2)
+              (get_local $53)
+              (get_local $47)
             )
           )
         )
       )
-      (set_local $$cmp442
+      (set_local $5
         (i32.lt_s
-          (get_local $$w$1)
-          (set_local $$add441
+          (get_local $16)
+          (set_local $1
             (i32.add
-              (get_local $$pl$2)
-              (set_local $$sub$ptr$sub433$p$5
+              (get_local $43)
+              (set_local $6
                 (select
-                  (get_local $$sub$ptr$sub433)
-                  (get_local $$p$5)
-                  (get_local $$cmp434)
+                  (get_local $7)
+                  (get_local $42)
+                  (get_local $1)
                 )
               )
             )
@@ -9713,123 +9003,123 @@
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 32)
-        (set_local $$w$2
+        (set_local $8
           (select
-            (get_local $$add441)
-            (get_local $$w$1)
-            (get_local $$cmp442)
+            (get_local $1)
+            (get_local $16)
+            (get_local $5)
           )
         )
-        (get_local $$add441)
-        (get_local $$fl$6)
+        (get_local $1)
+        (get_local $36)
       )
       (if
         (i32.eq
           (i32.and
             (i32.load
-              (get_local $$f)
+              (get_local $0)
             )
             (i32.const 32)
           )
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $$prefix$2)
-          (get_local $$pl$2)
-          (get_local $$f)
+          (get_local $51)
+          (get_local $43)
+          (get_local $0)
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 48)
-        (get_local $$w$2)
-        (get_local $$add441)
+        (get_local $8)
+        (get_local $1)
         (i32.xor
-          (get_local $$fl$6)
+          (get_local $36)
           (i32.const 65536)
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 48)
-        (get_local $$sub$ptr$sub433$p$5)
-        (get_local $$sub$ptr$sub433)
+        (get_local $6)
+        (get_local $7)
         (i32.const 0)
       )
       (if
         (i32.eq
           (i32.and
             (i32.load
-              (get_local $$f)
+              (get_local $0)
             )
             (i32.const 32)
           )
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $$a$2)
-          (get_local $$sub$ptr$sub433)
-          (get_local $$f)
+          (get_local $47)
+          (get_local $7)
+          (get_local $0)
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 32)
-        (get_local $$w$2)
-        (get_local $$add441)
+        (get_local $8)
+        (get_local $1)
         (i32.xor
-          (get_local $$fl$6)
+          (get_local $36)
           (i32.const 8192)
         )
       )
-      (set_local $$cnt$0
-        (get_local $$cnt$1)
+      (set_local $5
+        (get_local $19)
       )
-      (set_local $$incdec$ptr169275
-        (get_local $$incdec$ptr169$lcssa)
+      (set_local $12
+        (get_local $26)
       )
-      (set_local $$l$0
-        (get_local $$w$2)
+      (set_local $1
+        (get_local $8)
       )
-      (set_local $$l10n$0
-        (get_local $$l10n$3)
+      (set_local $8
+        (get_local $20)
       )
       (br $label$continue$L1)
     )
     (block $label$break$L343
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 242)
         )
         (if
           (i32.eq
-            (get_local $$f)
+            (get_local $0)
             (i32.const 0)
           )
           (if
             (i32.eq
-              (get_local $$l10n$0$lcssa)
+              (get_local $80)
               (i32.const 0)
             )
-            (set_local $$retval$0
+            (set_local $23
               (i32.const 0)
             )
             (block
-              (set_local $$i$2299
+              (set_local $1
                 (i32.const 1)
               )
               (loop $while-out$136 $while-in$137
                 (if
                   (i32.eq
-                    (set_local $$267
+                    (set_local $0
                       (i32.load
                         (i32.add
-                          (get_local $$nl_type)
+                          (get_local $4)
                           (i32.shl
-                            (get_local $$i$2299)
+                            (get_local $1)
                             (i32.const 2)
                           )
                         )
@@ -9838,38 +9128,38 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$i$2299$lcssa
-                      (get_local $$i$2299)
+                    (set_local $0
+                      (get_local $1)
                     )
                     (br $while-out$136)
                   )
                 )
                 (call $_pop_arg_336
                   (i32.add
-                    (get_local $$nl_arg)
+                    (get_local $3)
                     (i32.shl
-                      (get_local $$i$2299)
+                      (get_local $1)
                       (i32.const 3)
                     )
                   )
-                  (get_local $$267)
-                  (get_local $$ap)
+                  (get_local $0)
+                  (get_local $2)
                 )
                 (if
                   (i32.lt_s
-                    (set_local $$inc
+                    (set_local $0
                       (i32.add
-                        (get_local $$i$2299)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
                     (i32.const 10)
                   )
-                  (set_local $$i$2299
-                    (get_local $$inc)
+                  (set_local $1
+                    (get_local $0)
                   )
                   (block
-                    (set_local $$retval$0
+                    (set_local $23
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -9879,17 +9169,15 @@
               )
               (if
                 (i32.lt_s
-                  (get_local $$i$2299$lcssa)
+                  (get_local $0)
                   (i32.const 10)
                 )
                 (block
-                  (set_local $$i$3296
-                    (get_local $$i$2299$lcssa)
-                  )
+                  (get_local $0)
                   (loop $while-out$138 $while-in$139
-                    (set_local $$inc488
+                    (set_local $1
                       (i32.add
-                        (get_local $$i$3296)
+                        (get_local $0)
                         (i32.const 1)
                       )
                     )
@@ -9897,9 +9185,9 @@
                       (i32.ne
                         (i32.load
                           (i32.add
-                            (get_local $$nl_type)
+                            (get_local $4)
                             (i32.shl
-                              (get_local $$i$3296)
+                              (get_local $0)
                               (i32.const 2)
                             )
                           )
@@ -9907,7 +9195,7 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$retval$0
+                        (set_local $23
                           (i32.const -1)
                         )
                         (br $label$break$L343)
@@ -9915,14 +9203,14 @@
                     )
                     (if
                       (i32.lt_s
-                        (get_local $$inc488)
+                        (get_local $1)
                         (i32.const 10)
                       )
-                      (set_local $$i$3296
-                        (get_local $$inc488)
+                      (set_local $0
+                        (get_local $1)
                       )
                       (block
-                        (set_local $$retval$0
+                        (set_local $23
                           (i32.const 1)
                         )
                         (br $while-out$138)
@@ -9931,65 +9219,35 @@
                     (br $while-in$139)
                   )
                 )
-                (set_local $$retval$0
+                (set_local $23
                   (i32.const 1)
                 )
               )
             )
           )
-          (set_local $$retval$0
-            (get_local $$cnt$1$lcssa)
+          (set_local $23
+            (get_local $79)
           )
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $32)
     )
-    (get_local $$retval$0)
+    (get_local $23)
   )
-  (func $_pop_arg_336 (param $$arg i32) (param $$type i32) (param $$ap i32)
-    (local $$13 i32)
-    (local $$102 i32)
-    (local $$103 f64)
-    (local $$109 i32)
-    (local $$110 f64)
-    (local $$12 i32)
-    (local $$16 i32)
-    (local $$25 i32)
-    (local $$26 i32)
-    (local $$27 i32)
-    (local $$36 i32)
-    (local $$37 i32)
-    (local $$39 i32)
-    (local $$42 i32)
-    (local $$43 i32)
-    (local $$5 i32)
-    (local $$52 i32)
-    (local $$53 i32)
-    (local $$54 i32)
-    (local $$56 i32)
-    (local $$57 i32)
-    (local $$6 i32)
-    (local $$66 i32)
-    (local $$67 i32)
-    (local $$68 i32)
-    (local $$77 i32)
-    (local $$78 i32)
-    (local $$79 i32)
-    (local $$81 i32)
-    (local $$82 i32)
-    (local $$91 i32)
-    (local $$92 i32)
-    (local $$93 i32)
+  (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
+    (local $3 i32)
+    (local $4 f64)
+    (local $5 i32)
     (i32.load
       (i32.const 8)
     )
     (block $label$break$L1
       (if
         (i32.le_u
-          (get_local $$type)
+          (get_local $1)
           (i32.const 20)
         )
         (block $switch$3
@@ -10007,18 +9265,18 @@
                                 (block $switch-case$4
                                   (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
                                     (i32.sub
-                                      (get_local $$type)
+                                      (get_local $1)
                                       (i32.const 9)
                                     )
                                   )
                                 )
-                                (set_local $$6
+                                (set_local $3
                                   (i32.load
-                                    (set_local $$5
+                                    (set_local $1
                                       (i32.and
                                         (i32.add
                                           (i32.load
-                                            (get_local $$ap)
+                                            (get_local $2)
                                           )
                                           (i32.sub
                                             (i32.add
@@ -10043,25 +9301,25 @@
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$ap)
+                                  (get_local $2)
                                   (i32.add
-                                    (get_local $$5)
+                                    (get_local $1)
                                     (i32.const 4)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$arg)
-                                  (get_local $$6)
+                                  (get_local $0)
+                                  (get_local $3)
                                 )
                                 (br $label$break$L1)
                               )
-                              (set_local $$13
+                              (set_local $3
                                 (i32.load
-                                  (set_local $$12
+                                  (set_local $1
                                     (i32.and
                                       (i32.add
                                         (i32.load
-                                          (get_local $$ap)
+                                          (get_local $2)
                                         )
                                         (i32.sub
                                           (i32.add
@@ -10086,24 +9344,22 @@
                                 )
                               )
                               (i32.store
-                                (get_local $$ap)
+                                (get_local $2)
                                 (i32.add
-                                  (get_local $$12)
+                                  (get_local $1)
                                   (i32.const 4)
                                 )
                               )
                               (i32.store
-                                (set_local $$16
-                                  (get_local $$arg)
-                                )
-                                (get_local $$13)
+                                (get_local $0)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $$16)
+                                (get_local $0)
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.lt_s
-                                      (get_local $$13)
+                                      (get_local $3)
                                       (i32.const 0)
                                     )
                                     (i32.const 31)
@@ -10113,13 +9369,13 @@
                               )
                               (br $label$break$L1)
                             )
-                            (set_local $$26
+                            (set_local $3
                               (i32.load
-                                (set_local $$25
+                                (set_local $1
                                   (i32.and
                                     (i32.add
                                       (i32.load
-                                        (get_local $$ap)
+                                        (get_local $2)
                                       )
                                       (i32.sub
                                         (i32.add
@@ -10144,32 +9400,30 @@
                               )
                             )
                             (i32.store
-                              (get_local $$ap)
+                              (get_local $2)
                               (i32.add
-                                (get_local $$25)
+                                (get_local $1)
                                 (i32.const 4)
                               )
                             )
                             (i32.store
-                              (set_local $$27
-                                (get_local $$arg)
-                              )
-                              (get_local $$26)
+                              (get_local $0)
+                              (get_local $3)
                             )
                             (i32.store offset=4
-                              (get_local $$27)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (br $label$break$L1)
                           )
-                          (set_local $$39
+                          (set_local $5
                             (i32.load
-                              (set_local $$37
-                                (set_local $$36
+                              (set_local $3
+                                (set_local $1
                                   (i32.and
                                     (i32.add
                                       (i32.load
-                                        (get_local $$ap)
+                                        (get_local $2)
                                       )
                                       (i32.sub
                                         (i32.add
@@ -10194,37 +9448,35 @@
                               )
                             )
                           )
-                          (set_local $$42
+                          (set_local $3
                             (i32.load offset=4
-                              (get_local $$37)
+                              (get_local $3)
                             )
                           )
                           (i32.store
-                            (get_local $$ap)
+                            (get_local $2)
                             (i32.add
-                              (get_local $$36)
+                              (get_local $1)
                               (i32.const 8)
                             )
                           )
                           (i32.store
-                            (set_local $$43
-                              (get_local $$arg)
-                            )
-                            (get_local $$39)
+                            (get_local $0)
+                            (get_local $5)
                           )
                           (i32.store offset=4
-                            (get_local $$43)
-                            (get_local $$42)
+                            (get_local $0)
+                            (get_local $3)
                           )
                           (br $label$break$L1)
                         )
-                        (set_local $$53
+                        (set_local $3
                           (i32.load
-                            (set_local $$52
+                            (set_local $1
                               (i32.and
                                 (i32.add
                                   (i32.load
-                                    (get_local $$ap)
+                                    (get_local $2)
                                   )
                                   (i32.sub
                                     (i32.add
@@ -10249,21 +9501,21 @@
                           )
                         )
                         (i32.store
-                          (get_local $$ap)
+                          (get_local $2)
                           (i32.add
-                            (get_local $$52)
+                            (get_local $1)
                             (i32.const 4)
                           )
                         )
-                        (set_local $$56
+                        (set_local $2
                           (i32.shr_s
                             (i32.shl
                               (i32.lt_s
-                                (set_local $$54
+                                (set_local $1
                                   (i32.shr_s
                                     (i32.shl
                                       (i32.and
-                                        (get_local $$53)
+                                        (get_local $3)
                                         (i32.const 65535)
                                       )
                                       (i32.const 16)
@@ -10279,24 +9531,22 @@
                           )
                         )
                         (i32.store
-                          (set_local $$57
-                            (get_local $$arg)
-                          )
-                          (get_local $$54)
+                          (get_local $0)
+                          (get_local $1)
                         )
                         (i32.store offset=4
-                          (get_local $$57)
-                          (get_local $$56)
+                          (get_local $0)
+                          (get_local $2)
                         )
                         (br $label$break$L1)
                       )
-                      (set_local $$67
+                      (set_local $3
                         (i32.load
-                          (set_local $$66
+                          (set_local $1
                             (i32.and
                               (i32.add
                                 (i32.load
-                                  (get_local $$ap)
+                                  (get_local $2)
                                 )
                                 (i32.sub
                                   (i32.add
@@ -10321,34 +9571,32 @@
                         )
                       )
                       (i32.store
-                        (get_local $$ap)
+                        (get_local $2)
                         (i32.add
-                          (get_local $$66)
+                          (get_local $1)
                           (i32.const 4)
                         )
                       )
                       (i32.store
-                        (set_local $$68
-                          (get_local $$arg)
-                        )
+                        (get_local $0)
                         (i32.and
-                          (get_local $$67)
+                          (get_local $3)
                           (i32.const 65535)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $$68)
+                        (get_local $0)
                         (i32.const 0)
                       )
                       (br $label$break$L1)
                     )
-                    (set_local $$78
+                    (set_local $3
                       (i32.load
-                        (set_local $$77
+                        (set_local $1
                           (i32.and
                             (i32.add
                               (i32.load
-                                (get_local $$ap)
+                                (get_local $2)
                               )
                               (i32.sub
                                 (i32.add
@@ -10373,21 +9621,21 @@
                       )
                     )
                     (i32.store
-                      (get_local $$ap)
+                      (get_local $2)
                       (i32.add
-                        (get_local $$77)
+                        (get_local $1)
                         (i32.const 4)
                       )
                     )
-                    (set_local $$81
+                    (set_local $2
                       (i32.shr_s
                         (i32.shl
                           (i32.lt_s
-                            (set_local $$79
+                            (set_local $1
                               (i32.shr_s
                                 (i32.shl
                                   (i32.and
-                                    (get_local $$78)
+                                    (get_local $3)
                                     (i32.const 255)
                                   )
                                   (i32.const 24)
@@ -10403,24 +9651,22 @@
                       )
                     )
                     (i32.store
-                      (set_local $$82
-                        (get_local $$arg)
-                      )
-                      (get_local $$79)
+                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $$82)
-                      (get_local $$81)
+                      (get_local $0)
+                      (get_local $2)
                     )
                     (br $label$break$L1)
                   )
-                  (set_local $$92
+                  (set_local $3
                     (i32.load
-                      (set_local $$91
+                      (set_local $1
                         (i32.and
                           (i32.add
                             (i32.load
-                              (get_local $$ap)
+                              (get_local $2)
                             )
                             (i32.sub
                               (i32.add
@@ -10445,34 +9691,32 @@
                     )
                   )
                   (i32.store
-                    (get_local $$ap)
+                    (get_local $2)
                     (i32.add
-                      (get_local $$91)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
                   (i32.store
-                    (set_local $$93
-                      (get_local $$arg)
-                    )
+                    (get_local $0)
                     (i32.and
-                      (get_local $$92)
+                      (get_local $3)
                       (i32.const 255)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$93)
+                    (get_local $0)
                     (i32.const 0)
                   )
                   (br $label$break$L1)
                 )
-                (set_local $$103
+                (set_local $4
                   (f64.load
-                    (set_local $$102
+                    (set_local $1
                       (i32.and
                         (i32.add
                           (i32.load
-                            (get_local $$ap)
+                            (get_local $2)
                           )
                           (i32.sub
                             (i32.add
@@ -10497,25 +9741,25 @@
                   )
                 )
                 (i32.store
-                  (get_local $$ap)
+                  (get_local $2)
                   (i32.add
-                    (get_local $$102)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (f64.store
-                  (get_local $$arg)
-                  (get_local $$103)
+                  (get_local $0)
+                  (get_local $4)
                 )
                 (br $label$break$L1)
               )
-              (set_local $$110
+              (set_local $4
                 (f64.load
-                  (set_local $$109
+                  (set_local $1
                     (i32.and
                       (i32.add
                         (i32.load
-                          (get_local $$ap)
+                          (get_local $2)
                         )
                         (i32.sub
                           (i32.add
@@ -10540,15 +9784,15 @@
                 )
               )
               (i32.store
-                (get_local $$ap)
+                (get_local $2)
                 (i32.add
-                  (get_local $$109)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (f64.store
-                (get_local $$arg)
-                (get_local $$110)
+                (get_local $0)
+                (get_local $4)
               )
             )
           )
@@ -10556,59 +9800,45 @@
       )
     )
   )
-  (func $_fmt_u (param $$0 i32) (param $$1 i32) (param $$s i32) (result i32)
-    (local $$8 i32)
-    (local $$7 i32)
-    (local $$y$010 i32)
-    (local $$x$addr$0$lcssa$off0 i32)
-    (local $$13 i32)
-    (local $$14 i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr7 i32)
-    (local $$s$addr$0$lcssa i32)
-    (local $$s$addr$013 i32)
-    (local $$s$addr$1$lcssa i32)
-    (local $$s$addr$19 i32)
-    (local $$21 i32)
-    (local $$9 i32)
-    (local $$div9 i32)
-    (local $$incdec$ptr$lcssa i32)
+  (func $_fmt_u (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$s$addr$0$lcssa
+    (set_local $0
       (if
         (i32.or
           (i32.gt_u
-            (get_local $$1)
+            (get_local $1)
             (i32.const 0)
           )
           (i32.and
             (i32.eq
-              (get_local $$1)
+              (get_local $1)
               (i32.const 0)
             )
             (i32.gt_u
-              (get_local $$0)
+              (get_local $0)
               (i32.const -1)
             )
           )
         )
         (block
-          (set_local $$7
-            (get_local $$0)
+          (set_local $3
+            (get_local $0)
           )
-          (set_local $$8
-            (get_local $$1)
+          (set_local $4
+            (get_local $1)
           )
-          (set_local $$s$addr$013
-            (get_local $$s)
+          (set_local $1
+            (get_local $2)
           )
           (loop $while-out$0 $while-in$1
-            (set_local $$9
+            (set_local $0
               (call $___uremdi3
-                (get_local $$7)
-                (get_local $$8)
+                (get_local $3)
+                (get_local $4)
                 (i32.const 10)
                 (i32.const 0)
               )
@@ -10617,29 +9847,29 @@
               (i32.const 168)
             )
             (i32.store8
-              (set_local $$incdec$ptr
+              (set_local $2
                 (i32.add
-                  (get_local $$s$addr$013)
+                  (get_local $1)
                   (i32.const -1)
                 )
               )
               (i32.and
                 (i32.or
-                  (get_local $$9)
+                  (get_local $0)
                   (i32.const 48)
                 )
                 (i32.const 255)
               )
             )
-            (set_local $$13
+            (set_local $0
               (call $___udivdi3
-                (get_local $$7)
-                (get_local $$8)
+                (get_local $3)
+                (get_local $4)
                 (i32.const 10)
                 (i32.const 0)
               )
             )
-            (set_local $$14
+            (set_local $1
               (i32.load
                 (i32.const 168)
               )
@@ -10647,77 +9877,73 @@
             (if
               (i32.or
                 (i32.gt_u
-                  (get_local $$8)
+                  (get_local $4)
                   (i32.const 9)
                 )
                 (i32.and
                   (i32.eq
-                    (get_local $$8)
+                    (get_local $4)
                     (i32.const 9)
                   )
                   (i32.gt_u
-                    (get_local $$7)
+                    (get_local $3)
                     (i32.const -1)
                   )
                 )
               )
               (block
-                (set_local $$7
-                  (get_local $$13)
+                (set_local $3
+                  (get_local $0)
                 )
-                (set_local $$8
-                  (get_local $$14)
+                (set_local $4
+                  (get_local $1)
                 )
-                (set_local $$s$addr$013
-                  (get_local $$incdec$ptr)
+                (set_local $1
+                  (get_local $2)
                 )
               )
               (block
-                (set_local $$21
-                  (get_local $$13)
-                )
-                (get_local $$14)
-                (set_local $$incdec$ptr$lcssa
-                  (get_local $$incdec$ptr)
+                (get_local $0)
+                (get_local $1)
+                (set_local $1
+                  (get_local $2)
                 )
                 (br $while-out$0)
               )
             )
             (br $while-in$1)
           )
-          (set_local $$x$addr$0$lcssa$off0
-            (get_local $$21)
+          (set_local $3
+            (get_local $0)
           )
-          (get_local $$incdec$ptr$lcssa)
+          (get_local $1)
         )
         (block
-          (set_local $$x$addr$0$lcssa$off0
-            (get_local $$0)
+          (set_local $3
+            (get_local $0)
           )
-          (get_local $$s)
+          (get_local $2)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $$x$addr$0$lcssa$off0)
+        (get_local $3)
         (i32.const 0)
       )
-      (set_local $$s$addr$1$lcssa
-        (get_local $$s$addr$0$lcssa)
-      )
+      (get_local $0)
       (block
-        (set_local $$s$addr$19
-          (get_local $$s$addr$0$lcssa)
+        (set_local $1
+          (get_local $0)
         )
-        (set_local $$y$010
-          (get_local $$x$addr$0$lcssa$off0)
+        (set_local $2
+          (get_local $3)
         )
         (loop $while-out$2 $while-in$3
           (i32.store8
-            (set_local $$incdec$ptr7
+            (set_local $1
               (i32.add
-                (get_local $$s$addr$19)
+                (get_local $1)
                 (i32.const -1)
               )
             )
@@ -10725,7 +9951,7 @@
               (i32.or
                 (i32.and
                   (i32.rem_u
-                    (get_local $$y$010)
+                    (get_local $2)
                     (i32.const 10)
                   )
                   (i32.const -1)
@@ -10735,10 +9961,10 @@
               (i32.const 255)
             )
           )
-          (set_local $$div9
+          (set_local $0
             (i32.and
               (i32.div_u
-                (get_local $$y$010)
+                (get_local $2)
                 (i32.const 10)
               )
               (i32.const -1)
@@ -10746,21 +9972,19 @@
           )
           (if
             (i32.lt_u
-              (get_local $$y$010)
+              (get_local $2)
               (i32.const 10)
             )
             (block
-              (set_local $$s$addr$1$lcssa
-                (get_local $$incdec$ptr7)
+              (set_local $0
+                (get_local $1)
               )
               (br $while-out$2)
             )
             (block
-              (set_local $$s$addr$19
-                (get_local $$incdec$ptr7)
-              )
-              (set_local $$y$010
-                (get_local $$div9)
+              (get_local $1)
+              (set_local $2
+                (get_local $0)
               )
             )
           )
@@ -10768,25 +9992,13 @@
         )
       )
     )
-    (get_local $$s$addr$1$lcssa)
+    (get_local $0)
   )
-  (func $_pad (param $$f i32) (param $$c i32) (param $$w i32) (param $$l i32) (param $$fl i32)
-    (local $$sub i32)
-    (local $$pad i32)
-    (local $$4 i32)
-    (local $$l$addr$0$lcssa21 i32)
-    (local $$l$addr$017 i32)
-    (local $$tobool$i i32)
-    (local $$tobool$i$16 i32)
-    (local $$tobool$i18 i32)
-    (local $sp i32)
-    (local $$0 i32)
-    (local $$1 i32)
-    (local $$2 i32)
-    (local $$3 i32)
-    (local $$cmp1 i32)
-    (local $$sub5 i32)
-    (set_local $sp
+  (func $_pad (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (set_local $7
       (i32.load
         (i32.const 8)
       )
@@ -10811,51 +10023,51 @@
       )
       (call_import $abort)
     )
-    (set_local $$pad
-      (get_local $sp)
+    (set_local $6
+      (get_local $7)
     )
     (block $do-once$0
       (if
         (i32.and
           (i32.gt_s
-            (get_local $$w)
-            (get_local $$l)
+            (get_local $2)
+            (get_local $3)
           )
           (i32.eq
             (i32.and
-              (get_local $$fl)
+              (get_local $4)
               (i32.const 73728)
             )
             (i32.const 0)
           )
         )
         (block
-          (set_local $$cmp1
+          (set_local $4
             (i32.gt_u
-              (set_local $$sub
+              (set_local $5
                 (i32.sub
-                  (get_local $$w)
-                  (get_local $$l)
+                  (get_local $2)
+                  (get_local $3)
                 )
               )
               (i32.const 256)
             )
           )
           (call $_memset
-            (get_local $$pad)
-            (get_local $$c)
+            (get_local $6)
+            (get_local $1)
             (select
               (i32.const 256)
-              (get_local $$sub)
-              (get_local $$cmp1)
+              (get_local $5)
+              (get_local $4)
             )
           )
-          (set_local $$tobool$i$16
+          (set_local $4
             (i32.eq
               (i32.and
-                (set_local $$0
+                (set_local $1
                   (i32.load
-                    (get_local $$f)
+                    (get_local $0)
                   )
                 )
                 (i32.const 32)
@@ -10865,43 +10077,39 @@
           )
           (if
             (i32.gt_u
-              (get_local $$sub)
+              (get_local $5)
               (i32.const 255)
             )
             (block
-              (set_local $$1
+              (set_local $2
                 (i32.sub
-                  (get_local $$w)
-                  (get_local $$l)
+                  (get_local $2)
+                  (get_local $3)
                 )
               )
-              (set_local $$4
-                (get_local $$0)
+              (get_local $1)
+              (set_local $3
+                (get_local $5)
               )
-              (set_local $$l$addr$017
-                (get_local $$sub)
-              )
-              (set_local $$tobool$i18
-                (get_local $$tobool$i$16)
-              )
+              (get_local $4)
               (loop $while-out$2 $while-in$3
-                (set_local $$tobool$i
+                (set_local $4
                   (i32.eq
                     (i32.and
-                      (set_local $$2
+                      (set_local $1
                         (if
-                          (get_local $$tobool$i18)
+                          (get_local $4)
                           (block
                             (call $___fwritex
-                              (get_local $$pad)
+                              (get_local $6)
                               (i32.const 256)
-                              (get_local $$f)
+                              (get_local $0)
                             )
                             (i32.load
-                              (get_local $$f)
+                              (get_local $0)
                             )
                           )
-                          (get_local $$4)
+                          (get_local $1)
                         )
                       )
                       (i32.const 32)
@@ -10911,547 +10119,137 @@
                 )
                 (if
                   (i32.gt_u
-                    (set_local $$sub5
+                    (set_local $3
                       (i32.add
-                        (get_local $$l$addr$017)
+                        (get_local $3)
                         (i32.const -256)
                       )
                     )
                     (i32.const 255)
                   )
                   (block
-                    (set_local $$4
-                      (get_local $$2)
-                    )
-                    (set_local $$l$addr$017
-                      (get_local $$sub5)
-                    )
-                    (set_local $$tobool$i18
-                      (get_local $$tobool$i)
-                    )
+                    (get_local $1)
+                    (get_local $3)
+                    (get_local $4)
                   )
                   (br $while-out$2)
                 )
                 (br $while-in$3)
               )
-              (set_local $$3
+              (set_local $1
                 (i32.and
-                  (get_local $$1)
+                  (get_local $2)
                   (i32.const 255)
                 )
               )
               (if
-                (get_local $$tobool$i)
-                (set_local $$l$addr$0$lcssa21
-                  (get_local $$3)
-                )
+                (get_local $4)
+                (get_local $1)
                 (br $do-once$0)
               )
             )
             (if
-              (get_local $$tobool$i$16)
-              (set_local $$l$addr$0$lcssa21
-                (get_local $$sub)
+              (get_local $4)
+              (set_local $1
+                (get_local $5)
               )
               (br $do-once$0)
             )
           )
           (call $___fwritex
-            (get_local $$pad)
-            (get_local $$l$addr$0$lcssa21)
-            (get_local $$f)
+            (get_local $6)
+            (get_local $1)
+            (get_local $0)
           )
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $7)
     )
   )
-  (func $_malloc (param $$bytes i32) (result i32)
-    (local $$119 i32)
-    (local $label i32)
-    (local $$add$ptr17$i$i i32)
-    (local $$nb$0 i32)
-    (local $$add$ptr$i$161 i32)
-    (local $$v$4$lcssa$i i32)
-    (local $$add$ptr16$i$i i32)
-    (local $$tbase$796$i i32)
-    (local $$v$0$i$lcssa i32)
-    (local $$and145 i32)
-    (local $$rsize$4$lcssa$i i32)
-    (local $$R$3$i i32)
-    (local $$R$3$i$171 i32)
-    (local $$R$3$i$i i32)
-    (local $$tsize$795$i i32)
-    (local $$cond i32)
-    (local $$qsize$0$i$i i32)
-    (local $$ssize$2$ph$i i32)
-    (local $$sub$ptr$sub$i$i i32)
-    (local $$t$0$i$151 i32)
-    (local $$t$48$i i32)
-    (local $$149 i32)
-    (local $$R$1$i i32)
-    (local $$R$1$i$168 i32)
-    (local $$R$1$i$i i32)
-    (local $$rsize$0$i$lcssa i32)
-    (local $$ssize$0$i i32)
-    (local $$148 i32)
-    (local $$154 i32)
-    (local $$26 i32)
-    (local $$63 i32)
-    (local $$95 i32)
-    (local $$T$0$i i32)
-    (local $$T$0$i$58$i i32)
-    (local $$T$0$i$i i32)
-    (local $$add$ptr14$i$i i32)
-    (local $$and11$i i32)
-    (local $$cond13$i$i i32)
-    (local $$rsize$49$i i32)
-    (local $$sp$0$i$i i32)
-    (local $$sp$0$i$i$i i32)
-    (local $$sp$0108$i i32)
-    (local $$sp$1107$i i32)
-    (local $$10 i32)
-    (local $$14 i32)
-    (local $$150 i32)
-    (local $$3 i32)
-    (local $$46 i32)
-    (local $$I252$0$i$i i32)
-    (local $$I316$0$i i32)
-    (local $$I57$0$i$i i32)
-    (local $$RP$1$i i32)
-    (local $$RP$1$i$167 i32)
-    (local $$RP$1$i$i i32)
-    (local $$arrayidx$i$20$i i32)
-    (local $$arrayidx103 i32)
-    (local $$arrayidx196$i i32)
-    (local $$arrayidx223$i$i i32)
-    (local $$arrayidx289$i i32)
-    (local $$br$2$ph$i i32)
-    (local $$cond4$i i32)
-    (local $$rsize$0$i i32)
-    (local $$sub160 i32)
-    (local $$sub18$i$i i32)
-    (local $$v$3$i i32)
-    (local $$v$410$i i32)
-    (local $$13 i32)
-    (local $$147 i32)
-    (local $$155 i32)
-    (local $$169 i32)
-    (local $$170 i32)
-    (local $$2 i32)
-    (local $$27 i32)
-    (local $$41 i32)
-    (local $$42 i32)
-    (local $$64 i32)
-    (local $$78 i32)
-    (local $$79 i32)
-    (local $$9 i32)
-    (local $$94 i32)
-    (local $$F$0$i$i i32)
-    (local $$F104$0 i32)
-    (local $$F197$0$i i32)
-    (local $$F224$0$i$i i32)
-    (local $$F290$0$i i32)
-    (local $$K105$0$i$i i32)
-    (local $$K305$0$i$i i32)
-    (local $$K373$0$i i32)
-    (local $$T$0$i$58$i$lcssa i32)
-    (local $$T$0$i$i$lcssa i32)
-    (local $$T$0$i$lcssa i32)
-    (local $$add$ptr$i i32)
-    (local $$add$ptr227$i i32)
-    (local $$add$ptr4$i$26$i i32)
-    (local $$add$ptr4$i$37$i i32)
-    (local $$add26$i$i i32)
-    (local $$and80$i i32)
-    (local $$arrayidx$i$i i32)
-    (local $$arrayidx287$i$i i32)
-    (local $$arrayidx355$i i32)
-    (local $$arrayidx91$i$i i32)
-    (local $$call$i$i i32)
-    (local $$call131$i i32)
-    (local $$call37$i i32)
-    (local $$call83$i i32)
-    (local $$i$01$i$i i32)
-    (local $$idx$0$i i32)
-    (local $$rsize$0$i$152 i32)
-    (local $$rsize$1$i i32)
-    (local $$rsize$3$i i32)
-    (local $$shr i32)
-    (local $$shr3 i32)
-    (local $$sizebits$0$i i32)
-    (local $$ssize$5$i i32)
-    (local $$sub101$rsize$4$i i32)
-    (local $$sub5$i$27$i i32)
-    (local $$sub91 i32)
-    (local $$t$0$i i32)
-    (local $$t$2$i i32)
-    (local $$t$4$v$4$i i32)
-    (local $$v$0$i i32)
-    (local $$v$1$i i32)
-    (local $$$pre$phi$i$178Z2D i32)
-    (local $$$pre$phi$i$57$iZ2D i32)
-    (local $$$pre$phi$i$iZ2D i32)
-    (local $$$pre$phi$iZ2D i32)
-    (local $$$pre$phiZ2D i32)
-    (local $$0 i32)
-    (local $$104 i32)
-    (local $$108 i32)
-    (local $$156 i32)
-    (local $$182 i32)
-    (local $$19 i32)
-    (local $$20 i32)
-    (local $$204 i32)
-    (local $$208 i32)
-    (local $$25 i32)
-    (local $$28 i32)
-    (local $$54 i32)
-    (local $$55 i32)
-    (local $$62 i32)
-    (local $$65 i32)
-    (local $$91 i32)
-    (local $$98 i32)
-    (local $$RP$1$i$167$lcssa i32)
-    (local $$RP$1$i$i$lcssa i32)
-    (local $$RP$1$i$lcssa i32)
-    (local $$add$ptr$i$i$i$lcssa i32)
-    (local $$add$ptr166 i32)
-    (local $$add$ptr24$i$i i32)
-    (local $$add$ptr4$i$i i32)
-    (local $$add$ptr4$i$i$i i32)
-    (local $$add$ptr95 i32)
-    (local $$add150$i i32)
-    (local $$add54$i i32)
-    (local $$add64 i32)
-    (local $$add8 i32)
-    (local $$and104$i i32)
-    (local $$and3$i i32)
-    (local $$and37$i$i i32)
-    (local $$and46 i32)
-    (local $$and64$i i32)
-    (local $$and73$i i32)
-    (local $$arrayidx i32)
-    (local $$arrayidx126$i$i$lcssa i32)
-    (local $$arrayidx325$i$i$lcssa i32)
-    (local $$arrayidx394$i$lcssa i32)
-    (local $$arrayidx66 i32)
-    (local $$call132$i i32)
-    (local $$child$i$i i32)
-    (local $$cmp102$i i32)
-    (local $$cmp32$i i32)
-    (local $$fd68$pre$phi$i$iZ2D i32)
-    (local $$head$i$17$i i32)
-    (local $$p$0$i$i i32)
-    (local $$rst$0$i i32)
-    (local $$rst$1$i i32)
-    (local $$shr$i$139 i32)
-    (local $$shr$i$45$i i32)
-    (local $$shr$i$i i32)
-    (local $$shr214$i$i i32)
-    (local $$shr253$i$i i32)
-    (local $$shr283$i i32)
-    (local $$shr318$i i32)
-    (local $$shr58$i$i i32)
-    (local $$sp$1107$i$lcssa i32)
-    (local $$sub$i$138 i32)
-    (local $$sub33$i i32)
-    (local $$sub5$i$i i32)
-    (local $$sub5$i$i$i i32)
-    (local $$v$0$i$153 i32)
-    (local $$$lcssa i32)
-    (local $$$lcssa290 i32)
-    (local $$1 i32)
-    (local $$100 i32)
-    (local $$101 i32)
-    (local $$102 i32)
-    (local $$105 i32)
-    (local $$107 i32)
-    (local $$109 i32)
-    (local $$110 i32)
-    (local $$111 i32)
-    (local $$115 i32)
-    (local $$120 i32)
-    (local $$124 i32)
-    (local $$127 i32)
-    (local $$128 i32)
-    (local $$129 i32)
-    (local $$132 i32)
-    (local $$135 i32)
-    (local $$137 i32)
-    (local $$140 i32)
-    (local $$142 i32)
-    (local $$15 i32)
-    (local $$159 i32)
-    (local $$16 i32)
-    (local $$160 i32)
-    (local $$161 i32)
-    (local $$162 i32)
-    (local $$163 i32)
-    (local $$168 i32)
-    (local $$17 i32)
-    (local $$173 i32)
-    (local $$174 i32)
-    (local $$175 i32)
-    (local $$177 i32)
-    (local $$180 i32)
-    (local $$183 i32)
-    (local $$185 i32)
-    (local $$188 i32)
-    (local $$190 i32)
-    (local $$195 i32)
-    (local $$196 i32)
-    (local $$197 i32)
-    (local $$199 i32)
-    (local $$202 i32)
-    (local $$205 i32)
-    (local $$207 i32)
-    (local $$22 i32)
-    (local $$23 i32)
-    (local $$31 i32)
-    (local $$32 i32)
-    (local $$33 i32)
-    (local $$34 i32)
-    (local $$35 i32)
-    (local $$40 i32)
-    (local $$45 i32)
-    (local $$47 i32)
-    (local $$48 i32)
-    (local $$49 i32)
-    (local $$51 i32)
-    (local $$52 i32)
-    (local $$59 i32)
-    (local $$60 i32)
-    (local $$68 i32)
-    (local $$69 i32)
-    (local $$7 i32)
-    (local $$70 i32)
-    (local $$71 i32)
-    (local $$72 i32)
-    (local $$77 i32)
-    (local $$8 i32)
-    (local $$82 i32)
-    (local $$83 i32)
-    (local $$84 i32)
-    (local $$86 i32)
-    (local $$89 i32)
-    (local $$92 i32)
-    (local $$97 i32)
-    (local $$R$1$i$168$lcssa i32)
-    (local $$R$1$i$i$lcssa i32)
-    (local $$R$1$i$lcssa i32)
-    (local $$T$0$i$58$i$lcssa283 i32)
-    (local $$T$0$i$i$lcssa284 i32)
-    (local $$T$0$i$lcssa293 i32)
-    (local $$add$i$180 i32)
-    (local $$add$i$i i32)
-    (local $$add$ptr$i$i$i i32)
-    (local $$add$ptr193 i32)
-    (local $$add$ptr2$i$i i32)
-    (local $$add$ptr262$i i32)
-    (local $$add$ptr7$i$i i32)
-    (local $$add$ptr8$i122$i i32)
-    (local $$add144 i32)
-    (local $$add17$i i32)
-    (local $$add17$i$183 i32)
-    (local $$add177$i i32)
-    (local $$add246$i i32)
-    (local $$add268$i i32)
-    (local $$add278$i$i i32)
-    (local $$add346$i i32)
-    (local $$add83$i$i i32)
-    (local $$add9$i i32)
-    (local $$and$i$143 i32)
-    (local $$and12$i i32)
-    (local $$and13$i i32)
-    (local $$and17$i i32)
-    (local $$and209$i$i i32)
-    (local $$and264$i$i i32)
-    (local $$and268$i$i i32)
-    (local $$and273$i$i i32)
-    (local $$and32$i i32)
-    (local $$and331$i i32)
-    (local $$and336$i i32)
-    (local $$and341$i i32)
-    (local $$and41 i32)
-    (local $$and49 i32)
-    (local $$and53 i32)
-    (local $$and57 i32)
-    (local $$and6$i i32)
-    (local $$and61 i32)
-    (local $$and69$i$i i32)
-    (local $$and73$i$i i32)
-    (local $$and77$i i32)
-    (local $$and78$i$i i32)
-    (local $$and8$i i32)
-    (local $$and81$i i32)
-    (local $$and85$i i32)
-    (local $$and89$i i32)
-    (local $$and9$i i32)
-    (local $$arrayidx$i$48$i i32)
-    (local $$arrayidx103$i$i i32)
-    (local $$arrayidx107$i$i i32)
-    (local $$arrayidx113$i i32)
-    (local $$arrayidx123$i$i i32)
-    (local $$arrayidx126$i$i i32)
-    (local $$arrayidx143$i$i i32)
-    (local $$arrayidx151$i i32)
-    (local $$arrayidx155$i i32)
-    (local $$arrayidx161$i i32)
-    (local $$arrayidx165$i$169 i32)
-    (local $$arrayidx184$i i32)
-    (local $$arrayidx204$i i32)
-    (local $$arrayidx325$i$i i32)
-    (local $$arrayidx394$i i32)
-    (local $$arrayidx61$i i32)
-    (local $$arrayidx65$i i32)
-    (local $$arrayidx71$i i32)
-    (local $$arrayidx75$i i32)
-    (local $$arrayidx94$i i32)
-    (local $$arrayidx96$i$i i32)
-    (local $$base$i$i$lcssa i32)
-    (local $$base226$i$lcssa i32)
-    (local $$bk i32)
-    (local $$bk136$i i32)
-    (local $$bk47$i i32)
-    (local $$bk78 i32)
-    (local $$bk82$i$i i32)
-    (local $$call68$i i32)
-    (local $$child166$i$i i32)
-    (local $$child289$i$i i32)
-    (local $$child357$i i32)
-    (local $$cmp$i$13$i i32)
-    (local $$cmp$i$15$i i32)
-    (local $$cmp$i$2$i$i i32)
-    (local $$cmp$i$23$i i32)
-    (local $$cmp$i$34$i i32)
-    (local $$cmp45$i$155 i32)
-    (local $$cmp49$i i32)
-    (local $$cmp7$i$i i32)
-    (local $$cmp9$i$i i32)
-    (local $$cond$i$25$i i32)
-    (local $$cond$i$i i32)
-    (local $$cond$i$i$i i32)
-    (local $$fd139$i i32)
-    (local $$fd148$i$i i32)
-    (local $$fd344$i$i i32)
-    (local $$fd416$i i32)
-    (local $$fd50$i i32)
-    (local $$fd59$i$i i32)
-    (local $$fd69 i32)
-    (local $$fd85$i$i i32)
-    (local $$fd9 i32)
-    (local $$head179 i32)
-    (local $$head182$i i32)
-    (local $$head208$i$i i32)
-    (local $$head25 i32)
-    (local $$head274$i i32)
-    (local $$inc$i$i i32)
-    (local $$neg$i$182 i32)
-    (local $$or$cond4$i i32)
-    (local $$or180 i32)
-    (local $$or183$i i32)
-    (local $$or26 i32)
-    (local $$or275$i i32)
-    (local $$shl$i$144 i32)
-    (local $$shl105 i32)
-    (local $$shl127$i$i i32)
-    (local $$shl18$i i32)
-    (local $$shl198$i i32)
-    (local $$shl22 i32)
-    (local $$shl226$i$i i32)
-    (local $$shl265$i$i i32)
-    (local $$shl270$i$i i32)
-    (local $$shl279$i$i i32)
-    (local $$shl291$i i32)
-    (local $$shl294$i$i i32)
-    (local $$shl326$i$i i32)
-    (local $$shl333$i i32)
-    (local $$shl338$i i32)
-    (local $$shl347$i i32)
-    (local $$shl362$i i32)
-    (local $$shl37 i32)
-    (local $$shl39$i$i i32)
-    (local $$shl395$i i32)
-    (local $$shl60$i i32)
-    (local $$shl70$i$i i32)
-    (local $$shl75$i$i i32)
-    (local $$shl84$i$i i32)
-    (local $$shl9$i i32)
-    (local $$shl95$i$i i32)
-    (local $$shr101 i32)
-    (local $$shr11$i i32)
-    (local $$shr15$i i32)
-    (local $$shr194$i i32)
-    (local $$shr4$i i32)
-    (local $$shr47 i32)
-    (local $$shr51 i32)
-    (local $$shr55 i32)
-    (local $$shr59 i32)
-    (local $$shr7$i i32)
-    (local $$shr75$i i32)
-    (local $$shr79$i i32)
-    (local $$shr83$i i32)
-    (local $$shr87$i i32)
-    (local $$size$i$i i32)
-    (local $$size$i$i$lcssa i32)
-    (local $$size188$i i32)
-    (local $$size188$i$lcssa i32)
-    (local $$size245$i i32)
-    (local $$sizebits$0$shl52$i i32)
-    (local $$sp$0108$i$lcssa i32)
-    (local $$sub i32)
-    (local $$sub$i$181 i32)
-    (local $$sub$ptr$sub$i i32)
-    (local $$sub$ptr$sub$i$41$i i32)
-    (local $$sub101$i i32)
-    (local $$sub112$i i32)
-    (local $$sub190 i32)
-    (local $$sub2$i i32)
-    (local $$sub260$i i32)
-    (local $$sub31$i i32)
-    (local $$sub41$i i32)
-    (local $$sub42 i32)
-    (local $$sub44 i32)
-    (local $$sub63$i i32)
-    (local $$sub70$i i32)
-    (local $$t$4$ph$i i32)
+  (func $_malloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 i32)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
     (i32.load
       (i32.const 8)
     )
     (block $do-once$0
       (if
         (i32.lt_u
-          (get_local $$bytes)
+          (get_local $0)
           (i32.const 245)
         )
         (block
           (if
             (i32.ne
               (i32.and
-                (set_local $$shr3
+                (set_local $25
                   (i32.shr_u
-                    (set_local $$0
+                    (set_local $4
                       (i32.load
                         (i32.const 176)
                       )
                     )
-                    (set_local $$shr
+                    (set_local $22
                       (i32.shr_u
-                        (set_local $$cond
+                        (set_local $12
                           (select
                             (i32.const 16)
                             (i32.and
                               (i32.add
-                                (get_local $$bytes)
+                                (get_local $0)
                                 (i32.const 11)
                               )
                               (i32.const -8)
                             )
                             (i32.lt_u
-                              (get_local $$bytes)
+                              (get_local $0)
                               (i32.const 11)
                             )
                           )
@@ -11466,29 +10264,29 @@
               (i32.const 0)
             )
             (block
-              (set_local $$3
+              (set_local $2
                 (i32.load
-                  (set_local $$fd9
+                  (set_local $3
                     (i32.add
-                      (set_local $$2
+                      (set_local $1
                         (i32.load
-                          (set_local $$1
+                          (set_local $0
                             (i32.add
-                              (set_local $$arrayidx
+                              (set_local $8
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $$add8
+                                      (set_local $7
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $$shr3)
+                                              (get_local $25)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $$shr)
+                                          (get_local $22)
                                         )
                                       )
                                       (i32.const 1)
@@ -11509,17 +10307,17 @@
               )
               (if
                 (i32.eq
-                  (get_local $$arrayidx)
-                  (get_local $$3)
+                  (get_local $8)
+                  (get_local $2)
                 )
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $$0)
+                    (get_local $4)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $$add8)
+                        (get_local $7)
                       )
                       (i32.const -1)
                     )
@@ -11528,7 +10326,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$3)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -11538,23 +10336,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$bk
+                        (set_local $4
                           (i32.add
-                            (get_local $$3)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $$2)
+                      (get_local $1)
                     )
                     (block
                       (i32.store
-                        (get_local $$bk)
-                        (get_local $$arrayidx)
+                        (get_local $4)
+                        (get_local $8)
                       )
                       (i32.store
-                        (get_local $$1)
-                        (get_local $$3)
+                        (get_local $0)
+                        (get_local $2)
                       )
                     )
                     (call_import $_abort)
@@ -11562,25 +10360,25 @@
                 )
               )
               (i32.store offset=4
-                (get_local $$2)
+                (get_local $1)
                 (i32.or
-                  (set_local $$shl22
+                  (set_local $0
                     (i32.shl
-                      (get_local $$add8)
+                      (get_local $7)
                       (i32.const 3)
                     )
                   )
                   (i32.const 3)
                 )
               )
-              (set_local $$or26
+              (set_local $1
                 (i32.or
                   (i32.load
-                    (set_local $$head25
+                    (set_local $0
                       (i32.add
                         (i32.add
-                          (get_local $$2)
-                          (get_local $$shl22)
+                          (get_local $1)
+                          (get_local $0)
                         )
                         (i32.const 4)
                       )
@@ -11590,18 +10388,18 @@
                 )
               )
               (i32.store
-                (get_local $$head25)
-                (get_local $$or26)
+                (get_local $0)
+                (get_local $1)
               )
               (return
-                (get_local $$fd9)
+                (get_local $3)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $$cond)
-              (set_local $$7
+              (get_local $12)
+              (set_local $11
                 (i32.load
                   (i32.const 184)
                 )
@@ -11610,46 +10408,46 @@
             (block
               (if
                 (i32.ne
-                  (get_local $$shr3)
+                  (get_local $25)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$sub
+                  (set_local $1
                     (i32.sub
                       (i32.const 0)
-                      (set_local $$shl37
+                      (set_local $0
                         (i32.shl
                           (i32.const 2)
-                          (get_local $$shr)
+                          (get_local $22)
                         )
                       )
                     )
                   )
-                  (set_local $$sub42
+                  (set_local $1
                     (i32.sub
                       (i32.const 0)
-                      (set_local $$and41
+                      (set_local $0
                         (i32.and
                           (i32.shl
-                            (get_local $$shr3)
-                            (get_local $$shr)
+                            (get_local $25)
+                            (get_local $22)
                           )
                           (i32.or
-                            (get_local $$shl37)
-                            (get_local $$sub)
+                            (get_local $0)
+                            (get_local $1)
                           )
                         )
                       )
                     )
                   )
-                  (set_local $$and46
+                  (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (set_local $$sub44
+                        (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $$and41)
-                              (get_local $$sub42)
+                              (get_local $0)
+                              (get_local $1)
                             )
                             (i32.const -1)
                           )
@@ -11659,32 +10457,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $$10
+                  (set_local $0
                     (i32.load
-                      (set_local $$fd69
+                      (set_local $3
                         (i32.add
-                          (set_local $$9
+                          (set_local $2
                             (i32.load
-                              (set_local $$8
+                              (set_local $1
                                 (i32.add
-                                  (set_local $$arrayidx66
+                                  (set_local $8
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $$add64
+                                          (set_local $7
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $$and49
+                                                      (set_local $1
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $$shr47
+                                                            (set_local $2
                                                               (i32.shr_u
-                                                                (get_local $$sub44)
-                                                                (get_local $$and46)
+                                                                (get_local $1)
+                                                                (get_local $0)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -11692,15 +10490,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $$and46)
+                                                      (get_local $0)
                                                     )
-                                                    (set_local $$and53
+                                                    (set_local $0
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $$shr51
+                                                          (set_local $1
                                                             (i32.shr_u
-                                                              (get_local $$shr47)
-                                                              (get_local $$and49)
+                                                              (get_local $2)
+                                                              (get_local $1)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -11709,13 +10507,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $$and57
+                                                  (set_local $0
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $$shr55
+                                                        (set_local $1
                                                           (i32.shr_u
-                                                            (get_local $$shr51)
-                                                            (get_local $$and53)
+                                                            (get_local $1)
+                                                            (get_local $0)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -11724,13 +10522,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $$and61
+                                                (set_local $0
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $$shr59
+                                                      (set_local $1
                                                         (i32.shr_u
-                                                          (get_local $$shr55)
-                                                          (get_local $$and57)
+                                                          (get_local $1)
+                                                          (get_local $0)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -11740,8 +10538,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $$shr59)
-                                                (get_local $$and61)
+                                                (get_local $1)
+                                                (get_local $0)
                                               )
                                             )
                                           )
@@ -11763,31 +10561,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $$arrayidx66)
-                      (get_local $$10)
+                      (get_local $8)
+                      (get_local $0)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $$0)
+                          (get_local $4)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $$add64)
+                              (get_local $7)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $$13
-                        (get_local $$7)
+                      (set_local $6
+                        (get_local $11)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $$10)
+                          (get_local $0)
                           (i32.load
                             (i32.const 192)
                           )
@@ -11797,25 +10595,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $$bk78
+                            (set_local $4
                               (i32.add
-                                (get_local $$10)
+                                (get_local $0)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $$9)
+                          (get_local $2)
                         )
                         (block
                           (i32.store
-                            (get_local $$bk78)
-                            (get_local $$arrayidx66)
+                            (get_local $4)
+                            (get_local $8)
                           )
                           (i32.store
-                            (get_local $$8)
-                            (get_local $$10)
+                            (get_local $1)
+                            (get_local $0)
                           )
-                          (set_local $$13
+                          (set_local $6
                             (i32.load
                               (i32.const 184)
                             )
@@ -11826,27 +10624,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$9)
+                    (get_local $2)
                     (i32.or
-                      (get_local $$cond)
+                      (get_local $12)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $$add$ptr95
+                    (set_local $4
                       (i32.add
-                        (get_local $$9)
-                        (get_local $$cond)
+                        (get_local $2)
+                        (get_local $12)
                       )
                     )
                     (i32.or
-                      (set_local $$sub91
+                      (set_local $8
                         (i32.sub
                           (i32.shl
-                            (get_local $$add64)
+                            (get_local $7)
                             (i32.const 3)
                           )
-                          (get_local $$cond)
+                          (get_local $12)
                         )
                       )
                       (i32.const 1)
@@ -11854,30 +10652,30 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $$add$ptr95)
-                      (get_local $$sub91)
+                      (get_local $4)
+                      (get_local $8)
                     )
-                    (get_local $$sub91)
+                    (get_local $8)
                   )
                   (if
                     (i32.ne
-                      (get_local $$13)
+                      (get_local $6)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$14
+                      (set_local $0
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $$arrayidx103
+                      (set_local $7
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (set_local $$shr101
+                              (set_local $2
                                 (i32.shr_u
-                                  (get_local $$13)
+                                  (get_local $6)
                                   (i32.const 3)
                                 )
                               )
@@ -11890,15 +10688,15 @@
                       (if
                         (i32.eq
                           (i32.and
-                            (set_local $$15
+                            (set_local $1
                               (i32.load
                                 (i32.const 176)
                               )
                             )
-                            (set_local $$shl105
+                            (set_local $2
                               (i32.shl
                                 (i32.const 1)
-                                (get_local $$shr101)
+                                (get_local $2)
                               )
                             )
                           )
@@ -11908,27 +10706,27 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $$15)
-                              (get_local $$shl105)
+                              (get_local $1)
+                              (get_local $2)
                             )
                           )
-                          (set_local $$$pre$phiZ2D
+                          (set_local $5
                             (i32.add
-                              (get_local $$arrayidx103)
+                              (get_local $7)
                               (i32.const 8)
                             )
                           )
-                          (set_local $$F104$0
-                            (get_local $$arrayidx103)
+                          (set_local $9
+                            (get_local $7)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $$17
+                            (set_local $2
                               (i32.load
-                                (set_local $$16
+                                (set_local $1
                                   (i32.add
-                                    (get_local $$arrayidx103)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
@@ -11940,69 +10738,69 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $$$pre$phiZ2D
-                              (get_local $$16)
+                            (set_local $5
+                              (get_local $1)
                             )
-                            (set_local $$F104$0
-                              (get_local $$17)
+                            (set_local $9
+                              (get_local $2)
                             )
                           )
                         )
                       )
                       (i32.store
-                        (get_local $$$pre$phiZ2D)
-                        (get_local $$14)
+                        (get_local $5)
+                        (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $$F104$0)
-                        (get_local $$14)
+                        (get_local $9)
+                        (get_local $0)
                       )
                       (i32.store offset=8
-                        (get_local $$14)
-                        (get_local $$F104$0)
+                        (get_local $0)
+                        (get_local $9)
                       )
                       (i32.store offset=12
-                        (get_local $$14)
-                        (get_local $$arrayidx103)
+                        (get_local $0)
+                        (get_local $7)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $$sub91)
+                    (get_local $8)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $$add$ptr95)
+                    (get_local $4)
                   )
                   (return
-                    (get_local $$fd69)
+                    (get_local $3)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (set_local $$19
+                  (set_local $0
                     (i32.load
                       (i32.const 180)
                     )
                   )
                   (i32.const 0)
                 )
-                (set_local $$nb$0
-                  (get_local $$cond)
+                (set_local $9
+                  (get_local $12)
                 )
                 (block
-                  (set_local $$and3$i
+                  (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (set_local $$sub2$i
+                        (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $$19)
+                              (get_local $0)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $$19)
+                                (get_local $0)
                               )
                             )
                             (i32.const -1)
@@ -12013,11 +10811,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $$rsize$0$i
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $$20
+                          (set_local $0
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -12025,13 +10823,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $$and6$i
+                                          (set_local $1
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $$shr4$i
+                                                (set_local $2
                                                   (i32.shr_u
-                                                    (get_local $$sub2$i)
-                                                    (get_local $$and3$i)
+                                                    (get_local $1)
+                                                    (get_local $0)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -12039,15 +10837,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $$and3$i)
+                                          (get_local $0)
                                         )
-                                        (set_local $$and9$i
+                                        (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $$shr7$i
+                                              (set_local $1
                                                 (i32.shr_u
-                                                  (get_local $$shr4$i)
-                                                  (get_local $$and6$i)
+                                                  (get_local $2)
+                                                  (get_local $1)
                                                 )
                                               )
                                               (i32.const 2)
@@ -12056,13 +10854,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $$and13$i
+                                      (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $$shr11$i
+                                            (set_local $1
                                               (i32.shr_u
-                                                (get_local $$shr7$i)
-                                                (get_local $$and9$i)
+                                                (get_local $1)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -12071,13 +10869,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $$and17$i
+                                    (set_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $$shr15$i
+                                          (set_local $1
                                             (i32.shr_u
-                                              (get_local $$shr11$i)
-                                              (get_local $$and13$i)
+                                              (get_local $1)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -12087,8 +10885,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $$shr15$i)
-                                    (get_local $$and17$i)
+                                    (get_local $1)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 2)
@@ -12098,90 +10896,90 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $$cond)
+                      (get_local $12)
                     )
                   )
-                  (set_local $$t$0$i
-                    (get_local $$20)
+                  (set_local $4
+                    (get_local $0)
                   )
-                  (set_local $$v$0$i
-                    (get_local $$20)
+                  (set_local $7
+                    (get_local $0)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
                       (i32.eq
-                        (set_local $$22
+                        (set_local $0
                           (i32.load offset=16
-                            (get_local $$t$0$i)
+                            (get_local $4)
                           )
                         )
                         (i32.const 0)
                       )
                       (if
                         (i32.eq
-                          (set_local $$23
+                          (set_local $0
                             (i32.load offset=20
-                              (get_local $$t$0$i)
+                              (get_local $4)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$rsize$0$i$lcssa
-                            (get_local $$rsize$0$i)
+                          (set_local $6
+                            (get_local $2)
                           )
-                          (set_local $$v$0$i$lcssa
-                            (get_local $$v$0$i)
+                          (set_local $11
+                            (get_local $7)
                           )
                           (br $while-out$6)
                         )
-                        (set_local $$cond4$i
-                          (get_local $$23)
+                        (set_local $1
+                          (get_local $0)
                         )
                       )
-                      (set_local $$cond4$i
-                        (get_local $$22)
+                      (set_local $1
+                        (get_local $0)
                       )
                     )
-                    (set_local $$cmp32$i
+                    (set_local $0
                       (i32.lt_u
-                        (set_local $$sub31$i
+                        (set_local $4
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $$cond4$i)
+                                (get_local $1)
                               )
                               (i32.const -8)
                             )
-                            (get_local $$cond)
+                            (get_local $12)
                           )
                         )
-                        (get_local $$rsize$0$i)
+                        (get_local $2)
                       )
                     )
-                    (set_local $$rsize$0$i
+                    (set_local $2
                       (select
-                        (get_local $$sub31$i)
-                        (get_local $$rsize$0$i)
-                        (get_local $$cmp32$i)
+                        (get_local $4)
+                        (get_local $2)
+                        (get_local $0)
                       )
                     )
-                    (set_local $$t$0$i
-                      (get_local $$cond4$i)
+                    (set_local $4
+                      (get_local $1)
                     )
-                    (set_local $$v$0$i
+                    (set_local $7
                       (select
-                        (get_local $$cond4$i)
-                        (get_local $$v$0$i)
-                        (get_local $$cmp32$i)
+                        (get_local $1)
+                        (get_local $7)
+                        (get_local $0)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$v$0$i$lcssa)
-                      (set_local $$25
+                      (get_local $11)
+                      (set_local $0
                         (i32.load
                           (i32.const 192)
                         )
@@ -12191,39 +10989,39 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $$v$0$i$lcssa)
-                      (set_local $$add$ptr$i
+                      (get_local $11)
+                      (set_local $8
                         (i32.add
-                          (get_local $$v$0$i$lcssa)
-                          (get_local $$cond)
+                          (get_local $11)
+                          (get_local $12)
                         )
                       )
                     )
                     (call_import $_abort)
                   )
-                  (set_local $$26
+                  (set_local $1
                     (i32.load offset=24
-                      (get_local $$v$0$i$lcssa)
+                      (get_local $11)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $$27
+                        (set_local $2
                           (i32.load offset=12
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                           )
                         )
-                        (get_local $$v$0$i$lcssa)
+                        (get_local $11)
                       )
                       (block
                         (if
                           (i32.eq
-                            (set_local $$31
+                            (set_local $2
                               (i32.load
-                                (set_local $$arrayidx61$i
+                                (set_local $7
                                   (i32.add
-                                    (get_local $$v$0$i$lcssa)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
@@ -12233,11 +11031,11 @@
                           )
                           (if
                             (i32.eq
-                              (set_local $$32
+                              (set_local $2
                                 (i32.load
-                                  (set_local $$arrayidx65$i
+                                  (set_local $7
                                     (i32.add
-                                      (get_local $$v$0$i$lcssa)
+                                      (get_local $11)
                                       (i32.const 16)
                                     )
                                   )
@@ -12246,37 +11044,33 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $$R$3$i
+                              (set_local $14
                                 (i32.const 0)
                               )
                               (br $do-once$8)
                             )
                             (block
-                              (set_local $$R$1$i
-                                (get_local $$32)
+                              (set_local $4
+                                (get_local $2)
                               )
-                              (set_local $$RP$1$i
-                                (get_local $$arrayidx65$i)
-                              )
+                              (get_local $7)
                             )
                           )
                           (block
-                            (set_local $$R$1$i
-                              (get_local $$31)
+                            (set_local $4
+                              (get_local $2)
                             )
-                            (set_local $$RP$1$i
-                              (get_local $$arrayidx61$i)
-                            )
+                            (get_local $7)
                           )
                         )
                         (loop $while-out$10 $while-in$11
                           (if
                             (i32.ne
-                              (set_local $$33
+                              (set_local $2
                                 (i32.load
-                                  (set_local $$arrayidx71$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$R$1$i)
+                                      (get_local $4)
                                       (i32.const 20)
                                     )
                                   )
@@ -12285,22 +11079,22 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $$R$1$i
-                                (get_local $$33)
+                              (set_local $4
+                                (get_local $2)
                               )
-                              (set_local $$RP$1$i
-                                (get_local $$arrayidx71$i)
+                              (set_local $7
+                                (get_local $5)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
                             (i32.eq
-                              (set_local $$34
+                              (set_local $2
                                 (i32.load
-                                  (set_local $$arrayidx75$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$R$1$i)
+                                      (get_local $4)
                                       (i32.const 16)
                                     )
                                   )
@@ -12309,20 +11103,20 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $$R$1$i$lcssa
-                                (get_local $$R$1$i)
+                              (set_local $2
+                                (get_local $4)
                               )
-                              (set_local $$RP$1$i$lcssa
-                                (get_local $$RP$1$i)
+                              (set_local $4
+                                (get_local $7)
                               )
                               (br $while-out$10)
                             )
                             (block
-                              (set_local $$R$1$i
-                                (get_local $$34)
+                              (set_local $4
+                                (get_local $2)
                               )
-                              (set_local $$RP$1$i
-                                (get_local $$arrayidx75$i)
+                              (set_local $7
+                                (get_local $5)
                               )
                             )
                           )
@@ -12330,17 +11124,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $$RP$1$i$lcssa)
-                            (get_local $$25)
+                            (get_local $4)
+                            (get_local $0)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $$RP$1$i$lcssa)
+                              (get_local $4)
                               (i32.const 0)
                             )
-                            (set_local $$R$3$i
-                              (get_local $$R$1$i$lcssa)
+                            (set_local $14
+                              (get_local $2)
                             )
                           )
                         )
@@ -12348,52 +11142,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $$28
+                            (set_local $4
                               (i32.load offset=8
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                             )
-                            (get_local $$25)
+                            (get_local $0)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $$bk47$i
+                              (set_local $0
                                 (i32.add
-                                  (get_local $$28)
+                                  (get_local $4)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $$fd50$i
+                              (set_local $7
                                 (i32.add
-                                  (get_local $$27)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                           )
                           (block
                             (i32.store
-                              (get_local $$bk47$i)
-                              (get_local $$27)
+                              (get_local $0)
+                              (get_local $2)
                             )
                             (i32.store
-                              (get_local $$fd50$i)
-                              (get_local $$28)
+                              (get_local $7)
+                              (get_local $4)
                             )
-                            (set_local $$R$3$i
-                              (get_local $$27)
+                            (set_local $14
+                              (get_local $2)
                             )
                           )
                           (call_import $_abort)
@@ -12404,21 +11198,21 @@
                   (block $do-once$12
                     (if
                       (i32.ne
-                        (get_local $$26)
+                        (get_local $1)
                         (i32.const 0)
                       )
                       (block
                         (if
                           (i32.eq
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                             (i32.load
-                              (set_local $$arrayidx94$i
+                              (set_local $2
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (set_local $$35
+                                    (set_local $0
                                       (i32.load offset=28
-                                        (get_local $$v$0$i$lcssa)
+                                        (get_local $11)
                                       )
                                     )
                                     (i32.const 2)
@@ -12429,12 +11223,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $$arrayidx94$i)
-                              (get_local $$R$3$i)
+                              (get_local $2)
+                              (get_local $14)
                             )
                             (if
                               (i32.eq
-                                (get_local $$R$3$i)
+                                (get_local $14)
                                 (i32.const 0)
                               )
                               (block
@@ -12447,7 +11241,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $$35)
+                                        (get_local $0)
                                       )
                                       (i32.const -1)
                                     )
@@ -12460,7 +11254,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $$26)
+                                (get_local $1)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -12470,27 +11264,27 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $$arrayidx113$i
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $$26)
+                                      (get_local $1)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                               (i32.store
-                                (get_local $$arrayidx113$i)
-                                (get_local $$R$3$i)
+                                (get_local $0)
+                                (get_local $14)
                               )
                               (i32.store offset=20
-                                (get_local $$26)
-                                (get_local $$R$3$i)
+                                (get_local $1)
+                                (get_local $14)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eq
-                                (get_local $$R$3$i)
+                                (get_local $14)
                                 (i32.const 0)
                               )
                             )
@@ -12498,8 +11292,8 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $$R$3$i)
-                            (set_local $$40
+                            (get_local $14)
+                            (set_local $0
                               (i32.load
                                 (i32.const 192)
                               )
@@ -12508,48 +11302,48 @@
                           (call_import $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $$R$3$i)
-                          (get_local $$26)
+                          (get_local $14)
+                          (get_local $1)
                         )
                         (if
                           (i32.ne
-                            (set_local $$41
+                            (set_local $1
                               (i32.load offset=16
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                             )
                             (i32.const 0)
                           )
                           (if
                             (i32.lt_u
-                              (get_local $$41)
-                              (get_local $$40)
+                              (get_local $1)
+                              (get_local $0)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $$R$3$i)
-                                (get_local $$41)
+                                (get_local $14)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $$41)
-                                (get_local $$R$3$i)
+                                (get_local $1)
+                                (get_local $14)
                               )
                             )
                           )
                         )
                         (if
                           (i32.ne
-                            (set_local $$42
+                            (set_local $0
                               (i32.load offset=20
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                             )
                             (i32.const 0)
                           )
                           (if
                             (i32.lt_u
-                              (get_local $$42)
+                              (get_local $0)
                               (i32.load
                                 (i32.const 192)
                               )
@@ -12557,12 +11351,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $$R$3$i)
-                                (get_local $$42)
+                                (get_local $14)
+                                (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $$42)
-                                (get_local $$R$3$i)
+                                (get_local $0)
+                                (get_local $14)
                               )
                             )
                           )
@@ -12572,30 +11366,30 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$rsize$0$i$lcssa)
+                      (get_local $6)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $$v$0$i$lcssa)
+                        (get_local $11)
                         (i32.or
-                          (set_local $$add177$i
+                          (set_local $0
                             (i32.add
-                              (get_local $$rsize$0$i$lcssa)
-                              (get_local $$cond)
+                              (get_local $6)
+                              (get_local $12)
                             )
                           )
                           (i32.const 3)
                         )
                       )
-                      (set_local $$or183$i
+                      (set_local $1
                         (i32.or
                           (i32.load
-                            (set_local $$head182$i
+                            (set_local $0
                               (i32.add
                                 (i32.add
-                                  (get_local $$v$0$i$lcssa)
-                                  (get_local $$add177$i)
+                                  (get_local $11)
+                                  (get_local $0)
                                 )
                                 (i32.const 4)
                               )
@@ -12605,35 +11399,35 @@
                         )
                       )
                       (i32.store
-                        (get_local $$head182$i)
-                        (get_local $$or183$i)
+                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $$v$0$i$lcssa)
+                        (get_local $11)
                         (i32.or
-                          (get_local $$cond)
+                          (get_local $12)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $$add$ptr$i)
+                        (get_local $8)
                         (i32.or
-                          (get_local $$rsize$0$i$lcssa)
+                          (get_local $6)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $$add$ptr$i)
-                          (get_local $$rsize$0$i$lcssa)
+                          (get_local $8)
+                          (get_local $6)
                         )
-                        (get_local $$rsize$0$i$lcssa)
+                        (get_local $6)
                       )
                       (if
                         (i32.ne
-                          (set_local $$45
+                          (set_local $0
                             (i32.load
                               (i32.const 184)
                             )
@@ -12641,19 +11435,19 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$46
+                          (set_local $1
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $$arrayidx196$i
+                          (set_local $4
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $$shr194$i
+                                  (set_local $2
                                     (i32.shr_u
-                                      (get_local $$45)
+                                      (get_local $0)
                                       (i32.const 3)
                                     )
                                   )
@@ -12666,15 +11460,15 @@
                           (if
                             (i32.eq
                               (i32.and
-                                (set_local $$47
+                                (set_local $0
                                   (i32.load
                                     (i32.const 176)
                                   )
                                 )
-                                (set_local $$shl198$i
+                                (set_local $2
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $$shr194$i)
+                                    (get_local $2)
                                   )
                                 )
                               )
@@ -12684,27 +11478,27 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $$47)
-                                  (get_local $$shl198$i)
+                                  (get_local $0)
+                                  (get_local $2)
                                 )
                               )
-                              (set_local $$$pre$phi$iZ2D
+                              (set_local $3
                                 (i32.add
-                                  (get_local $$arrayidx196$i)
+                                  (get_local $4)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $$F197$0$i
-                                (get_local $$arrayidx196$i)
+                              (set_local $13
+                                (get_local $4)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $$49
+                                (set_local $2
                                   (i32.load
-                                    (set_local $$48
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $$arrayidx196$i)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
@@ -12716,71 +11510,71 @@
                               )
                               (call_import $_abort)
                               (block
-                                (set_local $$$pre$phi$iZ2D
-                                  (get_local $$48)
+                                (set_local $3
+                                  (get_local $0)
                                 )
-                                (set_local $$F197$0$i
-                                  (get_local $$49)
+                                (set_local $13
+                                  (get_local $2)
                                 )
                               )
                             )
                           )
                           (i32.store
-                            (get_local $$$pre$phi$iZ2D)
-                            (get_local $$46)
+                            (get_local $3)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $$F197$0$i)
-                            (get_local $$46)
+                            (get_local $13)
+                            (get_local $1)
                           )
                           (i32.store offset=8
-                            (get_local $$46)
-                            (get_local $$F197$0$i)
+                            (get_local $1)
+                            (get_local $13)
                           )
                           (i32.store offset=12
-                            (get_local $$46)
-                            (get_local $$arrayidx196$i)
+                            (get_local $1)
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $$rsize$0$i$lcssa)
+                        (get_local $6)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $$add$ptr$i)
+                        (get_local $8)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $$v$0$i$lcssa)
+                      (get_local $11)
                       (i32.const 8)
                     )
                   )
                 )
               )
             )
-            (set_local $$nb$0
-              (get_local $$cond)
+            (set_local $9
+              (get_local $12)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $$bytes)
+            (get_local $0)
             (i32.const -65)
           )
-          (set_local $$nb$0
+          (set_local $9
             (i32.const -1)
           )
           (block
-            (set_local $$and145
+            (set_local $5
               (i32.and
-                (set_local $$add144
+                (set_local $3
                   (i32.add
-                    (get_local $$bytes)
+                    (get_local $0)
                     (i32.const 11)
                   )
                 )
@@ -12789,35 +11583,35 @@
             )
             (if
               (i32.eq
-                (set_local $$51
+                (set_local $0
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (i32.const 0)
               )
-              (set_local $$nb$0
-                (get_local $$and145)
+              (set_local $9
+                (get_local $5)
               )
               (block
-                (set_local $$sub$i$138
+                (set_local $13
                   (i32.sub
                     (i32.const 0)
-                    (get_local $$and145)
+                    (get_local $5)
                   )
                 )
                 (block $label$break$L123
                   (if
                     (i32.eq
-                      (set_local $$52
+                      (set_local $3
                         (i32.load offset=480
                           (i32.shl
-                            (set_local $$idx$0$i
+                            (set_local $9
                               (if
                                 (i32.eq
-                                  (set_local $$shr$i$139
+                                  (set_local $3
                                     (i32.shr_u
-                                      (get_local $$add144)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
@@ -12826,31 +11620,31 @@
                                 (i32.const 0)
                                 (if
                                   (i32.gt_u
-                                    (get_local $$and145)
+                                    (get_local $5)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (block
-                                    (set_local $$shl18$i
+                                    (set_local $6
                                       (i32.shl
-                                        (set_local $$add17$i
+                                        (set_local $3
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (set_local $$and8$i
+                                                  (set_local $6
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $$shl$i$144
+                                                          (set_local $9
                                                             (i32.shl
-                                                              (get_local $$shr$i$139)
-                                                              (set_local $$and$i$143
+                                                              (get_local $3)
+                                                              (set_local $3
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $$shr$i$139)
+                                                                      (get_local $3)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -12867,16 +11661,16 @@
                                                       (i32.const 4)
                                                     )
                                                   )
-                                                  (get_local $$and$i$143)
+                                                  (get_local $3)
                                                 )
-                                                (set_local $$and12$i
+                                                (set_local $3
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $$shl9$i
+                                                        (set_local $6
                                                           (i32.shl
-                                                            (get_local $$shl$i$144)
-                                                            (get_local $$and8$i)
+                                                            (get_local $9)
+                                                            (get_local $6)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -12890,8 +11684,8 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $$shl9$i)
-                                                (get_local $$and12$i)
+                                                (get_local $6)
+                                                (get_local $3)
                                               )
                                               (i32.const 15)
                                             )
@@ -12903,15 +11697,15 @@
                                     (i32.or
                                       (i32.and
                                         (i32.shr_u
-                                          (get_local $$and145)
+                                          (get_local $5)
                                           (i32.add
-                                            (get_local $$add17$i)
+                                            (get_local $3)
                                             (i32.const 7)
                                           )
                                         )
                                         (i32.const 1)
                                       )
-                                      (get_local $$shl18$i)
+                                      (get_local $6)
                                     )
                                   )
                                 )
@@ -12924,135 +11718,131 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$rsize$3$i
-                        (get_local $$sub$i$138)
+                      (set_local $35
+                        (get_local $13)
                       )
-                      (set_local $$t$2$i
+                      (set_local $36
                         (i32.const 0)
                       )
-                      (set_local $$v$3$i
+                      (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $label
+                      (set_local $10
                         (i32.const 86)
                       )
                     )
                     (block
-                      (set_local $$rsize$0$i$152
-                        (get_local $$sub$i$138)
+                      (set_local $6
+                        (get_local $13)
                       )
-                      (set_local $$rst$0$i
+                      (set_local $14
                         (i32.const 0)
                       )
-                      (set_local $$sizebits$0$i
+                      (set_local $10
                         (i32.shl
-                          (get_local $$and145)
+                          (get_local $5)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $$idx$0$i)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $$idx$0$i)
+                              (get_local $9)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $$t$0$i$151
-                        (get_local $$52)
+                      (set_local $23
+                        (get_local $3)
                       )
-                      (set_local $$v$0$i$153
+                      (set_local $29
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $$sub33$i
+                            (set_local $13
                               (i32.sub
-                                (set_local $$and32$i
+                                (set_local $3
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $$t$0$i$151)
+                                      (get_local $23)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $$and145)
+                                (get_local $5)
                               )
                             )
-                            (get_local $$rsize$0$i$152)
+                            (get_local $6)
                           )
                           (if
                             (i32.eq
-                              (get_local $$and32$i)
-                              (get_local $$and145)
+                              (get_local $3)
+                              (get_local $5)
                             )
                             (block
-                              (set_local $$rsize$49$i
-                                (get_local $$sub33$i)
+                              (set_local $26
+                                (get_local $13)
                               )
-                              (set_local $$t$48$i
-                                (get_local $$t$0$i$151)
+                              (set_local $24
+                                (get_local $23)
                               )
-                              (set_local $$v$410$i
-                                (get_local $$t$0$i$151)
+                              (set_local $31
+                                (get_local $23)
                               )
-                              (set_local $label
+                              (set_local $10
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $$rsize$1$i
-                                (get_local $$sub33$i)
-                              )
-                              (set_local $$v$1$i
-                                (get_local $$t$0$i$151)
+                              (get_local $13)
+                              (set_local $29
+                                (get_local $23)
                               )
                             )
                           )
                           (block
-                            (set_local $$rsize$1$i
-                              (get_local $$rsize$0$i$152)
+                            (set_local $13
+                              (get_local $6)
                             )
-                            (set_local $$v$1$i
-                              (get_local $$v$0$i$153)
-                            )
+                            (get_local $29)
                           )
                         )
-                        (set_local $$cmp45$i$155
+                        (set_local $6
                           (i32.eq
-                            (set_local $$54
+                            (set_local $3
                               (i32.load offset=20
-                                (get_local $$t$0$i$151)
+                                (get_local $23)
                               )
                             )
                             (i32.const 0)
                           )
                         )
-                        (set_local $$rst$1$i
+                        (set_local $14
                           (select
-                            (get_local $$rst$0$i)
-                            (get_local $$54)
+                            (get_local $14)
+                            (get_local $3)
                             (i32.or
-                              (get_local $$cmp45$i$155)
+                              (get_local $6)
                               (i32.eq
-                                (get_local $$54)
-                                (set_local $$55
+                                (get_local $3)
+                                (set_local $3
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $$t$0$i$151)
+                                        (get_local $23)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $$sizebits$0$i)
+                                          (get_local $10)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -13064,14 +11854,14 @@
                             )
                           )
                         )
-                        (set_local $$sizebits$0$shl52$i
+                        (set_local $10
                           (i32.shl
-                            (get_local $$sizebits$0$i)
+                            (get_local $10)
                             (i32.xor
                               (i32.and
-                                (set_local $$cmp49$i
+                                (set_local $6
                                   (i32.eq
-                                    (get_local $$55)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -13082,38 +11872,32 @@
                           )
                         )
                         (if
-                          (get_local $$cmp49$i)
+                          (get_local $6)
                           (block
-                            (set_local $$rsize$3$i
-                              (get_local $$rsize$1$i)
+                            (set_local $35
+                              (get_local $13)
                             )
-                            (set_local $$t$2$i
-                              (get_local $$rst$1$i)
+                            (set_local $36
+                              (get_local $14)
                             )
-                            (set_local $$v$3$i
-                              (get_local $$v$1$i)
+                            (set_local $30
+                              (get_local $29)
                             )
-                            (set_local $label
+                            (set_local $10
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $$rsize$0$i$152
-                              (get_local $$rsize$1$i)
+                            (set_local $6
+                              (get_local $13)
                             )
-                            (set_local $$rst$0$i
-                              (get_local $$rst$1$i)
+                            (get_local $14)
+                            (get_local $10)
+                            (set_local $23
+                              (get_local $3)
                             )
-                            (set_local $$sizebits$0$i
-                              (get_local $$sizebits$0$shl52$i)
-                            )
-                            (set_local $$t$0$i$151
-                              (get_local $$55)
-                            )
-                            (set_local $$v$0$i$153
-                              (get_local $$v$1$i)
-                            )
+                            (get_local $29)
                           )
                         )
                         (br $while-in$18)
@@ -13123,65 +11907,65 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $label)
+                    (get_local $10)
                     (i32.const 86)
                   )
                   (if
                     (i32.eq
-                      (set_local $$t$4$ph$i
+                      (set_local $0
                         (if
                           (i32.and
                             (i32.eq
-                              (get_local $$t$2$i)
+                              (get_local $36)
                               (i32.const 0)
                             )
                             (i32.eq
-                              (get_local $$v$3$i)
+                              (get_local $30)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $$sub63$i
+                            (set_local $6
                               (i32.sub
                                 (i32.const 0)
-                                (set_local $$shl60$i
+                                (set_local $3
                                   (i32.shl
                                     (i32.const 2)
-                                    (get_local $$idx$0$i)
+                                    (get_local $9)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$and64$i
+                                (set_local $0
                                   (i32.and
-                                    (get_local $$51)
+                                    (get_local $0)
                                     (i32.or
-                                      (get_local $$shl60$i)
-                                      (get_local $$sub63$i)
+                                      (get_local $3)
+                                      (get_local $6)
                                     )
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$nb$0
-                                  (get_local $$and145)
+                                (set_local $9
+                                  (get_local $5)
                                 )
                                 (br $do-once$0)
                               )
                             )
-                            (set_local $$and73$i
+                            (set_local $0
                               (i32.and
                                 (i32.shr_u
-                                  (set_local $$sub70$i
+                                  (set_local $3
                                     (i32.add
                                       (i32.and
-                                        (get_local $$and64$i)
+                                        (get_local $0)
                                         (i32.sub
                                           (i32.const 0)
-                                          (get_local $$and64$i)
+                                          (get_local $0)
                                         )
                                       )
                                       (i32.const -1)
@@ -13199,13 +11983,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $$and77$i
+                                          (set_local $3
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $$shr75$i
+                                                (set_local $6
                                                   (i32.shr_u
-                                                    (get_local $$sub70$i)
-                                                    (get_local $$and73$i)
+                                                    (get_local $3)
+                                                    (get_local $0)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -13213,15 +11997,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $$and73$i)
+                                          (get_local $0)
                                         )
-                                        (set_local $$and81$i
+                                        (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $$shr79$i
+                                              (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $$shr75$i)
-                                                  (get_local $$and77$i)
+                                                  (get_local $6)
+                                                  (get_local $3)
                                                 )
                                               )
                                               (i32.const 2)
@@ -13230,13 +12014,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $$and85$i
+                                      (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $$shr83$i
+                                            (set_local $3
                                               (i32.shr_u
-                                                (get_local $$shr79$i)
-                                                (get_local $$and81$i)
+                                                (get_local $3)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -13245,13 +12029,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $$and89$i
+                                    (set_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $$shr87$i
+                                          (set_local $3
                                             (i32.shr_u
-                                              (get_local $$shr83$i)
-                                              (get_local $$and85$i)
+                                              (get_local $3)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -13261,38 +12045,38 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $$shr87$i)
-                                    (get_local $$and89$i)
+                                    (get_local $3)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 2)
                               )
                             )
                           )
-                          (get_local $$t$2$i)
+                          (get_local $36)
                         )
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$rsize$4$lcssa$i
-                        (get_local $$rsize$3$i)
+                      (set_local $17
+                        (get_local $35)
                       )
-                      (set_local $$v$4$lcssa$i
-                        (get_local $$v$3$i)
+                      (set_local $15
+                        (get_local $30)
                       )
                     )
                     (block
-                      (set_local $$rsize$49$i
-                        (get_local $$rsize$3$i)
+                      (set_local $26
+                        (get_local $35)
                       )
-                      (set_local $$t$48$i
-                        (get_local $$t$4$ph$i)
+                      (set_local $24
+                        (get_local $0)
                       )
-                      (set_local $$v$410$i
-                        (get_local $$v$3$i)
+                      (set_local $31
+                        (get_local $30)
                       )
-                      (set_local $label
+                      (set_local $10
                         (i32.const 90)
                       )
                     )
@@ -13300,99 +12084,95 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $label)
+                    (get_local $10)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $label
+                    (set_local $10
                       (i32.const 0)
                     )
-                    (set_local $$cmp102$i
+                    (set_local $0
                       (i32.lt_u
-                        (set_local $$sub101$i
+                        (set_local $3
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $$t$48$i)
+                                (get_local $24)
                               )
                               (i32.const -8)
                             )
-                            (get_local $$and145)
+                            (get_local $5)
                           )
                         )
-                        (get_local $$rsize$49$i)
+                        (get_local $26)
                       )
                     )
-                    (set_local $$sub101$rsize$4$i
+                    (set_local $3
                       (select
-                        (get_local $$sub101$i)
-                        (get_local $$rsize$49$i)
-                        (get_local $$cmp102$i)
+                        (get_local $3)
+                        (get_local $26)
+                        (get_local $0)
                       )
                     )
-                    (set_local $$t$4$v$4$i
+                    (set_local $6
                       (select
-                        (get_local $$t$48$i)
-                        (get_local $$v$410$i)
-                        (get_local $$cmp102$i)
+                        (get_local $24)
+                        (get_local $31)
+                        (get_local $0)
                       )
                     )
                     (if
                       (i32.ne
-                        (set_local $$59
+                        (set_local $0
                           (i32.load offset=16
-                            (get_local $$t$48$i)
+                            (get_local $24)
                           )
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$rsize$49$i
-                          (get_local $$sub101$rsize$4$i)
+                        (set_local $26
+                          (get_local $3)
                         )
-                        (set_local $$t$48$i
-                          (get_local $$59)
+                        (set_local $24
+                          (get_local $0)
                         )
-                        (set_local $$v$410$i
-                          (get_local $$t$4$v$4$i)
+                        (set_local $31
+                          (get_local $6)
                         )
-                        (set_local $label
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                         (br $while-in$20)
                       )
                     )
                     (if
                       (i32.eq
-                        (set_local $$60
+                        (set_local $0
                           (i32.load offset=20
-                            (get_local $$t$48$i)
+                            (get_local $24)
                           )
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$rsize$4$lcssa$i
-                          (get_local $$sub101$rsize$4$i)
+                        (set_local $17
+                          (get_local $3)
                         )
-                        (set_local $$v$4$lcssa$i
-                          (get_local $$t$4$v$4$i)
+                        (set_local $15
+                          (get_local $6)
                         )
                         (br $while-out$19)
                       )
                       (block
-                        (set_local $$rsize$49$i
-                          (get_local $$sub101$rsize$4$i)
+                        (set_local $26
+                          (get_local $3)
                         )
-                        (set_local $$t$48$i
-                          (get_local $$60)
+                        (set_local $24
+                          (get_local $0)
                         )
-                        (set_local $$v$410$i
-                          (get_local $$t$4$v$4$i)
+                        (set_local $31
+                          (get_local $6)
                         )
-                        (set_local $label
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                       )
                     )
                     (br $while-in$20)
@@ -13400,27 +12180,27 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $$v$4$lcssa$i)
+                    (get_local $15)
                     (i32.const 0)
                   )
-                  (set_local $$nb$0
-                    (get_local $$and145)
+                  (set_local $9
+                    (get_local $5)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$rsize$4$lcssa$i)
+                      (get_local $17)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $$and145)
+                        (get_local $5)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $$v$4$lcssa$i)
-                          (set_local $$62
+                          (get_local $15)
+                          (set_local $0
                             (i32.load
                               (i32.const 192)
                             )
@@ -13430,39 +12210,39 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $$v$4$lcssa$i)
-                          (set_local $$add$ptr$i$161
+                          (get_local $15)
+                          (set_local $3
                             (i32.add
-                              (get_local $$v$4$lcssa$i)
-                              (get_local $$and145)
+                              (get_local $15)
+                              (get_local $5)
                             )
                           )
                         )
                         (call_import $_abort)
                       )
-                      (set_local $$63
+                      (set_local $1
                         (i32.load offset=24
-                          (get_local $$v$4$lcssa$i)
+                          (get_local $15)
                         )
                       )
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $$64
+                            (set_local $2
                               (i32.load offset=12
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                               )
                             )
-                            (get_local $$v$4$lcssa$i)
+                            (get_local $15)
                           )
                           (block
                             (if
                               (i32.eq
-                                (set_local $$68
+                                (set_local $2
                                   (i32.load
-                                    (set_local $$arrayidx151$i
+                                    (set_local $8
                                       (i32.add
-                                        (get_local $$v$4$lcssa$i)
+                                        (get_local $15)
                                         (i32.const 20)
                                       )
                                     )
@@ -13472,11 +12252,11 @@
                               )
                               (if
                                 (i32.eq
-                                  (set_local $$69
+                                  (set_local $2
                                     (i32.load
-                                      (set_local $$arrayidx155$i
+                                      (set_local $8
                                         (i32.add
-                                          (get_local $$v$4$lcssa$i)
+                                          (get_local $15)
                                           (i32.const 16)
                                         )
                                       )
@@ -13485,37 +12265,33 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$R$3$i$171
+                                  (set_local $12
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168
-                                    (get_local $$69)
+                                  (set_local $7
+                                    (get_local $2)
                                   )
-                                  (set_local $$RP$1$i$167
-                                    (get_local $$arrayidx155$i)
-                                  )
+                                  (get_local $8)
                                 )
                               )
                               (block
-                                (set_local $$R$1$i$168
-                                  (get_local $$68)
+                                (set_local $7
+                                  (get_local $2)
                                 )
-                                (set_local $$RP$1$i$167
-                                  (get_local $$arrayidx151$i)
-                                )
+                                (get_local $8)
                               )
                             )
                             (loop $while-out$23 $while-in$24
                               (if
                                 (i32.ne
-                                  (set_local $$70
+                                  (set_local $2
                                     (i32.load
-                                      (set_local $$arrayidx161$i
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $$R$1$i$168)
+                                          (get_local $7)
                                           (i32.const 20)
                                         )
                                       )
@@ -13524,22 +12300,22 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168
-                                    (get_local $$70)
+                                  (set_local $7
+                                    (get_local $2)
                                   )
-                                  (set_local $$RP$1$i$167
-                                    (get_local $$arrayidx161$i)
+                                  (set_local $8
+                                    (get_local $6)
                                   )
                                   (br $while-in$24)
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (set_local $$71
+                                  (set_local $2
                                     (i32.load
-                                      (set_local $$arrayidx165$i$169
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $$R$1$i$168)
+                                          (get_local $7)
                                           (i32.const 16)
                                         )
                                       )
@@ -13548,20 +12324,20 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168$lcssa
-                                    (get_local $$R$1$i$168)
+                                  (set_local $2
+                                    (get_local $7)
                                   )
-                                  (set_local $$RP$1$i$167$lcssa
-                                    (get_local $$RP$1$i$167)
+                                  (set_local $7
+                                    (get_local $8)
                                   )
                                   (br $while-out$23)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168
-                                    (get_local $$71)
+                                  (set_local $7
+                                    (get_local $2)
                                   )
-                                  (set_local $$RP$1$i$167
-                                    (get_local $$arrayidx165$i$169)
+                                  (set_local $8
+                                    (get_local $6)
                                   )
                                 )
                               )
@@ -13569,17 +12345,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$RP$1$i$167$lcssa)
-                                (get_local $$62)
+                                (get_local $7)
+                                (get_local $0)
                               )
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $$RP$1$i$167$lcssa)
+                                  (get_local $7)
                                   (i32.const 0)
                                 )
-                                (set_local $$R$3$i$171
-                                  (get_local $$R$1$i$168$lcssa)
+                                (set_local $12
+                                  (get_local $2)
                                 )
                               )
                             )
@@ -13587,52 +12363,52 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $$65
+                                (set_local $7
                                   (i32.load offset=8
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                 )
-                                (get_local $$62)
+                                (get_local $0)
                               )
                               (call_import $_abort)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (set_local $$bk136$i
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $$65)
+                                      (get_local $7)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                               )
                               (call_import $_abort)
                             )
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $$fd139$i
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $$64)
+                                      (get_local $2)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                               )
                               (block
                                 (i32.store
-                                  (get_local $$bk136$i)
-                                  (get_local $$64)
+                                  (get_local $0)
+                                  (get_local $2)
                                 )
                                 (i32.store
-                                  (get_local $$fd139$i)
-                                  (get_local $$65)
+                                  (get_local $8)
+                                  (get_local $7)
                                 )
-                                (set_local $$R$3$i$171
-                                  (get_local $$64)
+                                (set_local $12
+                                  (get_local $2)
                                 )
                               )
                               (call_import $_abort)
@@ -13643,21 +12419,21 @@
                       (block $do-once$25
                         (if
                           (i32.ne
-                            (get_local $$63)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (block
                             (if
                               (i32.eq
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                                 (i32.load
-                                  (set_local $$arrayidx184$i
+                                  (set_local $2
                                     (i32.add
                                       (i32.const 480)
                                       (i32.shl
-                                        (set_local $$72
+                                        (set_local $0
                                           (i32.load offset=28
-                                            (get_local $$v$4$lcssa$i)
+                                            (get_local $15)
                                           )
                                         )
                                         (i32.const 2)
@@ -13668,12 +12444,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $$arrayidx184$i)
-                                  (get_local $$R$3$i$171)
+                                  (get_local $2)
+                                  (get_local $12)
                                 )
                                 (if
                                   (i32.eq
-                                    (get_local $$R$3$i$171)
+                                    (get_local $12)
                                     (i32.const 0)
                                   )
                                   (block
@@ -13686,7 +12462,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $$72)
+                                            (get_local $0)
                                           )
                                           (i32.const -1)
                                         )
@@ -13699,7 +12475,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $$63)
+                                    (get_local $1)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -13709,27 +12485,27 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $$arrayidx204$i
+                                      (set_local $0
                                         (i32.add
-                                          (get_local $$63)
+                                          (get_local $1)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                   (i32.store
-                                    (get_local $$arrayidx204$i)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $0)
+                                    (get_local $12)
                                   )
                                   (i32.store offset=20
-                                    (get_local $$63)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $1)
+                                    (get_local $12)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eq
-                                    (get_local $$R$3$i$171)
+                                    (get_local $12)
                                     (i32.const 0)
                                   )
                                 )
@@ -13737,8 +12513,8 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$R$3$i$171)
-                                (set_local $$77
+                                (get_local $12)
+                                (set_local $0
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -13747,48 +12523,48 @@
                               (call_import $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $$R$3$i$171)
-                              (get_local $$63)
+                              (get_local $12)
+                              (get_local $1)
                             )
                             (if
                               (i32.ne
-                                (set_local $$78
+                                (set_local $1
                                   (i32.load offset=16
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$78)
-                                  (get_local $$77)
+                                  (get_local $1)
+                                  (get_local $0)
                                 )
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $$R$3$i$171)
-                                    (get_local $$78)
+                                    (get_local $12)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$78)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $1)
+                                    (get_local $12)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.ne
-                                (set_local $$79
+                                (set_local $0
                                   (i32.load offset=20
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$79)
+                                  (get_local $0)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -13796,12 +12572,12 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $$R$3$i$171)
-                                    (get_local $$79)
+                                    (get_local $12)
+                                    (get_local $0)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$79)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $0)
+                                    (get_local $12)
                                   )
                                 )
                               )
@@ -13812,30 +12588,30 @@
                       (block $do-once$29
                         (if
                           (i32.lt_u
-                            (get_local $$rsize$4$lcssa$i)
+                            (get_local $17)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $$v$4$lcssa$i)
+                              (get_local $15)
                               (i32.or
-                                (set_local $$add268$i
+                                (set_local $0
                                   (i32.add
-                                    (get_local $$rsize$4$lcssa$i)
-                                    (get_local $$and145)
+                                    (get_local $17)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 3)
                               )
                             )
-                            (set_local $$or275$i
+                            (set_local $1
                               (i32.or
                                 (i32.load
-                                  (set_local $$head274$i
+                                  (set_local $0
                                     (i32.add
                                       (i32.add
-                                        (get_local $$v$4$lcssa$i)
-                                        (get_local $$add268$i)
+                                        (get_local $15)
+                                        (get_local $0)
                                       )
                                       (i32.const 4)
                                     )
@@ -13845,50 +12621,50 @@
                               )
                             )
                             (i32.store
-                              (get_local $$head274$i)
-                              (get_local $$or275$i)
+                              (get_local $0)
+                              (get_local $1)
                             )
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $$v$4$lcssa$i)
+                              (get_local $15)
                               (i32.or
-                                (get_local $$and145)
+                                (get_local $5)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $$add$ptr$i$161)
+                              (get_local $3)
                               (i32.or
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $$add$ptr$i$161)
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $3)
+                                (get_local $17)
                               )
-                              (get_local $$rsize$4$lcssa$i)
+                              (get_local $17)
                             )
-                            (set_local $$shr283$i
+                            (set_local $1
                               (i32.shr_u
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $$arrayidx289$i
+                                (set_local $2
                                   (i32.add
                                     (i32.const 216)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $$shr283$i)
+                                        (get_local $1)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -13898,15 +12674,15 @@
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $$82
+                                      (set_local $0
                                         (i32.load
                                           (i32.const 176)
                                         )
                                       )
-                                      (set_local $$shl291$i
+                                      (set_local $1
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $$shr283$i)
+                                          (get_local $1)
                                         )
                                       )
                                     )
@@ -13916,27 +12692,27 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $$82)
-                                        (get_local $$shl291$i)
+                                        (get_local $0)
+                                        (get_local $1)
                                       )
                                     )
-                                    (set_local $$$pre$phi$i$178Z2D
+                                    (set_local $4
                                       (i32.add
-                                        (get_local $$arrayidx289$i)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $$F290$0$i
-                                      (get_local $$arrayidx289$i)
+                                    (set_local $11
+                                      (get_local $2)
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $$84
+                                      (set_local $1
                                         (i32.load
-                                          (set_local $$83
+                                          (set_local $0
                                             (i32.add
-                                              (get_local $$arrayidx289$i)
+                                              (get_local $2)
                                               (i32.const 8)
                                             )
                                           )
@@ -13948,44 +12724,44 @@
                                     )
                                     (call_import $_abort)
                                     (block
-                                      (set_local $$$pre$phi$i$178Z2D
-                                        (get_local $$83)
+                                      (set_local $4
+                                        (get_local $0)
                                       )
-                                      (set_local $$F290$0$i
-                                        (get_local $$84)
+                                      (set_local $11
+                                        (get_local $1)
                                       )
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$$pre$phi$i$178Z2D)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $4)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$F290$0$i)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $11)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$F290$0$i)
+                                  (get_local $3)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$arrayidx289$i)
+                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $$arrayidx355$i
+                            (set_local $2
                               (i32.add
                                 (i32.const 480)
                                 (i32.shl
-                                  (set_local $$I316$0$i
+                                  (set_local $1
                                     (if
                                       (i32.eq
-                                        (set_local $$shr318$i
+                                        (set_local $0
                                           (i32.shr_u
-                                            (get_local $$rsize$4$lcssa$i)
+                                            (get_local $17)
                                             (i32.const 8)
                                           )
                                         )
@@ -13994,31 +12770,31 @@
                                       (i32.const 0)
                                       (if
                                         (i32.gt_u
-                                          (get_local $$rsize$4$lcssa$i)
+                                          (get_local $17)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (block
-                                          (set_local $$shl347$i
+                                          (set_local $1
                                             (i32.shl
-                                              (set_local $$add346$i
+                                              (set_local $0
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (set_local $$and336$i
+                                                        (set_local $1
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $$shl333$i
+                                                                (set_local $2
                                                                   (i32.shl
-                                                                    (get_local $$shr318$i)
-                                                                    (set_local $$and331$i
+                                                                    (get_local $0)
+                                                                    (set_local $0
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
-                                                                            (get_local $$shr318$i)
+                                                                            (get_local $0)
                                                                             (i32.const 1048320)
                                                                           )
                                                                           (i32.const 16)
@@ -14035,16 +12811,16 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $$and331$i)
+                                                        (get_local $0)
                                                       )
-                                                      (set_local $$and341$i
+                                                      (set_local $0
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $$shl338$i
+                                                              (set_local $1
                                                                 (i32.shl
-                                                                  (get_local $$shl333$i)
-                                                                  (get_local $$and336$i)
+                                                                  (get_local $2)
+                                                                  (get_local $1)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -14058,8 +12834,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $$shl338$i)
-                                                      (get_local $$and341$i)
+                                                      (get_local $1)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -14071,15 +12847,15 @@
                                           (i32.or
                                             (i32.and
                                               (i32.shr_u
-                                                (get_local $$rsize$4$lcssa$i)
+                                                (get_local $17)
                                                 (i32.add
-                                                  (get_local $$add346$i)
+                                                  (get_local $0)
                                                   (i32.const 7)
                                                 )
                                               )
                                               (i32.const 1)
                                             )
-                                            (get_local $$shl347$i)
+                                            (get_local $1)
                                           )
                                         )
                                       )
@@ -14090,34 +12866,34 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $$add$ptr$i$161)
-                              (get_local $$I316$0$i)
+                              (get_local $3)
+                              (get_local $1)
                             )
                             (i32.store offset=4
-                              (set_local $$child357$i
+                              (set_local $0
                                 (i32.add
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $3)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $$child357$i)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (if
                               (i32.eq
                                 (i32.and
-                                  (set_local $$86
+                                  (set_local $0
                                     (i32.load
                                       (i32.const 180)
                                     )
                                   )
-                                  (set_local $$shl362$i
+                                  (set_local $4
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $$I316$0$i)
+                                      (get_local $1)
                                     )
                                   )
                                 )
@@ -14127,51 +12903,51 @@
                                 (i32.store
                                   (i32.const 180)
                                   (i32.or
-                                    (get_local $$86)
-                                    (get_local $$shl362$i)
+                                    (get_local $0)
+                                    (get_local $4)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$arrayidx355$i)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$arrayidx355$i)
+                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $$K373$0$i
+                            (set_local $1
                               (i32.shl
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $$I316$0$i)
+                                      (get_local $1)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $$I316$0$i)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $$T$0$i
+                            (set_local $2
                               (i32.load
-                                (get_local $$arrayidx355$i)
+                                (get_local $2)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -14179,41 +12955,41 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $$T$0$i)
+                                      (get_local $2)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $$rsize$4$lcssa$i)
+                                  (get_local $17)
                                 )
                                 (block
-                                  (set_local $$T$0$i$lcssa
-                                    (get_local $$T$0$i)
+                                  (set_local $22
+                                    (get_local $2)
                                   )
-                                  (set_local $label
+                                  (set_local $10
                                     (i32.const 148)
                                   )
                                   (br $while-out$31)
                                 )
                               )
-                              (set_local $$shl395$i
+                              (set_local $4
                                 (i32.shl
-                                  (get_local $$K373$0$i)
+                                  (get_local $1)
                                   (i32.const 1)
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (set_local $$89
+                                  (set_local $0
                                     (i32.load
-                                      (set_local $$arrayidx394$i
+                                      (set_local $1
                                         (i32.add
                                           (i32.add
-                                            (get_local $$T$0$i)
+                                            (get_local $2)
                                             (i32.const 16)
                                           )
                                           (i32.shl
                                             (i32.shr_u
-                                              (get_local $$K373$0$i)
+                                              (get_local $1)
                                               (i32.const 31)
                                             )
                                             (i32.const 2)
@@ -14225,23 +13001,23 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$T$0$i$lcssa293
-                                    (get_local $$T$0$i)
+                                  (set_local $25
+                                    (get_local $2)
                                   )
-                                  (set_local $$arrayidx394$i$lcssa
-                                    (get_local $$arrayidx394$i)
+                                  (set_local $39
+                                    (get_local $1)
                                   )
-                                  (set_local $label
+                                  (set_local $10
                                     (i32.const 145)
                                   )
                                   (br $while-out$31)
                                 )
                                 (block
-                                  (set_local $$K373$0$i
-                                    (get_local $$shl395$i)
+                                  (set_local $1
+                                    (get_local $4)
                                   )
-                                  (set_local $$T$0$i
-                                    (get_local $$89)
+                                  (set_local $2
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -14249,12 +13025,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $label)
+                                (get_local $10)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$arrayidx394$i$lcssa)
+                                  (get_local $39)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -14262,71 +13038,71 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store
-                                    (get_local $$arrayidx394$i$lcssa)
-                                    (get_local $$add$ptr$i$161)
+                                    (get_local $39)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$add$ptr$i$161)
-                                    (get_local $$T$0$i$lcssa293)
+                                    (get_local $3)
+                                    (get_local $25)
                                   )
                                   (i32.store offset=12
-                                    (get_local $$add$ptr$i$161)
-                                    (get_local $$add$ptr$i$161)
+                                    (get_local $3)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $$add$ptr$i$161)
-                                    (get_local $$add$ptr$i$161)
+                                    (get_local $3)
+                                    (get_local $3)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $label)
+                                  (get_local $10)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (set_local $$91
+                                      (set_local $0
                                         (i32.load
-                                          (set_local $$fd416$i
+                                          (set_local $2
                                             (i32.add
-                                              (get_local $$T$0$i$lcssa)
+                                              (get_local $22)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $$92
+                                      (set_local $1
                                         (i32.load
                                           (i32.const 192)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $$T$0$i$lcssa)
-                                      (get_local $$92)
+                                      (get_local $22)
+                                      (get_local $1)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $$91)
-                                      (get_local $$add$ptr$i$161)
+                                      (get_local $0)
+                                      (get_local $3)
                                     )
                                     (i32.store
-                                      (get_local $$fd416$i)
-                                      (get_local $$add$ptr$i$161)
+                                      (get_local $2)
+                                      (get_local $3)
                                     )
                                     (i32.store offset=8
-                                      (get_local $$add$ptr$i$161)
-                                      (get_local $$91)
+                                      (get_local $3)
+                                      (get_local $0)
                                     )
                                     (i32.store offset=12
-                                      (get_local $$add$ptr$i$161)
-                                      (get_local $$T$0$i$lcssa)
+                                      (get_local $3)
+                                      (get_local $22)
                                     )
                                     (i32.store offset=24
-                                      (get_local $$add$ptr$i$161)
+                                      (get_local $3)
                                       (i32.const 0)
                                     )
                                   )
@@ -14339,13 +13115,13 @@
                       )
                       (return
                         (i32.add
-                          (get_local $$v$4$lcssa$i)
+                          (get_local $15)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $$nb$0
-                      (get_local $$and145)
+                    (set_local $9
+                      (get_local $5)
                     )
                   )
                 )
@@ -14357,25 +13133,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $$94
+        (set_local $0
           (i32.load
             (i32.const 184)
           )
         )
-        (get_local $$nb$0)
+        (get_local $9)
       )
       (block
-        (set_local $$95
+        (set_local $1
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (set_local $$sub160
+            (set_local $2
               (i32.sub
-                (get_local $$94)
-                (get_local $$nb$0)
+                (get_local $0)
+                (get_local $9)
               )
             )
             (i32.const 15)
@@ -14383,35 +13159,35 @@
           (block
             (i32.store
               (i32.const 196)
-              (set_local $$add$ptr166
+              (set_local $0
                 (i32.add
-                  (get_local $$95)
-                  (get_local $$nb$0)
+                  (get_local $1)
+                  (get_local $9)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $$sub160)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $$add$ptr166)
+              (get_local $0)
               (i32.or
-                (get_local $$sub160)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $$add$ptr166)
-                (get_local $$sub160)
+                (get_local $0)
+                (get_local $2)
               )
-              (get_local $$sub160)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $$95)
+              (get_local $1)
               (i32.or
-                (get_local $$nb$0)
+                (get_local $9)
                 (i32.const 3)
               )
             )
@@ -14426,20 +13202,20 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $$95)
+              (get_local $1)
               (i32.or
-                (get_local $$94)
+                (get_local $0)
                 (i32.const 3)
               )
             )
-            (set_local $$or180
+            (set_local $2
               (i32.or
                 (i32.load
-                  (set_local $$head179
+                  (set_local $0
                     (i32.add
                       (i32.add
-                        (get_local $$95)
-                        (get_local $$94)
+                        (get_local $1)
+                        (get_local $0)
                       )
                       (i32.const 4)
                     )
@@ -14449,14 +13225,14 @@
               )
             )
             (i32.store
-              (get_local $$head179)
-              (get_local $$or180)
+              (get_local $0)
+              (get_local $2)
             )
           )
         )
         (return
           (i32.add
-            (get_local $$95)
+            (get_local $1)
             (i32.const 8)
           )
         )
@@ -14464,53 +13240,53 @@
     )
     (if
       (i32.gt_u
-        (set_local $$97
+        (set_local $0
           (i32.load
             (i32.const 188)
           )
         )
-        (get_local $$nb$0)
+        (get_local $9)
       )
       (block
         (i32.store
           (i32.const 188)
-          (set_local $$sub190
+          (set_local $2
             (i32.sub
-              (get_local $$97)
-              (get_local $$nb$0)
+              (get_local $0)
+              (get_local $9)
             )
           )
         )
         (i32.store
           (i32.const 200)
-          (set_local $$add$ptr193
+          (set_local $1
             (i32.add
-              (set_local $$98
+              (set_local $0
                 (i32.load
                   (i32.const 200)
                 )
               )
-              (get_local $$nb$0)
+              (get_local $9)
             )
           )
         )
         (i32.store offset=4
-          (get_local $$add$ptr193)
+          (get_local $1)
           (i32.or
-            (get_local $$sub190)
+            (get_local $2)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $$98)
+          (get_local $0)
           (i32.or
-            (get_local $$nb$0)
+            (get_local $9)
             (i32.const 3)
           )
         )
         (return
           (i32.add
-            (get_local $$98)
+            (get_local $0)
             (i32.const 8)
           )
         )
@@ -14527,25 +13303,25 @@
         (i32.eq
           (i32.and
             (i32.add
-              (set_local $$call$i$i
+              (set_local $0
                 (call_import $_sysconf
                   (i32.const 30)
                 )
               )
               (i32.const -1)
             )
-            (get_local $$call$i$i)
+            (get_local $0)
           )
           (i32.const 0)
         )
         (block
           (i32.store
             (i32.const 656)
-            (get_local $$call$i$i)
+            (get_local $0)
           )
           (i32.store
             (i32.const 652)
-            (get_local $$call$i$i)
+            (get_local $0)
           )
           (i32.store
             (i32.const 660)
@@ -14579,40 +13355,40 @@
         (call_import $_abort)
       )
     )
-    (set_local $$add$i$180
+    (set_local $3
       (i32.add
-        (get_local $$nb$0)
+        (get_local $9)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $$and11$i
+        (set_local $11
           (i32.and
-            (set_local $$add9$i
+            (set_local $6
               (i32.add
-                (set_local $$100
+                (set_local $0
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (set_local $$sub$i$181
+                (set_local $12
                   (i32.add
-                    (get_local $$nb$0)
+                    (get_local $9)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $$neg$i$182
+            (set_local $13
               (i32.sub
                 (i32.const 0)
-                (get_local $$100)
+                (get_local $0)
               )
             )
           )
         )
-        (get_local $$nb$0)
+        (get_local $9)
       )
       (return
         (i32.const 0)
@@ -14620,7 +13396,7 @@
     )
     (if
       (i32.ne
-        (set_local $$101
+        (set_local $0
           (i32.load
             (i32.const 616)
           )
@@ -14630,21 +13406,21 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $$add17$i$183
+            (set_local $5
               (i32.add
-                (set_local $$102
+                (set_local $4
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $$and11$i)
+                (get_local $11)
               )
             )
-            (get_local $$102)
+            (get_local $4)
           )
           (i32.gt_u
-            (get_local $$add17$i$183)
-            (get_local $$101)
+            (get_local $5)
+            (get_local $0)
           )
         )
         (return
@@ -14654,7 +13430,7 @@
     )
     (if
       (i32.eq
-        (set_local $label
+        (set_local $10
           (block $label$break$L257
             (if
               (i32.eq
@@ -14670,51 +13446,51 @@
                 (block $label$break$L259
                   (if
                     (i32.eq
-                      (set_local $$104
+                      (set_local $0
                         (i32.load
                           (i32.const 200)
                         )
                       )
                       (i32.const 0)
                     )
-                    (set_local $label
+                    (set_local $10
                       (i32.const 173)
                     )
                     (block
-                      (set_local $$sp$0$i$i
+                      (set_local $14
                         (i32.const 624)
                       )
                       (loop $while-out$37 $while-in$38
                         (if
                           (i32.le_u
-                            (set_local $$105
+                            (set_local $4
                               (i32.load
-                                (get_local $$sp$0$i$i)
+                                (get_local $14)
                               )
                             )
-                            (get_local $$104)
+                            (get_local $0)
                           )
                           (if
                             (i32.gt_u
                               (i32.add
-                                (get_local $$105)
+                                (get_local $4)
                                 (i32.load
-                                  (set_local $$size$i$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$sp$0$i$i)
+                                      (get_local $14)
                                       (i32.const 4)
                                     )
                                   )
                                 )
                               )
-                              (get_local $$104)
+                              (get_local $0)
                             )
                             (block
-                              (set_local $$base$i$i$lcssa
-                                (get_local $$sp$0$i$i)
+                              (set_local $4
+                                (get_local $14)
                               )
-                              (set_local $$size$i$i$lcssa
-                                (get_local $$size$i$i)
+                              (set_local $14
+                                (get_local $5)
                               )
                               (br $while-out$37)
                             )
@@ -14722,67 +13498,67 @@
                         )
                         (if
                           (i32.eq
-                            (set_local $$107
+                            (set_local $4
                               (i32.load offset=8
-                                (get_local $$sp$0$i$i)
+                                (get_local $14)
                               )
                             )
                             (i32.const 0)
                           )
                           (block
-                            (set_local $label
+                            (set_local $10
                               (i32.const 173)
                             )
                             (br $label$break$L259)
                           )
-                          (set_local $$sp$0$i$i
-                            (get_local $$107)
+                          (set_local $14
+                            (get_local $4)
                           )
                         )
                         (br $while-in$38)
                       )
                       (if
                         (i32.lt_u
-                          (set_local $$and80$i
+                          (set_local $0
                             (i32.and
                               (i32.sub
-                                (get_local $$add9$i)
+                                (get_local $6)
                                 (i32.load
                                   (i32.const 188)
                                 )
                               )
-                              (get_local $$neg$i$182)
+                              (get_local $13)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $$call83$i
+                            (set_local $5
                               (call_import $_sbrk
-                                (get_local $$and80$i)
+                                (get_local $0)
                               )
                             )
                             (i32.add
                               (i32.load
-                                (get_local $$base$i$i$lcssa)
+                                (get_local $4)
                               )
                               (i32.load
-                                (get_local $$size$i$i$lcssa)
+                                (get_local $14)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $$call83$i)
+                              (get_local $5)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $$tbase$796$i
-                                (get_local $$call83$i)
+                              (set_local $16
+                                (get_local $5)
                               )
-                              (set_local $$tsize$795$i
-                                (get_local $$and80$i)
+                              (set_local $19
+                                (get_local $0)
                               )
                               (br $label$break$L257
                                 (i32.const 193)
@@ -14790,13 +13566,13 @@
                             )
                           )
                           (block
-                            (set_local $$br$2$ph$i
-                              (get_local $$call83$i)
+                            (set_local $28
+                              (get_local $5)
                             )
-                            (set_local $$ssize$2$ph$i
-                              (get_local $$and80$i)
+                            (set_local $21
+                              (get_local $0)
                             )
-                            (set_local $label
+                            (set_local $10
                               (i32.const 183)
                             )
                           )
@@ -14808,12 +13584,12 @@
                 (block $do-once$39
                   (if
                     (i32.eq
-                      (get_local $label)
+                      (get_local $10)
                       (i32.const 173)
                     )
                     (if
                       (i32.ne
-                        (set_local $$call37$i
+                        (set_local $6
                           (call_import $_sbrk
                             (i32.const 0)
                           )
@@ -14821,13 +13597,13 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $$ssize$0$i
+                        (set_local $13
                           (if
                             (i32.eq
                               (i32.and
-                                (set_local $$sub41$i
+                                (set_local $5
                                   (i32.add
-                                    (set_local $$109
+                                    (set_local $4
                                       (i32.load
                                         (i32.const 652)
                                       )
@@ -14835,56 +13611,56 @@
                                     (i32.const -1)
                                   )
                                 )
-                                (set_local $$108
-                                  (get_local $$call37$i)
+                                (set_local $0
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 0)
                             )
-                            (get_local $$and11$i)
+                            (get_local $11)
                             (i32.add
                               (i32.sub
-                                (get_local $$and11$i)
-                                (get_local $$108)
+                                (get_local $11)
+                                (get_local $0)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $$sub41$i)
-                                  (get_local $$108)
+                                  (get_local $5)
+                                  (get_local $0)
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$109)
+                                  (get_local $4)
                                 )
                               )
                             )
                           )
                         )
-                        (set_local $$add54$i
+                        (set_local $5
                           (i32.add
-                            (set_local $$110
+                            (set_local $0
                               (i32.load
                                 (i32.const 608)
                               )
                             )
-                            (get_local $$ssize$0$i)
+                            (get_local $13)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $$ssize$0$i)
-                              (get_local $$nb$0)
+                              (get_local $13)
+                              (get_local $9)
                             )
                             (i32.lt_u
-                              (get_local $$ssize$0$i)
+                              (get_local $13)
                               (i32.const 2147483647)
                             )
                           )
                           (block
                             (if
                               (i32.ne
-                                (set_local $$111
+                                (set_local $4
                                   (i32.load
                                     (i32.const 616)
                                   )
@@ -14894,44 +13670,44 @@
                               (br_if $do-once$39
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $$add54$i)
-                                    (get_local $$110)
+                                    (get_local $5)
+                                    (get_local $0)
                                   )
                                   (i32.gt_u
-                                    (get_local $$add54$i)
-                                    (get_local $$111)
+                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$call68$i
+                                (set_local $0
                                   (call_import $_sbrk
-                                    (get_local $$ssize$0$i)
+                                    (get_local $13)
                                   )
                                 )
-                                (get_local $$call37$i)
+                                (get_local $6)
                               )
                               (block
-                                (set_local $$tbase$796$i
-                                  (get_local $$call37$i)
+                                (set_local $16
+                                  (get_local $6)
                                 )
-                                (set_local $$tsize$795$i
-                                  (get_local $$ssize$0$i)
+                                (set_local $19
+                                  (get_local $13)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
                                 )
                               )
                               (block
-                                (set_local $$br$2$ph$i
-                                  (get_local $$call68$i)
+                                (set_local $28
+                                  (get_local $0)
                                 )
-                                (set_local $$ssize$2$ph$i
-                                  (get_local $$ssize$0$i)
+                                (set_local $21
+                                  (get_local $13)
                                 )
-                                (set_local $label
+                                (set_local $10
                                   (i32.const 183)
                                 )
                               )
@@ -14945,43 +13721,43 @@
                 (block $label$break$L279
                   (if
                     (i32.eq
-                      (get_local $label)
+                      (get_local $10)
                       (i32.const 183)
                     )
                     (block
-                      (set_local $$sub112$i
+                      (set_local $4
                         (i32.sub
                           (i32.const 0)
-                          (get_local $$ssize$2$ph$i)
+                          (get_local $21)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $$add$i$180)
-                            (get_local $$ssize$2$ph$i)
+                            (get_local $3)
+                            (get_local $21)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $$ssize$2$ph$i)
+                              (get_local $21)
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $$br$2$ph$i)
+                              (get_local $28)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $$and104$i
+                            (set_local $0
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $$sub$i$181)
-                                    (get_local $$ssize$2$ph$i)
+                                    (get_local $12)
+                                    (get_local $21)
                                   )
-                                  (set_local $$115
+                                  (set_local $0
                                     (i32.load
                                       (i32.const 656)
                                     )
@@ -14989,7 +13765,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$115)
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -14998,42 +13774,42 @@
                           (if
                             (i32.eq
                               (call_import $_sbrk
-                                (get_local $$and104$i)
+                                (get_local $0)
                               )
                               (i32.const -1)
                             )
                             (block
                               (call_import $_sbrk
-                                (get_local $$sub112$i)
+                                (get_local $4)
                               )
                               (br $label$break$L279)
                             )
-                            (set_local $$ssize$5$i
+                            (set_local $0
                               (i32.add
-                                (get_local $$and104$i)
-                                (get_local $$ssize$2$ph$i)
+                                (get_local $0)
+                                (get_local $21)
                               )
                             )
                           )
-                          (set_local $$ssize$5$i
-                            (get_local $$ssize$2$ph$i)
+                          (set_local $0
+                            (get_local $21)
                           )
                         )
-                        (set_local $$ssize$5$i
-                          (get_local $$ssize$2$ph$i)
+                        (set_local $0
+                          (get_local $21)
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $$br$2$ph$i)
+                          (get_local $28)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $$tbase$796$i
-                            (get_local $$br$2$ph$i)
+                          (set_local $16
+                            (get_local $28)
                           )
-                          (set_local $$tsize$795$i
-                            (get_local $$ssize$5$i)
+                          (set_local $19
+                            (get_local $0)
                           )
                           (br $label$break$L257
                             (i32.const 193)
@@ -15062,22 +13838,22 @@
       )
       (if
         (i32.lt_u
-          (get_local $$and11$i)
+          (get_local $11)
           (i32.const 2147483647)
         )
         (block
-          (set_local $$or$cond4$i
+          (set_local $3
             (i32.and
               (i32.ne
-                (set_local $$call131$i
+                (set_local $0
                   (call_import $_sbrk
-                    (get_local $$and11$i)
+                    (get_local $11)
                   )
                 )
                 (i32.const -1)
               )
               (i32.ne
-                (set_local $$call132$i
+                (set_local $4
                   (call_import $_sbrk
                     (i32.const 0)
                   )
@@ -15089,32 +13865,32 @@
           (if
             (i32.and
               (i32.lt_u
-                (get_local $$call131$i)
-                (get_local $$call132$i)
+                (get_local $0)
+                (get_local $4)
               )
-              (get_local $$or$cond4$i)
+              (get_local $3)
             )
             (if
               (i32.gt_u
-                (set_local $$sub$ptr$sub$i
+                (set_local $4
                   (i32.sub
-                    (get_local $$call132$i)
-                    (get_local $$call131$i)
+                    (get_local $4)
+                    (get_local $0)
                   )
                 )
                 (i32.add
-                  (get_local $$nb$0)
+                  (get_local $9)
                   (i32.const 40)
                 )
               )
               (block
-                (set_local $$tbase$796$i
-                  (get_local $$call131$i)
+                (set_local $16
+                  (get_local $0)
                 )
-                (set_local $$tsize$795$i
-                  (get_local $$sub$ptr$sub$i)
+                (set_local $19
+                  (get_local $4)
                 )
-                (set_local $label
+                (set_local $10
                   (i32.const 193)
                 )
               )
@@ -15125,37 +13901,37 @@
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $10)
         (i32.const 193)
       )
       (block
         (i32.store
           (i32.const 608)
-          (set_local $$add150$i
+          (set_local $0
             (i32.add
               (i32.load
                 (i32.const 608)
               )
-              (get_local $$tsize$795$i)
+              (get_local $19)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $$add150$i)
+            (get_local $0)
             (i32.load
               (i32.const 612)
             )
           )
           (i32.store
             (i32.const 612)
-            (get_local $$add150$i)
+            (get_local $0)
           )
         )
         (block $do-once$44
           (if
             (i32.eq
-              (set_local $$119
+              (set_local $0
                 (i32.load
                   (i32.const 200)
                 )
@@ -15166,7 +13942,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $$120
+                    (set_local $0
                       (i32.load
                         (i32.const 192)
                       )
@@ -15174,22 +13950,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $$tbase$796$i)
-                    (get_local $$120)
+                    (get_local $16)
+                    (get_local $0)
                   )
                 )
                 (i32.store
                   (i32.const 192)
-                  (get_local $$tbase$796$i)
+                  (get_local $16)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $$tbase$796$i)
+                (get_local $16)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $$tsize$795$i)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 636)
@@ -15205,52 +13981,52 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $$i$01$i$i
+              (set_local $1
                 (i32.const 0)
               )
               (loop $while-out$46 $while-in$47
                 (i32.store offset=12
-                  (set_local $$arrayidx$i$i
+                  (set_local $0
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $$i$01$i$i)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $$arrayidx$i$i)
+                  (get_local $0)
                 )
                 (i32.store offset=8
-                  (get_local $$arrayidx$i$i)
-                  (get_local $$arrayidx$i$i)
+                  (get_local $0)
+                  (get_local $0)
                 )
                 (if
                   (i32.eq
-                    (set_local $$inc$i$i
+                    (set_local $0
                       (i32.add
-                        (get_local $$i$01$i$i)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
                     (i32.const 32)
                   )
                   (br $while-out$46)
-                  (set_local $$i$01$i$i
-                    (get_local $$inc$i$i)
+                  (set_local $1
+                    (get_local $0)
                   )
                 )
                 (br $while-in$47)
               )
-              (set_local $$cmp$i$13$i
+              (set_local $1
                 (i32.eq
                   (i32.and
-                    (set_local $$124
+                    (set_local $0
                       (i32.add
-                        (get_local $$tbase$796$i)
+                        (get_local $16)
                         (i32.const 8)
                       )
                     )
@@ -15261,20 +14037,20 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $$add$ptr4$i$i
+                (set_local $0
                   (i32.add
-                    (get_local $$tbase$796$i)
-                    (set_local $$cond$i$i
+                    (get_local $16)
+                    (set_local $1
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (get_local $$124)
+                            (get_local $0)
                           )
                           (i32.const 7)
                         )
-                        (get_local $$cmp$i$13$i)
+                        (get_local $1)
                       )
                     )
                   )
@@ -15282,27 +14058,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $$sub5$i$i
+                (set_local $1
                   (i32.sub
                     (i32.add
-                      (get_local $$tsize$795$i)
+                      (get_local $19)
                       (i32.const -40)
                     )
-                    (get_local $$cond$i$i)
+                    (get_local $1)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr4$i$i)
+                (get_local $0)
                 (i32.or
-                  (get_local $$sub5$i$i)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $$add$ptr4$i$i)
-                  (get_local $$sub5$i$i)
+                  (get_local $0)
+                  (get_local $1)
                 )
                 (i32.const 40)
               )
@@ -15314,24 +14090,24 @@
               )
             )
             (block
-              (set_local $$sp$0108$i
+              (set_local $6
                 (i32.const 624)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
-                    (get_local $$tbase$796$i)
+                    (get_local $16)
                     (i32.add
-                      (set_local $$127
+                      (set_local $4
                         (i32.load
-                          (get_local $$sp$0108$i)
+                          (get_local $6)
                         )
                       )
-                      (set_local $$128
+                      (set_local $3
                         (i32.load
-                          (set_local $$size188$i
+                          (set_local $5
                             (i32.add
-                              (get_local $$sp$0108$i)
+                              (get_local $6)
                               (i32.const 4)
                             )
                           )
@@ -15340,19 +14116,19 @@
                     )
                   )
                   (block
-                    (set_local $$$lcssa
-                      (get_local $$127)
+                    (set_local $1
+                      (get_local $4)
                     )
-                    (set_local $$$lcssa290
-                      (get_local $$128)
+                    (set_local $2
+                      (get_local $3)
                     )
-                    (set_local $$size188$i$lcssa
-                      (get_local $$size188$i)
+                    (set_local $45
+                      (get_local $5)
                     )
-                    (set_local $$sp$0108$i$lcssa
-                      (get_local $$sp$0108$i)
+                    (set_local $46
+                      (get_local $6)
                     )
-                    (set_local $label
+                    (set_local $10
                       (i32.const 203)
                     )
                     (br $while-out$48)
@@ -15360,30 +14136,30 @@
                 )
                 (if
                   (i32.eq
-                    (set_local $$129
+                    (set_local $4
                       (i32.load offset=8
-                        (get_local $$sp$0108$i)
+                        (get_local $6)
                       )
                     )
                     (i32.const 0)
                   )
                   (br $while-out$48)
-                  (set_local $$sp$0108$i
-                    (get_local $$129)
+                  (set_local $6
+                    (get_local $4)
                   )
                 )
                 (br $while-in$49)
               )
               (if
                 (i32.eq
-                  (get_local $label)
+                  (get_local $10)
                   (i32.const 203)
                 )
                 (if
                   (i32.eq
                     (i32.and
                       (i32.load offset=12
-                        (get_local $$sp$0108$i$lcssa)
+                        (get_local $46)
                       )
                       (i32.const 8)
                     )
@@ -15392,28 +14168,28 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $$119)
-                        (get_local $$tbase$796$i)
+                        (get_local $0)
+                        (get_local $16)
                       )
                       (i32.ge_u
-                        (get_local $$119)
-                        (get_local $$$lcssa)
+                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $$size188$i$lcssa)
+                        (get_local $45)
                         (i32.add
-                          (get_local $$$lcssa290)
-                          (get_local $$tsize$795$i)
+                          (get_local $2)
+                          (get_local $19)
                         )
                       )
-                      (set_local $$cmp$i$23$i
+                      (set_local $2
                         (i32.eq
                           (i32.and
-                            (set_local $$132
+                            (set_local $1
                               (i32.add
-                                (get_local $$119)
+                                (get_local $0)
                                 (i32.const 8)
                               )
                             )
@@ -15422,29 +14198,29 @@
                           (i32.const 0)
                         )
                       )
-                      (set_local $$add$ptr4$i$26$i
+                      (set_local $0
                         (i32.add
-                          (get_local $$119)
-                          (set_local $$cond$i$25$i
+                          (get_local $0)
+                          (set_local $1
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$132)
+                                  (get_local $1)
                                 )
                                 (i32.const 7)
                               )
-                              (get_local $$cmp$i$23$i)
+                              (get_local $2)
                             )
                           )
                         )
                       )
-                      (set_local $$sub5$i$27$i
+                      (set_local $1
                         (i32.add
                           (i32.sub
-                            (get_local $$tsize$795$i)
-                            (get_local $$cond$i$25$i)
+                            (get_local $19)
+                            (get_local $1)
                           )
                           (i32.load
                             (i32.const 188)
@@ -15453,23 +14229,23 @@
                       )
                       (i32.store
                         (i32.const 200)
-                        (get_local $$add$ptr4$i$26$i)
+                        (get_local $0)
                       )
                       (i32.store
                         (i32.const 188)
-                        (get_local $$sub5$i$27$i)
+                        (get_local $1)
                       )
                       (i32.store offset=4
-                        (get_local $$add$ptr4$i$26$i)
+                        (get_local $0)
                         (i32.or
-                          (get_local $$sub5$i$27$i)
+                          (get_local $1)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $$add$ptr4$i$26$i)
-                          (get_local $$sub5$i$27$i)
+                          (get_local $0)
+                          (get_local $1)
                         )
                         (i32.const 40)
                       )
@@ -15484,11 +14260,11 @@
                   )
                 )
               )
-              (set_local $$150
+              (set_local $4
                 (if
                   (i32.lt_u
-                    (get_local $$tbase$796$i)
-                    (set_local $$135
+                    (get_local $16)
+                    (set_local $1
                       (i32.load
                         (i32.const 192)
                       )
@@ -15497,38 +14273,38 @@
                   (block
                     (i32.store
                       (i32.const 192)
-                      (get_local $$tbase$796$i)
+                      (get_local $16)
                     )
-                    (get_local $$tbase$796$i)
+                    (get_local $16)
                   )
-                  (get_local $$135)
+                  (get_local $1)
                 )
               )
-              (set_local $$add$ptr227$i
+              (set_local $3
                 (i32.add
-                  (get_local $$tbase$796$i)
-                  (get_local $$tsize$795$i)
+                  (get_local $16)
+                  (get_local $19)
                 )
               )
-              (set_local $$sp$1107$i
+              (set_local $1
                 (i32.const 624)
               )
               (loop $while-out$50 $while-in$51
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $$sp$1107$i)
+                      (get_local $1)
                     )
-                    (get_local $$add$ptr227$i)
+                    (get_local $3)
                   )
                   (block
-                    (set_local $$base226$i$lcssa
-                      (get_local $$sp$1107$i)
+                    (set_local $44
+                      (get_local $1)
                     )
-                    (set_local $$sp$1107$i$lcssa
-                      (get_local $$sp$1107$i)
+                    (set_local $41
+                      (get_local $1)
                     )
-                    (set_local $label
+                    (set_local $10
                       (i32.const 211)
                     )
                     (br $while-out$50)
@@ -15536,35 +14312,33 @@
                 )
                 (if
                   (i32.eq
-                    (set_local $$137
+                    (set_local $1
                       (i32.load offset=8
-                        (get_local $$sp$1107$i)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$sp$0$i$i$i
+                    (set_local $27
                       (i32.const 624)
                     )
                     (br $while-out$50)
                   )
-                  (set_local $$sp$1107$i
-                    (get_local $$137)
-                  )
+                  (get_local $1)
                 )
                 (br $while-in$51)
               )
               (if
                 (i32.eq
-                  (get_local $label)
+                  (get_local $10)
                   (i32.const 211)
                 )
                 (if
                   (i32.eq
                     (i32.and
                       (i32.load offset=12
-                        (get_local $$sp$1107$i$lcssa)
+                        (get_local $41)
                       )
                       (i32.const 8)
                     )
@@ -15572,32 +14346,32 @@
                   )
                   (block
                     (i32.store
-                      (get_local $$base226$i$lcssa)
-                      (get_local $$tbase$796$i)
+                      (get_local $44)
+                      (get_local $16)
                     )
-                    (set_local $$add246$i
+                    (set_local $1
                       (i32.add
                         (i32.load
-                          (set_local $$size245$i
+                          (set_local $2
                             (i32.add
-                              (get_local $$sp$1107$i$lcssa)
+                              (get_local $41)
                               (i32.const 4)
                             )
                           )
                         )
-                        (get_local $$tsize$795$i)
+                        (get_local $19)
                       )
                     )
                     (i32.store
-                      (get_local $$size245$i)
-                      (get_local $$add246$i)
+                      (get_local $2)
+                      (get_local $1)
                     )
-                    (set_local $$cmp$i$34$i
+                    (set_local $8
                       (i32.eq
                         (i32.and
-                          (set_local $$140
+                          (set_local $1
                             (i32.add
-                              (get_local $$tbase$796$i)
+                              (get_local $16)
                               (i32.const 8)
                             )
                           )
@@ -15606,12 +14380,12 @@
                         (i32.const 0)
                       )
                     )
-                    (set_local $$cmp7$i$i
+                    (set_local $5
                       (i32.eq
                         (i32.and
-                          (set_local $$142
+                          (set_local $2
                             (i32.add
-                              (get_local $$add$ptr227$i)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -15620,87 +14394,87 @@
                         (i32.const 0)
                       )
                     )
-                    (set_local $$sub$ptr$sub$i$41$i
+                    (set_local $1
                       (i32.sub
-                        (set_local $$add$ptr16$i$i
+                        (set_local $3
                           (i32.add
-                            (get_local $$add$ptr227$i)
+                            (get_local $3)
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$142)
+                                  (get_local $2)
                                 )
                                 (i32.const 7)
                               )
-                              (get_local $$cmp7$i$i)
+                              (get_local $5)
                             )
                           )
                         )
-                        (set_local $$add$ptr4$i$37$i
+                        (set_local $6
                           (i32.add
-                            (get_local $$tbase$796$i)
+                            (get_local $16)
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$140)
+                                  (get_local $1)
                                 )
                                 (i32.const 7)
                               )
-                              (get_local $$cmp$i$34$i)
+                              (get_local $8)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $$add$ptr17$i$i
+                    (set_local $5
                       (i32.add
-                        (get_local $$add$ptr4$i$37$i)
-                        (get_local $$nb$0)
+                        (get_local $6)
+                        (get_local $9)
                       )
                     )
-                    (set_local $$sub18$i$i
+                    (set_local $13
                       (i32.sub
-                        (get_local $$sub$ptr$sub$i$41$i)
-                        (get_local $$nb$0)
+                        (get_local $1)
+                        (get_local $9)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $$add$ptr4$i$37$i)
+                      (get_local $6)
                       (i32.or
-                        (get_local $$nb$0)
+                        (get_local $9)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$52
                       (if
                         (i32.eq
-                          (get_local $$add$ptr16$i$i)
-                          (get_local $$119)
+                          (get_local $3)
+                          (get_local $0)
                         )
                         (block
                           (i32.store
                             (i32.const 188)
-                            (set_local $$add$i$i
+                            (set_local $0
                               (i32.add
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $$sub18$i$i)
+                                (get_local $13)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $$add$ptr17$i$i)
+                            (get_local $5)
                           )
                           (i32.store offset=4
-                            (get_local $$add$ptr17$i$i)
+                            (get_local $5)
                             (i32.or
-                              (get_local $$add$i$i)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
@@ -15708,7 +14482,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $$add$ptr16$i$i)
+                              (get_local $3)
                               (i32.load
                                 (i32.const 196)
                               )
@@ -15716,47 +14490,47 @@
                             (block
                               (i32.store
                                 (i32.const 184)
-                                (set_local $$add26$i$i
+                                (set_local $0
                                   (i32.add
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $$sub18$i$i)
+                                    (get_local $13)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
                               )
                               (i32.store offset=4
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
                                 (i32.or
-                                  (get_local $$add26$i$i)
+                                  (get_local $0)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$add26$i$i)
+                                  (get_local $5)
+                                  (get_local $0)
                                 )
-                                (get_local $$add26$i$i)
+                                (get_local $0)
                               )
                               (br $do-once$52)
                             )
                           )
-                          (set_local $$and209$i$i
+                          (set_local $0
                             (i32.and
                               (i32.load
-                                (set_local $$head208$i$i
+                                (set_local $1
                                   (i32.add
                                     (if
                                       (i32.eq
                                         (i32.and
-                                          (set_local $$147
+                                          (set_local $0
                                             (i32.load offset=4
-                                              (get_local $$add$ptr16$i$i)
+                                              (get_local $3)
                                             )
                                           )
                                           (i32.const 3)
@@ -15764,44 +14538,44 @@
                                         (i32.const 1)
                                       )
                                       (block
-                                        (set_local $$and37$i$i
+                                        (set_local $11
                                           (i32.and
-                                            (get_local $$147)
+                                            (get_local $0)
                                             (i32.const -8)
                                           )
                                         )
-                                        (set_local $$shr$i$45$i
+                                        (set_local $8
                                           (i32.shr_u
-                                            (get_local $$147)
+                                            (get_local $0)
                                             (i32.const 3)
                                           )
                                         )
                                         (block $label$break$L331
                                           (if
                                             (i32.lt_u
-                                              (get_local $$147)
+                                              (get_local $0)
                                               (i32.const 256)
                                             )
                                             (block
-                                              (set_local $$149
+                                              (set_local $1
                                                 (i32.load offset=12
-                                                  (get_local $$add$ptr16$i$i)
+                                                  (get_local $3)
                                                 )
                                               )
                                               (block $do-once$55
                                                 (if
                                                   (i32.ne
-                                                    (set_local $$148
+                                                    (set_local $0
                                                       (i32.load offset=8
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                     )
-                                                    (set_local $$arrayidx$i$48$i
+                                                    (set_local $2
                                                       (i32.add
                                                         (i32.const 216)
                                                         (i32.shl
                                                           (i32.shl
-                                                            (get_local $$shr$i$45$i)
+                                                            (get_local $8)
                                                             (i32.const 1)
                                                           )
                                                           (i32.const 2)
@@ -15812,17 +14586,17 @@
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$148)
-                                                        (get_local $$150)
+                                                        (get_local $0)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (br_if $do-once$55
                                                       (i32.eq
                                                         (i32.load offset=12
-                                                          (get_local $$148)
+                                                          (get_local $0)
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                     )
                                                     (call_import $_abort)
@@ -15831,8 +14605,8 @@
                                               )
                                               (if
                                                 (i32.eq
-                                                  (get_local $$149)
-                                                  (get_local $$148)
+                                                  (get_local $1)
+                                                  (get_local $0)
                                                 )
                                                 (block
                                                   (i32.store
@@ -15844,7 +14618,7 @@
                                                       (i32.xor
                                                         (i32.shl
                                                           (i32.const 1)
-                                                          (get_local $$shr$i$45$i)
+                                                          (get_local $8)
                                                         )
                                                         (i32.const -1)
                                                       )
@@ -15856,38 +14630,38 @@
                                               (block $do-once$57
                                                 (if
                                                   (i32.eq
-                                                    (get_local $$149)
-                                                    (get_local $$arrayidx$i$48$i)
+                                                    (get_local $1)
+                                                    (get_local $2)
                                                   )
-                                                  (set_local $$fd68$pre$phi$i$iZ2D
+                                                  (set_local $40
                                                     (i32.add
-                                                      (get_local $$149)
+                                                      (get_local $1)
                                                       (i32.const 8)
                                                     )
                                                   )
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$149)
-                                                        (get_local $$150)
+                                                        (get_local $1)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (if
                                                       (i32.eq
                                                         (i32.load
-                                                          (set_local $$fd59$i$i
+                                                          (set_local $2
                                                             (i32.add
-                                                              (get_local $$149)
+                                                              (get_local $1)
                                                               (i32.const 8)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (block
-                                                        (set_local $$fd68$pre$phi$i$iZ2D
-                                                          (get_local $$fd59$i$i)
+                                                        (set_local $40
+                                                          (get_local $2)
                                                         )
                                                         (br $do-once$57)
                                                       )
@@ -15897,40 +14671,40 @@
                                                 )
                                               )
                                               (i32.store offset=12
-                                                (get_local $$148)
-                                                (get_local $$149)
+                                                (get_local $0)
+                                                (get_local $1)
                                               )
                                               (i32.store
-                                                (get_local $$fd68$pre$phi$i$iZ2D)
-                                                (get_local $$148)
+                                                (get_local $40)
+                                                (get_local $0)
                                               )
                                             )
                                             (block
-                                              (set_local $$154
+                                              (set_local $0
                                                 (i32.load offset=24
-                                                  (get_local $$add$ptr16$i$i)
+                                                  (get_local $3)
                                                 )
                                               )
                                               (block $do-once$59
                                                 (if
                                                   (i32.eq
-                                                    (set_local $$155
+                                                    (set_local $1
                                                       (i32.load offset=12
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                     )
-                                                    (get_local $$add$ptr16$i$i)
+                                                    (get_local $3)
                                                   )
                                                   (block
                                                     (if
                                                       (i32.eq
-                                                        (set_local $$159
+                                                        (set_local $1
                                                           (i32.load
-                                                            (set_local $$arrayidx96$i$i
+                                                            (set_local $8
                                                               (i32.add
-                                                                (set_local $$child$i$i
+                                                                (set_local $20
                                                                   (i32.add
-                                                                    (get_local $$add$ptr16$i$i)
+                                                                    (get_local $3)
                                                                     (i32.const 16)
                                                                   )
                                                                 )
@@ -15943,45 +14717,43 @@
                                                       )
                                                       (if
                                                         (i32.eq
-                                                          (set_local $$160
+                                                          (set_local $1
                                                             (i32.load
-                                                              (get_local $$child$i$i)
+                                                              (get_local $20)
                                                             )
                                                           )
                                                           (i32.const 0)
                                                         )
                                                         (block
-                                                          (set_local $$R$3$i$i
+                                                          (set_local $18
                                                             (i32.const 0)
                                                           )
                                                           (br $do-once$59)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i
-                                                            (get_local $$160)
+                                                          (set_local $2
+                                                            (get_local $1)
                                                           )
-                                                          (set_local $$RP$1$i$i
-                                                            (get_local $$child$i$i)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                         )
                                                       )
                                                       (block
-                                                        (set_local $$R$1$i$i
-                                                          (get_local $$159)
+                                                        (set_local $2
+                                                          (get_local $1)
                                                         )
-                                                        (set_local $$RP$1$i$i
-                                                          (get_local $$arrayidx96$i$i)
-                                                        )
+                                                        (get_local $8)
                                                       )
                                                     )
                                                     (loop $while-out$61 $while-in$62
                                                       (if
                                                         (i32.ne
-                                                          (set_local $$161
+                                                          (set_local $1
                                                             (i32.load
-                                                              (set_local $$arrayidx103$i$i
+                                                              (set_local $20
                                                                 (i32.add
-                                                                  (get_local $$R$1$i$i)
+                                                                  (get_local $2)
                                                                   (i32.const 20)
                                                                 )
                                                               )
@@ -15990,22 +14762,22 @@
                                                           (i32.const 0)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i
-                                                            (get_local $$161)
+                                                          (set_local $2
+                                                            (get_local $1)
                                                           )
-                                                          (set_local $$RP$1$i$i
-                                                            (get_local $$arrayidx103$i$i)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                           (br $while-in$62)
                                                         )
                                                       )
                                                       (if
                                                         (i32.eq
-                                                          (set_local $$162
+                                                          (set_local $1
                                                             (i32.load
-                                                              (set_local $$arrayidx107$i$i
+                                                              (set_local $20
                                                                 (i32.add
-                                                                  (get_local $$R$1$i$i)
+                                                                  (get_local $2)
                                                                   (i32.const 16)
                                                                 )
                                                               )
@@ -16014,20 +14786,20 @@
                                                           (i32.const 0)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i$lcssa
-                                                            (get_local $$R$1$i$i)
+                                                          (set_local $1
+                                                            (get_local $2)
                                                           )
-                                                          (set_local $$RP$1$i$i$lcssa
-                                                            (get_local $$RP$1$i$i)
+                                                          (set_local $2
+                                                            (get_local $8)
                                                           )
                                                           (br $while-out$61)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i
-                                                            (get_local $$162)
+                                                          (set_local $2
+                                                            (get_local $1)
                                                           )
-                                                          (set_local $$RP$1$i$i
-                                                            (get_local $$arrayidx107$i$i)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                         )
                                                       )
@@ -16035,17 +14807,17 @@
                                                     )
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$RP$1$i$i$lcssa)
-                                                        (get_local $$150)
+                                                        (get_local $2)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                       (block
                                                         (i32.store
-                                                          (get_local $$RP$1$i$i$lcssa)
+                                                          (get_local $2)
                                                           (i32.const 0)
                                                         )
-                                                        (set_local $$R$3$i$i
-                                                          (get_local $$R$1$i$i$lcssa)
+                                                        (set_local $18
+                                                          (get_local $1)
                                                         )
                                                       )
                                                     )
@@ -16053,52 +14825,52 @@
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (set_local $$156
+                                                        (set_local $2
                                                           (i32.load offset=8
-                                                            (get_local $$add$ptr16$i$i)
+                                                            (get_local $3)
                                                           )
                                                         )
-                                                        (get_local $$150)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (if
                                                       (i32.ne
                                                         (i32.load
-                                                          (set_local $$bk82$i$i
+                                                          (set_local $4
                                                             (i32.add
-                                                              (get_local $$156)
+                                                              (get_local $2)
                                                               (i32.const 12)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (if
                                                       (i32.eq
                                                         (i32.load
-                                                          (set_local $$fd85$i$i
+                                                          (set_local $8
                                                             (i32.add
-                                                              (get_local $$155)
+                                                              (get_local $1)
                                                               (i32.const 8)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (block
                                                         (i32.store
-                                                          (get_local $$bk82$i$i)
-                                                          (get_local $$155)
+                                                          (get_local $4)
+                                                          (get_local $1)
                                                         )
                                                         (i32.store
-                                                          (get_local $$fd85$i$i)
-                                                          (get_local $$156)
+                                                          (get_local $8)
+                                                          (get_local $2)
                                                         )
-                                                        (set_local $$R$3$i$i
-                                                          (get_local $$155)
+                                                        (set_local $18
+                                                          (get_local $1)
                                                         )
                                                       )
                                                       (call_import $_abort)
@@ -16108,22 +14880,22 @@
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eq
-                                                  (get_local $$154)
+                                                  (get_local $0)
                                                   (i32.const 0)
                                                 )
                                               )
                                               (block $do-once$63
                                                 (if
                                                   (i32.eq
-                                                    (get_local $$add$ptr16$i$i)
+                                                    (get_local $3)
                                                     (i32.load
-                                                      (set_local $$arrayidx123$i$i
+                                                      (set_local $2
                                                         (i32.add
                                                           (i32.const 480)
                                                           (i32.shl
-                                                            (set_local $$163
+                                                            (set_local $1
                                                               (i32.load offset=28
-                                                                (get_local $$add$ptr16$i$i)
+                                                                (get_local $3)
                                                               )
                                                             )
                                                             (i32.const 2)
@@ -16134,12 +14906,12 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $$arrayidx123$i$i)
-                                                      (get_local $$R$3$i$i)
+                                                      (get_local $2)
+                                                      (get_local $18)
                                                     )
                                                     (br_if $do-once$63
                                                       (i32.ne
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $18)
                                                         (i32.const 0)
                                                       )
                                                     )
@@ -16152,7 +14924,7 @@
                                                         (i32.xor
                                                           (i32.shl
                                                             (i32.const 1)
-                                                            (get_local $$163)
+                                                            (get_local $1)
                                                           )
                                                           (i32.const -1)
                                                         )
@@ -16163,7 +14935,7 @@
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$154)
+                                                        (get_local $0)
                                                         (i32.load
                                                           (i32.const 192)
                                                         )
@@ -16173,27 +14945,27 @@
                                                     (if
                                                       (i32.eq
                                                         (i32.load
-                                                          (set_local $$arrayidx143$i$i
+                                                          (set_local $1
                                                             (i32.add
-                                                              (get_local $$154)
+                                                              (get_local $0)
                                                               (i32.const 16)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (i32.store
-                                                        (get_local $$arrayidx143$i$i)
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $1)
+                                                        (get_local $18)
                                                       )
                                                       (i32.store offset=20
-                                                        (get_local $$154)
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $0)
+                                                        (get_local $18)
                                                       )
                                                     )
                                                     (br_if $label$break$L331
                                                       (i32.eq
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $18)
                                                         (i32.const 0)
                                                       )
                                                     )
@@ -16202,8 +14974,8 @@
                                               )
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $$R$3$i$i)
-                                                  (set_local $$168
+                                                  (get_local $18)
+                                                  (set_local $1
                                                     (i32.load
                                                       (i32.const 192)
                                                     )
@@ -16212,16 +14984,16 @@
                                                 (call_import $_abort)
                                               )
                                               (i32.store offset=24
-                                                (get_local $$R$3$i$i)
-                                                (get_local $$154)
+                                                (get_local $18)
+                                                (get_local $0)
                                               )
                                               (if
                                                 (i32.ne
-                                                  (set_local $$169
+                                                  (set_local $0
                                                     (i32.load
-                                                      (set_local $$child166$i$i
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $$add$ptr16$i$i)
+                                                          (get_local $3)
                                                           (i32.const 16)
                                                         )
                                                       )
@@ -16231,27 +15003,27 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $$169)
-                                                    (get_local $$168)
+                                                    (get_local $0)
+                                                    (get_local $1)
                                                   )
                                                   (call_import $_abort)
                                                   (block
                                                     (i32.store offset=16
-                                                      (get_local $$R$3$i$i)
-                                                      (get_local $$169)
+                                                      (get_local $18)
+                                                      (get_local $0)
                                                     )
                                                     (i32.store offset=24
-                                                      (get_local $$169)
-                                                      (get_local $$R$3$i$i)
+                                                      (get_local $0)
+                                                      (get_local $18)
                                                     )
                                                   )
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eq
-                                                  (set_local $$170
+                                                  (set_local $0
                                                     (i32.load offset=4
-                                                      (get_local $$child166$i$i)
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (i32.const 0)
@@ -16259,7 +15031,7 @@
                                               )
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $$170)
+                                                  (get_local $0)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -16267,34 +15039,34 @@
                                                 (call_import $_abort)
                                                 (block
                                                   (i32.store offset=20
-                                                    (get_local $$R$3$i$i)
-                                                    (get_local $$170)
+                                                    (get_local $18)
+                                                    (get_local $0)
                                                   )
                                                   (i32.store offset=24
-                                                    (get_local $$170)
-                                                    (get_local $$R$3$i$i)
+                                                    (get_local $0)
+                                                    (get_local $18)
                                                   )
                                                 )
                                               )
                                             )
                                           )
                                         )
-                                        (set_local $$qsize$0$i$i
+                                        (set_local $4
                                           (i32.add
-                                            (get_local $$and37$i$i)
-                                            (get_local $$sub18$i$i)
+                                            (get_local $11)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.add
-                                          (get_local $$add$ptr16$i$i)
-                                          (get_local $$and37$i$i)
+                                          (get_local $3)
+                                          (get_local $11)
                                         )
                                       )
                                       (block
-                                        (set_local $$qsize$0$i$i
-                                          (get_local $$sub18$i$i)
+                                        (set_local $4
+                                          (get_local $13)
                                         )
-                                        (get_local $$add$ptr16$i$i)
+                                        (get_local $3)
                                       )
                                     )
                                     (i32.const 4)
@@ -16305,41 +15077,41 @@
                             )
                           )
                           (i32.store
-                            (get_local $$head208$i$i)
-                            (get_local $$and209$i$i)
+                            (get_local $1)
+                            (get_local $0)
                           )
                           (i32.store offset=4
-                            (get_local $$add$ptr17$i$i)
+                            (get_local $5)
                             (i32.or
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $$add$ptr17$i$i)
-                              (get_local $$qsize$0$i$i)
+                              (get_local $5)
+                              (get_local $4)
                             )
-                            (get_local $$qsize$0$i$i)
+                            (get_local $4)
                           )
-                          (set_local $$shr214$i$i
+                          (set_local $1
                             (i32.shr_u
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $$arrayidx223$i$i
+                              (set_local $2
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $$shr214$i$i)
+                                      (get_local $1)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -16350,15 +15122,15 @@
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $$173
+                                      (set_local $0
                                         (i32.load
                                           (i32.const 176)
                                         )
                                       )
-                                      (set_local $$shl226$i$i
+                                      (set_local $1
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $$shr214$i$i)
+                                          (get_local $1)
                                         )
                                       )
                                     )
@@ -16368,28 +15140,28 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $$173)
-                                        (get_local $$shl226$i$i)
+                                        (get_local $0)
+                                        (get_local $1)
                                       )
                                     )
-                                    (set_local $$$pre$phi$i$57$iZ2D
+                                    (set_local $7
                                       (i32.add
-                                        (get_local $$arrayidx223$i$i)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $$F224$0$i$i
-                                      (get_local $$arrayidx223$i$i)
+                                    (set_local $32
+                                      (get_local $2)
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $$175
+                                        (set_local $1
                                           (i32.load
-                                            (set_local $$174
+                                            (set_local $0
                                               (i32.add
-                                                (get_local $$arrayidx223$i$i)
+                                                (get_local $2)
                                                 (i32.const 8)
                                               )
                                             )
@@ -16400,11 +15172,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $$$pre$phi$i$57$iZ2D
-                                          (get_local $$174)
+                                        (set_local $7
+                                          (get_local $0)
                                         )
-                                        (set_local $$F224$0$i$i
-                                          (get_local $$175)
+                                        (set_local $32
+                                          (get_local $1)
                                         )
                                         (br $do-once$67)
                                       )
@@ -16414,35 +15186,35 @@
                                 )
                               )
                               (i32.store
-                                (get_local $$$pre$phi$i$57$iZ2D)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $7)
+                                (get_local $5)
                               )
                               (i32.store offset=12
-                                (get_local $$F224$0$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $32)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$F224$0$i$i)
+                                (get_local $5)
+                                (get_local $32)
                               )
                               (i32.store offset=12
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$arrayidx223$i$i)
+                                (get_local $5)
+                                (get_local $2)
                               )
                               (br $do-once$52)
                             )
                           )
-                          (set_local $$arrayidx287$i$i
+                          (set_local $2
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $$I252$0$i$i
+                                (set_local $1
                                   (block $do-once$69
                                     (if
                                       (i32.eq
-                                        (set_local $$shr253$i$i
+                                        (set_local $0
                                           (i32.shr_u
-                                            (get_local $$qsize$0$i$i)
+                                            (get_local $4)
                                             (i32.const 8)
                                           )
                                         )
@@ -16452,33 +15224,33 @@
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $$qsize$0$i$i)
+                                            (get_local $4)
                                             (i32.const 16777215)
                                           )
                                           (br $do-once$69
                                             (i32.const 31)
                                           )
                                         )
-                                        (set_local $$shl279$i$i
+                                        (set_local $1
                                           (i32.shl
-                                            (set_local $$add278$i$i
+                                            (set_local $0
                                               (i32.add
                                                 (i32.sub
                                                   (i32.const 14)
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $$and268$i$i
+                                                      (set_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $$shl265$i$i
+                                                              (set_local $2
                                                                 (i32.shl
-                                                                  (get_local $$shr253$i$i)
-                                                                  (set_local $$and264$i$i
+                                                                  (get_local $0)
+                                                                  (set_local $0
                                                                     (i32.and
                                                                       (i32.shr_u
                                                                         (i32.add
-                                                                          (get_local $$shr253$i$i)
+                                                                          (get_local $0)
                                                                           (i32.const 1048320)
                                                                         )
                                                                         (i32.const 16)
@@ -16495,16 +15267,16 @@
                                                           (i32.const 4)
                                                         )
                                                       )
-                                                      (get_local $$and264$i$i)
+                                                      (get_local $0)
                                                     )
-                                                    (set_local $$and273$i$i
+                                                    (set_local $0
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $$shl270$i$i
+                                                            (set_local $1
                                                               (i32.shl
-                                                                (get_local $$shl265$i$i)
-                                                                (get_local $$and268$i$i)
+                                                                (get_local $2)
+                                                                (get_local $1)
                                                               )
                                                             )
                                                             (i32.const 245760)
@@ -16518,8 +15290,8 @@
                                                 )
                                                 (i32.shr_u
                                                   (i32.shl
-                                                    (get_local $$shl270$i$i)
-                                                    (get_local $$and273$i$i)
+                                                    (get_local $1)
+                                                    (get_local $0)
                                                   )
                                                   (i32.const 15)
                                                 )
@@ -16531,15 +15303,15 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $$qsize$0$i$i)
+                                              (get_local $4)
                                               (i32.add
-                                                (get_local $$add278$i$i)
+                                                (get_local $0)
                                                 (i32.const 7)
                                               )
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $$shl279$i$i)
+                                          (get_local $1)
                                         )
                                       )
                                     )
@@ -16550,34 +15322,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $$add$ptr17$i$i)
-                            (get_local $$I252$0$i$i)
+                            (get_local $5)
+                            (get_local $1)
                           )
                           (i32.store offset=4
-                            (set_local $$child289$i$i
+                            (set_local $0
                               (i32.add
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $$child289$i$i)
+                            (get_local $0)
                             (i32.const 0)
                           )
                           (if
                             (i32.eq
                               (i32.and
-                                (set_local $$177
+                                (set_local $0
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $$shl294$i$i
+                                (set_local $7
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $$I252$0$i$i)
+                                    (get_local $1)
                                   )
                                 )
                               )
@@ -16587,51 +15359,51 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $$177)
-                                  (get_local $$shl294$i$i)
+                                  (get_local $0)
+                                  (get_local $7)
                                 )
                               )
                               (i32.store
-                                (get_local $$arrayidx287$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $2)
+                                (get_local $5)
                               )
                               (i32.store offset=24
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$arrayidx287$i$i)
+                                (get_local $5)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (br $do-once$52)
                             )
                           )
-                          (set_local $$K305$0$i$i
+                          (set_local $1
                             (i32.shl
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $$I252$0$i$i)
+                                    (get_local $1)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $$I252$0$i$i)
+                                  (get_local $1)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $$T$0$i$58$i
+                          (set_local $2
                             (i32.load
-                              (get_local $$arrayidx287$i$i)
+                              (get_local $2)
                             )
                           )
                           (loop $while-out$71 $while-in$72
@@ -16639,41 +15411,41 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $$T$0$i$58$i)
+                                    (get_local $2)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $$qsize$0$i$i)
+                                (get_local $4)
                               )
                               (block
-                                (set_local $$T$0$i$58$i$lcssa
-                                  (get_local $$T$0$i$58$i)
+                                (set_local $33
+                                  (get_local $2)
                                 )
-                                (set_local $label
+                                (set_local $10
                                   (i32.const 281)
                                 )
                                 (br $while-out$71)
                               )
                             )
-                            (set_local $$shl326$i$i
+                            (set_local $7
                               (i32.shl
-                                (get_local $$K305$0$i$i)
+                                (get_local $1)
                                 (i32.const 1)
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$180
+                                (set_local $0
                                   (i32.load
-                                    (set_local $$arrayidx325$i$i
+                                    (set_local $1
                                       (i32.add
                                         (i32.add
-                                          (get_local $$T$0$i$58$i)
+                                          (get_local $2)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $$K305$0$i$i)
+                                            (get_local $1)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -16685,23 +15457,23 @@
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$T$0$i$58$i$lcssa283
-                                  (get_local $$T$0$i$58$i)
+                                (set_local $42
+                                  (get_local $2)
                                 )
-                                (set_local $$arrayidx325$i$i$lcssa
-                                  (get_local $$arrayidx325$i$i)
+                                (set_local $38
+                                  (get_local $1)
                                 )
-                                (set_local $label
+                                (set_local $10
                                   (i32.const 278)
                                 )
                                 (br $while-out$71)
                               )
                               (block
-                                (set_local $$K305$0$i$i
-                                  (get_local $$shl326$i$i)
+                                (set_local $1
+                                  (get_local $7)
                                 )
-                                (set_local $$T$0$i$58$i
-                                  (get_local $$180)
+                                (set_local $2
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -16709,12 +15481,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $label)
+                              (get_local $10)
                               (i32.const 278)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$arrayidx325$i$i$lcssa)
+                                (get_local $38)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -16722,71 +15494,71 @@
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $$arrayidx325$i$i$lcssa)
-                                  (get_local $$add$ptr17$i$i)
+                                  (get_local $38)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$T$0$i$58$i$lcssa283)
+                                  (get_local $5)
+                                  (get_local $42)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$add$ptr17$i$i)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$add$ptr17$i$i)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $label)
+                                (get_local $10)
                                 (i32.const 281)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $$182
+                                    (set_local $0
                                       (i32.load
-                                        (set_local $$fd344$i$i
+                                        (set_local $2
                                           (i32.add
-                                            (get_local $$T$0$i$58$i$lcssa)
+                                            (get_local $33)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $$183
+                                    (set_local $1
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $$T$0$i$58$i$lcssa)
-                                    (get_local $$183)
+                                    (get_local $33)
+                                    (get_local $1)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $$182)
-                                    (get_local $$add$ptr17$i$i)
+                                    (get_local $0)
+                                    (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $$fd344$i$i)
-                                    (get_local $$add$ptr17$i$i)
+                                    (get_local $2)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $$add$ptr17$i$i)
-                                    (get_local $$182)
+                                    (get_local $5)
+                                    (get_local $0)
                                   )
                                   (i32.store offset=12
-                                    (get_local $$add$ptr17$i$i)
-                                    (get_local $$T$0$i$58$i$lcssa)
+                                    (get_local $5)
+                                    (get_local $33)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$add$ptr17$i$i)
+                                    (get_local $5)
                                     (i32.const 0)
                                   )
                                 )
@@ -16799,12 +15571,12 @@
                     )
                     (return
                       (i32.add
-                        (get_local $$add$ptr4$i$37$i)
+                        (get_local $6)
                         (i32.const 8)
                       )
                     )
                   )
-                  (set_local $$sp$0$i$i$i
+                  (set_local $27
                     (i32.const 624)
                   )
                 )
@@ -16812,48 +15584,48 @@
               (loop $while-out$73 $while-in$74
                 (if
                   (i32.le_u
-                    (set_local $$185
+                    (set_local $1
                       (i32.load
-                        (get_local $$sp$0$i$i$i)
+                        (get_local $27)
                       )
                     )
-                    (get_local $$119)
+                    (get_local $0)
                   )
                   (if
                     (i32.gt_u
-                      (set_local $$add$ptr$i$i$i
+                      (set_local $1
                         (i32.add
-                          (get_local $$185)
+                          (get_local $1)
                           (i32.load offset=4
-                            (get_local $$sp$0$i$i$i)
+                            (get_local $27)
                           )
                         )
                       )
-                      (get_local $$119)
+                      (get_local $0)
                     )
                     (block
-                      (set_local $$add$ptr$i$i$i$lcssa
-                        (get_local $$add$ptr$i$i$i)
+                      (set_local $2
+                        (get_local $1)
                       )
                       (br $while-out$73)
                     )
                   )
                 )
-                (set_local $$sp$0$i$i$i
+                (set_local $27
                   (i32.load offset=8
-                    (get_local $$sp$0$i$i$i)
+                    (get_local $27)
                   )
                 )
                 (br $while-in$74)
               )
-              (set_local $$cmp$i$15$i
+              (set_local $7
                 (i32.eq
                   (i32.and
-                    (set_local $$188
+                    (set_local $1
                       (i32.add
-                        (set_local $$add$ptr2$i$i
+                        (set_local $4
                           (i32.add
-                            (get_local $$add$ptr$i$i$i$lcssa)
+                            (get_local $2)
                             (i32.const -47)
                           )
                         )
@@ -16865,50 +15637,50 @@
                   (i32.const 0)
                 )
               )
-              (set_local $$cmp9$i$i
+              (set_local $4
                 (i32.lt_u
-                  (set_local $$add$ptr7$i$i
+                  (set_local $1
                     (i32.add
-                      (get_local $$add$ptr2$i$i)
+                      (get_local $4)
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (get_local $$188)
+                            (get_local $1)
                           )
                           (i32.const 7)
                         )
-                        (get_local $$cmp$i$15$i)
+                        (get_local $7)
                       )
                     )
                   )
-                  (set_local $$add$ptr8$i122$i
+                  (set_local $7
                     (i32.add
-                      (get_local $$119)
+                      (get_local $0)
                       (i32.const 16)
                     )
                   )
                 )
               )
-              (set_local $$add$ptr14$i$i
+              (set_local $4
                 (i32.add
-                  (set_local $$cond13$i$i
+                  (set_local $5
                     (select
-                      (get_local $$119)
-                      (get_local $$add$ptr7$i$i)
-                      (get_local $$cmp9$i$i)
+                      (get_local $0)
+                      (get_local $1)
+                      (get_local $4)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $$cmp$i$2$i$i
+              (set_local $3
                 (i32.eq
                   (i32.and
-                    (set_local $$190
+                    (set_local $1
                       (i32.add
-                        (get_local $$tbase$796$i)
+                        (get_local $16)
                         (i32.const 8)
                       )
                     )
@@ -16919,20 +15691,20 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $$add$ptr4$i$i$i
+                (set_local $1
                   (i32.add
-                    (get_local $$tbase$796$i)
-                    (set_local $$cond$i$i$i
+                    (get_local $16)
+                    (set_local $3
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (get_local $$190)
+                            (get_local $1)
                           )
                           (i32.const 7)
                         )
-                        (get_local $$cmp$i$2$i$i)
+                        (get_local $3)
                       )
                     )
                   )
@@ -16940,27 +15712,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $$sub5$i$i$i
+                (set_local $3
                   (i32.sub
                     (i32.add
-                      (get_local $$tsize$795$i)
+                      (get_local $19)
                       (i32.const -40)
                     )
-                    (get_local $$cond$i$i$i)
+                    (get_local $3)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr4$i$i$i)
+                (get_local $1)
                 (i32.or
-                  (get_local $$sub5$i$i$i)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $$add$ptr4$i$i$i)
-                  (get_local $$sub5$i$i$i)
+                  (get_local $1)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -16971,45 +15743,45 @@
                 )
               )
               (i32.store
-                (set_local $$head$i$17$i
+                (set_local $3
                   (i32.add
-                    (get_local $$cond13$i$i)
+                    (get_local $5)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load offset=4
                   (i32.const 624)
                 )
               )
               (i32.store offset=8
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load offset=8
                   (i32.const 624)
                 )
               )
               (i32.store offset=12
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load offset=12
                   (i32.const 624)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $$tbase$796$i)
+                (get_local $16)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $$tsize$795$i)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 636)
@@ -17017,19 +15789,19 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
               )
-              (set_local $$p$0$i$i
+              (set_local $1
                 (i32.add
-                  (get_local $$cond13$i$i)
+                  (get_local $5)
                   (i32.const 24)
                 )
               )
               (loop $while-out$75 $while-in$76
                 (i32.store
-                  (set_local $$add$ptr24$i$i
+                  (set_local $1
                     (i32.add
-                      (get_local $$p$0$i$i)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
@@ -17038,67 +15810,65 @@
                 (if
                   (i32.lt_u
                     (i32.add
-                      (get_local $$add$ptr24$i$i)
+                      (get_local $1)
                       (i32.const 4)
                     )
-                    (get_local $$add$ptr$i$i$i$lcssa)
+                    (get_local $2)
                   )
-                  (set_local $$p$0$i$i
-                    (get_local $$add$ptr24$i$i)
-                  )
+                  (get_local $1)
                   (br $while-out$75)
                 )
                 (br $while-in$76)
               )
               (if
                 (i32.ne
-                  (get_local $$cond13$i$i)
-                  (get_local $$119)
+                  (get_local $5)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
-                    (get_local $$head$i$17$i)
+                    (get_local $3)
                     (i32.and
                       (i32.load
-                        (get_local $$head$i$17$i)
+                        (get_local $3)
                       )
                       (i32.const -2)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$119)
+                    (get_local $0)
                     (i32.or
-                      (set_local $$sub$ptr$sub$i$i
+                      (set_local $3
                         (i32.sub
-                          (get_local $$cond13$i$i)
-                          (get_local $$119)
+                          (get_local $5)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $$cond13$i$i)
-                    (get_local $$sub$ptr$sub$i$i)
+                    (get_local $5)
+                    (get_local $3)
                   )
-                  (set_local $$shr$i$i
+                  (set_local $2
                     (i32.shr_u
-                      (get_local $$sub$ptr$sub$i$i)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$sub$ptr$sub$i$i)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $$arrayidx$i$20$i
+                      (set_local $4
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (get_local $$shr$i$i)
+                              (get_local $2)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -17108,15 +15878,15 @@
                       (if
                         (i32.eq
                           (i32.and
-                            (set_local $$195
+                            (set_local $1
                               (i32.load
                                 (i32.const 176)
                               )
                             )
-                            (set_local $$shl39$i$i
+                            (set_local $2
                               (i32.shl
                                 (i32.const 1)
-                                (get_local $$shr$i$i)
+                                (get_local $2)
                               )
                             )
                           )
@@ -17126,27 +15896,27 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $$195)
-                              (get_local $$shl39$i$i)
+                              (get_local $1)
+                              (get_local $2)
                             )
                           )
-                          (set_local $$$pre$phi$i$iZ2D
+                          (set_local $8
                             (i32.add
-                              (get_local $$arrayidx$i$20$i)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
-                          (set_local $$F$0$i$i
-                            (get_local $$arrayidx$i$20$i)
+                          (set_local $20
+                            (get_local $4)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $$197
+                            (set_local $2
                               (i32.load
-                                (set_local $$196
+                                (set_local $1
                                   (i32.add
-                                    (get_local $$arrayidx$i$20$i)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -17158,44 +15928,44 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $$$pre$phi$i$iZ2D
-                              (get_local $$196)
+                            (set_local $8
+                              (get_local $1)
                             )
-                            (set_local $$F$0$i$i
-                              (get_local $$197)
+                            (set_local $20
+                              (get_local $2)
                             )
                           )
                         )
                       )
                       (i32.store
-                        (get_local $$$pre$phi$i$iZ2D)
-                        (get_local $$119)
+                        (get_local $8)
+                        (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $$F$0$i$i)
-                        (get_local $$119)
+                        (get_local $20)
+                        (get_local $0)
                       )
                       (i32.store offset=8
-                        (get_local $$119)
-                        (get_local $$F$0$i$i)
+                        (get_local $0)
+                        (get_local $20)
                       )
                       (i32.store offset=12
-                        (get_local $$119)
-                        (get_local $$arrayidx$i$20$i)
+                        (get_local $0)
+                        (get_local $4)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $$arrayidx91$i$i
+                  (set_local $4
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (set_local $$I57$0$i$i
+                        (set_local $2
                           (if
                             (i32.eq
-                              (set_local $$shr58$i$i
+                              (set_local $1
                                 (i32.shr_u
-                                  (get_local $$sub$ptr$sub$i$i)
+                                  (get_local $3)
                                   (i32.const 8)
                                 )
                               )
@@ -17204,31 +15974,31 @@
                             (i32.const 0)
                             (if
                               (i32.gt_u
-                                (get_local $$sub$ptr$sub$i$i)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (block
-                                (set_local $$shl84$i$i
+                                (set_local $2
                                   (i32.shl
-                                    (set_local $$add83$i$i
+                                    (set_local $1
                                       (i32.add
                                         (i32.sub
                                           (i32.const 14)
                                           (i32.or
                                             (i32.or
-                                              (set_local $$and73$i$i
+                                              (set_local $2
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $$shl70$i$i
+                                                      (set_local $4
                                                         (i32.shl
-                                                          (get_local $$shr58$i$i)
-                                                          (set_local $$and69$i$i
+                                                          (get_local $1)
+                                                          (set_local $1
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (get_local $$shr58$i$i)
+                                                                  (get_local $1)
                                                                   (i32.const 1048320)
                                                                 )
                                                                 (i32.const 16)
@@ -17245,16 +16015,16 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $$and69$i$i)
+                                              (get_local $1)
                                             )
-                                            (set_local $$and78$i$i
+                                            (set_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (set_local $$shl75$i$i
+                                                    (set_local $2
                                                       (i32.shl
-                                                        (get_local $$shl70$i$i)
-                                                        (get_local $$and73$i$i)
+                                                        (get_local $4)
+                                                        (get_local $2)
                                                       )
                                                     )
                                                     (i32.const 245760)
@@ -17268,8 +16038,8 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
-                                            (get_local $$shl75$i$i)
-                                            (get_local $$and78$i$i)
+                                            (get_local $2)
+                                            (get_local $1)
                                           )
                                           (i32.const 15)
                                         )
@@ -17281,15 +16051,15 @@
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $$sub$ptr$sub$i$i)
+                                      (get_local $3)
                                       (i32.add
-                                        (get_local $$add83$i$i)
+                                        (get_local $1)
                                         (i32.const 7)
                                       )
                                     )
                                     (i32.const 1)
                                   )
-                                  (get_local $$shl84$i$i)
+                                  (get_local $2)
                                 )
                               )
                             )
@@ -17300,29 +16070,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $$119)
-                    (get_local $$I57$0$i$i)
+                    (get_local $0)
+                    (get_local $2)
                   )
                   (i32.store offset=20
-                    (get_local $$119)
+                    (get_local $0)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $$add$ptr8$i122$i)
+                    (get_local $7)
                     (i32.const 0)
                   )
                   (if
                     (i32.eq
                       (i32.and
-                        (set_local $$199
+                        (set_local $1
                           (i32.load
                             (i32.const 180)
                           )
                         )
-                        (set_local $$shl95$i$i
+                        (set_local $7
                           (i32.shl
                             (i32.const 1)
-                            (get_local $$I57$0$i$i)
+                            (get_local $2)
                           )
                         )
                       )
@@ -17332,51 +16102,51 @@
                       (i32.store
                         (i32.const 180)
                         (i32.or
-                          (get_local $$199)
-                          (get_local $$shl95$i$i)
+                          (get_local $1)
+                          (get_local $7)
                         )
                       )
                       (i32.store
-                        (get_local $$arrayidx91$i$i)
-                        (get_local $$119)
+                        (get_local $4)
+                        (get_local $0)
                       )
                       (i32.store offset=24
-                        (get_local $$119)
-                        (get_local $$arrayidx91$i$i)
+                        (get_local $0)
+                        (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $$119)
-                        (get_local $$119)
+                        (get_local $0)
+                        (get_local $0)
                       )
                       (i32.store offset=8
-                        (get_local $$119)
-                        (get_local $$119)
+                        (get_local $0)
+                        (get_local $0)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $$K105$0$i$i
+                  (set_local $2
                     (i32.shl
-                      (get_local $$sub$ptr$sub$i$i)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $$I57$0$i$i)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $$I57$0$i$i)
+                          (get_local $2)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $$T$0$i$i
+                  (set_local $4
                     (i32.load
-                      (get_local $$arrayidx91$i$i)
+                      (get_local $4)
                     )
                   )
                   (loop $while-out$77 $while-in$78
@@ -17384,41 +16154,41 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $$T$0$i$i)
+                            (get_local $4)
                           )
                           (i32.const -8)
                         )
-                        (get_local $$sub$ptr$sub$i$i)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $$T$0$i$i$lcssa
-                          (get_local $$T$0$i$i)
+                        (set_local $34
+                          (get_local $4)
                         )
-                        (set_local $label
+                        (set_local $10
                           (i32.const 307)
                         )
                         (br $while-out$77)
                       )
                     )
-                    (set_local $$shl127$i$i
+                    (set_local $7
                       (i32.shl
-                        (get_local $$K105$0$i$i)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
                     (if
                       (i32.eq
-                        (set_local $$202
+                        (set_local $1
                           (i32.load
-                            (set_local $$arrayidx126$i$i
+                            (set_local $2
                               (i32.add
                                 (i32.add
-                                  (get_local $$T$0$i$i)
+                                  (get_local $4)
                                   (i32.const 16)
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $$K105$0$i$i)
+                                    (get_local $2)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -17430,23 +16200,23 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$T$0$i$i$lcssa284
-                          (get_local $$T$0$i$i)
+                        (set_local $43
+                          (get_local $4)
                         )
-                        (set_local $$arrayidx126$i$i$lcssa
-                          (get_local $$arrayidx126$i$i)
+                        (set_local $37
+                          (get_local $2)
                         )
-                        (set_local $label
+                        (set_local $10
                           (i32.const 304)
                         )
                         (br $while-out$77)
                       )
                       (block
-                        (set_local $$K105$0$i$i
-                          (get_local $$shl127$i$i)
+                        (set_local $2
+                          (get_local $7)
                         )
-                        (set_local $$T$0$i$i
-                          (get_local $$202)
+                        (set_local $4
+                          (get_local $1)
                         )
                       )
                     )
@@ -17454,12 +16224,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $label)
+                      (get_local $10)
                       (i32.const 304)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$arrayidx126$i$i$lcssa)
+                        (get_local $37)
                         (i32.load
                           (i32.const 192)
                         )
@@ -17467,71 +16237,71 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $$arrayidx126$i$i$lcssa)
-                          (get_local $$119)
+                          (get_local $37)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $$119)
-                          (get_local $$T$0$i$i$lcssa284)
+                          (get_local $0)
+                          (get_local $43)
                         )
                         (i32.store offset=12
-                          (get_local $$119)
-                          (get_local $$119)
+                          (get_local $0)
+                          (get_local $0)
                         )
                         (i32.store offset=8
-                          (get_local $$119)
-                          (get_local $$119)
+                          (get_local $0)
+                          (get_local $0)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $label)
+                        (get_local $10)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $$204
+                            (set_local $1
                               (i32.load
-                                (set_local $$fd148$i$i
+                                (set_local $4
                                   (i32.add
-                                    (get_local $$T$0$i$i$lcssa)
+                                    (get_local $34)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $$205
+                            (set_local $2
                               (i32.load
                                 (i32.const 192)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $$T$0$i$i$lcssa)
-                            (get_local $$205)
+                            (get_local $34)
+                            (get_local $2)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $$204)
-                            (get_local $$119)
+                            (get_local $1)
+                            (get_local $0)
                           )
                           (i32.store
-                            (get_local $$fd148$i$i)
-                            (get_local $$119)
+                            (get_local $4)
+                            (get_local $0)
                           )
                           (i32.store offset=8
-                            (get_local $$119)
-                            (get_local $$204)
+                            (get_local $0)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $$119)
-                            (get_local $$T$0$i$i$lcssa)
+                            (get_local $0)
+                            (get_local $34)
                           )
                           (i32.store offset=24
-                            (get_local $$119)
+                            (get_local $0)
                             (i32.const 0)
                           )
                         )
@@ -17546,53 +16316,53 @@
         )
         (if
           (i32.gt_u
-            (set_local $$207
+            (set_local $0
               (i32.load
                 (i32.const 188)
               )
             )
-            (get_local $$nb$0)
+            (get_local $9)
           )
           (block
             (i32.store
               (i32.const 188)
-              (set_local $$sub260$i
+              (set_local $2
                 (i32.sub
-                  (get_local $$207)
-                  (get_local $$nb$0)
+                  (get_local $0)
+                  (get_local $9)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (set_local $$add$ptr262$i
+              (set_local $1
                 (i32.add
-                  (set_local $$208
+                  (set_local $0
                     (i32.load
                       (i32.const 200)
                     )
                   )
-                  (get_local $$nb$0)
+                  (get_local $9)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $$add$ptr262$i)
+              (get_local $1)
               (i32.or
-                (get_local $$sub260$i)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $$208)
+              (get_local $0)
               (i32.or
-                (get_local $$nb$0)
+                (get_local $9)
                 (i32.const 3)
               )
             )
             (return
               (i32.add
-                (get_local $$208)
+                (get_local $0)
                 (i32.const 8)
               )
             )
@@ -17606,144 +16376,44 @@
     )
     (i32.const 0)
   )
-  (func $_free (param $$mem i32)
-    (local $$p$1 i32)
-    (local $$add$ptr16 i32)
-    (local $$add$ptr6 i32)
-    (local $$psize$1 i32)
-    (local $$R$3 i32)
-    (local $$R332$3 i32)
-    (local $$add17 i32)
-    (local $$psize$2 i32)
-    (local $$35 i32)
-    (local $$5 i32)
-    (local $$R$1 i32)
-    (local $$R332$1 i32)
-    (local $$0 i32)
-    (local $$28 i32)
-    (local $$34 i32)
-    (local $$4 i32)
-    (local $$41 i32)
-    (local $$9 i32)
-    (local $$T$0 i32)
-    (local $$add267 i32)
-    (local $$2 i32)
-    (local $$I534$0 i32)
-    (local $$RP$1 i32)
-    (local $$RP360$1 i32)
-    (local $$add$ptr i32)
-    (local $$arrayidx509 i32)
-    (local $$10 i32)
-    (local $$24 i32)
-    (local $$25 i32)
-    (local $$42 i32)
-    (local $$58 i32)
-    (local $$59 i32)
-    (local $$F510$0 i32)
-    (local $$K583$0 i32)
-    (local $$T$0$lcssa i32)
-    (local $$add258 i32)
-    (local $$arrayidx567 i32)
-    (local $label i32)
-    (local $$$pre$phiZ2D i32)
-    (local $$1 i32)
-    (local $$11 i32)
-    (local $$43 i32)
-    (local $$71 i32)
-    (local $$RP$1$lcssa i32)
-    (local $$RP360$1$lcssa i32)
-    (local $$and5 i32)
-    (local $$arrayidx599$lcssa i32)
-    (local $$child i32)
-    (local $$child361 i32)
-    (local $$fd322$pre$phiZ2D i32)
-    (local $$fd67$pre$phiZ2D i32)
-    (local $$shr i32)
-    (local $$shr268 i32)
-    (local $$shr501 i32)
-    (local $$shr535 i32)
-    (local $$sp$0$in$i i32)
-    (local $$14 i32)
-    (local $$15 i32)
-    (local $$16 i32)
-    (local $$17 i32)
-    (local $$18 i32)
-    (local $$23 i32)
-    (local $$27 i32)
-    (local $$47 i32)
-    (local $$48 i32)
-    (local $$49 i32)
-    (local $$50 i32)
-    (local $$52 i32)
-    (local $$57 i32)
-    (local $$62 i32)
-    (local $$63 i32)
-    (local $$64 i32)
-    (local $$66 i32)
-    (local $$69 i32)
-    (local $$72 i32)
-    (local $$R$1$lcssa i32)
-    (local $$R332$1$lcssa i32)
-    (local $$T$0$lcssa319 i32)
-    (local $$add246 i32)
-    (local $$add559 i32)
-    (local $$and i32)
-    (local $$and545 i32)
-    (local $$and549 i32)
-    (local $$and554 i32)
-    (local $$arrayidx i32)
-    (local $$arrayidx108 i32)
-    (local $$arrayidx113 i32)
-    (local $$arrayidx130 i32)
-    (local $$arrayidx149 i32)
-    (local $$arrayidx279 i32)
-    (local $$arrayidx362 i32)
-    (local $$arrayidx374 i32)
-    (local $$arrayidx379 i32)
-    (local $$arrayidx400 i32)
-    (local $$arrayidx419 i32)
-    (local $$arrayidx599 i32)
-    (local $$arrayidx99 i32)
-    (local $$bk343 i32)
-    (local $$bk82 i32)
-    (local $$child171 i32)
-    (local $$child443 i32)
-    (local $$cmp$i i32)
-    (local $$dec i32)
-    (local $$fd311 i32)
-    (local $$fd347 i32)
-    (local $$fd56 i32)
-    (local $$fd620 i32)
-    (local $$fd86 i32)
-    (local $$head209 i32)
-    (local $$head231 i32)
-    (local $$next4$i i32)
-    (local $$shl511 i32)
-    (local $$shl546 i32)
-    (local $$shl551 i32)
-    (local $$shl560 i32)
-    (local $$shl573 i32)
-    (local $$shl600 i32)
-    (local $$sp$0$i i32)
+  (func $_free (param $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
-        (get_local $$mem)
+        (get_local $0)
         (i32.const 0)
       )
       (return)
     )
     (if
       (i32.lt_u
-        (set_local $$add$ptr
+        (set_local $2
           (i32.add
-            (get_local $$mem)
+            (get_local $0)
             (i32.const -8)
           )
         )
-        (set_local $$0
+        (set_local $1
           (i32.load
             (i32.const 192)
           )
@@ -17753,12 +16423,12 @@
     )
     (if
       (i32.eq
-        (set_local $$and
+        (set_local $6
           (i32.and
-            (set_local $$1
+            (set_local $0
               (i32.load
                 (i32.add
-                  (get_local $$mem)
+                  (get_local $0)
                   (i32.const -4)
                 )
               )
@@ -17770,12 +16440,12 @@
       )
       (call_import $_abort)
     )
-    (set_local $$add$ptr6
+    (set_local $8
       (i32.add
-        (get_local $$add$ptr)
-        (set_local $$and5
+        (get_local $2)
+        (set_local $7
           (i32.and
-            (get_local $$1)
+            (get_local $0)
             (i32.const -8)
           )
         )
@@ -17785,48 +16455,48 @@
       (if
         (i32.eq
           (i32.and
-            (get_local $$1)
+            (get_local $0)
             (i32.const 1)
           )
           (i32.const 0)
         )
         (block
-          (set_local $$2
+          (set_local $0
             (i32.load
-              (get_local $$add$ptr)
+              (get_local $2)
             )
           )
           (if
             (i32.eq
-              (get_local $$and)
+              (get_local $6)
               (i32.const 0)
             )
             (return)
           )
-          (set_local $$add17
+          (set_local $12
             (i32.add
-              (get_local $$2)
-              (get_local $$and5)
+              (get_local $0)
+              (get_local $7)
             )
           )
           (if
             (i32.lt_u
-              (set_local $$add$ptr16
+              (set_local $4
                 (i32.add
-                  (get_local $$add$ptr)
+                  (get_local $2)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $$2)
+                    (get_local $0)
                   )
                 )
               )
-              (get_local $$0)
+              (get_local $1)
             )
             (call_import $_abort)
           )
           (if
             (i32.eq
-              (get_local $$add$ptr16)
+              (get_local $4)
               (i32.load
                 (i32.const 196)
               )
@@ -17835,11 +16505,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $$27
+                    (set_local $0
                       (i32.load
-                        (set_local $$head209
+                        (set_local $1
                           (i32.add
-                            (get_local $$add$ptr6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -17850,73 +16520,73 @@
                   (i32.const 3)
                 )
                 (block
-                  (set_local $$p$1
-                    (get_local $$add$ptr16)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $$psize$1
-                    (get_local $$add17)
+                  (set_local $10
+                    (get_local $12)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $$add17)
+                (get_local $12)
               )
               (i32.store
-                (get_local $$head209)
+                (get_local $1)
                 (i32.and
-                  (get_local $$27)
+                  (get_local $0)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr16)
+                (get_local $4)
                 (i32.or
-                  (get_local $$add17)
+                  (get_local $12)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $$add$ptr16)
-                  (get_local $$add17)
+                  (get_local $4)
+                  (get_local $12)
                 )
-                (get_local $$add17)
+                (get_local $12)
               )
               (return)
             )
           )
-          (set_local $$shr
+          (set_local $7
             (i32.shr_u
-              (get_local $$2)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $$2)
+              (get_local $0)
               (i32.const 256)
             )
             (block
-              (set_local $$5
+              (set_local $2
                 (i32.load offset=12
-                  (get_local $$add$ptr16)
+                  (get_local $4)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $$4
+                  (set_local $0
                     (i32.load offset=8
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
                   )
-                  (set_local $$arrayidx
+                  (set_local $6
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $$shr)
+                          (get_local $7)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -17927,17 +16597,17 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$4)
-                      (get_local $$0)
+                      (get_local $0)
+                      (get_local $1)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $$4)
+                        (get_local $0)
                       )
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
                     (call_import $_abort)
                   )
@@ -17945,8 +16615,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $$5)
-                  (get_local $$4)
+                  (get_local $2)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
@@ -17958,101 +16628,101 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $$shr)
+                          (get_local $7)
                         )
                         (i32.const -1)
                       )
                     )
                   )
-                  (set_local $$p$1
-                    (get_local $$add$ptr16)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $$psize$1
-                    (get_local $$add17)
+                  (set_local $10
+                    (get_local $12)
                   )
                   (br $do-once$0)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $$5)
-                  (get_local $$arrayidx)
+                  (get_local $2)
+                  (get_local $6)
                 )
-                (set_local $$fd67$pre$phiZ2D
+                (set_local $13
                   (i32.add
-                    (get_local $$5)
+                    (get_local $2)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$5)
-                      (get_local $$0)
+                      (get_local $2)
+                      (get_local $1)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$fd56
+                        (set_local $1
                           (i32.add
-                            (get_local $$5)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
-                    (set_local $$fd67$pre$phiZ2D
-                      (get_local $$fd56)
+                    (set_local $13
+                      (get_local $1)
                     )
                     (call_import $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $$4)
-                (get_local $$5)
+                (get_local $0)
+                (get_local $2)
               )
               (i32.store
-                (get_local $$fd67$pre$phiZ2D)
-                (get_local $$4)
+                (get_local $13)
+                (get_local $0)
               )
-              (set_local $$p$1
-                (get_local $$add$ptr16)
+              (set_local $3
+                (get_local $4)
               )
-              (set_local $$psize$1
-                (get_local $$add17)
+              (set_local $10
+                (get_local $12)
               )
               (br $do-once$0)
             )
           )
-          (set_local $$9
+          (set_local $6
             (i32.load offset=24
-              (get_local $$add$ptr16)
+              (get_local $4)
             )
           )
           (block $do-once$2
             (if
               (i32.eq
-                (set_local $$10
+                (set_local $0
                   (i32.load offset=12
-                    (get_local $$add$ptr16)
+                    (get_local $4)
                   )
                 )
-                (get_local $$add$ptr16)
+                (get_local $4)
               )
               (block
                 (if
                   (i32.eq
-                    (set_local $$14
+                    (set_local $0
                       (i32.load
-                        (set_local $$arrayidx99
+                        (set_local $7
                           (i32.add
-                            (set_local $$child
+                            (set_local $13
                               (i32.add
-                                (get_local $$add$ptr16)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
@@ -18065,45 +16735,43 @@
                   )
                   (if
                     (i32.eq
-                      (set_local $$15
+                      (set_local $0
                         (i32.load
-                          (get_local $$child)
+                          (get_local $13)
                         )
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$R$3
+                      (set_local $9
                         (i32.const 0)
                       )
                       (br $do-once$2)
                     )
                     (block
-                      (set_local $$R$1
-                        (get_local $$15)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $$RP$1
-                        (get_local $$child)
+                      (set_local $7
+                        (get_local $13)
                       )
                     )
                   )
                   (block
-                    (set_local $$R$1
-                      (get_local $$14)
+                    (set_local $2
+                      (get_local $0)
                     )
-                    (set_local $$RP$1
-                      (get_local $$arrayidx99)
-                    )
+                    (get_local $7)
                   )
                 )
                 (loop $while-out$4 $while-in$5
                   (if
                     (i32.ne
-                      (set_local $$16
+                      (set_local $0
                         (i32.load
-                          (set_local $$arrayidx108
+                          (set_local $13
                             (i32.add
-                              (get_local $$R$1)
+                              (get_local $2)
                               (i32.const 20)
                             )
                           )
@@ -18112,22 +16780,22 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$R$1
-                        (get_local $$16)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $$RP$1
-                        (get_local $$arrayidx108)
+                      (set_local $7
+                        (get_local $13)
                       )
                       (br $while-in$5)
                     )
                   )
                   (if
                     (i32.eq
-                      (set_local $$17
+                      (set_local $0
                         (i32.load
-                          (set_local $$arrayidx113
+                          (set_local $13
                             (i32.add
-                              (get_local $$R$1)
+                              (get_local $2)
                               (i32.const 16)
                             )
                           )
@@ -18136,20 +16804,20 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$R$1$lcssa
-                        (get_local $$R$1)
+                      (set_local $0
+                        (get_local $2)
                       )
-                      (set_local $$RP$1$lcssa
-                        (get_local $$RP$1)
+                      (set_local $2
+                        (get_local $7)
                       )
                       (br $while-out$4)
                     )
                     (block
-                      (set_local $$R$1
-                        (get_local $$17)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $$RP$1
-                        (get_local $$arrayidx113)
+                      (set_local $7
+                        (get_local $13)
                       )
                     )
                   )
@@ -18157,17 +16825,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $$RP$1$lcssa)
-                    (get_local $$0)
+                    (get_local $2)
+                    (get_local $1)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store
-                      (get_local $$RP$1$lcssa)
+                      (get_local $2)
                       (i32.const 0)
                     )
-                    (set_local $$R$3
-                      (get_local $$R$1$lcssa)
+                    (set_local $9
+                      (get_local $0)
                     )
                   )
                 )
@@ -18175,52 +16843,52 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $$11
+                    (set_local $2
                       (i32.load offset=8
-                        (get_local $$add$ptr16)
+                        (get_local $4)
                       )
                     )
-                    (get_local $$0)
+                    (get_local $1)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.ne
                     (i32.load
-                      (set_local $$bk82
+                      (set_local $1
                         (i32.add
-                          (get_local $$11)
+                          (get_local $2)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $$add$ptr16)
+                    (get_local $4)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $$fd86
+                      (set_local $7
                         (i32.add
-                          (get_local $$10)
+                          (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $$add$ptr16)
+                    (get_local $4)
                   )
                   (block
                     (i32.store
-                      (get_local $$bk82)
-                      (get_local $$10)
+                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $$fd86)
-                      (get_local $$11)
+                      (get_local $7)
+                      (get_local $2)
                     )
-                    (set_local $$R$3
-                      (get_local $$10)
+                    (set_local $9
+                      (get_local $0)
                     )
                   )
                   (call_import $_abort)
@@ -18230,29 +16898,29 @@
           )
           (if
             (i32.eq
-              (get_local $$9)
+              (get_local $6)
               (i32.const 0)
             )
             (block
-              (set_local $$p$1
-                (get_local $$add$ptr16)
+              (set_local $3
+                (get_local $4)
               )
-              (set_local $$psize$1
-                (get_local $$add17)
+              (set_local $10
+                (get_local $12)
               )
             )
             (block
               (if
                 (i32.eq
-                  (get_local $$add$ptr16)
+                  (get_local $4)
                   (i32.load
-                    (set_local $$arrayidx130
+                    (set_local $1
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (set_local $$18
+                          (set_local $0
                             (i32.load offset=28
-                              (get_local $$add$ptr16)
+                              (get_local $4)
                             )
                           )
                           (i32.const 2)
@@ -18263,12 +16931,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $$arrayidx130)
-                    (get_local $$R$3)
+                    (get_local $1)
+                    (get_local $9)
                   )
                   (if
                     (i32.eq
-                      (get_local $$R$3)
+                      (get_local $9)
                       (i32.const 0)
                     )
                     (block
@@ -18281,17 +16949,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $$18)
+                              (get_local $0)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $$p$1
-                        (get_local $$add$ptr16)
+                      (set_local $3
+                        (get_local $4)
                       )
-                      (set_local $$psize$1
-                        (get_local $$add17)
+                      (set_local $10
+                        (get_local $12)
                       )
                       (br $do-once$0)
                     )
@@ -18300,7 +16968,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$9)
+                      (get_local $6)
                       (i32.load
                         (i32.const 192)
                       )
@@ -18310,35 +16978,35 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$arrayidx149
+                        (set_local $0
                           (i32.add
-                            (get_local $$9)
+                            (get_local $6)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
                     (i32.store
-                      (get_local $$arrayidx149)
-                      (get_local $$R$3)
+                      (get_local $0)
+                      (get_local $9)
                     )
                     (i32.store offset=20
-                      (get_local $$9)
-                      (get_local $$R$3)
+                      (get_local $6)
+                      (get_local $9)
                     )
                   )
                   (if
                     (i32.eq
-                      (get_local $$R$3)
+                      (get_local $9)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$p$1
-                        (get_local $$add$ptr16)
+                      (set_local $3
+                        (get_local $4)
                       )
-                      (set_local $$psize$1
-                        (get_local $$add17)
+                      (set_local $10
+                        (get_local $12)
                       )
                       (br $do-once$0)
                     )
@@ -18347,8 +17015,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $$R$3)
-                  (set_local $$23
+                  (get_local $9)
+                  (set_local $0
                     (i32.load
                       (i32.const 192)
                     )
@@ -18357,16 +17025,16 @@
                 (call_import $_abort)
               )
               (i32.store offset=24
-                (get_local $$R$3)
-                (get_local $$9)
+                (get_local $9)
+                (get_local $6)
               )
               (if
                 (i32.ne
-                  (set_local $$24
+                  (set_local $1
                     (i32.load
-                      (set_local $$child171
+                      (set_local $2
                         (i32.add
-                          (get_local $$add$ptr16)
+                          (get_local $4)
                           (i32.const 16)
                         )
                       )
@@ -18376,42 +17044,42 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $$24)
-                    (get_local $$23)
+                    (get_local $1)
+                    (get_local $0)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $$R$3)
-                      (get_local $$24)
+                      (get_local $9)
+                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $$24)
-                      (get_local $$R$3)
+                      (get_local $1)
+                      (get_local $9)
                     )
                   )
                 )
               )
               (if
                 (i32.eq
-                  (set_local $$25
+                  (set_local $0
                     (i32.load offset=4
-                      (get_local $$child171)
+                      (get_local $2)
                     )
                   )
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$p$1
-                    (get_local $$add$ptr16)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $$psize$1
-                    (get_local $$add17)
+                  (set_local $10
+                    (get_local $12)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $$25)
+                    (get_local $0)
                     (i32.load
                       (i32.const 192)
                     )
@@ -18419,18 +17087,18 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $$R$3)
-                      (get_local $$25)
+                      (get_local $9)
+                      (get_local $0)
                     )
                     (i32.store offset=24
-                      (get_local $$25)
-                      (get_local $$R$3)
+                      (get_local $0)
+                      (get_local $9)
                     )
-                    (set_local $$p$1
-                      (get_local $$add$ptr16)
+                    (set_local $3
+                      (get_local $4)
                     )
-                    (set_local $$psize$1
-                      (get_local $$add17)
+                    (set_local $10
+                      (get_local $12)
                     )
                   )
                 )
@@ -18439,30 +17107,30 @@
           )
         )
         (block
-          (set_local $$p$1
-            (get_local $$add$ptr)
+          (set_local $3
+            (get_local $2)
           )
-          (set_local $$psize$1
-            (get_local $$and5)
+          (set_local $10
+            (get_local $7)
           )
         )
       )
     )
     (if
       (i32.ge_u
-        (get_local $$p$1)
-        (get_local $$add$ptr6)
+        (get_local $3)
+        (get_local $8)
       )
       (call_import $_abort)
     )
     (if
       (i32.eq
         (i32.and
-          (set_local $$28
+          (set_local $0
             (i32.load
-              (set_local $$head231
+              (set_local $1
                 (i32.add
-                  (get_local $$add$ptr6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -18477,7 +17145,7 @@
     (if
       (i32.eq
         (i32.and
-          (get_local $$28)
+          (get_local $0)
           (i32.const 2)
         )
         (i32.const 0)
@@ -18485,7 +17153,7 @@
       (block
         (if
           (i32.eq
-            (get_local $$add$ptr6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -18493,29 +17161,29 @@
           (block
             (i32.store
               (i32.const 188)
-              (set_local $$add246
+              (set_local $0
                 (i32.add
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $$psize$1)
+                  (get_local $10)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $$p$1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $$p$1)
+              (get_local $3)
               (i32.or
-                (get_local $$add246)
+                (get_local $0)
                 (i32.const 1)
               )
             )
             (if
               (i32.ne
-                (get_local $$p$1)
+                (get_local $3)
                 (i32.load
                   (i32.const 196)
                 )
@@ -18535,7 +17203,7 @@
         )
         (if
           (i32.eq
-            (get_local $$add$ptr6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -18543,76 +17211,76 @@
           (block
             (i32.store
               (i32.const 184)
-              (set_local $$add258
+              (set_local $0
                 (i32.add
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $$psize$1)
+                  (get_local $10)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $$p$1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $$p$1)
+              (get_local $3)
               (i32.or
-                (get_local $$add258)
+                (get_local $0)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $$p$1)
-                (get_local $$add258)
+                (get_local $3)
+                (get_local $0)
               )
-              (get_local $$add258)
+              (get_local $0)
             )
             (return)
           )
         )
-        (set_local $$add267
+        (set_local $9
           (i32.add
             (i32.and
-              (get_local $$28)
+              (get_local $0)
               (i32.const -8)
             )
-            (get_local $$psize$1)
+            (get_local $10)
           )
         )
-        (set_local $$shr268
+        (set_local $6
           (i32.shr_u
-            (get_local $$28)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (block $do-once$8
           (if
             (i32.lt_u
-              (get_local $$28)
+              (get_local $0)
               (i32.const 256)
             )
             (block
-              (set_local $$35
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $$add$ptr6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $$34
+                  (set_local $0
                     (i32.load offset=8
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                     )
                   )
-                  (set_local $$arrayidx279
+                  (set_local $2
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $$shr268)
+                          (get_local $6)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -18623,7 +17291,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$34)
+                      (get_local $0)
                       (i32.load
                         (i32.const 192)
                       )
@@ -18633,9 +17301,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $$34)
+                        (get_local $0)
                       )
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                     )
                     (call_import $_abort)
                   )
@@ -18643,8 +17311,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $$35)
-                  (get_local $$34)
+                  (get_local $1)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
@@ -18656,7 +17324,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $$shr268)
+                          (get_local $6)
                         )
                         (i32.const -1)
                       )
@@ -18667,19 +17335,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $$35)
-                  (get_local $$arrayidx279)
+                  (get_local $1)
+                  (get_local $2)
                 )
-                (set_local $$fd322$pre$phiZ2D
+                (set_local $17
                   (i32.add
-                    (get_local $$35)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$35)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -18689,57 +17357,57 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$fd311
+                        (set_local $2
                           (i32.add
-                            (get_local $$35)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                     )
-                    (set_local $$fd322$pre$phiZ2D
-                      (get_local $$fd311)
+                    (set_local $17
+                      (get_local $2)
                     )
                     (call_import $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $$34)
-                (get_local $$35)
+                (get_local $0)
+                (get_local $1)
               )
               (i32.store
-                (get_local $$fd322$pre$phiZ2D)
-                (get_local $$34)
+                (get_local $17)
+                (get_local $0)
               )
             )
             (block
-              (set_local $$41
+              (set_local $0
                 (i32.load offset=24
-                  (get_local $$add$ptr6)
+                  (get_local $8)
                 )
               )
               (block $do-once$10
                 (if
                   (i32.eq
-                    (set_local $$42
+                    (set_local $1
                       (i32.load offset=12
-                        (get_local $$add$ptr6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $$add$ptr6)
+                    (get_local $8)
                   )
                   (block
                     (if
                       (i32.eq
-                        (set_local $$47
+                        (set_local $1
                           (i32.load
-                            (set_local $$arrayidx362
+                            (set_local $6
                               (i32.add
-                                (set_local $$child361
+                                (set_local $7
                                   (i32.add
-                                    (get_local $$add$ptr6)
+                                    (get_local $8)
                                     (i32.const 16)
                                   )
                                 )
@@ -18752,45 +17420,43 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $$48
+                          (set_local $1
                             (i32.load
-                              (get_local $$child361)
+                              (get_local $7)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$R332$3
+                          (set_local $11
                             (i32.const 0)
                           )
                           (br $do-once$10)
                         )
                         (block
-                          (set_local $$R332$1
-                            (get_local $$48)
+                          (set_local $2
+                            (get_local $1)
                           )
-                          (set_local $$RP360$1
-                            (get_local $$child361)
+                          (set_local $6
+                            (get_local $7)
                           )
                         )
                       )
                       (block
-                        (set_local $$R332$1
-                          (get_local $$47)
+                        (set_local $2
+                          (get_local $1)
                         )
-                        (set_local $$RP360$1
-                          (get_local $$arrayidx362)
-                        )
+                        (get_local $6)
                       )
                     )
                     (loop $while-out$12 $while-in$13
                       (if
                         (i32.ne
-                          (set_local $$49
+                          (set_local $1
                             (i32.load
-                              (set_local $$arrayidx374
+                              (set_local $7
                                 (i32.add
-                                  (get_local $$R332$1)
+                                  (get_local $2)
                                   (i32.const 20)
                                 )
                               )
@@ -18799,22 +17465,22 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$R332$1
-                            (get_local $$49)
+                          (set_local $2
+                            (get_local $1)
                           )
-                          (set_local $$RP360$1
-                            (get_local $$arrayidx374)
+                          (set_local $6
+                            (get_local $7)
                           )
                           (br $while-in$13)
                         )
                       )
                       (if
                         (i32.eq
-                          (set_local $$50
+                          (set_local $1
                             (i32.load
-                              (set_local $$arrayidx379
+                              (set_local $7
                                 (i32.add
-                                  (get_local $$R332$1)
+                                  (get_local $2)
                                   (i32.const 16)
                                 )
                               )
@@ -18823,20 +17489,20 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$R332$1$lcssa
-                            (get_local $$R332$1)
+                          (set_local $1
+                            (get_local $2)
                           )
-                          (set_local $$RP360$1$lcssa
-                            (get_local $$RP360$1)
+                          (set_local $2
+                            (get_local $6)
                           )
                           (br $while-out$12)
                         )
                         (block
-                          (set_local $$R332$1
-                            (get_local $$50)
+                          (set_local $2
+                            (get_local $1)
                           )
-                          (set_local $$RP360$1
-                            (get_local $$arrayidx379)
+                          (set_local $6
+                            (get_local $7)
                           )
                         )
                       )
@@ -18844,7 +17510,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$RP360$1$lcssa)
+                        (get_local $2)
                         (i32.load
                           (i32.const 192)
                         )
@@ -18852,11 +17518,11 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $$RP360$1$lcssa)
+                          (get_local $2)
                           (i32.const 0)
                         )
-                        (set_local $$R332$3
-                          (get_local $$R332$1$lcssa)
+                        (set_local $11
+                          (get_local $1)
                         )
                       )
                     )
@@ -18864,9 +17530,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (set_local $$43
+                        (set_local $2
                           (i32.load offset=8
-                            (get_local $$add$ptr6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -18878,40 +17544,40 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $$bk343
+                          (set_local $6
                             (i32.add
-                              (get_local $$43)
+                              (get_local $2)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $$add$ptr6)
+                        (get_local $8)
                       )
                       (call_import $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $$fd347
+                          (set_local $7
                             (i32.add
-                              (get_local $$42)
+                              (get_local $1)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $$add$ptr6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $$bk343)
-                          (get_local $$42)
+                          (get_local $6)
+                          (get_local $1)
                         )
                         (i32.store
-                          (get_local $$fd347)
-                          (get_local $$43)
+                          (get_local $7)
+                          (get_local $2)
                         )
-                        (set_local $$R332$3
-                          (get_local $$42)
+                        (set_local $11
+                          (get_local $1)
                         )
                       )
                       (call_import $_abort)
@@ -18921,21 +17587,21 @@
               )
               (if
                 (i32.ne
-                  (get_local $$41)
+                  (get_local $0)
                   (i32.const 0)
                 )
                 (block
                   (if
                     (i32.eq
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                       (i32.load
-                        (set_local $$arrayidx400
+                        (set_local $2
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (set_local $$52
+                              (set_local $1
                                 (i32.load offset=28
-                                  (get_local $$add$ptr6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -18946,12 +17612,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $$arrayidx400)
-                        (get_local $$R332$3)
+                        (get_local $2)
+                        (get_local $11)
                       )
                       (if
                         (i32.eq
-                          (get_local $$R332$3)
+                          (get_local $11)
                           (i32.const 0)
                         )
                         (block
@@ -18964,7 +17630,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $$52)
+                                  (get_local $1)
                                 )
                                 (i32.const -1)
                               )
@@ -18977,7 +17643,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $$41)
+                          (get_local $0)
                           (i32.load
                             (i32.const 192)
                           )
@@ -18987,27 +17653,27 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $$arrayidx419
+                            (set_local $1
                               (i32.add
-                                (get_local $$41)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $$add$ptr6)
+                          (get_local $8)
                         )
                         (i32.store
-                          (get_local $$arrayidx419)
-                          (get_local $$R332$3)
+                          (get_local $1)
+                          (get_local $11)
                         )
                         (i32.store offset=20
-                          (get_local $$41)
-                          (get_local $$R332$3)
+                          (get_local $0)
+                          (get_local $11)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eq
-                          (get_local $$R332$3)
+                          (get_local $11)
                           (i32.const 0)
                         )
                       )
@@ -19015,8 +17681,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$R332$3)
-                      (set_local $$57
+                      (get_local $11)
+                      (set_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -19025,16 +17691,16 @@
                     (call_import $_abort)
                   )
                   (i32.store offset=24
-                    (get_local $$R332$3)
-                    (get_local $$41)
+                    (get_local $11)
+                    (get_local $0)
                   )
                   (if
                     (i32.ne
-                      (set_local $$58
+                      (set_local $0
                         (i32.load
-                          (set_local $$child443
+                          (set_local $2
                             (i32.add
-                              (get_local $$add$ptr6)
+                              (get_local $8)
                               (i32.const 16)
                             )
                           )
@@ -19044,34 +17710,34 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$58)
-                        (get_local $$57)
+                        (get_local $0)
+                        (get_local $1)
                       )
                       (call_import $_abort)
                       (block
                         (i32.store offset=16
-                          (get_local $$R332$3)
-                          (get_local $$58)
+                          (get_local $11)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $$58)
-                          (get_local $$R332$3)
+                          (get_local $0)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
                     (i32.ne
-                      (set_local $$59
+                      (set_local $0
                         (i32.load offset=4
-                          (get_local $$child443)
+                          (get_local $2)
                         )
                       )
                       (i32.const 0)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$59)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -19079,12 +17745,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=20
-                          (get_local $$R332$3)
-                          (get_local $$59)
+                          (get_local $11)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $$59)
-                          (get_local $$R332$3)
+                          (get_local $0)
+                          (get_local $11)
                         )
                       )
                     )
@@ -19095,22 +17761,22 @@
           )
         )
         (i32.store offset=4
-          (get_local $$p$1)
+          (get_local $3)
           (i32.or
-            (get_local $$add267)
+            (get_local $9)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $$p$1)
-            (get_local $$add267)
+            (get_local $3)
+            (get_local $9)
           )
-          (get_local $$add267)
+          (get_local $9)
         )
         (if
           (i32.eq
-            (get_local $$p$1)
+            (get_local $3)
             (i32.load
               (i32.const 196)
             )
@@ -19118,60 +17784,60 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $$add267)
+              (get_local $9)
             )
             (return)
           )
-          (set_local $$psize$2
-            (get_local $$add267)
+          (set_local $2
+            (get_local $9)
           )
         )
       )
       (block
         (i32.store
-          (get_local $$head231)
+          (get_local $1)
           (i32.and
-            (get_local $$28)
+            (get_local $0)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $$p$1)
+          (get_local $3)
           (i32.or
-            (get_local $$psize$1)
+            (get_local $10)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $$p$1)
-            (get_local $$psize$1)
+            (get_local $3)
+            (get_local $10)
           )
-          (get_local $$psize$1)
+          (get_local $10)
         )
-        (set_local $$psize$2
-          (get_local $$psize$1)
+        (set_local $2
+          (get_local $10)
         )
       )
     )
-    (set_local $$shr501
+    (set_local $1
       (i32.shr_u
-        (get_local $$psize$2)
+        (get_local $2)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $$psize$2)
+        (get_local $2)
         (i32.const 256)
       )
       (block
-        (set_local $$arrayidx509
+        (set_local $2
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $$shr501)
+                (get_local $1)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -19181,15 +17847,15 @@
         (if
           (i32.eq
             (i32.and
-              (set_local $$62
+              (set_local $0
                 (i32.load
                   (i32.const 176)
                 )
               )
-              (set_local $$shl511
+              (set_local $1
                 (i32.shl
                   (i32.const 1)
-                  (get_local $$shr501)
+                  (get_local $1)
                 )
               )
             )
@@ -19199,27 +17865,27 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $$62)
-                (get_local $$shl511)
+                (get_local $0)
+                (get_local $1)
               )
             )
-            (set_local $$$pre$phiZ2D
+            (set_local $5
               (i32.add
-                (get_local $$arrayidx509)
+                (get_local $2)
                 (i32.const 8)
               )
             )
-            (set_local $$F510$0
-              (get_local $$arrayidx509)
+            (set_local $14
+              (get_local $2)
             )
           )
           (if
             (i32.lt_u
-              (set_local $$64
+              (set_local $1
                 (i32.load
-                  (set_local $$63
+                  (set_local $0
                     (i32.add
-                      (get_local $$arrayidx509)
+                      (get_local $2)
                       (i32.const 8)
                     )
                   )
@@ -19231,44 +17897,44 @@
             )
             (call_import $_abort)
             (block
-              (set_local $$$pre$phiZ2D
-                (get_local $$63)
+              (set_local $5
+                (get_local $0)
               )
-              (set_local $$F510$0
-                (get_local $$64)
+              (set_local $14
+                (get_local $1)
               )
             )
           )
         )
         (i32.store
-          (get_local $$$pre$phiZ2D)
-          (get_local $$p$1)
+          (get_local $5)
+          (get_local $3)
         )
         (i32.store offset=12
-          (get_local $$F510$0)
-          (get_local $$p$1)
+          (get_local $14)
+          (get_local $3)
         )
         (i32.store offset=8
-          (get_local $$p$1)
-          (get_local $$F510$0)
+          (get_local $3)
+          (get_local $14)
         )
         (i32.store offset=12
-          (get_local $$p$1)
-          (get_local $$arrayidx509)
+          (get_local $3)
+          (get_local $2)
         )
         (return)
       )
     )
-    (set_local $$arrayidx567
+    (set_local $1
       (i32.add
         (i32.const 480)
         (i32.shl
-          (set_local $$I534$0
+          (set_local $5
             (if
               (i32.eq
-                (set_local $$shr535
+                (set_local $0
                   (i32.shr_u
-                    (get_local $$psize$2)
+                    (get_local $2)
                     (i32.const 8)
                   )
                 )
@@ -19277,31 +17943,31 @@
               (i32.const 0)
               (if
                 (i32.gt_u
-                  (get_local $$psize$2)
+                  (get_local $2)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (block
-                  (set_local $$shl560
+                  (set_local $5
                     (i32.shl
-                      (set_local $$add559
+                      (set_local $0
                         (i32.add
                           (i32.sub
                             (i32.const 14)
                             (i32.or
                               (i32.or
-                                (set_local $$and549
+                                (set_local $5
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $$shl546
+                                        (set_local $1
                                           (i32.shl
-                                            (get_local $$shr535)
-                                            (set_local $$and545
+                                            (get_local $0)
+                                            (set_local $0
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (get_local $$shr535)
+                                                    (get_local $0)
                                                     (i32.const 1048320)
                                                   )
                                                   (i32.const 16)
@@ -19318,16 +17984,16 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (get_local $$and545)
+                                (get_local $0)
                               )
-                              (set_local $$and554
+                              (set_local $0
                                 (i32.and
                                   (i32.shr_u
                                     (i32.add
-                                      (set_local $$shl551
+                                      (set_local $5
                                         (i32.shl
-                                          (get_local $$shl546)
-                                          (get_local $$and549)
+                                          (get_local $1)
+                                          (get_local $5)
                                         )
                                       )
                                       (i32.const 245760)
@@ -19341,8 +18007,8 @@
                           )
                           (i32.shr_u
                             (i32.shl
-                              (get_local $$shl551)
-                              (get_local $$and554)
+                              (get_local $5)
+                              (get_local $0)
                             )
                             (i32.const 15)
                           )
@@ -19354,15 +18020,15 @@
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$psize$2)
+                        (get_local $2)
                         (i32.add
-                          (get_local $$add559)
+                          (get_local $0)
                           (i32.const 7)
                         )
                       )
                       (i32.const 1)
                     )
-                    (get_local $$shl560)
+                    (get_local $5)
                   )
                 )
               )
@@ -19373,29 +18039,29 @@
       )
     )
     (i32.store offset=28
-      (get_local $$p$1)
-      (get_local $$I534$0)
+      (get_local $3)
+      (get_local $5)
     )
     (i32.store offset=20
-      (get_local $$p$1)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $$p$1)
+      (get_local $3)
       (i32.const 0)
     )
     (if
       (i32.eq
         (i32.and
-          (set_local $$66
+          (set_local $0
             (i32.load
               (i32.const 180)
             )
           )
-          (set_local $$shl573
+          (set_local $6
             (i32.shl
               (i32.const 1)
-              (get_local $$I534$0)
+              (get_local $5)
             )
           )
         )
@@ -19405,50 +18071,50 @@
         (i32.store
           (i32.const 180)
           (i32.or
-            (get_local $$66)
-            (get_local $$shl573)
+            (get_local $0)
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $$arrayidx567)
-          (get_local $$p$1)
+          (get_local $1)
+          (get_local $3)
         )
         (i32.store offset=24
-          (get_local $$p$1)
-          (get_local $$arrayidx567)
+          (get_local $3)
+          (get_local $1)
         )
         (i32.store offset=12
-          (get_local $$p$1)
-          (get_local $$p$1)
+          (get_local $3)
+          (get_local $3)
         )
         (i32.store offset=8
-          (get_local $$p$1)
-          (get_local $$p$1)
+          (get_local $3)
+          (get_local $3)
         )
       )
       (block
-        (set_local $$K583$0
+        (set_local $5
           (i32.shl
-            (get_local $$psize$2)
+            (get_local $2)
             (select
               (i32.const 0)
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $$I534$0)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $$I534$0)
+                (get_local $5)
                 (i32.const 31)
               )
             )
           )
         )
-        (set_local $$T$0
+        (set_local $1
           (i32.load
-            (get_local $$arrayidx567)
+            (get_local $1)
           )
         )
         (loop $while-out$18 $while-in$19
@@ -19456,41 +18122,41 @@
             (i32.eq
               (i32.and
                 (i32.load offset=4
-                  (get_local $$T$0)
+                  (get_local $1)
                 )
                 (i32.const -8)
               )
-              (get_local $$psize$2)
+              (get_local $2)
             )
             (block
-              (set_local $$T$0$lcssa
-                (get_local $$T$0)
+              (set_local $15
+                (get_local $1)
               )
-              (set_local $label
+              (set_local $0
                 (i32.const 130)
               )
               (br $while-out$18)
             )
           )
-          (set_local $$shl600
+          (set_local $6
             (i32.shl
-              (get_local $$K583$0)
+              (get_local $5)
               (i32.const 1)
             )
           )
           (if
             (i32.eq
-              (set_local $$69
+              (set_local $0
                 (i32.load
-                  (set_local $$arrayidx599
+                  (set_local $5
                     (i32.add
                       (i32.add
-                        (get_local $$T$0)
+                        (get_local $1)
                         (i32.const 16)
                       )
                       (i32.shl
                         (i32.shr_u
-                          (get_local $$K583$0)
+                          (get_local $5)
                           (i32.const 31)
                         )
                         (i32.const 2)
@@ -19502,23 +18168,23 @@
               (i32.const 0)
             )
             (block
-              (set_local $$T$0$lcssa319
-                (get_local $$T$0)
+              (set_local $18
+                (get_local $1)
               )
-              (set_local $$arrayidx599$lcssa
-                (get_local $$arrayidx599)
+              (set_local $16
+                (get_local $5)
               )
-              (set_local $label
+              (set_local $0
                 (i32.const 127)
               )
               (br $while-out$18)
             )
             (block
-              (set_local $$K583$0
-                (get_local $$shl600)
+              (set_local $5
+                (get_local $6)
               )
-              (set_local $$T$0
-                (get_local $$69)
+              (set_local $1
+                (get_local $0)
               )
             )
           )
@@ -19526,12 +18192,12 @@
         )
         (if
           (i32.eq
-            (get_local $label)
+            (get_local $0)
             (i32.const 127)
           )
           (if
             (i32.lt_u
-              (get_local $$arrayidx599$lcssa)
+              (get_local $16)
               (i32.load
                 (i32.const 192)
               )
@@ -19539,71 +18205,71 @@
             (call_import $_abort)
             (block
               (i32.store
-                (get_local $$arrayidx599$lcssa)
-                (get_local $$p$1)
+                (get_local $16)
+                (get_local $3)
               )
               (i32.store offset=24
-                (get_local $$p$1)
-                (get_local $$T$0$lcssa319)
+                (get_local $3)
+                (get_local $18)
               )
               (i32.store offset=12
-                (get_local $$p$1)
-                (get_local $$p$1)
+                (get_local $3)
+                (get_local $3)
               )
               (i32.store offset=8
-                (get_local $$p$1)
-                (get_local $$p$1)
+                (get_local $3)
+                (get_local $3)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $label)
+              (get_local $0)
               (i32.const 130)
             )
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $$71
+                  (set_local $0
                     (i32.load
-                      (set_local $$fd620
+                      (set_local $1
                         (i32.add
-                          (get_local $$T$0$lcssa)
+                          (get_local $15)
                           (i32.const 8)
                         )
                       )
                     )
                   )
-                  (set_local $$72
+                  (set_local $5
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.ge_u
-                  (get_local $$T$0$lcssa)
-                  (get_local $$72)
+                  (get_local $15)
+                  (get_local $5)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $$71)
-                  (get_local $$p$1)
+                  (get_local $0)
+                  (get_local $3)
                 )
                 (i32.store
-                  (get_local $$fd620)
-                  (get_local $$p$1)
+                  (get_local $1)
+                  (get_local $3)
                 )
                 (i32.store offset=8
-                  (get_local $$p$1)
-                  (get_local $$71)
+                  (get_local $3)
+                  (get_local $0)
                 )
                 (i32.store offset=12
-                  (get_local $$p$1)
-                  (get_local $$T$0$lcssa)
+                  (get_local $3)
+                  (get_local $15)
                 )
                 (i32.store offset=24
-                  (get_local $$p$1)
+                  (get_local $3)
                   (i32.const 0)
                 )
               )
@@ -19615,7 +18281,7 @@
     )
     (i32.store
       (i32.const 208)
-      (set_local $$dec
+      (set_local $0
         (i32.add
           (i32.load
             (i32.const 208)
@@ -19626,36 +18292,36 @@
     )
     (if
       (i32.eq
-        (get_local $$dec)
+        (get_local $0)
         (i32.const 0)
       )
-      (set_local $$sp$0$in$i
+      (set_local $0
         (i32.const 632)
       )
       (return)
     )
     (loop $while-out$20 $while-in$21
-      (set_local $$cmp$i
+      (set_local $0
         (i32.eq
-          (set_local $$sp$0$i
+          (set_local $5
             (i32.load
-              (get_local $$sp$0$in$i)
+              (get_local $0)
             )
           )
           (i32.const 0)
         )
       )
-      (set_local $$next4$i
+      (set_local $5
         (i32.add
-          (get_local $$sp$0$i)
+          (get_local $5)
           (i32.const 8)
         )
       )
       (if
-        (get_local $$cmp$i)
+        (get_local $0)
         (br $while-out$20)
-        (set_local $$sp$0$in$i
-          (get_local $$next4$i)
+        (set_local $0
+          (get_local $5)
         )
       )
       (br $while-in$21)
@@ -19668,97 +18334,96 @@
   (func $runPostSets
     (nop)
   )
-  (func $_i64Subtract (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
+  (func $_i64Subtract (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (i32.sub
-      (get_local $b)
-      (get_local $d)
+      (get_local $1)
+      (get_local $3)
     )
     (i32.store
       (i32.const 168)
       (i32.sub
         (i32.sub
-          (get_local $b)
-          (get_local $d)
+          (get_local $1)
+          (get_local $3)
         )
         (i32.gt_u
-          (get_local $c)
-          (get_local $a)
+          (get_local $2)
+          (get_local $0)
         )
       )
     )
     (i32.sub
-      (get_local $a)
-      (get_local $c)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $_i64Add (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
-    (local $l i32)
+  (func $_i64Add (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (i32.store
       (i32.const 168)
       (i32.add
         (i32.add
-          (get_local $b)
-          (get_local $d)
+          (get_local $1)
+          (get_local $3)
         )
         (i32.lt_u
-          (set_local $l
+          (set_local $1
             (i32.add
-              (get_local $a)
-              (get_local $c)
+              (get_local $0)
+              (get_local $2)
             )
           )
-          (get_local $a)
+          (get_local $0)
         )
       )
     )
-    (get_local $l)
+    (get_local $1)
   )
-  (func $_memset (param $ptr i32) (param $value i32) (param $num i32) (result i32)
-    (local $unaligned i32)
-    (local $stop i32)
-    (local $value4 i32)
-    (local $stop4 i32)
-    (set_local $stop
+  (func $_memset (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $4
       (i32.add
-        (get_local $ptr)
-        (get_local $num)
+        (get_local $0)
+        (get_local $2)
       )
     )
     (if
       (i32.ge_s
-        (get_local $num)
+        (get_local $2)
         (i32.const 20)
       )
       (block
-        (set_local $value4
+        (set_local $5
           (i32.or
             (i32.or
               (i32.or
-                (set_local $value
+                (set_local $1
                   (i32.and
-                    (get_local $value)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.shl
-                  (get_local $value)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (i32.shl
-                (get_local $value)
+                (get_local $1)
                 (i32.const 16)
               )
             )
             (i32.shl
-              (get_local $value)
+              (get_local $1)
               (i32.const 24)
             )
           )
         )
-        (set_local $stop4
+        (set_local $6
           (i32.and
-            (get_local $stop)
+            (get_local $4)
             (i32.xor
               (i32.const 3)
               (i32.const -1)
@@ -19766,36 +18431,36 @@
           )
         )
         (if
-          (set_local $unaligned
+          (set_local $3
             (i32.and
-              (get_local $ptr)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (block
-            (set_local $unaligned
+            (set_local $3
               (i32.sub
                 (i32.add
-                  (get_local $ptr)
+                  (get_local $0)
                   (i32.const 4)
                 )
-                (get_local $unaligned)
+                (get_local $3)
               )
             )
             (loop $while-out$0 $while-in$1
               (br_if $while-out$0
                 (i32.ge_s
-                  (get_local $ptr)
-                  (get_local $unaligned)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (i32.store8
-                (get_local $ptr)
-                (get_local $value)
+                (get_local $0)
+                (get_local $1)
               )
-              (set_local $ptr
+              (set_local $0
                 (i32.add
-                  (get_local $ptr)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
@@ -19806,17 +18471,17 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.ge_s
-              (get_local $ptr)
-              (get_local $stop4)
+              (get_local $0)
+              (get_local $6)
             )
           )
           (i32.store
-            (get_local $ptr)
-            (get_local $value4)
+            (get_local $0)
+            (get_local $5)
           )
-          (set_local $ptr
+          (set_local $0
             (i32.add
-              (get_local $ptr)
+              (get_local $0)
               (i32.const 4)
             )
           )
@@ -19827,61 +18492,61 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.ge_s
-          (get_local $ptr)
-          (get_local $stop)
+          (get_local $0)
+          (get_local $4)
         )
       )
       (i32.store8
-        (get_local $ptr)
-        (get_local $value)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $ptr
+      (set_local $0
         (i32.add
-          (get_local $ptr)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
     (i32.sub
-      (get_local $ptr)
-      (get_local $num)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $_bitshift64Lshr (param $low i32) (param $high i32) (param $bits i32) (result i32)
+  (func $_bitshift64Lshr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (if
       (i32.lt_s
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
       (block
         (i32.store
           (i32.const 168)
           (i32.shr_u
-            (get_local $high)
-            (get_local $bits)
+            (get_local $1)
+            (get_local $2)
           )
         )
         (return
           (i32.or
             (i32.shr_u
-              (get_local $low)
-              (get_local $bits)
+              (get_local $0)
+              (get_local $2)
             )
             (i32.shl
               (i32.and
-                (get_local $high)
+                (get_local $1)
                 (i32.sub
                   (i32.shl
                     (i32.const 1)
-                    (get_local $bits)
+                    (get_local $2)
                   )
                   (i32.const 1)
                 )
               )
               (i32.sub
                 (i32.const 32)
-                (get_local $bits)
+                (get_local $2)
               )
             )
           )
@@ -19893,17 +18558,17 @@
       (i32.const 0)
     )
     (i32.shr_u
-      (get_local $high)
+      (get_local $1)
       (i32.sub
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
     )
   )
-  (func $_bitshift64Shl (param $low i32) (param $high i32) (param $bits i32) (result i32)
+  (func $_bitshift64Shl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (if
       (i32.lt_s
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
       (block
@@ -19911,37 +18576,37 @@
           (i32.const 168)
           (i32.or
             (i32.shl
-              (get_local $high)
-              (get_local $bits)
+              (get_local $1)
+              (get_local $2)
             )
             (i32.shr_u
               (i32.and
-                (get_local $low)
+                (get_local $0)
                 (i32.shl
                   (i32.sub
                     (i32.shl
                       (i32.const 1)
-                      (get_local $bits)
+                      (get_local $2)
                     )
                     (i32.const 1)
                   )
                   (i32.sub
                     (i32.const 32)
-                    (get_local $bits)
+                    (get_local $2)
                   )
                 )
               )
               (i32.sub
                 (i32.const 32)
-                (get_local $bits)
+                (get_local $2)
               )
             )
           )
         )
         (return
           (i32.shl
-            (get_local $low)
-            (get_local $bits)
+            (get_local $0)
+            (get_local $2)
           )
         )
       )
@@ -19949,41 +18614,41 @@
     (i32.store
       (i32.const 168)
       (i32.shl
-        (get_local $low)
+        (get_local $0)
         (i32.sub
-          (get_local $bits)
+          (get_local $2)
           (i32.const 32)
         )
       )
     )
     (i32.const 0)
   )
-  (func $_memcpy (param $dest i32) (param $src i32) (param $num i32) (result i32)
-    (local $ret i32)
+  (func $_memcpy (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
     (if
       (i32.ge_s
-        (get_local $num)
+        (get_local $2)
         (i32.const 4096)
       )
       (return
         (call_import $_emscripten_memcpy_big
-          (get_local $dest)
-          (get_local $src)
-          (get_local $num)
+          (get_local $0)
+          (get_local $1)
+          (get_local $2)
         )
       )
     )
-    (set_local $ret
-      (get_local $dest)
+    (set_local $3
+      (get_local $0)
     )
     (if
       (i32.eq
         (i32.and
-          (get_local $dest)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.and
-          (get_local $src)
+          (get_local $1)
           (i32.const 3)
         )
       )
@@ -19992,41 +18657,41 @@
           (br_if $while-out$0
             (i32.eqz
               (i32.and
-                (get_local $dest)
+                (get_local $0)
                 (i32.const 3)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $num)
+              (get_local $2)
               (i32.const 0)
             )
             (return
-              (get_local $ret)
+              (get_local $3)
             )
           )
           (i32.store8
-            (get_local $dest)
+            (get_local $0)
             (i32.load8_s
-              (get_local $src)
+              (get_local $1)
             )
           )
-          (set_local $dest
+          (set_local $0
             (i32.add
-              (get_local $dest)
+              (get_local $0)
               (i32.const 1)
             )
           )
-          (set_local $src
+          (set_local $1
             (i32.add
-              (get_local $src)
+              (get_local $1)
               (i32.const 1)
             )
           )
-          (set_local $num
+          (set_local $2
             (i32.sub
-              (get_local $num)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -20035,31 +18700,31 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.lt_s
-              (get_local $num)
+              (get_local $2)
               (i32.const 4)
             )
           )
           (i32.store
-            (get_local $dest)
+            (get_local $0)
             (i32.load
-              (get_local $src)
+              (get_local $1)
             )
           )
-          (set_local $dest
+          (set_local $0
             (i32.add
-              (get_local $dest)
+              (get_local $0)
               (i32.const 4)
             )
           )
-          (set_local $src
+          (set_local $1
             (i32.add
-              (get_local $src)
+              (get_local $1)
               (i32.const 4)
             )
           )
-          (set_local $num
+          (set_local $2
             (i32.sub
-              (get_local $num)
+              (get_local $2)
               (i32.const 4)
             )
           )
@@ -20070,72 +18735,72 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.le_s
-          (get_local $num)
+          (get_local $2)
           (i32.const 0)
         )
       )
       (i32.store8
-        (get_local $dest)
+        (get_local $0)
         (i32.load8_s
-          (get_local $src)
+          (get_local $1)
         )
       )
-      (set_local $dest
+      (set_local $0
         (i32.add
-          (get_local $dest)
+          (get_local $0)
           (i32.const 1)
         )
       )
-      (set_local $src
+      (set_local $1
         (i32.add
-          (get_local $src)
+          (get_local $1)
           (i32.const 1)
         )
       )
-      (set_local $num
+      (set_local $2
         (i32.sub
-          (get_local $num)
+          (get_local $2)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
-    (get_local $ret)
+    (get_local $3)
   )
-  (func $_bitshift64Ashr (param $low i32) (param $high i32) (param $bits i32) (result i32)
+  (func $_bitshift64Ashr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (if
       (i32.lt_s
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
       (block
         (i32.store
           (i32.const 168)
           (i32.shr_s
-            (get_local $high)
-            (get_local $bits)
+            (get_local $1)
+            (get_local $2)
           )
         )
         (return
           (i32.or
             (i32.shr_u
-              (get_local $low)
-              (get_local $bits)
+              (get_local $0)
+              (get_local $2)
             )
             (i32.shl
               (i32.and
-                (get_local $high)
+                (get_local $1)
                 (i32.sub
                   (i32.shl
                     (i32.const 1)
-                    (get_local $bits)
+                    (get_local $2)
                   )
                   (i32.const 1)
                 )
               )
               (i32.sub
                 (i32.const 32)
-                (get_local $bits)
+                (get_local $2)
               )
             )
           )
@@ -20148,41 +18813,37 @@
         (i32.const -1)
         (i32.const 0)
         (i32.lt_s
-          (get_local $high)
+          (get_local $1)
           (i32.const 0)
         )
       )
     )
     (i32.shr_s
-      (get_local $high)
+      (get_local $1)
       (i32.sub
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
     )
   )
-  (func $___muldsi3 (param $$a i32) (param $$b i32) (result i32)
-    (local $$8 i32)
-    (local $$12 i32)
-    (local $$1 i32)
-    (local $$2 i32)
-    (local $$3 i32)
-    (local $$6 i32)
-    (local $$11 i32)
-    (set_local $$8
+  (func $___muldsi3 (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $2
       (i32.add
         (i32.shr_u
-          (set_local $$3
+          (set_local $4
             (i32.mul
-              (set_local $$2
+              (set_local $2
                 (i32.and
-                  (get_local $$b)
+                  (get_local $1)
                   (i32.const 65535)
                 )
               )
-              (set_local $$1
+              (set_local $3
                 (i32.and
-                  (get_local $$a)
+                  (get_local $0)
                   (i32.const 65535)
                 )
               )
@@ -20191,25 +18852,25 @@
           (i32.const 16)
         )
         (i32.mul
-          (get_local $$2)
-          (set_local $$6
+          (get_local $2)
+          (set_local $0
             (i32.shr_u
-              (get_local $$a)
+              (get_local $0)
               (i32.const 16)
             )
           )
         )
       )
     )
-    (set_local $$12
+    (set_local $3
       (i32.mul
-        (set_local $$11
+        (set_local $1
           (i32.shr_u
-            (get_local $$b)
+            (get_local $1)
             (i32.const 16)
           )
         )
-        (get_local $$1)
+        (get_local $3)
       )
     )
     (i32.store
@@ -20217,21 +18878,21 @@
       (i32.add
         (i32.add
           (i32.shr_u
-            (get_local $$8)
+            (get_local $2)
             (i32.const 16)
           )
           (i32.mul
-            (get_local $$11)
-            (get_local $$6)
+            (get_local $1)
+            (get_local $0)
           )
         )
         (i32.shr_u
           (i32.add
             (i32.and
-              (get_local $$8)
+              (get_local $2)
               (i32.const 65535)
             )
-            (get_local $$12)
+            (get_local $3)
           )
           (i32.const 16)
         )
@@ -20242,34 +18903,29 @@
       (i32.or
         (i32.shl
           (i32.add
-            (get_local $$8)
-            (get_local $$12)
+            (get_local $2)
+            (get_local $3)
           )
           (i32.const 16)
         )
         (i32.and
-          (get_local $$3)
+          (get_local $4)
           (i32.const 65535)
         )
       )
     )
   )
-  (func $___divdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$1$0 i32)
-    (local $$1$1 i32)
-    (local $$2$0 i32)
-    (local $$2$1 i32)
-    (local $$7$0 i32)
-    (local $$7$1 i32)
+  (func $___divdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
     (call $_i64Subtract
       (i32.xor
         (call $___udivmoddi4
           (call $_i64Subtract
             (i32.xor
-              (set_local $$1$0
+              (set_local $4
                 (i32.or
                   (i32.shr_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 31)
                   )
                   (i32.shl
@@ -20277,7 +18933,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20285,17 +18941,17 @@
                   )
                 )
               )
-              (get_local $$a$0)
+              (get_local $0)
             )
             (i32.xor
-              (set_local $$1$1
+              (set_local $0
                 (i32.or
                   (i32.shr_s
                     (select
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20306,7 +18962,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20314,20 +18970,20 @@
                   )
                 )
               )
-              (get_local $$a$1)
+              (get_local $1)
             )
-            (get_local $$1$0)
-            (get_local $$1$1)
+            (get_local $4)
+            (get_local $0)
           )
           (i32.load
             (i32.const 168)
           )
           (call $_i64Subtract
             (i32.xor
-              (set_local $$2$0
+              (set_local $1
                 (i32.or
                   (i32.shr_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 31)
                   )
                   (i32.shl
@@ -20335,7 +18991,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$b$1)
+                        (get_local $3)
                         (i32.const 0)
                       )
                     )
@@ -20343,17 +18999,17 @@
                   )
                 )
               )
-              (get_local $$b$0)
+              (get_local $2)
             )
             (i32.xor
-              (set_local $$2$1
+              (set_local $2
                 (i32.or
                   (i32.shr_s
                     (select
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$b$1)
+                        (get_local $3)
                         (i32.const 0)
                       )
                     )
@@ -20364,7 +19020,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$b$1)
+                        (get_local $3)
                         (i32.const 0)
                       )
                     )
@@ -20372,20 +19028,20 @@
                   )
                 )
               )
-              (get_local $$b$1)
+              (get_local $3)
             )
-            (get_local $$2$0)
-            (get_local $$2$1)
+            (get_local $1)
+            (get_local $2)
           )
           (i32.load
             (i32.const 168)
           )
           (i32.const 0)
         )
-        (set_local $$7$0
+        (set_local $1
           (i32.xor
-            (get_local $$2$0)
-            (get_local $$1$0)
+            (get_local $1)
+            (get_local $4)
           )
         )
       )
@@ -20393,27 +19049,22 @@
         (i32.load
           (i32.const 168)
         )
-        (set_local $$7$1
+        (set_local $0
           (i32.xor
-            (get_local $$2$1)
-            (get_local $$1$1)
+            (get_local $2)
+            (get_local $0)
           )
         )
       )
-      (get_local $$7$0)
-      (get_local $$7$1)
+      (get_local $1)
+      (get_local $0)
     )
   )
-  (func $___remdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$1$0 i32)
-    (local $$1$1 i32)
-    (local $$rem i32)
-    (local $__stackBase__ i32)
-    (local $$2$0 i32)
-    (local $$2$1 i32)
-    (local $$10$0 i32)
-    (local $$10$1 i32)
-    (set_local $__stackBase__
+  (func $___remdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $6
       (i32.load
         (i32.const 8)
       )
@@ -20430,10 +19081,10 @@
     (call $___udivmoddi4
       (call $_i64Subtract
         (i32.xor
-          (set_local $$1$0
+          (set_local $4
             (i32.or
               (i32.shr_s
-                (get_local $$a$1)
+                (get_local $1)
                 (i32.const 31)
               )
               (i32.shl
@@ -20441,7 +19092,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -20449,17 +19100,17 @@
               )
             )
           )
-          (get_local $$a$0)
+          (get_local $0)
         )
         (i32.xor
-          (set_local $$1$1
+          (set_local $5
             (i32.or
               (i32.shr_s
                 (select
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -20470,7 +19121,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -20478,20 +19129,20 @@
               )
             )
           )
-          (get_local $$a$1)
+          (get_local $1)
         )
-        (get_local $$1$0)
-        (get_local $$1$1)
+        (get_local $4)
+        (get_local $5)
       )
       (i32.load
         (i32.const 168)
       )
       (call $_i64Subtract
         (i32.xor
-          (set_local $$2$0
+          (set_local $0
             (i32.or
               (i32.shr_s
-                (get_local $$b$1)
+                (get_local $3)
                 (i32.const 31)
               )
               (i32.shl
@@ -20499,7 +19150,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -20507,17 +19158,17 @@
               )
             )
           )
-          (get_local $$b$0)
+          (get_local $2)
         )
         (i32.xor
-          (set_local $$2$1
+          (set_local $1
             (i32.or
               (i32.shr_s
                 (select
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -20528,7 +19179,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -20536,64 +19187,57 @@
               )
             )
           )
-          (get_local $$b$1)
+          (get_local $3)
         )
-        (get_local $$2$0)
-        (get_local $$2$1)
+        (get_local $0)
+        (get_local $1)
       )
       (i32.load
         (i32.const 168)
       )
-      (set_local $$rem
-        (get_local $__stackBase__)
+      (set_local $0
+        (get_local $6)
       )
     )
-    (set_local $$10$0
+    (set_local $0
       (call $_i64Subtract
         (i32.xor
           (i32.load
-            (get_local $$rem)
+            (get_local $0)
           )
-          (get_local $$1$0)
+          (get_local $4)
         )
         (i32.xor
           (i32.load offset=4
-            (get_local $$rem)
+            (get_local $0)
           )
-          (get_local $$1$1)
+          (get_local $5)
         )
-        (get_local $$1$0)
-        (get_local $$1$1)
+        (get_local $4)
+        (get_local $5)
       )
     )
-    (set_local $$10$1
+    (set_local $1
       (i32.load
         (i32.const 168)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $__stackBase__)
+      (get_local $6)
     )
     (i32.store
       (i32.const 168)
-      (get_local $$10$1)
+      (get_local $1)
     )
-    (get_local $$10$0)
+    (get_local $0)
   )
-  (func $___muldi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$x_sroa_0_0_extract_trunc i32)
-    (local $$y_sroa_0_0_extract_trunc i32)
-    (local $$1$0 i32)
-    (local $$1$1 i32)
-    (set_local $$1$0
+  (func $___muldi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (set_local $4
       (call $___muldsi3
-        (set_local $$x_sroa_0_0_extract_trunc
-          (get_local $$a$0)
-        )
-        (set_local $$y_sroa_0_0_extract_trunc
-          (get_local $$b$0)
-        )
+        (get_local $0)
+        (get_local $2)
       )
     )
     (i32.store
@@ -20602,22 +19246,22 @@
         (i32.add
           (i32.add
             (i32.mul
-              (get_local $$b$1)
-              (get_local $$x_sroa_0_0_extract_trunc)
+              (get_local $3)
+              (get_local $0)
             )
             (i32.mul
-              (get_local $$a$1)
-              (get_local $$y_sroa_0_0_extract_trunc)
+              (get_local $1)
+              (get_local $2)
             )
           )
-          (set_local $$1$1
+          (set_local $0
             (i32.load
               (i32.const 168)
             )
           )
         )
         (i32.and
-          (get_local $$1$1)
+          (get_local $0)
           (i32.const 0)
         )
       )
@@ -20625,24 +19269,23 @@
     (i32.or
       (i32.const 0)
       (i32.and
-        (get_local $$1$0)
+        (get_local $4)
         (i32.const -1)
       )
     )
   )
-  (func $___udivdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
+  (func $___udivdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call $___udivmoddi4
-      (get_local $$a$0)
-      (get_local $$a$1)
-      (get_local $$b$0)
-      (get_local $$b$1)
+      (get_local $0)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
       (i32.const 0)
     )
   )
-  (func $___uremdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$rem i32)
-    (local $__stackBase__ i32)
-    (set_local $__stackBase__
+  (func $___uremdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -20657,132 +19300,84 @@
       )
     )
     (call $___udivmoddi4
-      (get_local $$a$0)
-      (get_local $$a$1)
-      (get_local $$b$0)
-      (get_local $$b$1)
-      (set_local $$rem
-        (get_local $__stackBase__)
+      (get_local $0)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
+      (set_local $0
+        (get_local $4)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $__stackBase__)
+      (get_local $4)
     )
     (i32.store
       (i32.const 168)
       (i32.load offset=4
-        (get_local $$rem)
+        (get_local $0)
       )
     )
     (i32.load
-      (get_local $$rem)
+      (get_local $0)
     )
   )
-  (func $___udivmoddi4 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (param $$rem i32) (result i32)
-    (local $$n_sroa_1_4_extract_trunc i32)
-    (local $$n_sroa_0_0_extract_trunc i32)
-    (local $$d_sroa_0_0_extract_trunc i32)
-    (local $$d_sroa_1_4_extract_trunc i32)
-    (local $$88 i32)
-    (local $$q_sroa_1_1_ph i32)
-    (local $$q_sroa_0_1_ph i32)
-    (local $$r_sroa_1_1_ph i32)
-    (local $$r_sroa_0_1_ph i32)
-    (local $$sr_1_ph i32)
-    (local $$n_sroa_1_4_extract_shift$0 i32)
-    (local $$91 i32)
-    (local $$119 i32)
-    (local $$r_sroa_0_1201 i32)
-    (local $$q_sroa_0_1199 i32)
-    (local $$q_sroa_1_1198 i32)
-    (local $$150$1 i32)
-    (local $$q_sroa_0_0_insert_ext75$0 i32)
-    (local $$4 i32)
-    (local $$17 i32)
-    (local $$51 i32)
-    (local $$57 i32)
-    (local $$78 i32)
-    (local $$89 i32)
-    (local $$92 i32)
-    (local $$95 i32)
-    (local $$105 i32)
-    (local $$125 i32)
-    (local $$carry_0203 i32)
-    (local $$sr_1202 i32)
-    (local $$r_sroa_1_1200 i32)
-    (local $$147 i32)
-    (local $$149 i32)
-    (local $$152 i32)
-    (local $$r_sroa_0_0_extract_trunc i32)
-    (local $$r_sroa_1_4_extract_trunc i32)
-    (local $$carry_0_lcssa$1 i32)
-    (local $$r_sroa_0_1_lcssa i32)
-    (local $$r_sroa_1_1_lcssa i32)
-    (local $$q_sroa_0_1_lcssa i32)
-    (local $$q_sroa_1_1_lcssa i32)
-    (local $$d_sroa_1_4_extract_shift$0 i32)
-    (local $$37 i32)
-    (local $$58 i32)
-    (local $$66 i32)
-    (local $$126 i32)
-    (local $$130 i32)
-    (local $$d_sroa_0_0_insert_insert99$0 i32)
-    (local $$d_sroa_0_0_insert_insert99$1 i32)
-    (local $$137$0 i32)
-    (local $$137$1 i32)
-    (local $$r_sroa_0_0_insert_insert42$0 i32)
-    (local $$r_sroa_0_0_insert_insert42$1 i32)
-    (local $$151$0 i32)
-    (local $$155 i32)
-    (local $$carry_0_lcssa$0 i32)
-    (local $$q_sroa_0_0_insert_ext75$1 i32)
-    (local $$q_sroa_0_0_insert_insert77$1 i32)
-    (set_local $$n_sroa_0_0_extract_trunc
-      (get_local $$a$0)
+  (func $___udivmoddi4 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (set_local $7
+      (get_local $0)
     )
-    (set_local $$d_sroa_0_0_extract_trunc
-      (get_local $$b$0)
+    (set_local $5
+      (get_local $2)
     )
-    (set_local $$d_sroa_1_4_extract_trunc
-      (set_local $$d_sroa_1_4_extract_shift$0
-        (get_local $$b$1)
+    (set_local $8
+      (set_local $11
+        (get_local $3)
       )
     )
     (if
       (i32.eq
-        (set_local $$n_sroa_1_4_extract_trunc
-          (set_local $$n_sroa_1_4_extract_shift$0
-            (get_local $$a$1)
+        (set_local $6
+          (set_local $9
+            (get_local $1)
           )
         )
         (i32.const 0)
       )
       (block
-        (set_local $$4
+        (set_local $2
           (i32.ne
-            (get_local $$rem)
+            (get_local $4)
             (i32.const 0)
           )
         )
         (if
           (i32.eq
-            (get_local $$d_sroa_1_4_extract_trunc)
+            (get_local $8)
             (i32.const 0)
           )
           (block
             (if
-              (get_local $$4)
+              (get_local $2)
               (block
                 (i32.store
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.rem_u
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$d_sroa_0_0_extract_trunc)
+                    (get_local $7)
+                    (get_local $5)
                   )
                 )
                 (i32.store offset=4
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
               )
@@ -20794,8 +19389,8 @@
                   (i32.const 0)
                 )
                 (i32.div_u
-                  (get_local $$n_sroa_0_0_extract_trunc)
-                  (get_local $$d_sroa_0_0_extract_trunc)
+                  (get_local $7)
+                  (get_local $5)
                 )
               )
             )
@@ -20803,7 +19398,7 @@
           (block
             (if
               (i32.eqz
-                (get_local $$4)
+                (get_local $2)
               )
               (return
                 (block
@@ -20816,16 +19411,16 @@
               )
             )
             (i32.store
-              (get_local $$rem)
+              (get_local $4)
               (i32.and
-                (get_local $$a$0)
+                (get_local $0)
                 (i32.const -1)
               )
             )
             (i32.store offset=4
-              (get_local $$rem)
+              (get_local $4)
               (i32.and
-                (get_local $$a$1)
+                (get_local $1)
                 (i32.const 0)
               )
             )
@@ -20842,37 +19437,37 @@
         )
       )
     )
-    (set_local $$17
+    (set_local $10
       (i32.eq
-        (get_local $$d_sroa_1_4_extract_trunc)
+        (get_local $8)
         (i32.const 0)
       )
     )
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $$d_sroa_0_0_extract_trunc)
+          (get_local $5)
           (i32.const 0)
         )
         (block
           (if
-            (get_local $$17)
+            (get_local $10)
             (block
               (if
                 (i32.ne
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (block
                   (i32.store
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.rem_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (get_local $$d_sroa_0_0_extract_trunc)
+                      (get_local $6)
+                      (get_local $5)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.const 0)
                   )
                 )
@@ -20884,8 +19479,8 @@
                     (i32.const 0)
                   )
                   (i32.div_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (get_local $$d_sroa_0_0_extract_trunc)
+                    (get_local $6)
+                    (get_local $5)
                   )
                 )
               )
@@ -20893,25 +19488,25 @@
           )
           (if
             (i32.eq
-              (get_local $$n_sroa_0_0_extract_trunc)
+              (get_local $7)
               (i32.const 0)
             )
             (block
               (if
                 (i32.ne
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (block
                   (i32.store
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.const 0)
                   )
                   (i32.store offset=4
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.rem_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (get_local $$d_sroa_1_4_extract_trunc)
+                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                 )
@@ -20923,8 +19518,8 @@
                     (i32.const 0)
                   )
                   (i32.div_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (get_local $$d_sroa_1_4_extract_trunc)
+                    (get_local $6)
+                    (get_local $8)
                   )
                 )
               )
@@ -20933,42 +19528,42 @@
           (if
             (i32.eq
               (i32.and
-                (set_local $$37
+                (set_local $5
                   (i32.sub
-                    (get_local $$d_sroa_1_4_extract_trunc)
+                    (get_local $8)
                     (i32.const 1)
                   )
                 )
-                (get_local $$d_sroa_1_4_extract_trunc)
+                (get_local $8)
               )
               (i32.const 0)
             )
             (block
               (if
                 (i32.ne
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (block
                   (i32.store
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.or
                       (i32.const 0)
                       (i32.and
-                        (get_local $$a$0)
+                        (get_local $0)
                         (i32.const -1)
                       )
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.or
                       (i32.and
-                        (get_local $$37)
-                        (get_local $$n_sroa_1_4_extract_trunc)
+                        (get_local $5)
+                        (get_local $6)
                       )
                       (i32.and
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20982,9 +19577,9 @@
                     (i32.const 0)
                   )
                   (i32.shr_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
+                    (get_local $6)
                     (i32.ctz
-                      (get_local $$d_sroa_1_4_extract_trunc)
+                      (get_local $8)
                     )
                   )
                 )
@@ -20993,57 +19588,57 @@
           )
           (if
             (i32.le_u
-              (set_local $$51
+              (set_local $5
                 (i32.sub
                   (i32.clz
-                    (get_local $$d_sroa_1_4_extract_trunc)
+                    (get_local $8)
                   )
                   (i32.clz
-                    (get_local $$n_sroa_1_4_extract_trunc)
+                    (get_local $6)
                   )
                 )
               )
               (i32.const 30)
             )
             (block
-              (set_local $$sr_1_ph
-                (set_local $$57
+              (set_local $14
+                (set_local $0
                   (i32.add
-                    (get_local $$51)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
               )
-              (set_local $$r_sroa_0_1_ph
+              (set_local $13
                 (i32.or
                   (i32.shl
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (set_local $$58
+                    (get_local $6)
+                    (set_local $1
                       (i32.sub
                         (i32.const 31)
-                        (get_local $$51)
+                        (get_local $5)
                       )
                     )
                   )
                   (i32.shr_u
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$57)
+                    (get_local $7)
+                    (get_local $0)
                   )
                 )
               )
-              (set_local $$r_sroa_1_1_ph
+              (set_local $12
                 (i32.shr_u
-                  (get_local $$n_sroa_1_4_extract_trunc)
-                  (get_local $$57)
+                  (get_local $6)
+                  (get_local $0)
                 )
               )
-              (set_local $$q_sroa_0_1_ph
+              (set_local $10
                 (i32.const 0)
               )
-              (set_local $$q_sroa_1_1_ph
+              (set_local $0
                 (i32.shl
-                  (get_local $$n_sroa_0_0_extract_trunc)
-                  (get_local $$58)
+                  (get_local $7)
+                  (get_local $1)
                 )
               )
               (br $do-once$0)
@@ -21051,7 +19646,7 @@
           )
           (if
             (i32.eq
-              (get_local $$rem)
+              (get_local $4)
               (i32.const 0)
             )
             (return
@@ -21065,21 +19660,21 @@
             )
           )
           (i32.store
-            (get_local $$rem)
+            (get_local $4)
             (i32.or
               (i32.const 0)
               (i32.and
-                (get_local $$a$0)
+                (get_local $0)
                 (i32.const -1)
               )
             )
           )
           (i32.store offset=4
-            (get_local $$rem)
+            (get_local $4)
             (i32.or
-              (get_local $$n_sroa_1_4_extract_shift$0)
+              (get_local $9)
               (i32.and
-                (get_local $$a$1)
+                (get_local $1)
                 (i32.const 0)
               )
             )
@@ -21097,43 +19692,43 @@
         (block
           (if
             (i32.eqz
-              (get_local $$17)
+              (get_local $10)
             )
             (block
               (if
                 (i32.le_u
-                  (set_local $$119
+                  (set_local $5
                     (i32.sub
                       (i32.clz
-                        (get_local $$d_sroa_1_4_extract_trunc)
+                        (get_local $8)
                       )
                       (i32.clz
-                        (get_local $$n_sroa_1_4_extract_trunc)
+                        (get_local $6)
                       )
                     )
                   )
                   (i32.const 31)
                 )
                 (block
-                  (set_local $$sr_1_ph
-                    (set_local $$125
+                  (set_local $14
+                    (set_local $0
                       (i32.add
-                        (get_local $$119)
+                        (get_local $5)
                         (i32.const 1)
                       )
                     )
                   )
-                  (set_local $$r_sroa_0_1_ph
+                  (set_local $13
                     (i32.or
                       (i32.and
                         (i32.shr_u
-                          (get_local $$n_sroa_0_0_extract_trunc)
-                          (get_local $$125)
+                          (get_local $7)
+                          (get_local $0)
                         )
-                        (set_local $$130
+                        (set_local $9
                           (i32.shr_s
                             (i32.sub
-                              (get_local $$119)
+                              (get_local $5)
                               (i32.const 31)
                             )
                             (i32.const 31)
@@ -21141,32 +19736,32 @@
                         )
                       )
                       (i32.shl
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (set_local $$126
+                        (get_local $6)
+                        (set_local $1
                           (i32.sub
                             (i32.const 31)
-                            (get_local $$119)
+                            (get_local $5)
                           )
                         )
                       )
                     )
                   )
-                  (set_local $$r_sroa_1_1_ph
+                  (set_local $12
                     (i32.and
                       (i32.shr_u
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (get_local $$125)
+                        (get_local $6)
+                        (get_local $0)
                       )
-                      (get_local $$130)
+                      (get_local $9)
                     )
                   )
-                  (set_local $$q_sroa_0_1_ph
+                  (set_local $10
                     (i32.const 0)
                   )
-                  (set_local $$q_sroa_1_1_ph
+                  (set_local $0
                     (i32.shl
-                      (get_local $$n_sroa_0_0_extract_trunc)
-                      (get_local $$126)
+                      (get_local $7)
+                      (get_local $1)
                     )
                   )
                   (br $do-once$0)
@@ -21174,7 +19769,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (return
@@ -21188,21 +19783,21 @@
                 )
               )
               (i32.store
-                (get_local $$rem)
+                (get_local $4)
                 (i32.or
                   (i32.const 0)
                   (i32.and
-                    (get_local $$a$0)
+                    (get_local $0)
                     (i32.const -1)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $$rem)
+                (get_local $4)
                 (i32.or
-                  (get_local $$n_sroa_1_4_extract_shift$0)
+                  (get_local $9)
                   (i32.and
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -21221,131 +19816,131 @@
           (if
             (i32.ne
               (i32.and
-                (set_local $$66
+                (set_local $8
                   (i32.sub
-                    (get_local $$d_sroa_0_0_extract_trunc)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
-                (get_local $$d_sroa_0_0_extract_trunc)
+                (get_local $5)
               )
               (i32.const 0)
             )
             (block
-              (set_local $$89
+              (set_local $1
                 (i32.sub
                   (i32.const 64)
-                  (set_local $$88
+                  (set_local $0
                     (i32.sub
                       (i32.add
                         (i32.clz
-                          (get_local $$d_sroa_0_0_extract_trunc)
+                          (get_local $5)
                         )
                         (i32.const 33)
                       )
                       (i32.clz
-                        (get_local $$n_sroa_1_4_extract_trunc)
+                        (get_local $6)
                       )
                     )
                   )
                 )
               )
-              (set_local $$92
+              (set_local $5
                 (i32.shr_s
-                  (set_local $$91
+                  (set_local $9
                     (i32.sub
                       (i32.const 32)
-                      (get_local $$88)
+                      (get_local $0)
                     )
                   )
                   (i32.const 31)
                 )
               )
-              (set_local $$105
+              (set_local $10
                 (i32.shr_s
-                  (set_local $$95
+                  (set_local $8
                     (i32.sub
-                      (get_local $$88)
+                      (get_local $0)
                       (i32.const 32)
                     )
                   )
                   (i32.const 31)
                 )
               )
-              (set_local $$sr_1_ph
-                (get_local $$88)
+              (set_local $14
+                (get_local $0)
               )
-              (set_local $$r_sroa_0_1_ph
+              (set_local $13
                 (i32.or
                   (i32.and
                     (i32.shr_s
                       (i32.sub
-                        (get_local $$91)
+                        (get_local $9)
                         (i32.const 1)
                       )
                       (i32.const 31)
                     )
                     (i32.shr_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (get_local $$95)
+                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                   (i32.and
                     (i32.or
                       (i32.shl
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (get_local $$91)
+                        (get_local $6)
+                        (get_local $9)
                       )
                       (i32.shr_u
-                        (get_local $$n_sroa_0_0_extract_trunc)
-                        (get_local $$88)
+                        (get_local $7)
+                        (get_local $0)
                       )
                     )
-                    (get_local $$105)
+                    (get_local $10)
                   )
                 )
               )
-              (set_local $$r_sroa_1_1_ph
+              (set_local $12
                 (i32.and
-                  (get_local $$105)
+                  (get_local $10)
                   (i32.shr_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (get_local $$88)
+                    (get_local $6)
+                    (get_local $0)
                   )
                 )
               )
-              (set_local $$q_sroa_0_1_ph
+              (set_local $10
                 (i32.and
                   (i32.shl
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$89)
+                    (get_local $7)
+                    (get_local $1)
                   )
-                  (get_local $$92)
+                  (get_local $5)
                 )
               )
-              (set_local $$q_sroa_1_1_ph
+              (set_local $0
                 (i32.or
                   (i32.and
                     (i32.or
                       (i32.shl
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (get_local $$89)
+                        (get_local $6)
+                        (get_local $1)
                       )
                       (i32.shr_u
-                        (get_local $$n_sroa_0_0_extract_trunc)
-                        (get_local $$95)
+                        (get_local $7)
+                        (get_local $8)
                       )
                     )
-                    (get_local $$92)
+                    (get_local $5)
                   )
                   (i32.and
                     (i32.shl
-                      (get_local $$n_sroa_0_0_extract_trunc)
-                      (get_local $$91)
+                      (get_local $7)
+                      (get_local $9)
                     )
                     (i32.shr_s
                       (i32.sub
-                        (get_local $$88)
+                        (get_local $0)
                         (i32.const 33)
                       )
                       (i32.const 31)
@@ -21358,26 +19953,26 @@
           )
           (if
             (i32.ne
-              (get_local $$rem)
+              (get_local $4)
               (i32.const 0)
             )
             (block
               (i32.store
-                (get_local $$rem)
+                (get_local $4)
                 (i32.and
-                  (get_local $$66)
-                  (get_local $$n_sroa_0_0_extract_trunc)
+                  (get_local $8)
+                  (get_local $7)
                 )
               )
               (i32.store offset=4
-                (get_local $$rem)
+                (get_local $4)
                 (i32.const 0)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $$d_sroa_0_0_extract_trunc)
+              (get_local $5)
               (i32.const 1)
             )
             (return
@@ -21385,9 +19980,9 @@
                 (i32.store
                   (i32.const 168)
                   (i32.or
-                    (get_local $$n_sroa_1_4_extract_shift$0)
+                    (get_local $9)
                     (i32.and
-                      (get_local $$a$1)
+                      (get_local $1)
                       (i32.const 0)
                     )
                   )
@@ -21395,7 +19990,7 @@
                 (i32.or
                   (i32.const 0)
                   (i32.and
-                    (get_local $$a$0)
+                    (get_local $0)
                     (i32.const -1)
                   )
                 )
@@ -21408,10 +20003,10 @@
                   (i32.or
                     (i32.const 0)
                     (i32.shr_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (set_local $$78
+                      (get_local $6)
+                      (set_local $0
                         (i32.ctz
-                          (get_local $$d_sroa_0_0_extract_trunc)
+                          (get_local $5)
                         )
                       )
                     )
@@ -21419,15 +20014,15 @@
                 )
                 (i32.or
                   (i32.shl
-                    (get_local $$n_sroa_1_4_extract_trunc)
+                    (get_local $6)
                     (i32.sub
                       (i32.const 32)
-                      (get_local $$78)
+                      (get_local $0)
                     )
                   )
                   (i32.shr_u
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$78)
+                    (get_local $7)
+                    (get_local $0)
                   )
                 )
               )
@@ -21436,47 +20031,47 @@
         )
       )
     )
-    (set_local $$carry_0_lcssa$0
+    (set_local $0
       (if
         (i32.eq
-          (get_local $$sr_1_ph)
+          (get_local $14)
           (i32.const 0)
         )
         (block
-          (set_local $$q_sroa_1_1_lcssa
-            (get_local $$q_sroa_1_1_ph)
+          (set_local $9
+            (get_local $0)
           )
-          (set_local $$q_sroa_0_1_lcssa
-            (get_local $$q_sroa_0_1_ph)
+          (set_local $7
+            (get_local $10)
           )
-          (set_local $$r_sroa_1_1_lcssa
-            (get_local $$r_sroa_1_1_ph)
+          (set_local $3
+            (get_local $12)
           )
-          (set_local $$r_sroa_0_1_lcssa
-            (get_local $$r_sroa_0_1_ph)
+          (set_local $2
+            (get_local $13)
           )
-          (set_local $$carry_0_lcssa$1
+          (set_local $1
             (i32.const 0)
           )
           (i32.const 0)
         )
         (block
-          (set_local $$137$0
+          (set_local $3
             (call $_i64Add
-              (set_local $$d_sroa_0_0_insert_insert99$0
+              (set_local $1
                 (i32.or
                   (i32.const 0)
                   (i32.and
-                    (get_local $$b$0)
+                    (get_local $2)
                     (i32.const -1)
                   )
                 )
               )
-              (set_local $$d_sroa_0_0_insert_insert99$1
+              (set_local $2
                 (i32.or
-                  (get_local $$d_sroa_1_4_extract_shift$0)
+                  (get_local $11)
                   (i32.and
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -21485,88 +20080,88 @@
               (i32.const -1)
             )
           )
-          (set_local $$137$1
+          (set_local $7
             (i32.load
               (i32.const 168)
             )
           )
-          (set_local $$q_sroa_1_1198
-            (get_local $$q_sroa_1_1_ph)
+          (set_local $8
+            (get_local $0)
           )
-          (set_local $$q_sroa_0_1199
-            (get_local $$q_sroa_0_1_ph)
+          (set_local $11
+            (get_local $10)
           )
-          (set_local $$r_sroa_1_1200
-            (get_local $$r_sroa_1_1_ph)
+          (set_local $5
+            (get_local $12)
           )
-          (set_local $$r_sroa_0_1201
-            (get_local $$r_sroa_0_1_ph)
+          (set_local $6
+            (get_local $13)
           )
-          (set_local $$sr_1202
-            (get_local $$sr_1_ph)
+          (set_local $9
+            (get_local $14)
           )
-          (set_local $$carry_0203
+          (set_local $0
             (i32.const 0)
           )
           (loop $while-out$2 $while-in$3
-            (set_local $$147
+            (set_local $10
               (i32.or
                 (i32.shr_u
-                  (get_local $$q_sroa_0_1199)
+                  (get_local $11)
                   (i32.const 31)
                 )
                 (i32.shl
-                  (get_local $$q_sroa_1_1198)
+                  (get_local $8)
                   (i32.const 1)
                 )
               )
             )
-            (set_local $$149
+            (set_local $0
               (i32.or
-                (get_local $$carry_0203)
+                (get_local $0)
                 (i32.shl
-                  (get_local $$q_sroa_0_1199)
+                  (get_local $11)
                   (i32.const 1)
                 )
               )
             )
             (call $_i64Subtract
-              (get_local $$137$0)
-              (get_local $$137$1)
-              (set_local $$r_sroa_0_0_insert_insert42$0
+              (get_local $3)
+              (get_local $7)
+              (set_local $11
                 (i32.or
                   (i32.const 0)
                   (i32.or
                     (i32.shl
-                      (get_local $$r_sroa_0_1201)
+                      (get_local $6)
                       (i32.const 1)
                     )
                     (i32.shr_u
-                      (get_local $$q_sroa_1_1198)
+                      (get_local $8)
                       (i32.const 31)
                     )
                   )
                 )
               )
-              (set_local $$r_sroa_0_0_insert_insert42$1
+              (set_local $6
                 (i32.or
                   (i32.shr_u
-                    (get_local $$r_sroa_0_1201)
+                    (get_local $6)
                     (i32.const 31)
                   )
                   (i32.shl
-                    (get_local $$r_sroa_1_1200)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
               )
             )
-            (set_local $$152
+            (set_local $12
               (i32.and
-                (set_local $$151$0
+                (set_local $8
                   (i32.or
                     (i32.shr_s
-                      (set_local $$150$1
+                      (set_local $5
                         (i32.load
                           (i32.const 168)
                         )
@@ -21578,7 +20173,7 @@
                         (i32.const -1)
                         (i32.const 0)
                         (i32.lt_s
-                          (get_local $$150$1)
+                          (get_local $5)
                           (i32.const 0)
                         )
                       )
@@ -21589,13 +20184,13 @@
                 (i32.const 1)
               )
             )
-            (set_local $$r_sroa_0_0_extract_trunc
+            (set_local $6
               (call $_i64Subtract
-                (get_local $$r_sroa_0_0_insert_insert42$0)
-                (get_local $$r_sroa_0_0_insert_insert42$1)
+                (get_local $11)
+                (get_local $6)
                 (i32.and
-                  (get_local $$151$0)
-                  (get_local $$d_sroa_0_0_insert_insert99$0)
+                  (get_local $8)
+                  (get_local $1)
                 )
                 (i32.and
                   (i32.or
@@ -21604,7 +20199,7 @@
                         (i32.const -1)
                         (i32.const 0)
                         (i32.lt_s
-                          (get_local $$150$1)
+                          (get_local $5)
                           (i32.const 0)
                         )
                       )
@@ -21615,27 +20210,27 @@
                         (i32.const -1)
                         (i32.const 0)
                         (i32.lt_s
-                          (get_local $$150$1)
+                          (get_local $5)
                           (i32.const 0)
                         )
                       )
                       (i32.const 1)
                     )
                   )
-                  (get_local $$d_sroa_0_0_insert_insert99$1)
+                  (get_local $2)
                 )
               )
             )
-            (set_local $$r_sroa_1_4_extract_trunc
+            (set_local $5
               (i32.load
                 (i32.const 168)
               )
             )
             (if
               (i32.eq
-                (set_local $$155
+                (set_local $9
                   (i32.sub
-                    (get_local $$sr_1202)
+                    (get_local $9)
                     (i32.const 1)
                   )
                 )
@@ -21643,74 +20238,66 @@
               )
               (br $while-out$2)
               (block
-                (set_local $$q_sroa_1_1198
-                  (get_local $$147)
+                (set_local $8
+                  (get_local $10)
                 )
-                (set_local $$q_sroa_0_1199
-                  (get_local $$149)
+                (set_local $11
+                  (get_local $0)
                 )
-                (set_local $$r_sroa_1_1200
-                  (get_local $$r_sroa_1_4_extract_trunc)
-                )
-                (set_local $$r_sroa_0_1201
-                  (get_local $$r_sroa_0_0_extract_trunc)
-                )
-                (set_local $$sr_1202
-                  (get_local $$155)
-                )
-                (set_local $$carry_0203
-                  (get_local $$152)
+                (get_local $5)
+                (get_local $6)
+                (get_local $9)
+                (set_local $0
+                  (get_local $12)
                 )
               )
             )
             (br $while-in$3)
           )
-          (set_local $$q_sroa_1_1_lcssa
-            (get_local $$147)
+          (set_local $9
+            (get_local $10)
           )
-          (set_local $$q_sroa_0_1_lcssa
-            (get_local $$149)
+          (set_local $7
+            (get_local $0)
           )
-          (set_local $$r_sroa_1_1_lcssa
-            (get_local $$r_sroa_1_4_extract_trunc)
+          (set_local $3
+            (get_local $5)
           )
-          (set_local $$r_sroa_0_1_lcssa
-            (get_local $$r_sroa_0_0_extract_trunc)
+          (set_local $2
+            (get_local $6)
           )
-          (set_local $$carry_0_lcssa$1
+          (set_local $1
             (i32.const 0)
           )
-          (get_local $$152)
+          (get_local $12)
         )
       )
     )
-    (set_local $$q_sroa_0_0_insert_ext75$0
-      (get_local $$q_sroa_0_1_lcssa)
-    )
-    (set_local $$q_sroa_0_0_insert_insert77$1
+    (get_local $7)
+    (set_local $6
       (i32.or
-        (get_local $$q_sroa_1_1_lcssa)
-        (set_local $$q_sroa_0_0_insert_ext75$1
+        (get_local $9)
+        (set_local $9
           (i32.const 0)
         )
       )
     )
     (if
       (i32.ne
-        (get_local $$rem)
+        (get_local $4)
         (i32.const 0)
       )
       (block
         (i32.store
-          (get_local $$rem)
+          (get_local $4)
           (i32.or
             (i32.const 0)
-            (get_local $$r_sroa_0_1_lcssa)
+            (get_local $2)
           )
         )
         (i32.store offset=4
-          (get_local $$rem)
-          (get_local $$r_sroa_1_1_lcssa)
+          (get_local $4)
+          (get_local $3)
         )
       )
     )
@@ -21722,37 +20309,37 @@
             (i32.shr_u
               (i32.or
                 (i32.const 0)
-                (get_local $$q_sroa_0_0_insert_ext75$0)
+                (get_local $7)
               )
               (i32.const 31)
             )
             (i32.shl
-              (get_local $$q_sroa_0_0_insert_insert77$1)
+              (get_local $6)
               (i32.const 1)
             )
           )
           (i32.and
             (i32.or
               (i32.shl
-                (get_local $$q_sroa_0_0_insert_ext75$1)
+                (get_local $9)
                 (i32.const 1)
               )
               (i32.shr_u
-                (get_local $$q_sroa_0_0_insert_ext75$0)
+                (get_local $7)
                 (i32.const 31)
               )
             )
             (i32.const 0)
           )
         )
-        (get_local $$carry_0_lcssa$1)
+        (get_local $1)
       )
     )
     (i32.or
       (i32.and
         (i32.or
           (i32.shl
-            (get_local $$q_sroa_0_0_insert_ext75$0)
+            (get_local $7)
             (i32.const 1)
           )
           (i32.shr_u
@@ -21762,60 +20349,60 @@
         )
         (i32.const -2)
       )
-      (get_local $$carry_0_lcssa$0)
+      (get_local $0)
     )
   )
-  (func $dynCall_ii (param $index i32) (param $a1 i32) (result i32)
+  (func $dynCall_ii (param $0 i32) (param $1 i32) (result i32)
     (call_indirect $FUNCSIG$ii
       (i32.add
         (i32.and
-          (get_local $index)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 0)
       )
-      (get_local $a1)
+      (get_local $1)
     )
   )
-  (func $dynCall_iiii (param $index i32) (param $a1 i32) (param $a2 i32) (param $a3 i32) (result i32)
+  (func $dynCall_iiii (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call_indirect $FUNCSIG$iiii
       (i32.add
         (i32.and
-          (get_local $index)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 2)
       )
-      (get_local $a1)
-      (get_local $a2)
-      (get_local $a3)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
     )
   )
-  (func $dynCall_vi (param $index i32) (param $a1 i32)
+  (func $dynCall_vi (param $0 i32) (param $1 i32)
     (call_indirect $FUNCSIG$vi
       (i32.add
         (i32.and
-          (get_local $index)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 10)
       )
-      (get_local $a1)
+      (get_local $1)
     )
   )
-  (func $b0 (param $p0 i32) (result i32)
+  (func $b0 (param $0 i32) (result i32)
     (call_import $nullFunc_ii
       (i32.const 0)
     )
     (i32.const 0)
   )
-  (func $b1 (param $p0 i32) (param $p1 i32) (param $p2 i32) (result i32)
+  (func $b1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (call_import $nullFunc_iiii
       (i32.const 1)
     )
     (i32.const 0)
   )
-  (func $b2 (param $p0 i32)
+  (func $b2 (param $0 i32)
     (call_import $nullFunc_vi
       (i32.const 2)
     )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -50,9 +50,9 @@
   (export "dynCall_vi" $dynCall_vi)
   (export "___udivmoddi4" $___udivmoddi4)
   (table $b0 $___stdio_close $b1 $b1 $___stdout_write $___stdio_seek $___stdio_write $b1 $b1 $b1 $b2 $b2 $b2 $b2 $b2 $_cleanup $b2 $b2)
-  (func $stackAlloc (param $size i32) (result i32)
-    (local $ret i32)
-    (set_local $ret
+  (func $stackAlloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -63,7 +63,7 @@
         (i32.load
           (i32.const 8)
         )
-        (get_local $size)
+        (get_local $0)
       )
     )
     (i32.store
@@ -89,30 +89,30 @@
       )
       (call_import $abort)
     )
-    (get_local $ret)
+    (get_local $1)
   )
   (func $stackSave (result i32)
     (i32.load
       (i32.const 8)
     )
   )
-  (func $stackRestore (param $top i32)
+  (func $stackRestore (param $0 i32)
     (i32.store
       (i32.const 8)
-      (get_local $top)
+      (get_local $0)
     )
   )
-  (func $establishStackSpace (param $stackBase i32) (param $stackMax i32)
+  (func $establishStackSpace (param $0 i32) (param $1 i32)
     (i32.store
       (i32.const 8)
-      (get_local $stackBase)
+      (get_local $0)
     )
     (i32.store
       (i32.const 16)
-      (get_local $stackMax)
+      (get_local $1)
     )
   )
-  (func $setThrew (param $threw i32) (param $value i32)
+  (func $setThrew (param $0 i32) (param $1 i32)
     (if
       (i32.eq
         (i32.load
@@ -123,22 +123,22 @@
       (block
         (i32.store
           (i32.const 48)
-          (get_local $threw)
+          (get_local $0)
         )
         (i32.store
           (i32.const 56)
-          (get_local $value)
+          (get_local $1)
         )
       )
     )
   )
-  (func $copyTempFloat (param $ptr i32)
+  (func $copyTempFloat (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -146,7 +146,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -154,7 +154,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -162,17 +162,17 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $ptr)
+        (get_local $0)
       )
     )
   )
-  (func $copyTempDouble (param $ptr i32)
+  (func $copyTempDouble (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -180,7 +180,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -188,7 +188,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -196,7 +196,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=4
@@ -204,7 +204,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=4
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=5
@@ -212,7 +212,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=5
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=6
@@ -220,7 +220,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=6
-        (get_local $ptr)
+        (get_local $0)
       )
     )
     (i32.store8 offset=7
@@ -228,14 +228,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=7
-        (get_local $ptr)
+        (get_local $0)
       )
     )
   )
-  (func $setTempRet0 (param $value i32)
+  (func $setTempRet0 (param $0 i32)
     (i32.store
       (i32.const 168)
-      (get_local $value)
+      (get_local $0)
     )
   )
   (func $getTempRet0 (result i32)
@@ -244,8 +244,8 @@
     )
   )
   (func $_main (result i32)
-    (local $sp i32)
-    (set_local $sp
+    (local $0 i32)
+    (set_local $0
       (i32.load
         (i32.const 8)
       )
@@ -273,21 +273,18 @@
     (i32.const 0)
     (call $_printf
       (i32.const 672)
-      (get_local $sp)
+      (get_local $0)
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $0)
     )
     (i32.const 0)
   )
-  (func $_frexp (param $$x f64) (param $$e i32) (result f64)
-    (local $$x$addr$0 f64)
-    (local $$0 i32)
-    (local $$1 i32)
-    (local $$2 i32)
-    (local $$conv i32)
-    (local $$storemerge i32)
+  (func $_frexp (param $0 f64) (param $1 i32) (result f64)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
     (i32.load
       (i32.const 8)
     )
@@ -295,18 +292,18 @@
       (i32.load
         (i32.const 24)
       )
-      (get_local $$x)
+      (get_local $0)
     )
-    (set_local $$2
+    (set_local $3
       (call $_bitshift64Lshr
-        (set_local $$0
+        (set_local $2
           (i32.load
             (i32.load
               (i32.const 24)
             )
           )
         )
-        (set_local $$1
+        (set_local $4
           (i32.load offset=4
             (i32.load
               (i32.const 24)
@@ -326,9 +323,9 @@
             (block $switch-case$1
               (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
                 (i32.sub
-                  (set_local $$conv
+                  (set_local $3
                     (i32.and
-                      (get_local $$2)
+                      (get_local $3)
                       (i32.const 2047)
                     )
                   )
@@ -336,53 +333,51 @@
                 )
               )
             )
-            (set_local $$storemerge
+            (set_local $2
               (if
                 (f64.ne
-                  (get_local $$x)
+                  (get_local $0)
                   (f64.const 0)
                 )
                 (block
-                  (set_local $$x$addr$0
+                  (set_local $0
                     (call $_frexp
                       (f64.mul
-                        (get_local $$x)
+                        (get_local $0)
                         (f64.const 18446744073709551615)
                       )
-                      (get_local $$e)
+                      (get_local $1)
                     )
                   )
                   (i32.add
                     (i32.load
-                      (get_local $$e)
+                      (get_local $1)
                     )
                     (i32.const -64)
                   )
                 )
                 (block
-                  (set_local $$x$addr$0
-                    (get_local $$x)
-                  )
+                  (get_local $0)
                   (i32.const 0)
                 )
               )
             )
             (i32.store
-              (get_local $$e)
-              (get_local $$storemerge)
+              (get_local $1)
+              (get_local $2)
             )
             (br $switch$0
-              (get_local $$x$addr$0)
+              (get_local $0)
             )
           )
           (br $switch$0
-            (get_local $$x)
+            (get_local $0)
           )
         )
         (i32.store
-          (get_local $$e)
+          (get_local $1)
           (i32.add
-            (get_local $$conv)
+            (get_local $3)
             (i32.const -1022)
           )
         )
@@ -390,7 +385,7 @@
           (i32.load
             (i32.const 24)
           )
-          (get_local $$0)
+          (get_local $2)
         )
         (i32.store offset=4
           (i32.load
@@ -398,7 +393,7 @@
           )
           (i32.or
             (i32.and
-              (get_local $$1)
+              (get_local $4)
               (i32.const -2146435073)
             )
             (i32.const 1071644672)
@@ -412,31 +407,25 @@
       )
     )
   )
-  (func $_frexpl (param $$x f64) (param $$e i32) (result f64)
+  (func $_frexpl (param $0 f64) (param $1 i32) (result f64)
     (i32.load
       (i32.const 8)
     )
     (call $_frexp
-      (get_local $$x)
-      (get_local $$e)
+      (get_local $0)
+      (get_local $1)
     )
   )
-  (func $_strerror (param $$e i32) (result i32)
-    (local $label i32)
-    (local $$i$012 i32)
-    (local $$i$111 i32)
-    (local $$s$010 i32)
-    (local $$s$1 i32)
-    (local $$i$012$lcssa i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr$lcssa i32)
-    (local $$s$0$lcssa i32)
-    (local $$dec i32)
-    (local $$inc i32)
+  (func $_strerror (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$i$012
+    (set_local $1
       (i32.const 0)
     )
     (loop $while-out$0 $while-in$1
@@ -444,17 +433,17 @@
         (i32.eq
           (i32.and
             (i32.load8_s offset=687
-              (get_local $$i$012)
+              (get_local $1)
             )
             (i32.const 255)
           )
-          (get_local $$e)
+          (get_local $0)
         )
         (block
-          (set_local $$i$012$lcssa
-            (get_local $$i$012)
+          (set_local $4
+            (get_local $1)
           )
-          (set_local $label
+          (set_local $0
             (i32.const 2)
           )
           (br $while-out$0)
@@ -462,53 +451,51 @@
       )
       (if
         (i32.eq
-          (set_local $$inc
+          (set_local $1
             (i32.add
-              (get_local $$i$012)
+              (get_local $1)
               (i32.const 1)
             )
           )
           (i32.const 87)
         )
         (block
-          (set_local $$i$111
+          (set_local $2
             (i32.const 87)
           )
-          (set_local $$s$010
+          (set_local $3
             (i32.const 775)
           )
-          (set_local $label
+          (set_local $0
             (i32.const 5)
           )
           (br $while-out$0)
         )
-        (set_local $$i$012
-          (get_local $$inc)
-        )
+        (get_local $1)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $0)
         (i32.const 2)
       )
       (if
         (i32.eq
-          (get_local $$i$012$lcssa)
+          (get_local $4)
           (i32.const 0)
         )
-        (set_local $$s$0$lcssa
+        (set_local $5
           (i32.const 775)
         )
         (block
-          (set_local $$i$111
-            (get_local $$i$012$lcssa)
+          (set_local $2
+            (get_local $4)
           )
-          (set_local $$s$010
+          (set_local $3
             (i32.const 775)
           )
-          (set_local $label
+          (set_local $0
             (i32.const 5)
           )
         )
@@ -516,20 +503,18 @@
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $0)
         (i32.const 5)
       )
       (loop $while-out$2 $while-in$3
-        (set_local $label
-          (i32.const 0)
-        )
-        (set_local $$s$1
-          (get_local $$s$010)
+        (i32.const 0)
+        (set_local $1
+          (get_local $3)
         )
         (loop $while-out$4 $while-in$5
-          (set_local $$incdec$ptr
+          (set_local $0
             (i32.add
-              (get_local $$s$1)
+              (get_local $1)
               (i32.const 1)
             )
           )
@@ -538,7 +523,7 @@
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $$s$1)
+                    (get_local $1)
                   )
                   (i32.const 24)
                 )
@@ -547,49 +532,47 @@
               (i32.const 0)
             )
             (block
-              (set_local $$incdec$ptr$lcssa
-                (get_local $$incdec$ptr)
+              (set_local $1
+                (get_local $0)
               )
               (br $while-out$4)
             )
-            (set_local $$s$1
-              (get_local $$incdec$ptr)
+            (set_local $1
+              (get_local $0)
             )
           )
           (br $while-in$5)
         )
         (if
           (i32.eq
-            (set_local $$dec
+            (set_local $0
               (i32.add
-                (get_local $$i$111)
+                (get_local $2)
                 (i32.const -1)
               )
             )
             (i32.const 0)
           )
           (block
-            (set_local $$s$0$lcssa
-              (get_local $$incdec$ptr$lcssa)
+            (set_local $5
+              (get_local $1)
             )
             (br $while-out$2)
           )
           (block
-            (set_local $$i$111
-              (get_local $$dec)
+            (set_local $2
+              (get_local $0)
             )
-            (set_local $$s$010
-              (get_local $$incdec$ptr$lcssa)
+            (set_local $3
+              (get_local $1)
             )
-            (set_local $label
-              (i32.const 5)
-            )
+            (i32.const 5)
           )
         )
         (br $while-in$3)
       )
     )
-    (get_local $$s$0$lcssa)
+    (get_local $5)
   )
   (func $___errno_location (result i32)
     (i32.load
@@ -608,11 +591,10 @@
       )
     )
   )
-  (func $___stdio_close (param $$f i32) (result i32)
-    (local $sp i32)
-    (local $$call1 i32)
-    (local $$vararg_buffer i32)
-    (set_local $sp
+  (func $___stdio_close (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -638,33 +620,32 @@
       (call_import $abort)
     )
     (i32.store
-      (set_local $$vararg_buffer
-        (get_local $sp)
+      (set_local $2
+        (get_local $1)
       )
       (i32.load offset=60
-        (get_local $$f)
+        (get_local $0)
       )
     )
-    (set_local $$call1
+    (set_local $0
       (call $___syscall_ret
         (call_import $___syscall6
           (i32.const 6)
-          (get_local $$vararg_buffer)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $1)
     )
-    (get_local $$call1)
+    (get_local $0)
   )
-  (func $___stdout_write (param $$f i32) (param $$buf i32) (param $$len i32) (result i32)
-    (local $$vararg_buffer i32)
-    (local $sp i32)
-    (local $$call3 i32)
-    (local $$tio i32)
-    (set_local $sp
+  (func $___stdout_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -689,24 +670,24 @@
       )
       (call_import $abort)
     )
-    (set_local $$vararg_buffer
-      (get_local $sp)
+    (set_local $3
+      (get_local $4)
     )
-    (set_local $$tio
+    (set_local $5
       (i32.add
-        (get_local $sp)
+        (get_local $4)
         (i32.const 12)
       )
     )
     (i32.store offset=36
-      (get_local $$f)
+      (get_local $0)
       (i32.const 4)
     )
     (if
       (i32.eq
         (i32.and
           (i32.load
-            (get_local $$f)
+            (get_local $0)
           )
           (i32.const 64)
         )
@@ -714,53 +695,51 @@
       )
       (block
         (i32.store
-          (get_local $$vararg_buffer)
+          (get_local $3)
           (i32.load offset=60
-            (get_local $$f)
+            (get_local $0)
           )
         )
         (i32.store offset=4
-          (get_local $$vararg_buffer)
+          (get_local $3)
           (i32.const 21505)
         )
         (i32.store offset=8
-          (get_local $$vararg_buffer)
-          (get_local $$tio)
+          (get_local $3)
+          (get_local $5)
         )
         (if
           (i32.ne
             (call_import $___syscall54
               (i32.const 54)
-              (get_local $$vararg_buffer)
+              (get_local $3)
             )
             (i32.const 0)
           )
           (i32.store8 offset=75
-            (get_local $$f)
+            (get_local $0)
             (i32.const -1)
           )
         )
       )
     )
-    (set_local $$call3
+    (set_local $0
       (call $___stdio_write
-        (get_local $$f)
-        (get_local $$buf)
-        (get_local $$len)
+        (get_local $0)
+        (get_local $1)
+        (get_local $2)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $4)
     )
-    (get_local $$call3)
+    (get_local $0)
   )
-  (func $___stdio_seek (param $$f i32) (param $$off i32) (param $$whence i32) (result i32)
-    (local $$vararg_buffer i32)
-    (local $sp i32)
-    (local $$ret i32)
-    (local $$1 i32)
-    (set_local $sp
+  (func $___stdio_seek (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -786,85 +765,77 @@
       (call_import $abort)
     )
     (i32.store
-      (set_local $$vararg_buffer
-        (get_local $sp)
+      (set_local $3
+        (get_local $4)
       )
       (i32.load offset=60
-        (get_local $$f)
+        (get_local $0)
       )
     )
     (i32.store offset=4
-      (get_local $$vararg_buffer)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=8
-      (get_local $$vararg_buffer)
-      (get_local $$off)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $$vararg_buffer)
-      (set_local $$ret
+      (get_local $3)
+      (set_local $0
         (i32.add
-          (get_local $sp)
+          (get_local $4)
           (i32.const 20)
         )
       )
     )
     (i32.store offset=16
-      (get_local $$vararg_buffer)
-      (get_local $$whence)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $$1
+    (set_local $0
       (if
         (i32.lt_s
           (call $___syscall_ret
             (call_import $___syscall140
               (i32.const 140)
-              (get_local $$vararg_buffer)
+              (get_local $3)
             )
           )
           (i32.const 0)
         )
         (block
           (i32.store
-            (get_local $$ret)
+            (get_local $0)
             (i32.const -1)
           )
           (i32.const -1)
         )
         (i32.load
-          (get_local $$ret)
+          (get_local $0)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $4)
     )
-    (get_local $$1)
+    (get_local $0)
   )
-  (func $_fflush (param $$f i32) (result i32)
-    (local $$f$addr$022 i32)
-    (local $$r$021 i32)
-    (local $$call1 i32)
-    (local $$cond10 i32)
-    (local $$r$0$lcssa i32)
-    (local $$r$1 i32)
-    (local $$cond19 i32)
-    (local $$f$addr$0 i32)
-    (local $$f$addr$0$19 i32)
-    (local $$phitmp i32)
+  (func $_fflush (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (i32.load
       (i32.const 8)
     )
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (block
-          (set_local $$cond10
+          (set_local $0
             (if
               (i32.eq
                 (i32.load
@@ -885,88 +856,82 @@
           )
           (if
             (i32.eq
-              (set_local $$f$addr$0$19
+              (set_local $1
                 (i32.load
                   (i32.const 40)
                 )
               )
               (i32.const 0)
             )
-            (set_local $$r$0$lcssa
-              (get_local $$cond10)
-            )
+            (get_local $0)
             (block
-              (set_local $$f$addr$022
-                (get_local $$f$addr$0$19)
-              )
-              (set_local $$r$021
-                (get_local $$cond10)
+              (get_local $1)
+              (set_local $2
+                (get_local $0)
               )
               (loop $while-out$2 $while-in$3
-                (set_local $$cond19
+                (set_local $0
                   (if
                     (i32.gt_s
                       (i32.load offset=76
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                       (i32.const -1)
                     )
                     (call $___lockfile
-                      (get_local $$f$addr$022)
+                      (get_local $1)
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $$r$1
+                (set_local $2
                   (if
                     (i32.gt_u
                       (i32.load offset=20
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                       (i32.load offset=28
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                     )
                     (i32.or
                       (call $___fflush_unlocked
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
-                      (get_local $$r$021)
+                      (get_local $2)
                     )
-                    (get_local $$r$021)
+                    (get_local $2)
                   )
                 )
                 (if
                   (i32.ne
-                    (get_local $$cond19)
+                    (get_local $0)
                     (i32.const 0)
                   )
                   (call $___unlockfile
-                    (get_local $$f$addr$022)
+                    (get_local $1)
                   )
                 )
                 (if
                   (i32.eq
-                    (set_local $$f$addr$0
+                    (set_local $0
                       (i32.load offset=56
-                        (get_local $$f$addr$022)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$r$0$lcssa
-                      (get_local $$r$1)
+                    (set_local $0
+                      (get_local $2)
                     )
                     (br $while-out$2)
                   )
                   (block
-                    (set_local $$f$addr$022
-                      (get_local $$f$addr$0)
+                    (set_local $1
+                      (get_local $0)
                     )
-                    (set_local $$r$021
-                      (get_local $$r$1)
-                    )
+                    (get_local $2)
                   )
                 )
                 (br $while-in$3)
@@ -976,54 +941,53 @@
           (call_import $___unlock
             (i32.const 44)
           )
-          (get_local $$r$0$lcssa)
+          (get_local $0)
         )
         (block
           (if
             (i32.le_s
               (i32.load offset=76
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const -1)
             )
             (br $do-once$0
               (call $___fflush_unlocked
-                (get_local $$f)
+                (get_local $0)
               )
             )
           )
-          (set_local $$phitmp
+          (set_local $2
             (i32.eq
               (call $___lockfile
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $$call1
+          (set_local $1
             (call $___fflush_unlocked
-              (get_local $$f)
+              (get_local $0)
             )
           )
           (if
-            (get_local $$phitmp)
-            (get_local $$call1)
+            (get_local $2)
+            (get_local $1)
             (block
               (call $___unlockfile
-                (get_local $$f)
+                (get_local $0)
               )
-              (get_local $$call1)
+              (get_local $1)
             )
           )
         )
       )
     )
   )
-  (func $_printf (param $$fmt i32) (param $$varargs i32) (result i32)
-    (local $sp i32)
-    (local $$ap i32)
-    (local $$call i32)
-    (set_local $sp
+  (func $_printf (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (set_local $2
       (i32.load
         (i32.const 8)
       )
@@ -1049,67 +1013,54 @@
       (call_import $abort)
     )
     (i32.store
-      (set_local $$ap
-        (get_local $sp)
+      (set_local $3
+        (get_local $2)
       )
-      (get_local $$varargs)
+      (get_local $1)
     )
-    (set_local $$call
+    (set_local $0
       (call $_vfprintf
         (i32.load
           (i32.const 8)
         )
-        (get_local $$fmt)
-        (get_local $$ap)
+        (get_local $0)
+        (get_local $3)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $2)
     )
-    (get_local $$call)
+    (get_local $0)
   )
-  (func $___lockfile (param $$f i32) (result i32)
+  (func $___lockfile (param $0 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (i32.const 0)
   )
-  (func $___unlockfile (param $$f i32)
+  (func $___unlockfile (param $0 i32)
     (i32.load
       (i32.const 8)
     )
   )
-  (func $___stdio_write (param $$f i32) (param $$buf i32) (param $$len i32) (result i32)
-    (local $$iov$0 i32)
-    (local $$cnt$0 i32)
-    (local $$iovcnt$0 i32)
-    (local $$iov$1 i32)
-    (local $$wbase i32)
-    (local $$cnt$1 i32)
-    (local $$iovs i32)
-    (local $$vararg_buffer i32)
-    (local $$vararg_buffer3 i32)
-    (local $sp i32)
-    (local $$10 i32)
-    (local $$iovcnt$1 i32)
-    (local $$rem$0 i32)
-    (local $$wpos i32)
-    (local $label i32)
-    (local $$buf31 i32)
-    (local $$fd8 i32)
-    (local $$retval$0 i32)
-    (local $$0 i32)
-    (local $$11 i32)
-    (local $$14 i32)
-    (local $$5 i32)
-    (local $$7 i32)
-    (local $$call7 i32)
-    (local $$iov$0$lcssa57 i32)
-    (local $$iovcnt$0$lcssa58 i32)
-    (local $$sub$ptr$sub i32)
-    (local $$sub26 i32)
-    (set_local $sp
+  (func $___stdio_write (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (set_local $10
       (i32.load
         (i32.const 8)
       )
@@ -1134,27 +1085,27 @@
       )
       (call_import $abort)
     )
-    (set_local $$vararg_buffer3
+    (set_local $9
       (i32.add
-        (get_local $sp)
+        (get_local $10)
         (i32.const 16)
       )
     )
-    (set_local $$vararg_buffer
-      (get_local $sp)
+    (set_local $8
+      (get_local $10)
     )
     (i32.store
-      (set_local $$iovs
+      (set_local $3
         (i32.add
-          (get_local $sp)
+          (get_local $10)
           (i32.const 32)
         )
       )
-      (set_local $$0
+      (set_local $4
         (i32.load
-          (set_local $$wbase
+          (set_local $7
             (i32.add
-              (get_local $$f)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -1162,55 +1113,55 @@
       )
     )
     (i32.store offset=4
-      (get_local $$iovs)
-      (set_local $$sub$ptr$sub
+      (get_local $3)
+      (set_local $4
         (i32.sub
           (i32.load
-            (set_local $$wpos
+            (set_local $11
               (i32.add
-                (get_local $$f)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $$0)
+          (get_local $4)
         )
       )
     )
     (i32.store offset=8
-      (get_local $$iovs)
-      (get_local $$buf)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $$iovs)
-      (get_local $$len)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $$fd8
+    (set_local $13
       (i32.add
-        (get_local $$f)
+        (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $$buf31
+    (set_local $12
       (i32.add
-        (get_local $$f)
+        (get_local $0)
         (i32.const 44)
       )
     )
-    (set_local $$iov$0
-      (get_local $$iovs)
+    (set_local $5
+      (get_local $3)
     )
-    (set_local $$iovcnt$0
+    (set_local $6
       (i32.const 2)
     )
-    (set_local $$rem$0
+    (set_local $4
       (i32.add
-        (get_local $$sub$ptr$sub)
-        (get_local $$len)
+        (get_local $4)
+        (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $$cnt$0
+      (set_local $3
         (if
           (i32.eq
             (i32.load
@@ -1220,67 +1171,67 @@
           )
           (block
             (i32.store
-              (get_local $$vararg_buffer3)
+              (get_local $9)
               (i32.load
-                (get_local $$fd8)
+                (get_local $13)
               )
             )
             (i32.store offset=4
-              (get_local $$vararg_buffer3)
-              (get_local $$iov$0)
+              (get_local $9)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $$vararg_buffer3)
-              (get_local $$iovcnt$0)
+              (get_local $9)
+              (get_local $6)
             )
             (call $___syscall_ret
               (call_import $___syscall146
                 (i32.const 146)
-                (get_local $$vararg_buffer3)
+                (get_local $9)
               )
             )
           )
           (block
             (call_import $_pthread_cleanup_push
               (i32.const 5)
-              (get_local $$f)
+              (get_local $0)
             )
             (i32.store
-              (get_local $$vararg_buffer)
+              (get_local $8)
               (i32.load
-                (get_local $$fd8)
+                (get_local $13)
               )
             )
             (i32.store offset=4
-              (get_local $$vararg_buffer)
-              (get_local $$iov$0)
+              (get_local $8)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $$vararg_buffer)
-              (get_local $$iovcnt$0)
+              (get_local $8)
+              (get_local $6)
             )
-            (set_local $$call7
+            (set_local $1
               (call $___syscall_ret
                 (call_import $___syscall146
                   (i32.const 146)
-                  (get_local $$vararg_buffer)
+                  (get_local $8)
                 )
               )
             )
             (call_import $_pthread_cleanup_pop
               (i32.const 0)
             )
-            (get_local $$call7)
+            (get_local $1)
           )
         )
       )
       (if
         (i32.eq
-          (get_local $$rem$0)
-          (get_local $$cnt$0)
+          (get_local $4)
+          (get_local $3)
         )
         (block
-          (set_local $label
+          (set_local $1
             (i32.const 6)
           )
           (br $while-out$0)
@@ -1288,212 +1239,208 @@
       )
       (if
         (i32.lt_s
-          (get_local $$cnt$0)
+          (get_local $3)
           (i32.const 0)
         )
         (block
-          (set_local $$iov$0$lcssa57
-            (get_local $$iov$0)
+          (set_local $15
+            (get_local $5)
           )
-          (set_local $$iovcnt$0$lcssa58
-            (get_local $$iovcnt$0)
+          (set_local $16
+            (get_local $6)
           )
-          (set_local $label
+          (set_local $1
             (i32.const 8)
           )
           (br $while-out$0)
         )
       )
-      (set_local $$sub26
+      (set_local $17
         (i32.sub
-          (get_local $$rem$0)
-          (get_local $$cnt$0)
+          (get_local $4)
+          (get_local $3)
         )
       )
-      (set_local $$14
+      (set_local $1
         (if
           (i32.gt_u
-            (get_local $$cnt$0)
-            (set_local $$10
+            (get_local $3)
+            (set_local $1
               (i32.load offset=4
-                (get_local $$iov$0)
+                (get_local $5)
               )
             )
           )
           (block
             (i32.store
-              (get_local $$wbase)
-              (set_local $$11
+              (get_local $7)
+              (set_local $4
                 (i32.load
-                  (get_local $$buf31)
+                  (get_local $12)
                 )
               )
             )
             (i32.store
-              (get_local $$wpos)
-              (get_local $$11)
+              (get_local $11)
+              (get_local $4)
             )
-            (set_local $$cnt$1
+            (set_local $4
               (i32.sub
-                (get_local $$cnt$0)
-                (get_local $$10)
+                (get_local $3)
+                (get_local $1)
               )
             )
-            (set_local $$iov$1
+            (set_local $3
               (i32.add
-                (get_local $$iov$0)
+                (get_local $5)
                 (i32.const 8)
               )
             )
-            (set_local $$iovcnt$1
+            (set_local $6
               (i32.add
-                (get_local $$iovcnt$0)
+                (get_local $6)
                 (i32.const -1)
               )
             )
             (i32.load offset=12
-              (get_local $$iov$0)
+              (get_local $5)
             )
           )
           (if
             (i32.eq
-              (get_local $$iovcnt$0)
+              (get_local $6)
               (i32.const 2)
             )
             (block
               (i32.store
-                (get_local $$wbase)
+                (get_local $7)
                 (i32.add
                   (i32.load
-                    (get_local $$wbase)
+                    (get_local $7)
                   )
-                  (get_local $$cnt$0)
+                  (get_local $3)
                 )
               )
-              (set_local $$cnt$1
-                (get_local $$cnt$0)
+              (set_local $4
+                (get_local $3)
               )
-              (set_local $$iov$1
-                (get_local $$iov$0)
+              (set_local $3
+                (get_local $5)
               )
-              (set_local $$iovcnt$1
+              (set_local $6
                 (i32.const 2)
               )
-              (get_local $$10)
+              (get_local $1)
             )
             (block
-              (set_local $$cnt$1
-                (get_local $$cnt$0)
+              (set_local $4
+                (get_local $3)
               )
-              (set_local $$iov$1
-                (get_local $$iov$0)
+              (set_local $3
+                (get_local $5)
               )
-              (set_local $$iovcnt$1
-                (get_local $$iovcnt$0)
-              )
-              (get_local $$10)
+              (get_local $6)
+              (get_local $1)
             )
           )
         )
       )
       (i32.store
-        (get_local $$iov$1)
+        (get_local $3)
         (i32.add
           (i32.load
-            (get_local $$iov$1)
+            (get_local $3)
           )
-          (get_local $$cnt$1)
+          (get_local $4)
         )
       )
       (i32.store offset=4
-        (get_local $$iov$1)
+        (get_local $3)
         (i32.sub
-          (get_local $$14)
-          (get_local $$cnt$1)
+          (get_local $1)
+          (get_local $4)
         )
       )
-      (set_local $$iov$0
-        (get_local $$iov$1)
+      (set_local $5
+        (get_local $3)
       )
-      (set_local $$iovcnt$0
-        (get_local $$iovcnt$1)
-      )
-      (set_local $$rem$0
-        (get_local $$sub26)
+      (get_local $6)
+      (set_local $4
+        (get_local $17)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $1)
         (i32.const 6)
       )
       (block
         (i32.store offset=16
-          (get_local $$f)
+          (get_local $0)
           (i32.add
-            (set_local $$5
+            (set_local $1
               (i32.load
-                (get_local $$buf31)
+                (get_local $12)
               )
             )
             (i32.load offset=48
-              (get_local $$f)
+              (get_local $0)
             )
           )
         )
         (i32.store
-          (get_local $$wbase)
-          (set_local $$7
-            (get_local $$5)
+          (get_local $7)
+          (set_local $0
+            (get_local $1)
           )
         )
         (i32.store
-          (get_local $$wpos)
-          (get_local $$7)
+          (get_local $11)
+          (get_local $0)
         )
-        (set_local $$retval$0
-          (get_local $$len)
+        (set_local $14
+          (get_local $2)
         )
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $1)
           (i32.const 8)
         )
         (block
           (i32.store offset=16
-            (get_local $$f)
+            (get_local $0)
             (i32.const 0)
           )
           (i32.store
-            (get_local $$wbase)
+            (get_local $7)
             (i32.const 0)
           )
           (i32.store
-            (get_local $$wpos)
+            (get_local $11)
             (i32.const 0)
           )
           (i32.store
-            (get_local $$f)
+            (get_local $0)
             (i32.or
               (i32.load
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 32)
             )
           )
-          (set_local $$retval$0
+          (set_local $14
             (if
               (i32.eq
-                (get_local $$iovcnt$0$lcssa58)
+                (get_local $16)
                 (i32.const 2)
               )
               (i32.const 0)
               (i32.sub
-                (get_local $$len)
+                (get_local $2)
                 (i32.load offset=4
-                  (get_local $$iov$0$lcssa57)
+                  (get_local $15)
                 )
               )
             )
@@ -1503,33 +1450,24 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $10)
     )
-    (get_local $$retval$0)
+    (get_local $14)
   )
-  (func $_vfprintf (param $$f i32) (param $$fmt i32) (param $$ap i32) (result i32)
-    (local $sp i32)
-    (local $$ap2 i32)
-    (local $$internal_buf i32)
-    (local $$nl_arg i32)
-    (local $$nl_type i32)
-    (local $dest i32)
-    (local $$4 i32)
-    (local $$buf i32)
-    (local $$buf_size i32)
-    (local $$call21 i32)
-    (local $$wpos i32)
-    (local $$$call21 i32)
-    (local $$1 i32)
-    (local $$7 i32)
-    (local $$and i32)
-    (local $$cond i32)
-    (local $$ret$1$ i32)
-    (local $$retval$0 i32)
-    (local $$wbase i32)
-    (local $$wend i32)
-    (local $stop i32)
-    (set_local $sp
+  (func $_vfprintf (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -1554,27 +1492,27 @@
       )
       (call_import $abort)
     )
-    (set_local $$ap2
+    (set_local $5
       (i32.add
-        (get_local $sp)
+        (get_local $4)
         (i32.const 120)
       )
     )
-    (set_local $$nl_arg
-      (get_local $sp)
+    (set_local $8
+      (get_local $4)
     )
-    (set_local $$internal_buf
+    (set_local $7
       (i32.add
-        (get_local $sp)
+        (get_local $4)
         (i32.const 136)
       )
     )
-    (set_local $stop
+    (set_local $6
       (i32.add
-        (set_local $dest
-          (set_local $$nl_type
+        (set_local $3
+          (set_local $9
             (i32.add
-              (get_local $sp)
+              (get_local $4)
               (i32.const 80)
             )
           )
@@ -1584,60 +1522,60 @@
     )
     (loop $do-out$0 $do-in$1
       (i32.store
-        (get_local $dest)
+        (get_local $3)
         (i32.const 0)
       )
       (br_if $do-in$1
         (i32.lt_s
-          (set_local $dest
+          (set_local $3
             (i32.add
-              (get_local $dest)
+              (get_local $3)
               (i32.const 4)
             )
           )
-          (get_local $stop)
+          (get_local $6)
         )
       )
     )
     (i32.store
-      (get_local $$ap2)
+      (get_local $5)
       (i32.load
-        (get_local $$ap)
+        (get_local $2)
       )
     )
-    (set_local $$retval$0
+    (set_local $0
       (if
         (i32.lt_s
           (call $_printf_core
             (i32.const 0)
-            (get_local $$fmt)
-            (get_local $$ap2)
-            (get_local $$nl_arg)
-            (get_local $$nl_type)
+            (get_local $1)
+            (get_local $5)
+            (get_local $8)
+            (get_local $9)
           )
           (i32.const 0)
         )
         (i32.const -1)
         (block
-          (set_local $$cond
+          (set_local $12
             (if
               (i32.gt_s
                 (i32.load offset=76
-                  (get_local $$f)
+                  (get_local $0)
                 )
                 (i32.const -1)
               )
               (call $___lockfile
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $$and
+          (set_local $3
             (i32.and
-              (set_local $$1
+              (set_local $2
                 (i32.load
-                  (get_local $$f)
+                  (get_local $0)
                 )
               )
               (i32.const 32)
@@ -1648,7 +1586,7 @@
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s offset=74
-                    (get_local $$f)
+                    (get_local $0)
                   )
                   (i32.const 24)
                 )
@@ -1657,21 +1595,21 @@
               (i32.const 1)
             )
             (i32.store
-              (get_local $$f)
+              (get_local $0)
               (i32.and
-                (get_local $$1)
+                (get_local $2)
                 (i32.const -33)
               )
             )
           )
-          (set_local $$ret$1$
+          (set_local $2
             (select
               (if
                 (i32.eq
                   (i32.load
-                    (set_local $$buf_size
+                    (set_local $10
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 48)
                       )
                     )
@@ -1679,134 +1617,134 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$4
+                  (set_local $2
                     (i32.load
-                      (set_local $$buf
+                      (set_local $6
                         (i32.add
-                          (get_local $$f)
+                          (get_local $0)
                           (i32.const 44)
                         )
                       )
                     )
                   )
                   (i32.store
-                    (get_local $$buf)
-                    (get_local $$internal_buf)
+                    (get_local $6)
+                    (get_local $7)
                   )
                   (i32.store
-                    (set_local $$wbase
+                    (set_local $13
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 28)
                       )
                     )
-                    (get_local $$internal_buf)
+                    (get_local $7)
                   )
                   (i32.store
-                    (set_local $$wpos
+                    (set_local $11
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 20)
                       )
                     )
-                    (get_local $$internal_buf)
+                    (get_local $7)
                   )
                   (i32.store
-                    (get_local $$buf_size)
+                    (get_local $10)
                     (i32.const 80)
                   )
                   (i32.store
-                    (set_local $$wend
+                    (set_local $14
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
                     (i32.add
-                      (get_local $$internal_buf)
+                      (get_local $7)
                       (i32.const 80)
                     )
                   )
-                  (set_local $$call21
+                  (set_local $1
                     (call $_printf_core
-                      (get_local $$f)
-                      (get_local $$fmt)
-                      (get_local $$ap2)
-                      (get_local $$nl_arg)
-                      (get_local $$nl_type)
+                      (get_local $0)
+                      (get_local $1)
+                      (get_local $5)
+                      (get_local $8)
+                      (get_local $9)
                     )
                   )
                   (if
                     (i32.eq
-                      (get_local $$4)
+                      (get_local $2)
                       (i32.const 0)
                     )
-                    (get_local $$call21)
+                    (get_local $1)
                     (block
                       (call_indirect $FUNCSIG$iiii
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $$f)
+                              (get_local $0)
                             )
                             (i32.const 7)
                           )
                           (i32.const 2)
                         )
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 0)
                         (i32.const 0)
                       )
-                      (set_local $$$call21
+                      (set_local $1
                         (select
                           (i32.const -1)
-                          (get_local $$call21)
+                          (get_local $1)
                           (i32.eq
                             (i32.load
-                              (get_local $$wpos)
+                              (get_local $11)
                             )
                             (i32.const 0)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $$buf)
-                        (get_local $$4)
+                        (get_local $6)
+                        (get_local $2)
                       )
                       (i32.store
-                        (get_local $$buf_size)
+                        (get_local $10)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $$wend)
+                        (get_local $14)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $$wbase)
+                        (get_local $13)
                         (i32.const 0)
                       )
                       (i32.store
-                        (get_local $$wpos)
+                        (get_local $11)
                         (i32.const 0)
                       )
-                      (get_local $$$call21)
+                      (get_local $1)
                     )
                   )
                 )
                 (call $_printf_core
-                  (get_local $$f)
-                  (get_local $$fmt)
-                  (get_local $$ap2)
-                  (get_local $$nl_arg)
-                  (get_local $$nl_type)
+                  (get_local $0)
+                  (get_local $1)
+                  (get_local $5)
+                  (get_local $8)
+                  (get_local $9)
                 )
               )
               (i32.const -1)
               (i32.eq
                 (i32.and
-                  (set_local $$7
+                  (set_local $1
                     (i32.load
-                      (get_local $$f)
+                      (get_local $0)
                     )
                   )
                   (i32.const 32)
@@ -1816,57 +1754,47 @@
             )
           )
           (i32.store
-            (get_local $$f)
+            (get_local $0)
             (i32.or
-              (get_local $$7)
-              (get_local $$and)
+              (get_local $1)
+              (get_local $3)
             )
           )
           (if
             (i32.ne
-              (get_local $$cond)
+              (get_local $12)
               (i32.const 0)
             )
             (call $___unlockfile
-              (get_local $$f)
+              (get_local $0)
             )
           )
-          (get_local $$ret$1$)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $4)
     )
-    (get_local $$retval$0)
+    (get_local $0)
   )
-  (func $___fwritex (param $$s i32) (param $$l i32) (param $$f i32) (result i32)
-    (local $$i$0$lcssa36 i32)
-    (local $$l$addr$0 i32)
-    (local $$i$0 i32)
-    (local $$retval$0 i32)
-    (local $$i$1 i32)
-    (local $$s$addr$0 i32)
-    (local $$wpos i32)
-    (local $$3 i32)
-    (local $$4 i32)
-    (local $label i32)
-    (local $$0 i32)
-    (local $$2 i32)
-    (local $$cmp i32)
-    (local $$sub i32)
-    (local $$wend i32)
+  (func $___fwritex (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
-        (set_local $$0
+        (set_local $3
           (i32.load
-            (set_local $$wend
+            (set_local $6
               (i32.add
-                (get_local $$f)
+                (get_local $2)
                 (i32.const 16)
               )
             )
@@ -1877,29 +1805,29 @@
       (if
         (i32.eq
           (call $___towrite
-            (get_local $$f)
+            (get_local $2)
           )
           (i32.const 0)
         )
         (block
-          (set_local $$3
+          (set_local $4
             (i32.load
-              (get_local $$wend)
+              (get_local $6)
             )
           )
-          (set_local $label
+          (set_local $7
             (i32.const 5)
           )
         )
-        (set_local $$retval$0
+        (set_local $5
           (i32.const 0)
         )
       )
       (block
-        (set_local $$3
-          (get_local $$0)
+        (set_local $4
+          (get_local $3)
         )
-        (set_local $label
+        (set_local $7
           (i32.const 5)
         )
       )
@@ -1907,48 +1835,46 @@
     (block $label$break$L5
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $7)
           (i32.const 5)
         )
         (block
-          (set_local $$cmp
+          (set_local $4
             (i32.lt_u
               (i32.sub
-                (get_local $$3)
-                (set_local $$2
+                (get_local $4)
+                (set_local $3
                   (i32.load
-                    (set_local $$wpos
+                    (set_local $6
                       (i32.add
-                        (get_local $$f)
+                        (get_local $2)
                         (i32.const 20)
                       )
                     )
                   )
                 )
               )
-              (get_local $$l)
+              (get_local $1)
             )
           )
-          (set_local $$4
-            (get_local $$2)
-          )
+          (get_local $3)
           (if
-            (get_local $$cmp)
+            (get_local $4)
             (block
-              (set_local $$retval$0
+              (set_local $5
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $$f)
+                        (get_local $2)
                       )
                       (i32.const 7)
                     )
                     (i32.const 2)
                   )
-                  (get_local $$f)
-                  (get_local $$s)
-                  (get_local $$l)
+                  (get_local $2)
+                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br $label$break$L5)
@@ -1961,7 +1887,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s offset=75
-                        (get_local $$f)
+                        (get_local $2)
                       )
                       (i32.const 24)
                     )
@@ -1970,27 +1896,23 @@
                   (i32.const -1)
                 )
                 (block
-                  (set_local $$i$0
-                    (get_local $$l)
+                  (set_local $4
+                    (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eq
-                        (get_local $$i$0)
+                        (get_local $4)
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$i$1
+                        (set_local $2
                           (i32.const 0)
                         )
-                        (set_local $$l$addr$0
-                          (get_local $$l)
-                        )
-                        (set_local $$s$addr$0
-                          (get_local $$s)
-                        )
+                        (get_local $1)
+                        (get_local $0)
                         (br $label$break$L10
-                          (get_local $$4)
+                          (get_local $3)
                         )
                       )
                     )
@@ -2000,10 +1922,10 @@
                           (i32.shl
                             (i32.load8_s
                               (i32.add
-                                (get_local $$s)
-                                (set_local $$sub
+                                (get_local $0)
+                                (set_local $5
                                   (i32.add
-                                    (get_local $$i$0)
+                                    (get_local $4)
                                     (i32.const -1)
                                   )
                                 )
@@ -2016,13 +1938,13 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $$i$0$lcssa36
-                          (get_local $$i$0)
+                        (set_local $3
+                          (get_local $4)
                         )
                         (br $while-out$2)
                       )
-                      (set_local $$i$0
-                        (get_local $$sub)
+                      (set_local $4
+                        (get_local $5)
                       )
                     )
                     (br $while-in$3)
@@ -2033,101 +1955,94 @@
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $$f)
+                              (get_local $2)
                             )
                             (i32.const 7)
                           )
                           (i32.const 2)
                         )
-                        (get_local $$f)
-                        (get_local $$s)
-                        (get_local $$i$0$lcssa36)
+                        (get_local $2)
+                        (get_local $0)
+                        (get_local $3)
                       )
-                      (get_local $$i$0$lcssa36)
+                      (get_local $3)
                     )
                     (block
-                      (set_local $$retval$0
-                        (get_local $$i$0$lcssa36)
+                      (set_local $5
+                        (get_local $3)
                       )
                       (br $label$break$L5)
                     )
                   )
-                  (set_local $$i$1
-                    (get_local $$i$0$lcssa36)
+                  (set_local $2
+                    (get_local $3)
                   )
-                  (set_local $$l$addr$0
+                  (set_local $1
                     (i32.sub
-                      (get_local $$l)
-                      (get_local $$i$0$lcssa36)
+                      (get_local $1)
+                      (get_local $3)
                     )
                   )
-                  (set_local $$s$addr$0
+                  (set_local $0
                     (i32.add
-                      (get_local $$s)
-                      (get_local $$i$0$lcssa36)
+                      (get_local $0)
+                      (get_local $3)
                     )
                   )
                   (i32.load
-                    (get_local $$wpos)
+                    (get_local $6)
                   )
                 )
                 (block
-                  (set_local $$i$1
+                  (set_local $2
                     (i32.const 0)
                   )
-                  (set_local $$l$addr$0
-                    (get_local $$l)
-                  )
-                  (set_local $$s$addr$0
-                    (get_local $$s)
-                  )
-                  (get_local $$4)
+                  (get_local $1)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
             )
-            (get_local $$s$addr$0)
-            (get_local $$l$addr$0)
+            (get_local $0)
+            (get_local $1)
           )
           (i32.store
-            (get_local $$wpos)
+            (get_local $6)
             (i32.add
               (i32.load
-                (get_local $$wpos)
+                (get_local $6)
               )
-              (get_local $$l$addr$0)
+              (get_local $1)
             )
           )
-          (set_local $$retval$0
+          (set_local $5
             (i32.add
-              (get_local $$i$1)
-              (get_local $$l$addr$0)
+              (get_local $2)
+              (get_local $1)
             )
           )
         )
       )
     )
-    (get_local $$retval$0)
+    (get_local $5)
   )
-  (func $___towrite (param $$f i32) (result i32)
-    (local $$2 i32)
-    (local $$1 i32)
-    (local $$conv i32)
-    (local $$conv3 i32)
-    (local $$mode i32)
+  (func $___towrite (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$conv3
+    (set_local $1
       (i32.and
         (i32.or
           (i32.add
-            (set_local $$conv
+            (set_local $1
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (set_local $$mode
+                    (set_local $2
                       (i32.add
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 74)
                       )
                     )
@@ -2139,21 +2054,21 @@
             )
             (i32.const 255)
           )
-          (get_local $$conv)
+          (get_local $1)
         )
         (i32.const 255)
       )
     )
     (i32.store8
-      (get_local $$mode)
-      (get_local $$conv3)
+      (get_local $2)
+      (get_local $1)
     )
     (if
       (i32.eq
         (i32.and
-          (set_local $$1
+          (set_local $1
             (i32.load
-              (get_local $$f)
+              (get_local $0)
             )
           )
           (i32.const 8)
@@ -2162,31 +2077,31 @@
       )
       (block
         (i32.store offset=8
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=4
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=28
-          (get_local $$f)
-          (set_local $$2
+          (get_local $0)
+          (set_local $1
             (i32.load offset=44
-              (get_local $$f)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=20
-          (get_local $$f)
-          (get_local $$2)
+          (get_local $0)
+          (get_local $1)
         )
         (i32.store offset=16
-          (get_local $$f)
+          (get_local $0)
           (i32.add
-            (get_local $$2)
+            (get_local $1)
             (i32.load offset=48
-              (get_local $$f)
+              (get_local $0)
             )
           )
         )
@@ -2194,9 +2109,9 @@
       )
       (block
         (i32.store
-          (get_local $$f)
+          (get_local $0)
           (i32.or
-            (get_local $$1)
+            (get_local $1)
             (i32.const 32)
           )
         )
@@ -2204,28 +2119,28 @@
       )
     )
   )
-  (func $_wcrtomb (param $$s i32) (param $$wc i32) (param $$st i32) (result i32)
+  (func $_wcrtomb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $$s)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.const 1)
         (block
           (if
             (i32.lt_u
-              (get_local $$wc)
+              (get_local $1)
               (i32.const 128)
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
-                  (get_local $$wc)
+                  (get_local $1)
                   (i32.const 255)
                 )
               )
@@ -2236,16 +2151,16 @@
           )
           (if
             (i32.lt_u
-              (get_local $$wc)
+              (get_local $1)
               (i32.const 2048)
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.shr_u
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 6)
                     )
                     (i32.const 192)
@@ -2254,11 +2169,11 @@
                 )
               )
               (i32.store8 offset=1
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 63)
                     )
                     (i32.const 128)
@@ -2274,12 +2189,12 @@
           (if
             (i32.or
               (i32.lt_u
-                (get_local $$wc)
+                (get_local $1)
                 (i32.const 55296)
               )
               (i32.eq
                 (i32.and
-                  (get_local $$wc)
+                  (get_local $1)
                   (i32.const -8192)
                 )
                 (i32.const 57344)
@@ -2287,11 +2202,11 @@
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.shr_u
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 12)
                     )
                     (i32.const 224)
@@ -2300,12 +2215,12 @@
                 )
               )
               (i32.store8 offset=1
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$wc)
+                        (get_local $1)
                         (i32.const 6)
                       )
                       (i32.const 63)
@@ -2316,11 +2231,11 @@
                 )
               )
               (i32.store8 offset=2
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 63)
                     )
                     (i32.const 128)
@@ -2336,18 +2251,18 @@
           (if
             (i32.lt_u
               (i32.add
-                (get_local $$wc)
+                (get_local $1)
                 (i32.const -65536)
               )
               (i32.const 1048576)
             )
             (block
               (i32.store8
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.shr_u
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 18)
                     )
                     (i32.const 240)
@@ -2356,12 +2271,12 @@
                 )
               )
               (i32.store8 offset=1
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$wc)
+                        (get_local $1)
                         (i32.const 12)
                       )
                       (i32.const 63)
@@ -2372,12 +2287,12 @@
                 )
               )
               (i32.store8 offset=2
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$wc)
+                        (get_local $1)
                         (i32.const 6)
                       )
                       (i32.const 63)
@@ -2388,11 +2303,11 @@
                 )
               )
               (i32.store8 offset=3
-                (get_local $$s)
+                (get_local $0)
                 (i32.and
                   (i32.or
                     (i32.and
-                      (get_local $$wc)
+                      (get_local $1)
                       (i32.const 63)
                     )
                     (i32.const 128)
@@ -2414,94 +2329,76 @@
       )
     )
   )
-  (func $_wctomb (param $$s i32) (param $$wc i32) (result i32)
+  (func $_wctomb (param $0 i32) (param $1 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
-        (get_local $$s)
+        (get_local $0)
         (i32.const 0)
       )
       (i32.const 0)
       (call $_wcrtomb
-        (get_local $$s)
-        (get_local $$wc)
+        (get_local $0)
+        (get_local $1)
         (i32.const 0)
       )
     )
   )
-  (func $_memchr (param $$src i32) (param $$c i32) (param $$n i32) (result i32)
-    (local $label i32)
-    (local $$n$addr$0$lcssa61 i32)
-    (local $$n$addr$3 i32)
-    (local $$s$0$lcssa60 i32)
-    (local $$s$128 i32)
-    (local $$s$2 i32)
-    (local $$n$addr$227 i32)
-    (local $$s$044 i32)
-    (local $$w$034 i32)
-    (local $$n$addr$043 i32)
-    (local $$n$addr$1$lcssa i32)
-    (local $$n$addr$133 i32)
-    (local $$s$0$lcssa i32)
-    (local $$w$0$lcssa i32)
-    (local $$dec i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr21 i32)
-    (local $$incdec$ptr33 i32)
-    (local $$n$addr$0$lcssa i32)
-    (local $$sub22 i32)
-    (local $$tobool2$lcssa i32)
-    (local $$1 i32)
-    (local $$5 i32)
-    (local $$conv1 i32)
-    (local $$dec34 i32)
-    (local $$mul i32)
-    (local $$n$addr$133$lcssa i32)
-    (local $$sub i32)
-    (local $$tobool2 i32)
-    (local $$tobool2$41 i32)
-    (local $$w$034$lcssa i32)
-    (local $$xor i32)
+  (func $_memchr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$conv1
+    (set_local $5
       (i32.and
-        (get_local $$c)
+        (get_local $1)
         (i32.const 255)
       )
     )
     (block $label$break$L1
       (if
         (i32.and
-          (set_local $$tobool2$41
+          (set_local $4
             (i32.ne
-              (get_local $$n)
+              (get_local $2)
               (i32.const 0)
             )
           )
           (i32.ne
             (i32.and
-              (get_local $$src)
+              (get_local $0)
               (i32.const 3)
             )
             (i32.const 0)
           )
         )
         (block
-          (set_local $$1
+          (set_local $4
             (i32.and
-              (get_local $$c)
+              (get_local $1)
               (i32.const 255)
             )
           )
-          (set_local $$n$addr$043
-            (get_local $$n)
+          (set_local $3
+            (get_local $2)
           )
-          (set_local $$s$044
-            (get_local $$src)
+          (set_local $2
+            (get_local $0)
           )
           (loop $while-out$1 $while-in$2
             (if
@@ -2509,7 +2406,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $$s$044)
+                      (get_local $2)
                     )
                     (i32.const 24)
                   )
@@ -2517,20 +2414,20 @@
                 )
                 (i32.shr_s
                   (i32.shl
-                    (get_local $$1)
+                    (get_local $4)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
               (block
-                (set_local $$n$addr$0$lcssa61
-                  (get_local $$n$addr$043)
+                (set_local $6
+                  (get_local $3)
                 )
-                (set_local $$s$0$lcssa60
-                  (get_local $$s$044)
+                (set_local $8
+                  (get_local $2)
                 )
-                (set_local $label
+                (set_local $3
                   (i32.const 6)
                 )
                 (br $label$break$L1)
@@ -2538,11 +2435,11 @@
             )
             (if
               (i32.and
-                (set_local $$tobool2
+                (set_local $3
                   (i32.ne
-                    (set_local $$dec
+                    (set_local $0
                       (i32.add
-                        (get_local $$n$addr$043)
+                        (get_local $3)
                         (i32.const -1)
                       )
                     )
@@ -2551,9 +2448,9 @@
                 )
                 (i32.ne
                   (i32.and
-                    (set_local $$incdec$ptr
+                    (set_local $2
                       (i32.add
-                        (get_local $$s$044)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
@@ -2563,24 +2460,22 @@
                 )
               )
               (block
-                (set_local $$n$addr$043
-                  (get_local $$dec)
+                (set_local $3
+                  (get_local $0)
                 )
-                (set_local $$s$044
-                  (get_local $$incdec$ptr)
-                )
+                (get_local $2)
               )
               (block
-                (set_local $$n$addr$0$lcssa
-                  (get_local $$dec)
+                (set_local $11
+                  (get_local $0)
                 )
-                (set_local $$s$0$lcssa
-                  (get_local $$incdec$ptr)
+                (set_local $14
+                  (get_local $2)
                 )
-                (set_local $$tobool2$lcssa
-                  (get_local $$tobool2)
+                (set_local $16
+                  (get_local $3)
                 )
-                (set_local $label
+                (set_local $3
                   (i32.const 5)
                 )
                 (br $while-out$1)
@@ -2590,16 +2485,16 @@
           )
         )
         (block
-          (set_local $$n$addr$0$lcssa
-            (get_local $$n)
+          (set_local $11
+            (get_local $2)
           )
-          (set_local $$s$0$lcssa
-            (get_local $$src)
+          (set_local $14
+            (get_local $0)
           )
-          (set_local $$tobool2$lcssa
-            (get_local $$tobool2$41)
+          (set_local $16
+            (get_local $4)
           )
-          (set_local $label
+          (set_local $3
             (i32.const 5)
           )
         )
@@ -2607,28 +2502,28 @@
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $3)
         (i32.const 5)
       )
       (if
-        (get_local $$tobool2$lcssa)
+        (get_local $16)
         (block
-          (set_local $$n$addr$0$lcssa61
-            (get_local $$n$addr$0$lcssa)
+          (set_local $6
+            (get_local $11)
           )
-          (set_local $$s$0$lcssa60
-            (get_local $$s$0$lcssa)
+          (set_local $8
+            (get_local $14)
           )
-          (set_local $label
+          (set_local $3
             (i32.const 6)
           )
         )
         (block
-          (set_local $$n$addr$3
+          (set_local $7
             (i32.const 0)
           )
-          (set_local $$s$2
-            (get_local $$s$0$lcssa)
+          (set_local $10
+            (get_local $14)
           )
         )
       )
@@ -2636,7 +2531,7 @@
     (block $label$break$L8
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $3)
           (i32.const 6)
         )
         (if
@@ -2644,7 +2539,7 @@
             (i32.shr_s
               (i32.shl
                 (i32.load8_s
-                  (get_local $$s$0$lcssa60)
+                  (get_local $8)
                 )
                 (i32.const 24)
               )
@@ -2652,9 +2547,9 @@
             )
             (i32.shr_s
               (i32.shl
-                (set_local $$5
+                (set_local $0
                   (i32.and
-                    (get_local $$c)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
@@ -2664,42 +2559,42 @@
             )
           )
           (block
-            (set_local $$n$addr$3
-              (get_local $$n$addr$0$lcssa61)
+            (set_local $7
+              (get_local $6)
             )
-            (set_local $$s$2
-              (get_local $$s$0$lcssa60)
+            (set_local $10
+              (get_local $8)
             )
           )
           (block
-            (set_local $$mul
+            (set_local $2
               (i32.mul
-                (get_local $$conv1)
+                (get_local $5)
                 (i32.const 16843009)
               )
             )
             (block $label$break$L11
               (if
                 (i32.gt_u
-                  (get_local $$n$addr$0$lcssa61)
+                  (get_local $6)
                   (i32.const 3)
                 )
                 (block
-                  (set_local $$n$addr$133
-                    (get_local $$n$addr$0$lcssa61)
+                  (set_local $4
+                    (get_local $6)
                   )
-                  (set_local $$w$034
-                    (get_local $$s$0$lcssa60)
+                  (set_local $5
+                    (get_local $8)
                   )
                   (loop $while-out$5 $while-in$6
-                    (set_local $$sub
+                    (set_local $1
                       (i32.add
-                        (set_local $$xor
+                        (set_local $11
                           (i32.xor
                             (i32.load
-                              (get_local $$w$034)
+                              (get_local $5)
                             )
-                            (get_local $$mul)
+                            (get_local $2)
                           )
                         )
                         (i32.const -16843009)
@@ -2710,57 +2605,55 @@
                         (i32.and
                           (i32.xor
                             (i32.and
-                              (get_local $$xor)
+                              (get_local $11)
                               (i32.const -2139062144)
                             )
                             (i32.const -2139062144)
                           )
-                          (get_local $$sub)
+                          (get_local $1)
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$n$addr$133$lcssa
-                          (get_local $$n$addr$133)
+                        (set_local $1
+                          (get_local $4)
                         )
-                        (set_local $$w$034$lcssa
-                          (get_local $$w$034)
+                        (set_local $2
+                          (get_local $5)
                         )
                         (br $while-out$5)
                       )
                     )
-                    (set_local $$incdec$ptr21
+                    (set_local $1
                       (i32.add
-                        (get_local $$w$034)
+                        (get_local $5)
                         (i32.const 4)
                       )
                     )
                     (if
                       (i32.gt_u
-                        (set_local $$sub22
+                        (set_local $4
                           (i32.add
-                            (get_local $$n$addr$133)
+                            (get_local $4)
                             (i32.const -4)
                           )
                         )
                         (i32.const 3)
                       )
                       (block
-                        (set_local $$n$addr$133
-                          (get_local $$sub22)
-                        )
-                        (set_local $$w$034
-                          (get_local $$incdec$ptr21)
+                        (get_local $4)
+                        (set_local $5
+                          (get_local $1)
                         )
                       )
                       (block
-                        (set_local $$n$addr$1$lcssa
-                          (get_local $$sub22)
+                        (set_local $13
+                          (get_local $4)
                         )
-                        (set_local $$w$0$lcssa
-                          (get_local $$incdec$ptr21)
+                        (set_local $15
+                          (get_local $1)
                         )
-                        (set_local $label
+                        (set_local $3
                           (i32.const 11)
                         )
                         (br $label$break$L11)
@@ -2768,21 +2661,21 @@
                     )
                     (br $while-in$6)
                   )
-                  (set_local $$n$addr$227
-                    (get_local $$n$addr$133$lcssa)
+                  (set_local $12
+                    (get_local $1)
                   )
-                  (set_local $$s$128
-                    (get_local $$w$034$lcssa)
+                  (set_local $9
+                    (get_local $2)
                   )
                 )
                 (block
-                  (set_local $$n$addr$1$lcssa
-                    (get_local $$n$addr$0$lcssa61)
+                  (set_local $13
+                    (get_local $6)
                   )
-                  (set_local $$w$0$lcssa
-                    (get_local $$s$0$lcssa60)
+                  (set_local $15
+                    (get_local $8)
                   )
-                  (set_local $label
+                  (set_local $3
                     (i32.const 11)
                   )
                 )
@@ -2790,29 +2683,29 @@
             )
             (if
               (i32.eq
-                (get_local $label)
+                (get_local $3)
                 (i32.const 11)
               )
               (if
                 (i32.eq
-                  (get_local $$n$addr$1$lcssa)
+                  (get_local $13)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$n$addr$3
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $$s$2
-                    (get_local $$w$0$lcssa)
+                  (set_local $10
+                    (get_local $15)
                   )
                   (br $label$break$L8)
                 )
                 (block
-                  (set_local $$n$addr$227
-                    (get_local $$n$addr$1$lcssa)
+                  (set_local $12
+                    (get_local $13)
                   )
-                  (set_local $$s$128
-                    (get_local $$w$0$lcssa)
+                  (set_local $9
+                    (get_local $15)
                   )
                 )
               )
@@ -2823,7 +2716,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s
-                        (get_local $$s$128)
+                        (get_local $9)
                       )
                       (i32.const 24)
                     )
@@ -2831,53 +2724,53 @@
                   )
                   (i32.shr_s
                     (i32.shl
-                      (get_local $$5)
+                      (get_local $0)
                       (i32.const 24)
                     )
                     (i32.const 24)
                   )
                 )
                 (block
-                  (set_local $$n$addr$3
-                    (get_local $$n$addr$227)
+                  (set_local $7
+                    (get_local $12)
                   )
-                  (set_local $$s$2
-                    (get_local $$s$128)
+                  (set_local $10
+                    (get_local $9)
                   )
                   (br $label$break$L8)
                 )
               )
-              (set_local $$incdec$ptr33
+              (set_local $2
                 (i32.add
-                  (get_local $$s$128)
+                  (get_local $9)
                   (i32.const 1)
                 )
               )
               (if
                 (i32.eq
-                  (set_local $$dec34
+                  (set_local $1
                     (i32.add
-                      (get_local $$n$addr$227)
+                      (get_local $12)
                       (i32.const -1)
                     )
                   )
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$n$addr$3
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $$s$2
-                    (get_local $$incdec$ptr33)
+                  (set_local $10
+                    (get_local $2)
                   )
                   (br $while-out$7)
                 )
                 (block
-                  (set_local $$n$addr$227
-                    (get_local $$dec34)
+                  (set_local $12
+                    (get_local $1)
                   )
-                  (set_local $$s$128
-                    (get_local $$incdec$ptr33)
+                  (set_local $9
+                    (get_local $2)
                   )
                 )
               )
@@ -2888,21 +2781,21 @@
       )
     )
     (select
-      (get_local $$s$2)
+      (get_local $10)
       (i32.const 0)
       (i32.ne
-        (get_local $$n$addr$3)
+        (get_local $7)
         (i32.const 0)
       )
     )
   )
-  (func $___syscall_ret (param $$r i32) (result i32)
+  (func $___syscall_ret (param $0 i32) (result i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.gt_u
-        (get_local $$r)
+        (get_local $0)
         (i32.const -4096)
       )
       (block
@@ -2910,40 +2803,38 @@
           (call $___errno_location)
           (i32.sub
             (i32.const 0)
-            (get_local $$r)
+            (get_local $0)
           )
         )
         (i32.const -1)
       )
-      (get_local $$r)
+      (get_local $0)
     )
   )
-  (func $___fflush_unlocked (param $$f i32) (result i32)
-    (local $$retval$0 i32)
-    (local $$wpos i32)
-    (local $label i32)
-    (local $$4 i32)
-    (local $$5 i32)
-    (local $$rend i32)
-    (local $$rpos i32)
-    (local $$wbase i32)
+  (func $___fflush_unlocked (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.gt_u
         (i32.load
-          (set_local $$wpos
+          (set_local $3
             (i32.add
-              (get_local $$f)
+              (get_local $0)
               (i32.const 20)
             )
           )
         )
         (i32.load
-          (set_local $$wbase
+          (set_local $6
             (i32.add
-              (get_local $$f)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -2954,58 +2845,58 @@
           (i32.add
             (i32.and
               (i32.load offset=36
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 7)
             )
             (i32.const 2)
           )
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
           (i32.const 0)
         )
         (if
           (i32.eq
             (i32.load
-              (get_local $$wpos)
+              (get_local $3)
             )
             (i32.const 0)
           )
-          (set_local $$retval$0
+          (set_local $1
             (i32.const -1)
           )
-          (set_local $label
+          (set_local $2
             (i32.const 3)
           )
         )
       )
-      (set_local $label
+      (set_local $2
         (i32.const 3)
       )
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $2)
         (i32.const 3)
       )
       (block
         (if
           (i32.lt_u
-            (set_local $$4
+            (set_local $1
               (i32.load
-                (set_local $$rpos
+                (set_local $5
                   (i32.add
-                    (get_local $$f)
+                    (get_local $0)
                     (i32.const 4)
                   )
                 )
               )
             )
-            (set_local $$5
+            (set_local $2
               (i32.load
-                (set_local $$rend
+                (set_local $4
                   (i32.add
-                    (get_local $$f)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
@@ -3016,517 +2907,144 @@
             (i32.add
               (i32.and
                 (i32.load offset=40
-                  (get_local $$f)
+                  (get_local $0)
                 )
                 (i32.const 7)
               )
               (i32.const 2)
             )
-            (get_local $$f)
+            (get_local $0)
             (i32.sub
-              (get_local $$4)
-              (get_local $$5)
+              (get_local $1)
+              (get_local $2)
             )
             (i32.const 1)
           )
         )
         (i32.store offset=16
-          (get_local $$f)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$wbase)
+          (get_local $6)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$wpos)
+          (get_local $3)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$rend)
+          (get_local $4)
           (i32.const 0)
         )
         (i32.store
-          (get_local $$rpos)
+          (get_local $5)
           (i32.const 0)
         )
-        (set_local $$retval$0
+        (set_local $1
           (i32.const 0)
         )
       )
     )
-    (get_local $$retval$0)
+    (get_local $1)
   )
-  (func $_cleanup (param $$p i32)
+  (func $_cleanup (param $0 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
         (i32.load offset=68
-          (get_local $$p)
+          (get_local $0)
         )
         (i32.const 0)
       )
       (call $___unlockfile
-        (get_local $$p)
+        (get_local $0)
       )
     )
   )
-  (func $_printf_core (param $$f i32) (param $$fmt i32) (param $$ap i32) (param $$nl_arg i32) (param $$nl_type i32) (result i32)
-    (local $label i32)
-    (local $$p$0 i32)
-    (local $$w$1 i32)
-    (local $$fl$1$and219 i32)
-    (local $$arg i32)
-    (local $$cnt$1 i32)
-    (local $$incdec$ptr169275 i32)
-    (local $$cnt$0 i32)
-    (local $$l10n$0 i32)
-    (local $$l10n$3 i32)
-    (local $$l$0 i32)
-    (local $$retval$0 i32)
-    (local $$e2$i i32)
-    (local $$incdec$ptr169$lcssa i32)
-    (local $$e$5$ph$i i32)
-    (local $$p$addr$3$i i32)
-    (local $$sub$ptr$sub i32)
-    (local $$add$ptr205 i32)
-    (local $$buf$i i32)
-    (local $$incdec$ptr169269 i32)
-    (local $$a$3$lcssa$i i32)
-    (local $$a$3539$i i32)
-    (local $$i$0$lcssa i32)
-    (local $$p$2 i32)
-    (local $sp i32)
-    (local $$add$ptr358$i i32)
-    (local $$arraydecay208$add$ptr213$i i32)
-    (local $$t$0 i32)
-    (local $$fl$0284 i32)
-    (local $$fl$4 i32)
-    (local $$fl$6 i32)
-    (local $$i$0$lcssa368 i32)
-    (local $$pl$1 i32)
-    (local $$prefix$0$i i32)
-    (local $$prefix$1 i32)
-    (local $$storemerge$186282 i32)
-    (local $$z$3$lcssa$i i32)
-    (local $$z$3538$i i32)
-    (local $$a$1549$i i32)
-    (local $$a$9$ph$i i32)
-    (local $$e$1$i i32)
-    (local $$fl$1 i32)
-    (local $$incdec$ptr169274 i32)
-    (local $$incdec$ptr169276$lcssa i32)
-    (local $$p$5 i32)
-    (local $$pl$2 i32)
-    (local $$s753$2$i i32)
-    (local $$sub$ptr$lhs$cast160$i i32)
-    (local $$y$addr$0$i f64)
-    (local $$z$7$i$lcssa i32)
-    (local $$$p$i i32)
-    (local $$249 i32)
-    (local $$a$1 i32)
-    (local $$a$2 i32)
-    (local $$a$5$lcssa$i i32)
-    (local $$add$ptr671$i i32)
-    (local $$call384 i32)
-    (local $$fl$3 i32)
-    (local $$i$0316 i32)
-    (local $$i$1$lcssa$i i32)
-    (local $$i$2299 i32)
-    (local $$j$2$i i32)
-    (local $$mul$i$240 f64)
-    (local $$p$addr$2$i i32)
-    (local $$p$addr$4489$i i32)
-    (local $$p$addr$5501$i i32)
-    (local $$pl$0$i i32)
-    (local $$prefix$2 i32)
-    (local $$s668$1$i i32)
-    (local $$s753$0$i i32)
-    (local $$t$addr$0$i i32)
-    (local $$t$addr$1$i i32)
-    (local $$tobool25 i32)
-    (local $$z$2 i32)
-    (local $$z$2$i i32)
-    (local $$z$7$i i32)
-    (local $$12 i32)
-    (local $$149 i32)
-    (local $$181 f64)
-    (local $$7 i32)
-    (local $$a$0 i32)
-    (local $$a$5521$i i32)
-    (local $$a$8$i i32)
-    (local $$add165$i i32)
-    (local $$add441 i32)
-    (local $$add653$i i32)
-    (local $$arrayidx$i$236 i32)
-    (local $$cond271$i i32)
-    (local $$d$0545$i i32)
-    (local $$d$1534$i i32)
-    (local $$d$4$i i32)
-    (local $$d$5494$i i32)
-    (local $$d$7500$i i32)
-    (local $$e$4$i i32)
-    (local $$incdec$ptr115$i i32)
-    (local $$incdec$ptr169271 i32)
-    (local $$incdec$ptr169276301 i32)
-    (local $$incdec$ptr419$i i32)
-    (local $$incdec$ptr689$i i32)
-    (local $$l10n$1 i32)
-    (local $$mul80$i$lcssa f64)
-    (local $$p$1 i32)
-    (local $$pl$0 i32)
-    (local $$prefix$0 i32)
-    (local $$s$0$i i32)
-    (local $$s$addr$0$lcssa$i$229 i32)
-    (local $$sub$ptr$rhs$cast345$i i32)
-    (local $$w$0 i32)
-    (local $$z$0$lcssa i32)
-    (local $$z$4$i i32)
-    (local $$$396$i f64)
-    (local $$$pr477$i i32)
-    (local $$126 i32)
-    (local $$137 i32)
-    (local $$140 i32)
-    (local $$148 i32)
-    (local $$198 i32)
-    (local $$211 i32)
-    (local $$9 i32)
-    (local $$99 i32)
-    (local $$a$1$lcssa$i i32)
-    (local $$a$2$ph$i i32)
-    (local $$add$i$239 i32)
-    (local $$and219 i32)
-    (local $$argpos$0 i32)
-    (local $$arrayidx119 i32)
-    (local $$arrayidx68 i32)
-    (local $$cmp450$lcssa$i i32)
-    (local $$d$2$lcssa$i i32)
-    (local $$d$2520$i i32)
-    (local $$d$6488$i i32)
-    (local $$estr$1$lcssa$i i32)
-    (local $$fl$0310 i32)
-    (local $$i$3296 i32)
-    (local $$incdec$ptr122$i i32)
-    (local $$incdec$ptr292$a$3573$i i32)
-    (local $$incdec$ptr639$i i32)
-    (local $$incdec$ptr681$i i32)
-    (local $$incdec$ptr725$i i32)
-    (local $$incdec$ptr773$i i32)
-    (local $$incdec$ptr776$i i32)
-    (local $$l$2 i32)
-    (local $$l10n$2 i32)
-    (local $$mb i32)
-    (local $$mul125$i f64)
-    (local $$or$i$241 i32)
-    (local $$p$4365 i32)
-    (local $$rem370$i i32)
-    (local $$small$0$i f64)
-    (local $$small$1$i f64)
-    (local $$st$0 i32)
-    (local $$storemerge i32)
-    (local $$storemerge$186309 i32)
-    (local $$storemerge$191 i32)
-    (local $$sub$ptr$rhs$cast$i i32)
-    (local $$sub$ptr$sub433 i32)
-    (local $$sub$ptr$sub789$i i32)
-    (local $$sub256$i i32)
-    (local $$t$1 i32)
-    (local $$w$2 i32)
-    (local $$ws$0317 i32)
-    (local $$ws$1326 i32)
-    (local $$y$addr$2$i f64)
-    (local $$y$addr$4$i f64)
-    (local $$z$0$i i32)
-    (local $$z$0302 i32)
-    (local $$z$1$lcssa$i i32)
-    (local $$z$1548$i i32)
-    (local $$z$2$i$lcssa i32)
-    (local $$$lcssa i32)
-    (local $$$p$inc468$i i32)
-    (local $$$pr$i i32)
-    (local $$$pre566$i i32)
-    (local $$1 i32)
-    (local $$10 i32)
-    (local $$101 i32)
-    (local $$129 i32)
-    (local $$142 i32)
-    (local $$143 i32)
-    (local $$219 i32)
-    (local $$223 i32)
-    (local $$231 i32)
-    (local $$237 i32)
-    (local $$243 i32)
-    (local $$255 i32)
-    (local $$29 i32)
-    (local $$49 i32)
-    (local $$a$6$i i32)
-    (local $$add$i i32)
-    (local $$add$i$203 i32)
-    (local $$add$i$lcssa i32)
-    (local $$add$ptr i32)
-    (local $$add$ptr311$z$4$i i32)
-    (local $$add$ptr340 i32)
-    (local $$add275$i i32)
-    (local $$add313$i i32)
-    (local $$add395 i32)
-    (local $$add412 i32)
-    (local $$add67$i i32)
-    (local $$and309$fl$4 i32)
-    (local $$and610$pre$phi$iZ2D i32)
-    (local $$arrayidx114 i32)
-    (local $$arrayidx31 i32)
-    (local $$call356 i32)
-    (local $$carry$0544$i i32)
-    (local $$carry262$0535$i i32)
-    (local $$cmp184 i32)
-    (local $$cmp37 i32)
-    (local $$cond233$i i32)
-    (local $$conv174 i32)
-    (local $$conv174$lcssa i32)
-    (local $$conv207 i32)
-    (local $$conv242$i$lcssa i32)
-    (local $$conv48311 i32)
-    (local $$e$0531$i i32)
-    (local $$e$2517$i i32)
-    (local $$estr$1507$i i32)
-    (local $$estr$2$i i32)
-    (local $$i$0530$i i32)
-    (local $$i$07$i i32)
-    (local $$i$07$i$201 i32)
-    (local $$i$1325 i32)
-    (local $$i$1526$i i32)
-    (local $$i$2299$lcssa i32)
-    (local $$i$2516$i i32)
-    (local $$i$3512$i i32)
-    (local $$inc$i i32)
-    (local $$inc438$i i32)
-    (local $$inc488 i32)
-    (local $$inc500$i i32)
-    (local $$incdec$ptr$i i32)
-    (local $$incdec$ptr$i$204 i32)
-    (local $$incdec$ptr$i$212 i32)
-    (local $$incdec$ptr$i$212$lcssa i32)
-    (local $$incdec$ptr$i$225 i32)
-    (local $$incdec$ptr106$i i32)
-    (local $$incdec$ptr169 i32)
-    (local $$incdec$ptr217$i i32)
-    (local $$incdec$ptr217$i$lcssa i32)
-    (local $$incdec$ptr23 i32)
-    (local $$incdec$ptr292$a$3$i i32)
-    (local $$incdec$ptr62 i32)
-    (local $$incdec$ptr647$i i32)
-    (local $$incdec$ptr698$i i32)
-    (local $$incdec$ptr698$i$lcssa i32)
-    (local $$isdigittmp8$i i32)
-    (local $$isdigittmp8$i$200 i32)
-    (local $$j$0527$i i32)
-    (local $$j$1513$i i32)
-    (local $$l$1315 i32)
-    (local $$mul286$i i32)
-    (local $$mul286$i$lcssa i32)
-    (local $$mul322$i i32)
-    (local $$mul367$i i32)
-    (local $$mul431$i i32)
-    (local $$mul513$i i32)
-    (local $$mul80$i f64)
-    (local $$or i32)
-    (local $$p$addr$4$lcssa$i i32)
-    (local $$p$addr$5$lcssa$i i32)
-    (local $$pl$1$i i32)
-    (local $$prefix$0$add$ptr65$i i32)
-    (local $$re$1482$i i32)
-    (local $$round$0481$i f64)
-    (local $$round377$1$i f64)
-    (local $$s$1$i i32)
-    (local $$s$addr$06$i i32)
-    (local $$s$addr$06$i$221 i32)
-    (local $$s668$0492$i i32)
-    (local $$s715$0$lcssa$i i32)
-    (local $$s715$0484$i i32)
-    (local $$s753$1496$i i32)
-    (local $$st$0$lcssa415 i32)
-    (local $$sub$ptr$lhs$cast317 i32)
-    (local $$sub$ptr$lhs$cast694$i i32)
-    (local $$sub$ptr$sub172$i i32)
-    (local $$sub$ptr$sub650$pn$i i32)
-    (local $$sub735$i i32)
-    (local $$sub806$i i32)
-    (local $$tobool357 i32)
-    (local $$wc i32)
-    (local $$y$addr$3$i f64)
-    (local $$z$7$ph$i i32)
-    (local $$$ i32)
-    (local $$$sub514$i i32)
-    (local $$$sub562$i i32)
-    (local $$0 i32)
-    (local $$102 i32)
-    (local $$103 i32)
-    (local $$107 i32)
-    (local $$116 i32)
-    (local $$118 i32)
-    (local $$121 i32)
-    (local $$130 i32)
-    (local $$131 i32)
-    (local $$135 i32)
-    (local $$144 i32)
-    (local $$151 i32)
-    (local $$159 i32)
-    (local $$16 i32)
-    (local $$161 i32)
-    (local $$163 i32)
-    (local $$169 i32)
-    (local $$170 i32)
-    (local $$172 i32)
-    (local $$177 i32)
-    (local $$179 i32)
-    (local $$18 i32)
-    (local $$187 i32)
-    (local $$193 i32)
-    (local $$200 i32)
-    (local $$201 i32)
-    (local $$210 i32)
-    (local $$215 i32)
-    (local $$216 i32)
-    (local $$217 i32)
-    (local $$225 i32)
-    (local $$228 i32)
-    (local $$234 i32)
-    (local $$239 i32)
-    (local $$242 i32)
-    (local $$259 i32)
-    (local $$267 i32)
-    (local $$27 i32)
-    (local $$28 i32)
-    (local $$32 i32)
-    (local $$36 i32)
-    (local $$38 i32)
-    (local $$47 i32)
-    (local $$48 i32)
-    (local $$5 i32)
-    (local $$52 i32)
-    (local $$54 i32)
-    (local $$56 i32)
-    (local $$59 i32)
-    (local $$60 i32)
-    (local $$65 i32)
-    (local $$76 i32)
-    (local $$86 i32)
-    (local $$90 i32)
-    (local $$92 i32)
-    (local $$95 i32)
-    (local $$add$ptr213$i i32)
-    (local $$add$ptr43$arrayidx31 i32)
-    (local $$add$ptr442$i i32)
-    (local $$add269 i32)
-    (local $$add322 i32)
-    (local $$add355$i i32)
-    (local $$add414$i i32)
-    (local $$and12$i i32)
-    (local $$and249 i32)
-    (local $$and282$i i32)
-    (local $$and294 i32)
-    (local $$and483$i i32)
-    (local $$and62$i i32)
-    (local $$arrayidx251$i i32)
-    (local $$arrayidx370 i32)
-    (local $$arrayidx453$i i32)
-    (local $$big$i i32)
-    (local $$buf i32)
-    (local $$call411 i32)
-    (local $$cmp265$i i32)
-    (local $$cmp270 i32)
-    (local $$cmp299$i i32)
-    (local $$cmp308$i i32)
-    (local $$cmp323 i32)
-    (local $$cmp338$i i32)
-    (local $$cmp374$i i32)
-    (local $$cmp38$i i32)
-    (local $$cmp434 i32)
-    (local $$cmp442 i32)
-    (local $$cmp443$i i32)
-    (local $$cmp515$i i32)
-    (local $$cmp528$i i32)
-    (local $$cmp563$i i32)
-    (local $$cmp577$i i32)
-    (local $$cmp614$i i32)
-    (local $$cmp94$i i32)
-    (local $$cnt$1$lcssa i32)
-    (local $$cond$i i32)
-    (local $$cond100$i i32)
-    (local $$cond304$i i32)
-    (local $$cond629$i i32)
-    (local $$conv116$i i32)
-    (local $$conv216$i i32)
-    (local $$conv48 i32)
-    (local $$conv48$307 i32)
-    (local $$d$0$542$i i32)
-    (local $$d$0$i i32)
-    (local $$dec78$i i32)
-    (local $$div384$i i32)
-    (local $$ebuf0$i i32)
-    (local $$estr$0$i i32)
-    (local $$inc i32)
-    (local $$inc425$i i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr$i$lcssa i32)
-    (local $$incdec$ptr169271$lcssa414 i32)
-    (local $$incdec$ptr246$i i32)
-    (local $$incdec$ptr288$i i32)
-    (local $$incdec$ptr383 i32)
-    (local $$incdec$ptr410 i32)
-    (local $$incdec$ptr423$i i32)
-    (local $$incdec$ptr734$i i32)
-    (local $$incdec$ptr808$i i32)
-    (local $$isdigittmp i32)
-    (local $$isdigittmp$5$i i32)
-    (local $$isdigittmp$5$i$198 i32)
-    (local $$isdigittmp$i i32)
-    (local $$isdigittmp$i$206 i32)
-    (local $$isdigittmp187 i32)
-    (local $$isdigittmp189 i32)
-    (local $$j$0$524$i i32)
-    (local $$j$0$i i32)
-    (local $$l$0$i i32)
-    (local $$l10n$0$lcssa i32)
-    (local $$lor$ext$i i32)
-    (local $$mul220$i f64)
-    (local $$mul328$i i32)
-    (local $$mul437$i i32)
-    (local $$mul499$i i32)
-    (local $$notrhs$i i32)
-    (local $$or$cond192 i32)
-    (local $$or$cond384 i32)
-    (local $$r$0$a$9$i i32)
-    (local $$retval$0$i i32)
-    (local $$s$1$i$lcssa i32)
-    (local $$s35$0$i i32)
-    (local $$shr285$i i32)
-    (local $$sub$ptr$sub145$i i32)
-    (local $$sub$ptr$sub153$i i32)
-    (local $$sub$ptr$sub159$i i32)
-    (local $$sub$ptr$sub175$i i32)
-    (local $$sub$ptr$sub433$p$5 i32)
-    (local $$sub164 i32)
-    (local $$sub203$i i32)
-    (local $$sub264$i i32)
-    (local $$sub281$i i32)
-    (local $$sub343$i i32)
-    (local $$sub409$i i32)
-    (local $$sub514$i i32)
-    (local $$sub562$i i32)
-    (local $$sub626$le$i i32)
-    (local $$sub74$i i32)
-    (local $$tobool135$i i32)
-    (local $$tobool341$i i32)
-    (local $$tobool349 i32)
-    (local $$tobool37$i i32)
-    (local $$tobool56$i i32)
-    (local $$tobool781$i i32)
-    (local $$y$addr$1$i f64)
-    (local $$z$7$add$ptr742$i i32)
-    (set_local $sp
+  (func $_printf_core (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 f64)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 f64)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
+    (local $47 i32)
+    (local $48 i32)
+    (local $49 i32)
+    (local $50 i32)
+    (local $51 i32)
+    (local $52 i32)
+    (local $53 i32)
+    (local $54 i32)
+    (local $55 i32)
+    (local $56 i32)
+    (local $57 i32)
+    (local $58 i32)
+    (local $59 i32)
+    (local $60 i32)
+    (local $61 i32)
+    (local $62 i32)
+    (local $63 i32)
+    (local $64 i32)
+    (local $65 i32)
+    (local $66 i32)
+    (local $67 i32)
+    (local $68 i32)
+    (local $69 i32)
+    (local $70 i32)
+    (local $71 i32)
+    (local $72 i32)
+    (local $73 i32)
+    (local $74 i32)
+    (local $75 i32)
+    (local $76 i32)
+    (local $77 i32)
+    (local $78 i32)
+    (local $79 i32)
+    (local $80 i32)
+    (local $81 i32)
+    (local $82 i32)
+    (local $83 i32)
+    (set_local $32
       (i32.load
         (i32.const 8)
       )
@@ -3551,33 +3069,33 @@
       )
       (call_import $abort)
     )
-    (set_local $$e2$i
+    (set_local $25
       (i32.add
-        (get_local $sp)
+        (get_local $32)
         (i32.const 16)
       )
     )
-    (set_local $$arg
-      (get_local $sp)
+    (set_local $18
+      (get_local $32)
     )
-    (set_local $$mb
+    (set_local $64
       (i32.add
-        (get_local $sp)
+        (get_local $32)
         (i32.const 528)
       )
     )
-    (set_local $$tobool25
+    (set_local $52
       (i32.ne
-        (get_local $$f)
+        (get_local $0)
         (i32.const 0)
       )
     )
-    (set_local $$sub$ptr$lhs$cast317
-      (set_local $$add$ptr205
+    (set_local $73
+      (set_local $28
         (i32.add
-          (set_local $$buf
+          (set_local $5
             (i32.add
-              (get_local $sp)
+              (get_local $32)
               (i32.const 536)
             )
           )
@@ -3585,117 +3103,117 @@
         )
       )
     )
-    (set_local $$add$ptr340
+    (set_local $71
       (i32.add
-        (get_local $$buf)
+        (get_local $5)
         (i32.const 39)
       )
     )
-    (set_local $$arrayidx370
+    (set_local $77
       (i32.add
-        (set_local $$wc
+        (set_local $75
           (i32.add
-            (get_local $sp)
+            (get_local $32)
             (i32.const 8)
           )
         )
         (i32.const 4)
       )
     )
-    (set_local $$arrayidx$i$236
+    (set_local $55
       (i32.add
-        (set_local $$ebuf0$i
+        (set_local $5
           (i32.add
-            (get_local $sp)
+            (get_local $32)
             (i32.const 576)
           )
         )
         (i32.const 12)
       )
     )
-    (set_local $$incdec$ptr106$i
+    (set_local $72
       (i32.add
-        (get_local $$ebuf0$i)
+        (get_local $5)
         (i32.const 11)
       )
     )
-    (set_local $$sub$ptr$sub159$i
+    (set_local $83
       (i32.sub
-        (set_local $$sub$ptr$lhs$cast160$i
-          (get_local $$arrayidx$i$236)
+        (set_local $44
+          (get_local $55)
         )
-        (set_local $$sub$ptr$rhs$cast$i
-          (set_local $$buf$i
+        (set_local $67
+          (set_local $29
             (i32.add
-              (get_local $sp)
+              (get_local $32)
               (i32.const 588)
             )
           )
         )
       )
     )
-    (set_local $$sub$ptr$sub145$i
+    (set_local $81
       (i32.sub
         (i32.const -2)
-        (get_local $$sub$ptr$rhs$cast$i)
+        (get_local $67)
       )
     )
-    (set_local $$sub$ptr$sub153$i
+    (set_local $82
       (i32.add
-        (get_local $$sub$ptr$lhs$cast160$i)
+        (get_local $44)
         (i32.const 2)
       )
     )
-    (set_local $$add$ptr213$i
+    (set_local $76
       (i32.add
-        (set_local $$big$i
+        (set_local $78
           (i32.add
-            (get_local $sp)
+            (get_local $32)
             (i32.const 24)
           )
         )
         (i32.const 288)
       )
     )
-    (set_local $$sub$ptr$lhs$cast694$i
-      (set_local $$add$ptr671$i
+    (set_local $74
+      (set_local $48
         (i32.add
-          (get_local $$buf$i)
+          (get_local $29)
           (i32.const 9)
         )
       )
     )
-    (set_local $$incdec$ptr689$i
+    (set_local $57
       (i32.add
-        (get_local $$buf$i)
+        (get_local $29)
         (i32.const 8)
       )
     )
-    (set_local $$cnt$0
+    (set_local $5
       (i32.const 0)
     )
-    (set_local $$incdec$ptr169275
-      (get_local $$fmt)
+    (set_local $12
+      (get_local $1)
     )
-    (set_local $$l$0
+    (set_local $1
       (i32.const 0)
     )
-    (set_local $$l10n$0
+    (set_local $8
       (i32.const 0)
     )
     (loop $label$break$L1 $label$continue$L1
-      (set_local $$cnt$1
+      (set_local $19
         (if
           (i32.gt_s
-            (get_local $$cnt$0)
+            (get_local $5)
             (i32.const -1)
           )
           (if
             (i32.gt_s
-              (get_local $$l$0)
+              (get_local $1)
               (i32.sub
                 (i32.const 2147483647)
-                (get_local $$cnt$0)
+                (get_local $5)
               )
             )
             (block
@@ -3706,20 +3224,20 @@
               (i32.const -1)
             )
             (i32.add
-              (get_local $$l$0)
-              (get_local $$cnt$0)
+              (get_local $1)
+              (get_local $5)
             )
           )
-          (get_local $$cnt$0)
+          (get_local $5)
         )
       )
       (if
         (i32.eq
           (i32.shr_s
             (i32.shl
-              (set_local $$0
+              (set_local $1
                 (i32.load8_s
-                  (get_local $$incdec$ptr169275)
+                  (get_local $12)
                 )
               )
               (i32.const 24)
@@ -3729,23 +3247,21 @@
           (i32.const 0)
         )
         (block
-          (set_local $$cnt$1$lcssa
-            (get_local $$cnt$1)
+          (set_local $79
+            (get_local $19)
           )
-          (set_local $$l10n$0$lcssa
-            (get_local $$l10n$0)
+          (set_local $80
+            (get_local $8)
           )
-          (set_local $label
+          (set_local $13
             (i32.const 242)
           )
           (br $label$break$L1)
         )
         (block
-          (set_local $$1
-            (get_local $$0)
-          )
-          (set_local $$incdec$ptr169274
-            (get_local $$incdec$ptr169275)
+          (get_local $1)
+          (set_local $5
+            (get_local $12)
           )
         )
       )
@@ -3759,7 +3275,7 @@
                     (i32.sub
                       (i32.shr_s
                         (i32.shl
-                          (get_local $$1)
+                          (get_local $1)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -3768,50 +3284,48 @@
                     )
                   )
                 )
-                (set_local $$incdec$ptr169276301
-                  (get_local $$incdec$ptr169274)
+                (set_local $56
+                  (get_local $5)
                 )
-                (set_local $$z$0302
-                  (get_local $$incdec$ptr169274)
+                (set_local $70
+                  (get_local $5)
                 )
-                (set_local $label
+                (set_local $13
                   (i32.const 9)
                 )
                 (br $label$break$L9)
               )
-              (set_local $$incdec$ptr169276$lcssa
-                (get_local $$incdec$ptr169274)
+              (set_local $41
+                (get_local $5)
               )
-              (set_local $$z$0$lcssa
-                (get_local $$incdec$ptr169274)
+              (set_local $62
+                (get_local $5)
               )
               (br $label$break$L9)
             )
           )
         )
-        (set_local $$1
+        (set_local $1
           (i32.load8_s
-            (set_local $$incdec$ptr
+            (set_local $5
               (i32.add
-                (get_local $$incdec$ptr169274)
+                (get_local $5)
                 (i32.const 1)
               )
             )
           )
         )
-        (set_local $$incdec$ptr169274
-          (get_local $$incdec$ptr)
-        )
+        (get_local $5)
         (br $label$continue$L9)
       )
       (block $label$break$L12
         (if
           (i32.eq
-            (get_local $label)
+            (get_local $13)
             (i32.const 9)
           )
           (loop $while-out$7 $while-in$8
-            (set_local $label
+            (set_local $13
               (i32.const 0)
             )
             (if
@@ -3819,7 +3333,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s offset=1
-                      (get_local $$incdec$ptr169276301)
+                      (get_local $56)
                     )
                     (i32.const 24)
                   )
@@ -3828,18 +3342,18 @@
                 (i32.const 37)
               )
               (block
-                (set_local $$incdec$ptr169276$lcssa
-                  (get_local $$incdec$ptr169276301)
+                (set_local $41
+                  (get_local $56)
                 )
-                (set_local $$z$0$lcssa
-                  (get_local $$z$0302)
+                (set_local $62
+                  (get_local $70)
                 )
                 (br $label$break$L12)
               )
             )
-            (set_local $$incdec$ptr23
+            (set_local $5
               (i32.add
-                (get_local $$z$0302)
+                (get_local $70)
                 (i32.const 1)
               )
             )
@@ -3848,9 +3362,9 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (set_local $$add$ptr
+                      (set_local $1
                         (i32.add
-                          (get_local $$incdec$ptr169276301)
+                          (get_local $56)
                           (i32.const 2)
                         )
                       )
@@ -3862,22 +3376,20 @@
                 (i32.const 37)
               )
               (block
-                (set_local $$incdec$ptr169276301
-                  (get_local $$add$ptr)
+                (set_local $56
+                  (get_local $1)
                 )
-                (set_local $$z$0302
-                  (get_local $$incdec$ptr23)
+                (set_local $70
+                  (get_local $5)
                 )
-                (set_local $label
-                  (i32.const 9)
-                )
+                (i32.const 9)
               )
               (block
-                (set_local $$incdec$ptr169276$lcssa
-                  (get_local $$add$ptr)
+                (set_local $41
+                  (get_local $1)
                 )
-                (set_local $$z$0$lcssa
-                  (get_local $$incdec$ptr23)
+                (set_local $62
+                  (get_local $5)
                 )
                 (br $while-out$7)
               )
@@ -3886,64 +3398,62 @@
           )
         )
       )
-      (set_local $$sub$ptr$sub
+      (set_local $15
         (i32.sub
-          (get_local $$z$0$lcssa)
-          (get_local $$incdec$ptr169275)
+          (get_local $62)
+          (get_local $12)
         )
       )
       (if
-        (get_local $$tobool25)
+        (get_local $52)
         (if
           (i32.eq
             (i32.and
               (i32.load
-                (get_local $$f)
+                (get_local $0)
               )
               (i32.const 32)
             )
             (i32.const 0)
           )
           (call $___fwritex
-            (get_local $$incdec$ptr169275)
-            (get_local $$sub$ptr$sub)
-            (get_local $$f)
+            (get_local $12)
+            (get_local $15)
+            (get_local $0)
           )
         )
       )
       (if
         (i32.ne
-          (get_local $$z$0$lcssa)
-          (get_local $$incdec$ptr169275)
+          (get_local $62)
+          (get_local $12)
         )
         (block
-          (set_local $$cnt$0
-            (get_local $$cnt$1)
+          (set_local $5
+            (get_local $19)
           )
-          (set_local $$incdec$ptr169275
-            (get_local $$incdec$ptr169276$lcssa)
+          (set_local $12
+            (get_local $41)
           )
-          (set_local $$l$0
-            (get_local $$sub$ptr$sub)
+          (set_local $1
+            (get_local $15)
           )
-          (set_local $$l10n$0
-            (get_local $$l10n$0)
-          )
+          (get_local $8)
           (br $label$continue$L1)
         )
       )
-      (set_local $$argpos$0
+      (set_local $7
         (if
           (i32.lt_u
-            (set_local $$isdigittmp
+            (set_local $6
               (i32.add
                 (i32.shr_s
                   (i32.shl
-                    (set_local $$5
+                    (set_local $1
                       (i32.load8_s
-                        (set_local $$arrayidx31
+                        (set_local $5
                           (i32.add
-                            (get_local $$incdec$ptr169276$lcssa)
+                            (get_local $41)
                             (i32.const 1)
                           )
                         )
@@ -3959,21 +3469,21 @@
             (i32.const 10)
           )
           (block
-            (set_local $$7
+            (set_local $1
               (i32.load8_s
-                (set_local $$add$ptr43$arrayidx31
+                (set_local $5
                   (select
                     (i32.add
-                      (get_local $$incdec$ptr169276$lcssa)
+                      (get_local $41)
                       (i32.const 3)
                     )
-                    (get_local $$arrayidx31)
-                    (set_local $$cmp37
+                    (get_local $5)
+                    (set_local $7
                       (i32.eq
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s offset=2
-                              (get_local $$incdec$ptr169276$lcssa)
+                              (get_local $41)
                             )
                             (i32.const 24)
                           )
@@ -3986,31 +3496,29 @@
                 )
               )
             )
-            (set_local $$l10n$1
+            (set_local $11
               (select
                 (i32.const 1)
-                (get_local $$l10n$0)
-                (get_local $$cmp37)
+                (get_local $8)
+                (get_local $7)
               )
             )
-            (set_local $$storemerge
-              (get_local $$add$ptr43$arrayidx31)
+            (set_local $10
+              (get_local $5)
             )
             (select
-              (get_local $$isdigittmp)
+              (get_local $6)
               (i32.const -1)
-              (get_local $$cmp37)
+              (get_local $7)
             )
           )
           (block
-            (set_local $$7
-              (get_local $$5)
+            (get_local $1)
+            (set_local $11
+              (get_local $8)
             )
-            (set_local $$l10n$1
-              (get_local $$l10n$0)
-            )
-            (set_local $$storemerge
-              (get_local $$arrayidx31)
+            (set_local $10
+              (get_local $5)
             )
             (i32.const -1)
           )
@@ -4020,10 +3528,10 @@
         (if
           (i32.eq
             (i32.and
-              (set_local $$conv48$307
+              (set_local $5
                 (i32.shr_s
                   (i32.shl
-                    (get_local $$7)
+                    (get_local $1)
                     (i32.const 24)
                   )
                   (i32.const 24)
@@ -4034,18 +3542,12 @@
             (i32.const 32)
           )
           (block
-            (set_local $$9
-              (get_local $$7)
-            )
-            (set_local $$conv48311
-              (get_local $$conv48$307)
-            )
-            (set_local $$fl$0310
+            (get_local $1)
+            (get_local $5)
+            (set_local $6
               (i32.const 0)
             )
-            (set_local $$storemerge$186309
-              (get_local $$storemerge)
-            )
+            (get_local $10)
             (loop $while-out$10 $while-in$11
               (if
                 (i32.eq
@@ -4053,7 +3555,7 @@
                     (i32.shl
                       (i32.const 1)
                       (i32.add
-                        (get_local $$conv48311)
+                        (get_local $5)
                         (i32.const -32)
                       )
                     )
@@ -4062,26 +3564,22 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$12
-                    (get_local $$9)
+                  (get_local $1)
+                  (set_local $8
+                    (get_local $6)
                   )
-                  (set_local $$fl$0284
-                    (get_local $$fl$0310)
-                  )
-                  (set_local $$storemerge$186282
-                    (get_local $$storemerge$186309)
-                  )
+                  (get_local $10)
                   (br $label$break$L25)
                 )
               )
-              (set_local $$or
+              (set_local $6
                 (i32.or
                   (i32.shl
                     (i32.const 1)
                     (i32.add
                       (i32.shr_s
                         (i32.shl
-                          (get_local $$9)
+                          (get_local $1)
                           (i32.const 24)
                         )
                         (i32.const 24)
@@ -4089,20 +3587,20 @@
                       (i32.const -32)
                     )
                   )
-                  (get_local $$fl$0310)
+                  (get_local $6)
                 )
               )
               (if
                 (i32.eq
                   (i32.and
-                    (set_local $$conv48
+                    (set_local $5
                       (i32.shr_s
                         (i32.shl
-                          (set_local $$10
+                          (set_local $1
                             (i32.load8_s
-                              (set_local $$incdec$ptr62
+                              (set_local $10
                                 (i32.add
-                                  (get_local $$storemerge$186309)
+                                  (get_local $10)
                                   (i32.const 1)
                                 )
                               )
@@ -4118,29 +3616,17 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $$9
-                    (get_local $$10)
-                  )
-                  (set_local $$conv48311
-                    (get_local $$conv48)
-                  )
-                  (set_local $$fl$0310
-                    (get_local $$or)
-                  )
-                  (set_local $$storemerge$186309
-                    (get_local $$incdec$ptr62)
-                  )
+                  (get_local $1)
+                  (get_local $5)
+                  (get_local $6)
+                  (get_local $10)
                 )
                 (block
-                  (set_local $$12
-                    (get_local $$10)
+                  (get_local $1)
+                  (set_local $8
+                    (get_local $6)
                   )
-                  (set_local $$fl$0284
-                    (get_local $$or)
-                  )
-                  (set_local $$storemerge$186282
-                    (get_local $$incdec$ptr62)
-                  )
+                  (get_local $10)
                   (br $while-out$10)
                 )
               )
@@ -4148,15 +3634,11 @@
             )
           )
           (block
-            (set_local $$12
-              (get_local $$7)
-            )
-            (set_local $$fl$0284
+            (get_local $1)
+            (set_local $8
               (i32.const 0)
             )
-            (set_local $$storemerge$186282
-              (get_local $$storemerge)
-            )
+            (get_local $10)
           )
         )
       )
@@ -4165,7 +3647,7 @@
           (i32.eq
             (i32.shr_s
               (i32.shl
-                (get_local $$12)
+                (get_local $1)
                 (i32.const 24)
               )
               (i32.const 24)
@@ -4175,14 +3657,14 @@
           (block
             (if
               (i32.lt_u
-                (set_local $$isdigittmp189
+                (set_local $1
                   (i32.add
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s
-                          (set_local $$arrayidx68
+                          (set_local $6
                             (i32.add
-                              (get_local $$storemerge$186282)
+                              (get_local $10)
                               (i32.const 1)
                             )
                           )
@@ -4201,7 +3683,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s offset=2
-                        (get_local $$storemerge$186282)
+                        (get_local $10)
                       )
                       (i32.const 24)
                     )
@@ -4212,25 +3694,25 @@
                 (block
                   (i32.store
                     (i32.add
-                      (get_local $$nl_type)
+                      (get_local $4)
                       (i32.shl
-                        (get_local $$isdigittmp189)
+                        (get_local $1)
                         (i32.const 2)
                       )
                     )
                     (i32.const 10)
                   )
-                  (set_local $$18
+                  (set_local $5
                     (i32.load
-                      (set_local $$16
+                      (set_local $1
                         (i32.add
-                          (get_local $$nl_arg)
+                          (get_local $3)
                           (i32.shl
                             (i32.add
                               (i32.shr_s
                                 (i32.shl
                                   (i32.load8_s
-                                    (get_local $$arrayidx68)
+                                    (get_local $6)
                                   )
                                   (i32.const 24)
                                 )
@@ -4245,45 +3727,45 @@
                     )
                   )
                   (i32.load offset=4
-                    (get_local $$16)
+                    (get_local $1)
                   )
-                  (set_local $$l10n$2
+                  (set_local $63
                     (i32.const 1)
                   )
-                  (set_local $$storemerge$191
+                  (set_local $66
                     (i32.add
-                      (get_local $$storemerge$186282)
+                      (get_local $10)
                       (i32.const 3)
                     )
                   )
-                  (set_local $$w$0
-                    (get_local $$18)
+                  (set_local $61
+                    (get_local $5)
                   )
                 )
-                (set_local $label
+                (set_local $13
                   (i32.const 24)
                 )
               )
-              (set_local $label
+              (set_local $13
                 (i32.const 24)
               )
             )
             (if
               (i32.eq
-                (get_local $label)
+                (get_local $13)
                 (i32.const 24)
               )
               (block
-                (set_local $label
+                (set_local $13
                   (i32.const 0)
                 )
                 (if
                   (i32.ne
-                    (get_local $$l10n$1)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$retval$0
+                    (set_local $23
                       (i32.const -1)
                     )
                     (br $label$break$L1)
@@ -4291,31 +3773,29 @@
                 )
                 (if
                   (i32.eqz
-                    (get_local $$tobool25)
+                    (get_local $52)
                   )
                   (block
-                    (set_local $$fl$1
-                      (get_local $$fl$0284)
+                    (get_local $8)
+                    (set_local $10
+                      (get_local $6)
                     )
-                    (set_local $$incdec$ptr169269
-                      (get_local $$arrayidx68)
-                    )
-                    (set_local $$l10n$3
+                    (set_local $20
                       (i32.const 0)
                     )
-                    (set_local $$w$1
+                    (set_local $16
                       (i32.const 0)
                     )
                     (br $do-once$12)
                   )
                 )
-                (set_local $$28
+                (set_local $5
                   (i32.load
-                    (set_local $$27
+                    (set_local $1
                       (i32.and
                         (i32.add
                           (i32.load
-                            (get_local $$ap)
+                            (get_local $2)
                           )
                           (i32.sub
                             (i32.add
@@ -4340,69 +3820,69 @@
                   )
                 )
                 (i32.store
-                  (get_local $$ap)
+                  (get_local $2)
                   (i32.add
-                    (get_local $$27)
+                    (get_local $1)
                     (i32.const 4)
                   )
                 )
-                (set_local $$l10n$2
+                (set_local $63
                   (i32.const 0)
                 )
-                (set_local $$storemerge$191
-                  (get_local $$arrayidx68)
+                (set_local $66
+                  (get_local $6)
                 )
-                (set_local $$w$0
-                  (get_local $$28)
+                (set_local $61
+                  (get_local $5)
                 )
               )
             )
-            (set_local $$fl$1
+            (set_local $8
               (if
                 (i32.lt_s
-                  (get_local $$w$0)
+                  (get_local $61)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$incdec$ptr169269
-                    (get_local $$storemerge$191)
+                  (set_local $10
+                    (get_local $66)
                   )
-                  (set_local $$l10n$3
-                    (get_local $$l10n$2)
+                  (set_local $20
+                    (get_local $63)
                   )
-                  (set_local $$w$1
+                  (set_local $16
                     (i32.sub
                       (i32.const 0)
-                      (get_local $$w$0)
+                      (get_local $61)
                     )
                   )
                   (i32.or
-                    (get_local $$fl$0284)
+                    (get_local $8)
                     (i32.const 8192)
                   )
                 )
                 (block
-                  (set_local $$incdec$ptr169269
-                    (get_local $$storemerge$191)
+                  (set_local $10
+                    (get_local $66)
                   )
-                  (set_local $$l10n$3
-                    (get_local $$l10n$2)
+                  (set_local $20
+                    (get_local $63)
                   )
-                  (set_local $$w$1
-                    (get_local $$w$0)
+                  (set_local $16
+                    (get_local $61)
                   )
-                  (get_local $$fl$0284)
+                  (get_local $8)
                 )
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $$isdigittmp$5$i
+              (set_local $6
                 (i32.add
                   (i32.shr_s
                     (i32.shl
-                      (get_local $$12)
+                      (get_local $1)
                       (i32.const 24)
                     )
                     (i32.const 24)
@@ -4413,35 +3893,33 @@
               (i32.const 10)
             )
             (block
-              (set_local $$29
-                (get_local $$storemerge$186282)
+              (set_local $1
+                (get_local $10)
               )
-              (set_local $$i$07$i
+              (set_local $5
                 (i32.const 0)
               )
-              (set_local $$isdigittmp8$i
-                (get_local $$isdigittmp$5$i)
-              )
+              (get_local $6)
               (loop $while-out$14 $while-in$15
-                (set_local $$add$i
+                (set_local $5
                   (i32.add
                     (i32.mul
-                      (get_local $$i$07$i)
+                      (get_local $5)
                       (i32.const 10)
                     )
-                    (get_local $$isdigittmp8$i)
+                    (get_local $6)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (set_local $$isdigittmp$i
+                    (set_local $10
                       (i32.add
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s
-                              (set_local $$incdec$ptr$i
+                              (set_local $6
                                 (i32.add
-                                  (get_local $$29)
+                                  (get_local $1)
                                   (i32.const 1)
                                 )
                               )
@@ -4456,22 +3934,20 @@
                     (i32.const 10)
                   )
                   (block
-                    (set_local $$29
-                      (get_local $$incdec$ptr$i)
+                    (set_local $1
+                      (get_local $6)
                     )
-                    (set_local $$i$07$i
-                      (get_local $$add$i)
-                    )
-                    (set_local $$isdigittmp8$i
-                      (get_local $$isdigittmp$i)
+                    (get_local $5)
+                    (set_local $6
+                      (get_local $10)
                     )
                   )
                   (block
-                    (set_local $$add$i$lcssa
-                      (get_local $$add$i)
+                    (set_local $1
+                      (get_local $5)
                     )
-                    (set_local $$incdec$ptr$i$lcssa
-                      (get_local $$incdec$ptr$i)
+                    (set_local $5
+                      (get_local $6)
                     )
                     (br $while-out$14)
                   )
@@ -4480,56 +3956,50 @@
               )
               (if
                 (i32.lt_s
-                  (get_local $$add$i$lcssa)
+                  (get_local $1)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$retval$0
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
                 (block
-                  (set_local $$fl$1
-                    (get_local $$fl$0284)
+                  (get_local $8)
+                  (set_local $10
+                    (get_local $5)
                   )
-                  (set_local $$incdec$ptr169269
-                    (get_local $$incdec$ptr$i$lcssa)
+                  (set_local $20
+                    (get_local $11)
                   )
-                  (set_local $$l10n$3
-                    (get_local $$l10n$1)
-                  )
-                  (set_local $$w$1
-                    (get_local $$add$i$lcssa)
+                  (set_local $16
+                    (get_local $1)
                   )
                 )
               )
             )
             (block
-              (set_local $$fl$1
-                (get_local $$fl$0284)
+              (get_local $8)
+              (get_local $10)
+              (set_local $20
+                (get_local $11)
               )
-              (set_local $$incdec$ptr169269
-                (get_local $$storemerge$186282)
-              )
-              (set_local $$l10n$3
-                (get_local $$l10n$1)
-              )
-              (set_local $$w$1
+              (set_local $16
                 (i32.const 0)
               )
             )
           )
         )
       )
-      (set_local $$incdec$ptr169271
+      (set_local $11
         (block $label$break$L46
           (if
             (i32.eq
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $$incdec$ptr169269)
+                    (get_local $10)
                   )
                   (i32.const 24)
                 )
@@ -4542,11 +4012,11 @@
                 (i32.ne
                   (i32.shr_s
                     (i32.shl
-                      (set_local $$32
+                      (set_local $1
                         (i32.load8_s
-                          (set_local $$arrayidx114
+                          (set_local $5
                             (i32.add
-                              (get_local $$incdec$ptr169269)
+                              (get_local $10)
                               (i32.const 1)
                             )
                           )
@@ -4561,11 +4031,11 @@
                 (block
                   (if
                     (i32.lt_u
-                      (set_local $$isdigittmp$5$i$198
+                      (set_local $6
                         (i32.add
                           (i32.shr_s
                             (i32.shl
-                              (get_local $$32)
+                              (get_local $1)
                               (i32.const 24)
                             )
                             (i32.const 24)
@@ -4576,45 +4046,43 @@
                       (i32.const 10)
                     )
                     (block
-                      (set_local $$49
-                        (get_local $$arrayidx114)
+                      (set_local $1
+                        (get_local $5)
                       )
-                      (set_local $$i$07$i$201
+                      (set_local $5
                         (i32.const 0)
                       )
-                      (set_local $$isdigittmp8$i$200
-                        (get_local $$isdigittmp$5$i$198)
-                      )
+                      (get_local $6)
                     )
                     (block
-                      (set_local $$p$0
+                      (set_local $9
                         (i32.const 0)
                       )
                       (br $label$break$L46
-                        (get_local $$arrayidx114)
+                        (get_local $5)
                       )
                     )
                   )
                   (loop $while-out$17 $while-in$18
-                    (set_local $$add$i$203
+                    (set_local $5
                       (i32.add
                         (i32.mul
-                          (get_local $$i$07$i$201)
+                          (get_local $5)
                           (i32.const 10)
                         )
-                        (get_local $$isdigittmp8$i$200)
+                        (get_local $6)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (set_local $$isdigittmp$i$206
+                        (set_local $6
                           (i32.add
                             (i32.shr_s
                               (i32.shl
                                 (i32.load8_s
-                                  (set_local $$incdec$ptr$i$204
+                                  (set_local $1
                                     (i32.add
-                                      (get_local $$49)
+                                      (get_local $1)
                                       (i32.const 1)
                                     )
                                   )
@@ -4629,22 +4097,16 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $$49
-                          (get_local $$incdec$ptr$i$204)
-                        )
-                        (set_local $$i$07$i$201
-                          (get_local $$add$i$203)
-                        )
-                        (set_local $$isdigittmp8$i$200
-                          (get_local $$isdigittmp$i$206)
-                        )
+                        (get_local $1)
+                        (get_local $5)
+                        (get_local $6)
                       )
                       (block
-                        (set_local $$p$0
-                          (get_local $$add$i$203)
+                        (set_local $9
+                          (get_local $5)
                         )
                         (br $label$break$L46
-                          (get_local $$incdec$ptr$i$204)
+                          (get_local $1)
                         )
                       )
                     )
@@ -4654,14 +4116,14 @@
               )
               (if
                 (i32.lt_u
-                  (set_local $$isdigittmp187
+                  (set_local $1
                     (i32.add
                       (i32.shr_s
                         (i32.shl
                           (i32.load8_s
-                            (set_local $$arrayidx119
+                            (set_local $6
                               (i32.add
-                                (get_local $$incdec$ptr169269)
+                                (get_local $10)
                                 (i32.const 2)
                               )
                             )
@@ -4680,7 +4142,7 @@
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s offset=3
-                          (get_local $$incdec$ptr169269)
+                          (get_local $10)
                         )
                         (i32.const 24)
                       )
@@ -4691,25 +4153,25 @@
                   (block
                     (i32.store
                       (i32.add
-                        (get_local $$nl_type)
+                        (get_local $4)
                         (i32.shl
-                          (get_local $$isdigittmp187)
+                          (get_local $1)
                           (i32.const 2)
                         )
                       )
                       (i32.const 10)
                     )
-                    (set_local $$38
+                    (set_local $5
                       (i32.load
-                        (set_local $$36
+                        (set_local $1
                           (i32.add
-                            (get_local $$nl_arg)
+                            (get_local $3)
                             (i32.shl
                               (i32.add
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.load8_s
-                                      (get_local $$arrayidx119)
+                                      (get_local $6)
                                     )
                                     (i32.const 24)
                                   )
@@ -4724,14 +4186,14 @@
                       )
                     )
                     (i32.load offset=4
-                      (get_local $$36)
+                      (get_local $1)
                     )
-                    (set_local $$p$0
-                      (get_local $$38)
+                    (set_local $9
+                      (get_local $5)
                     )
                     (br $label$break$L46
                       (i32.add
-                        (get_local $$incdec$ptr169269)
+                        (get_local $10)
                         (i32.const 4)
                       )
                     )
@@ -4740,26 +4202,26 @@
               )
               (if
                 (i32.ne
-                  (get_local $$l10n$3)
+                  (get_local $20)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$retval$0
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
               )
               (if
-                (get_local $$tobool25)
+                (get_local $52)
                 (block
-                  (set_local $$48
+                  (set_local $5
                     (i32.load
-                      (set_local $$47
+                      (set_local $1
                         (i32.and
                           (i32.add
                             (i32.load
-                              (get_local $$ap)
+                              (get_local $2)
                             )
                             (i32.sub
                               (i32.add
@@ -4784,46 +4246,46 @@
                     )
                   )
                   (i32.store
-                    (get_local $$ap)
+                    (get_local $2)
                     (i32.add
-                      (get_local $$47)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
-                  (set_local $$p$0
-                    (get_local $$48)
+                  (set_local $9
+                    (get_local $5)
                   )
-                  (get_local $$arrayidx119)
+                  (get_local $6)
                 )
                 (block
-                  (set_local $$p$0
+                  (set_local $9
                     (i32.const 0)
                   )
-                  (get_local $$arrayidx119)
+                  (get_local $6)
                 )
               )
             )
             (block
-              (set_local $$p$0
+              (set_local $9
                 (i32.const -1)
               )
-              (get_local $$incdec$ptr169269)
+              (get_local $10)
             )
           )
         )
       )
-      (set_local $$st$0
+      (set_local $21
         (i32.const 0)
       )
       (loop $while-out$19 $while-in$20
         (if
           (i32.gt_u
-            (set_local $$sub164
+            (set_local $1
               (i32.add
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $$incdec$ptr169271)
+                      (get_local $11)
                     )
                     (i32.const 24)
                   )
@@ -4835,34 +4297,34 @@
             (i32.const 57)
           )
           (block
-            (set_local $$retval$0
+            (set_local $23
               (i32.const -1)
             )
             (br $label$break$L1)
           )
         )
-        (set_local $$incdec$ptr169
+        (set_local $10
           (i32.add
-            (get_local $$incdec$ptr169271)
+            (get_local $11)
             (i32.const 1)
           )
         )
         (if
           (i32.lt_u
             (i32.add
-              (set_local $$conv174
+              (set_local $5
                 (i32.and
-                  (set_local $$52
+                  (set_local $1
                     (i32.load8_s
                       (i32.add
                         (i32.add
                           (i32.const 3611)
                           (i32.mul
-                            (get_local $$st$0)
+                            (get_local $21)
                             (i32.const 58)
                           )
                         )
-                        (get_local $$sub164)
+                        (get_local $1)
                       )
                     )
                   )
@@ -4874,28 +4336,26 @@
             (i32.const 8)
           )
           (block
-            (set_local $$incdec$ptr169271
-              (get_local $$incdec$ptr169)
+            (set_local $11
+              (get_local $10)
             )
-            (set_local $$st$0
-              (get_local $$conv174)
+            (set_local $21
+              (get_local $5)
             )
           )
           (block
-            (set_local $$$lcssa
-              (get_local $$52)
+            (get_local $1)
+            (set_local $6
+              (get_local $5)
             )
-            (set_local $$conv174$lcssa
-              (get_local $$conv174)
+            (set_local $26
+              (get_local $10)
             )
-            (set_local $$incdec$ptr169$lcssa
-              (get_local $$incdec$ptr169)
+            (set_local $10
+              (get_local $11)
             )
-            (set_local $$incdec$ptr169271$lcssa414
-              (get_local $$incdec$ptr169271)
-            )
-            (set_local $$st$0$lcssa415
-              (get_local $$st$0)
+            (set_local $11
+              (get_local $21)
             )
             (br $while-out$19)
           )
@@ -4906,7 +4366,7 @@
         (i32.eq
           (i32.shr_s
             (i32.shl
-              (get_local $$$lcssa)
+              (get_local $1)
               (i32.const 24)
             )
             (i32.const 24)
@@ -4914,15 +4374,15 @@
           (i32.const 0)
         )
         (block
-          (set_local $$retval$0
+          (set_local $23
             (i32.const -1)
           )
           (br $label$break$L1)
         )
       )
-      (set_local $$cmp184
+      (set_local $5
         (i32.gt_s
-          (get_local $$argpos$0)
+          (get_local $7)
           (i32.const -1)
         )
       )
@@ -4931,7 +4391,7 @@
           (i32.eq
             (i32.shr_s
               (i32.shl
-                (get_local $$$lcssa)
+                (get_local $1)
                 (i32.const 24)
               )
               (i32.const 24)
@@ -4939,60 +4399,60 @@
             (i32.const 19)
           )
           (if
-            (get_local $$cmp184)
+            (get_local $5)
             (block
-              (set_local $$retval$0
+              (set_local $23
                 (i32.const -1)
               )
               (br $label$break$L1)
             )
-            (set_local $label
+            (set_local $13
               (i32.const 52)
             )
           )
           (block
             (if
-              (get_local $$cmp184)
+              (get_local $5)
               (block
                 (i32.store
                   (i32.add
-                    (get_local $$nl_type)
+                    (get_local $4)
                     (i32.shl
-                      (get_local $$argpos$0)
+                      (get_local $7)
                       (i32.const 2)
                     )
                   )
-                  (get_local $$conv174$lcssa)
+                  (get_local $6)
                 )
-                (set_local $$56
+                (set_local $5
                   (i32.load
-                    (set_local $$54
+                    (set_local $1
                       (i32.add
-                        (get_local $$nl_arg)
+                        (get_local $3)
                         (i32.shl
-                          (get_local $$argpos$0)
+                          (get_local $7)
                           (i32.const 3)
                         )
                       )
                     )
                   )
                 )
-                (set_local $$59
+                (set_local $1
                   (i32.load offset=4
-                    (get_local $$54)
+                    (get_local $1)
                   )
                 )
                 (i32.store
-                  (set_local $$60
-                    (get_local $$arg)
+                  (set_local $7
+                    (get_local $18)
                   )
-                  (get_local $$56)
+                  (get_local $5)
                 )
                 (i32.store offset=4
-                  (get_local $$60)
-                  (get_local $$59)
+                  (get_local $7)
+                  (get_local $1)
                 )
-                (set_local $label
+                (set_local $13
                   (i32.const 52)
                 )
                 (br $do-once$21)
@@ -5000,67 +4460,67 @@
             )
             (if
               (i32.eqz
-                (get_local $$tobool25)
+                (get_local $52)
               )
               (block
-                (set_local $$retval$0
+                (set_local $23
                   (i32.const 0)
                 )
                 (br $label$break$L1)
               )
             )
             (call $_pop_arg_336
-              (get_local $$arg)
-              (get_local $$conv174$lcssa)
-              (get_local $$ap)
+              (get_local $18)
+              (get_local $6)
+              (get_local $2)
             )
           )
         )
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 52)
         )
         (block
-          (set_local $label
+          (set_local $13
             (i32.const 0)
           )
           (if
             (i32.eqz
-              (get_local $$tobool25)
+              (get_local $52)
             )
             (block
-              (set_local $$cnt$0
-                (get_local $$cnt$1)
+              (set_local $5
+                (get_local $19)
               )
-              (set_local $$incdec$ptr169275
-                (get_local $$incdec$ptr169$lcssa)
+              (set_local $12
+                (get_local $26)
               )
-              (set_local $$l$0
-                (get_local $$sub$ptr$sub)
+              (set_local $1
+                (get_local $15)
               )
-              (set_local $$l10n$0
-                (get_local $$l10n$3)
+              (set_local $8
+                (get_local $20)
               )
               (br $label$continue$L1)
             )
           )
         )
       )
-      (set_local $$or$cond192
+      (set_local $5
         (i32.and
           (i32.ne
-            (get_local $$st$0$lcssa415)
+            (get_local $11)
             (i32.const 0)
           )
           (i32.eq
             (i32.and
-              (set_local $$conv207
+              (set_local $1
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $$incdec$ptr169271$lcssa414)
+                      (get_local $10)
                     )
                     (i32.const 24)
                   )
@@ -5073,18 +4533,18 @@
           )
         )
       )
-      (set_local $$fl$1$and219
+      (set_local $17
         (select
-          (get_local $$fl$1)
-          (set_local $$and219
+          (get_local $8)
+          (set_local $6
             (i32.and
-              (get_local $$fl$1)
+              (get_local $8)
               (i32.const -65537)
             )
           )
           (i32.eq
             (i32.and
-              (get_local $$fl$1)
+              (get_local $8)
               (i32.const 8192)
             )
             (i32.const 0)
@@ -5118,14 +4578,14 @@
                                                       (block $switch-case$34
                                                         (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
                                                           (i32.sub
-                                                            (set_local $$t$0
+                                                            (set_local $33
                                                               (select
                                                                 (i32.and
-                                                                  (get_local $$conv207)
+                                                                  (get_local $1)
                                                                   (i32.const -33)
                                                                 )
-                                                                (get_local $$conv207)
-                                                                (get_local $$or$cond192)
+                                                                (get_local $1)
+                                                                (get_local $5)
                                                               )
                                                             )
                                                             (i32.const 65)
@@ -5144,65 +4604,65 @@
                                                                         (block $switch-case$26
                                                                           (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
                                                                             (i32.sub
-                                                                              (get_local $$st$0$lcssa415)
+                                                                              (get_local $11)
                                                                               (i32.const 0)
                                                                             )
                                                                           )
                                                                         )
                                                                         (i32.store
                                                                           (i32.load
-                                                                            (get_local $$arg)
+                                                                            (get_local $18)
                                                                           )
-                                                                          (get_local $$cnt$1)
+                                                                          (get_local $19)
                                                                         )
-                                                                        (set_local $$cnt$0
-                                                                          (get_local $$cnt$1)
+                                                                        (set_local $5
+                                                                          (get_local $19)
                                                                         )
-                                                                        (set_local $$incdec$ptr169275
-                                                                          (get_local $$incdec$ptr169$lcssa)
+                                                                        (set_local $12
+                                                                          (get_local $26)
                                                                         )
-                                                                        (set_local $$l$0
-                                                                          (get_local $$sub$ptr$sub)
+                                                                        (set_local $1
+                                                                          (get_local $15)
                                                                         )
-                                                                        (set_local $$l10n$0
-                                                                          (get_local $$l10n$3)
+                                                                        (set_local $8
+                                                                          (get_local $20)
                                                                         )
                                                                         (br $label$continue$L1)
                                                                       )
                                                                       (i32.store
                                                                         (i32.load
-                                                                          (get_local $$arg)
+                                                                          (get_local $18)
                                                                         )
-                                                                        (get_local $$cnt$1)
+                                                                        (get_local $19)
                                                                       )
-                                                                      (set_local $$cnt$0
-                                                                        (get_local $$cnt$1)
+                                                                      (set_local $5
+                                                                        (get_local $19)
                                                                       )
-                                                                      (set_local $$incdec$ptr169275
-                                                                        (get_local $$incdec$ptr169$lcssa)
+                                                                      (set_local $12
+                                                                        (get_local $26)
                                                                       )
-                                                                      (set_local $$l$0
-                                                                        (get_local $$sub$ptr$sub)
+                                                                      (set_local $1
+                                                                        (get_local $15)
                                                                       )
-                                                                      (set_local $$l10n$0
-                                                                        (get_local $$l10n$3)
+                                                                      (set_local $8
+                                                                        (get_local $20)
                                                                       )
                                                                       (br $label$continue$L1)
                                                                     )
                                                                     (i32.store
-                                                                      (set_local $$76
+                                                                      (set_local $1
                                                                         (i32.load
-                                                                          (get_local $$arg)
+                                                                          (get_local $18)
                                                                         )
                                                                       )
-                                                                      (get_local $$cnt$1)
+                                                                      (get_local $19)
                                                                     )
                                                                     (i32.store offset=4
-                                                                      (get_local $$76)
+                                                                      (get_local $1)
                                                                       (i32.shr_s
                                                                         (i32.shl
                                                                           (i32.lt_s
-                                                                            (get_local $$cnt$1)
+                                                                            (get_local $19)
                                                                             (i32.const 0)
                                                                           )
                                                                           (i32.const 31)
@@ -5210,100 +4670,100 @@
                                                                         (i32.const 31)
                                                                       )
                                                                     )
-                                                                    (set_local $$cnt$0
-                                                                      (get_local $$cnt$1)
+                                                                    (set_local $5
+                                                                      (get_local $19)
                                                                     )
-                                                                    (set_local $$incdec$ptr169275
-                                                                      (get_local $$incdec$ptr169$lcssa)
+                                                                    (set_local $12
+                                                                      (get_local $26)
                                                                     )
-                                                                    (set_local $$l$0
-                                                                      (get_local $$sub$ptr$sub)
+                                                                    (set_local $1
+                                                                      (get_local $15)
                                                                     )
-                                                                    (set_local $$l10n$0
-                                                                      (get_local $$l10n$3)
+                                                                    (set_local $8
+                                                                      (get_local $20)
                                                                     )
                                                                     (br $label$continue$L1)
                                                                   )
                                                                   (i32.store16
                                                                     (i32.load
-                                                                      (get_local $$arg)
+                                                                      (get_local $18)
                                                                     )
                                                                     (i32.and
-                                                                      (get_local $$cnt$1)
+                                                                      (get_local $19)
                                                                       (i32.const 65535)
                                                                     )
                                                                   )
-                                                                  (set_local $$cnt$0
-                                                                    (get_local $$cnt$1)
+                                                                  (set_local $5
+                                                                    (get_local $19)
                                                                   )
-                                                                  (set_local $$incdec$ptr169275
-                                                                    (get_local $$incdec$ptr169$lcssa)
+                                                                  (set_local $12
+                                                                    (get_local $26)
                                                                   )
-                                                                  (set_local $$l$0
-                                                                    (get_local $$sub$ptr$sub)
+                                                                  (set_local $1
+                                                                    (get_local $15)
                                                                   )
-                                                                  (set_local $$l10n$0
-                                                                    (get_local $$l10n$3)
+                                                                  (set_local $8
+                                                                    (get_local $20)
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
                                                                 (i32.store8
                                                                   (i32.load
-                                                                    (get_local $$arg)
+                                                                    (get_local $18)
                                                                   )
                                                                   (i32.and
-                                                                    (get_local $$cnt$1)
+                                                                    (get_local $19)
                                                                     (i32.const 255)
                                                                   )
                                                                 )
-                                                                (set_local $$cnt$0
-                                                                  (get_local $$cnt$1)
+                                                                (set_local $5
+                                                                  (get_local $19)
                                                                 )
-                                                                (set_local $$incdec$ptr169275
-                                                                  (get_local $$incdec$ptr169$lcssa)
+                                                                (set_local $12
+                                                                  (get_local $26)
                                                                 )
-                                                                (set_local $$l$0
-                                                                  (get_local $$sub$ptr$sub)
+                                                                (set_local $1
+                                                                  (get_local $15)
                                                                 )
-                                                                (set_local $$l10n$0
-                                                                  (get_local $$l10n$3)
+                                                                (set_local $8
+                                                                  (get_local $20)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
                                                               (i32.store
                                                                 (i32.load
-                                                                  (get_local $$arg)
+                                                                  (get_local $18)
                                                                 )
-                                                                (get_local $$cnt$1)
+                                                                (get_local $19)
                                                               )
-                                                              (set_local $$cnt$0
-                                                                (get_local $$cnt$1)
+                                                              (set_local $5
+                                                                (get_local $19)
                                                               )
-                                                              (set_local $$incdec$ptr169275
-                                                                (get_local $$incdec$ptr169$lcssa)
+                                                              (set_local $12
+                                                                (get_local $26)
                                                               )
-                                                              (set_local $$l$0
-                                                                (get_local $$sub$ptr$sub)
+                                                              (set_local $1
+                                                                (get_local $15)
                                                               )
-                                                              (set_local $$l10n$0
-                                                                (get_local $$l10n$3)
+                                                              (set_local $8
+                                                                (get_local $20)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
                                                             (i32.store
-                                                              (set_local $$86
+                                                              (set_local $1
                                                                 (i32.load
-                                                                  (get_local $$arg)
+                                                                  (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $$cnt$1)
+                                                              (get_local $19)
                                                             )
                                                             (i32.store offset=4
-                                                              (get_local $$86)
+                                                              (get_local $1)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $$cnt$1)
+                                                                    (get_local $19)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -5311,72 +4771,72 @@
                                                                 (i32.const 31)
                                                               )
                                                             )
-                                                            (set_local $$cnt$0
-                                                              (get_local $$cnt$1)
+                                                            (set_local $5
+                                                              (get_local $19)
                                                             )
-                                                            (set_local $$incdec$ptr169275
-                                                              (get_local $$incdec$ptr169$lcssa)
+                                                            (set_local $12
+                                                              (get_local $26)
                                                             )
-                                                            (set_local $$l$0
-                                                              (get_local $$sub$ptr$sub)
+                                                            (set_local $1
+                                                              (get_local $15)
                                                             )
-                                                            (set_local $$l10n$0
-                                                              (get_local $$l10n$3)
+                                                            (set_local $8
+                                                              (get_local $20)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
-                                                          (set_local $$cnt$0
-                                                            (get_local $$cnt$1)
+                                                          (set_local $5
+                                                            (get_local $19)
                                                           )
-                                                          (set_local $$incdec$ptr169275
-                                                            (get_local $$incdec$ptr169$lcssa)
+                                                          (set_local $12
+                                                            (get_local $26)
                                                           )
-                                                          (set_local $$l$0
-                                                            (get_local $$sub$ptr$sub)
+                                                          (set_local $1
+                                                            (get_local $15)
                                                           )
-                                                          (set_local $$l10n$0
-                                                            (get_local $$l10n$3)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
                                                       )
                                                       (br $switch$24)
                                                     )
-                                                    (set_local $$fl$3
+                                                    (set_local $49
                                                       (i32.or
-                                                        (get_local $$fl$1$and219)
+                                                        (get_local $17)
                                                         (i32.const 8)
                                                       )
                                                     )
-                                                    (set_local $$p$1
+                                                    (set_local $58
                                                       (select
-                                                        (get_local $$p$0)
+                                                        (get_local $9)
                                                         (i32.const 8)
                                                         (i32.gt_u
-                                                          (get_local $$p$0)
+                                                          (get_local $9)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (set_local $$t$1
+                                                    (set_local $69
                                                       (i32.const 120)
                                                     )
-                                                    (set_local $label
+                                                    (set_local $13
                                                       (i32.const 64)
                                                     )
                                                     (br $switch$24)
                                                   )
                                                 )
-                                                (set_local $$fl$3
-                                                  (get_local $$fl$1$and219)
+                                                (set_local $49
+                                                  (get_local $17)
                                                 )
-                                                (set_local $$p$1
-                                                  (get_local $$p$0)
+                                                (set_local $58
+                                                  (get_local $9)
                                                 )
-                                                (set_local $$t$1
-                                                  (get_local $$t$0)
+                                                (set_local $69
+                                                  (get_local $33)
                                                 )
-                                                (set_local $label
+                                                (set_local $13
                                                   (i32.const 64)
                                                 )
                                                 (br $switch$24)
@@ -5384,49 +4844,45 @@
                                               (if
                                                 (i32.and
                                                   (i32.eq
-                                                    (set_local $$118
+                                                    (set_local $5
                                                       (i32.load
-                                                        (set_local $$116
-                                                          (get_local $$arg)
+                                                        (set_local $1
+                                                          (get_local $18)
                                                         )
                                                       )
                                                     )
                                                     (i32.const 0)
                                                   )
                                                   (i32.eq
-                                                    (set_local $$121
+                                                    (set_local $1
                                                       (i32.load offset=4
-                                                        (get_local $$116)
+                                                        (get_local $1)
                                                       )
                                                     )
                                                     (i32.const 0)
                                                   )
                                                 )
-                                                (set_local $$s$addr$0$lcssa$i$229
-                                                  (get_local $$add$ptr205)
+                                                (set_local $7
+                                                  (get_local $28)
                                                 )
                                                 (block
-                                                  (set_local $$126
-                                                    (get_local $$118)
-                                                  )
-                                                  (set_local $$129
-                                                    (get_local $$121)
-                                                  )
-                                                  (set_local $$s$addr$06$i$221
-                                                    (get_local $$add$ptr205)
+                                                  (get_local $5)
+                                                  (get_local $1)
+                                                  (set_local $7
+                                                    (get_local $28)
                                                   )
                                                   (loop $while-out$38 $while-in$39
                                                     (i32.store8
-                                                      (set_local $$incdec$ptr$i$225
+                                                      (set_local $34
                                                         (i32.add
-                                                          (get_local $$s$addr$06$i$221)
+                                                          (get_local $7)
                                                           (i32.const -1)
                                                         )
                                                       )
                                                       (i32.and
                                                         (i32.or
                                                           (i32.and
-                                                            (get_local $$126)
+                                                            (get_local $5)
                                                             (i32.const 7)
                                                           )
                                                           (i32.const 48)
@@ -5437,17 +4893,17 @@
                                                     (if
                                                       (i32.and
                                                         (i32.eq
-                                                          (set_local $$130
+                                                          (set_local $1
                                                             (call $_bitshift64Lshr
-                                                              (get_local $$126)
-                                                              (get_local $$129)
+                                                              (get_local $5)
+                                                              (get_local $1)
                                                               (i32.const 3)
                                                             )
                                                           )
                                                           (i32.const 0)
                                                         )
                                                         (i32.eq
-                                                          (set_local $$131
+                                                          (set_local $7
                                                             (i32.load
                                                               (i32.const 168)
                                                             )
@@ -5456,20 +4912,20 @@
                                                         )
                                                       )
                                                       (block
-                                                        (set_local $$s$addr$0$lcssa$i$229
-                                                          (get_local $$incdec$ptr$i$225)
+                                                        (set_local $7
+                                                          (get_local $34)
                                                         )
                                                         (br $while-out$38)
                                                       )
                                                       (block
-                                                        (set_local $$126
-                                                          (get_local $$130)
+                                                        (set_local $5
+                                                          (get_local $1)
                                                         )
-                                                        (set_local $$129
-                                                          (get_local $$131)
+                                                        (set_local $1
+                                                          (get_local $7)
                                                         )
-                                                        (set_local $$s$addr$06$i$221
-                                                          (get_local $$incdec$ptr$i$225)
+                                                        (set_local $7
+                                                          (get_local $34)
                                                         )
                                                       )
                                                     )
@@ -5477,150 +4933,150 @@
                                                   )
                                                 )
                                               )
-                                              (set_local $$a$0
+                                              (set_local $34
                                                 (if
                                                   (i32.eq
                                                     (i32.and
-                                                      (get_local $$fl$1$and219)
+                                                      (get_local $17)
                                                       (i32.const 8)
                                                     )
                                                     (i32.const 0)
                                                   )
                                                   (block
-                                                    (set_local $$fl$4
-                                                      (get_local $$fl$1$and219)
+                                                    (set_local $35
+                                                      (get_local $17)
                                                     )
-                                                    (set_local $$p$2
-                                                      (get_local $$p$0)
+                                                    (set_local $31
+                                                      (get_local $9)
                                                     )
-                                                    (set_local $$pl$1
+                                                    (set_local $38
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $$prefix$1
+                                                    (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $label
+                                                    (set_local $13
                                                       (i32.const 77)
                                                     )
-                                                    (get_local $$s$addr$0$lcssa$i$229)
+                                                    (get_local $7)
                                                   )
                                                   (block
-                                                    (set_local $$cmp270
+                                                    (set_local $5
                                                       (i32.lt_s
-                                                        (get_local $$p$0)
-                                                        (set_local $$add269
+                                                        (get_local $9)
+                                                        (set_local $1
                                                           (i32.add
                                                             (i32.sub
-                                                              (get_local $$sub$ptr$lhs$cast317)
-                                                              (get_local $$s$addr$0$lcssa$i$229)
+                                                              (get_local $73)
+                                                              (get_local $7)
                                                             )
                                                             (i32.const 1)
                                                           )
                                                         )
                                                       )
                                                     )
-                                                    (set_local $$fl$4
-                                                      (get_local $$fl$1$and219)
+                                                    (set_local $35
+                                                      (get_local $17)
                                                     )
-                                                    (set_local $$p$2
+                                                    (set_local $31
                                                       (select
-                                                        (get_local $$add269)
-                                                        (get_local $$p$0)
-                                                        (get_local $$cmp270)
+                                                        (get_local $1)
+                                                        (get_local $9)
+                                                        (get_local $5)
                                                       )
                                                     )
-                                                    (set_local $$pl$1
+                                                    (set_local $38
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $$prefix$1
+                                                    (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $label
+                                                    (set_local $13
                                                       (i32.const 77)
                                                     )
-                                                    (get_local $$s$addr$0$lcssa$i$229)
+                                                    (get_local $7)
                                                   )
                                                 )
                                               )
                                               (br $switch$24)
                                             )
                                           )
-                                          (set_local $$137
+                                          (set_local $5
                                             (i32.load
-                                              (set_local $$135
-                                                (get_local $$arg)
+                                              (set_local $1
+                                                (get_local $18)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (set_local $$140
+                                              (set_local $7
                                                 (i32.load offset=4
-                                                  (get_local $$135)
+                                                  (get_local $1)
                                                 )
                                               )
                                               (i32.const 0)
                                             )
                                             (block
-                                              (set_local $$142
+                                              (set_local $1
                                                 (call $_i64Subtract
                                                   (i32.const 0)
                                                   (i32.const 0)
-                                                  (get_local $$137)
-                                                  (get_local $$140)
+                                                  (get_local $5)
+                                                  (get_local $7)
                                                 )
                                               )
-                                              (set_local $$143
+                                              (set_local $5
                                                 (i32.load
                                                   (i32.const 168)
                                                 )
                                               )
                                               (i32.store
-                                                (set_local $$144
-                                                  (get_local $$arg)
+                                                (set_local $7
+                                                  (get_local $18)
                                                 )
-                                                (get_local $$142)
+                                                (get_local $1)
                                               )
                                               (i32.store offset=4
-                                                (get_local $$144)
-                                                (get_local $$143)
+                                                (get_local $7)
+                                                (get_local $5)
                                               )
-                                              (set_local $$148
-                                                (get_local $$142)
+                                              (set_local $45
+                                                (get_local $1)
                                               )
-                                              (set_local $$149
-                                                (get_local $$143)
+                                              (set_local $54
+                                                (get_local $5)
                                               )
-                                              (set_local $$pl$0
+                                              (set_local $59
                                                 (i32.const 1)
                                               )
-                                              (set_local $$prefix$0
+                                              (set_local $60
                                                 (i32.const 4091)
                                               )
-                                              (set_local $label
+                                              (set_local $13
                                                 (i32.const 76)
                                               )
                                               (br $label$break$L75)
                                             )
                                           )
-                                          (set_local $$148
+                                          (set_local $45
                                             (if
                                               (i32.eq
                                                 (i32.and
-                                                  (get_local $$fl$1$and219)
+                                                  (get_local $17)
                                                   (i32.const 2048)
                                                 )
                                                 (i32.const 0)
                                               )
                                               (block
-                                                (set_local $$$
+                                                (set_local $1
                                                   (select
                                                     (i32.const 4091)
                                                     (i32.const 4093)
                                                     (i32.eq
-                                                      (set_local $$and294
+                                                      (set_local $45
                                                         (i32.and
-                                                          (get_local $$fl$1$and219)
+                                                          (get_local $17)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -5628,185 +5084,185 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $$149
-                                                  (get_local $$140)
+                                                (set_local $54
+                                                  (get_local $7)
                                                 )
-                                                (set_local $$pl$0
-                                                  (get_local $$and294)
+                                                (set_local $59
+                                                  (get_local $45)
                                                 )
-                                                (set_local $$prefix$0
-                                                  (get_local $$$)
+                                                (set_local $60
+                                                  (get_local $1)
                                                 )
-                                                (set_local $label
+                                                (set_local $13
                                                   (i32.const 76)
                                                 )
-                                                (get_local $$137)
+                                                (get_local $5)
                                               )
                                               (block
-                                                (set_local $$149
-                                                  (get_local $$140)
+                                                (set_local $54
+                                                  (get_local $7)
                                                 )
-                                                (set_local $$pl$0
+                                                (set_local $59
                                                   (i32.const 1)
                                                 )
-                                                (set_local $$prefix$0
+                                                (set_local $60
                                                   (i32.const 4092)
                                                 )
-                                                (set_local $label
+                                                (set_local $13
                                                   (i32.const 76)
                                                 )
-                                                (get_local $$137)
+                                                (get_local $5)
                                               )
                                             )
                                           )
                                           (br $switch$24)
                                         )
-                                        (set_local $$148
+                                        (set_local $45
                                           (i32.load
-                                            (set_local $$65
-                                              (get_local $$arg)
+                                            (set_local $1
+                                              (get_local $18)
                                             )
                                           )
                                         )
-                                        (set_local $$149
+                                        (set_local $54
                                           (i32.load offset=4
-                                            (get_local $$65)
+                                            (get_local $1)
                                           )
                                         )
-                                        (set_local $$pl$0
+                                        (set_local $59
                                           (i32.const 0)
                                         )
-                                        (set_local $$prefix$0
+                                        (set_local $60
                                           (i32.const 4091)
                                         )
-                                        (set_local $label
+                                        (set_local $13
                                           (i32.const 76)
                                         )
                                         (br $switch$24)
                                       )
-                                      (set_local $$163
+                                      (set_local $5
                                         (i32.load
-                                          (set_local $$161
-                                            (get_local $$arg)
+                                          (set_local $1
+                                            (get_local $18)
                                           )
                                         )
                                       )
                                       (i32.load offset=4
-                                        (get_local $$161)
+                                        (get_local $1)
                                       )
                                       (i32.store8
-                                        (get_local $$add$ptr340)
+                                        (get_local $71)
                                         (i32.and
-                                          (get_local $$163)
+                                          (get_local $5)
                                           (i32.const 255)
                                         )
                                       )
-                                      (set_local $$a$2
-                                        (get_local $$add$ptr340)
+                                      (set_local $47
+                                        (get_local $71)
                                       )
-                                      (set_local $$fl$6
-                                        (get_local $$and219)
+                                      (set_local $36
+                                        (get_local $6)
                                       )
-                                      (set_local $$p$5
+                                      (set_local $42
                                         (i32.const 1)
                                       )
-                                      (set_local $$pl$2
+                                      (set_local $43
                                         (i32.const 0)
                                       )
-                                      (set_local $$prefix$2
+                                      (set_local $51
                                         (i32.const 4091)
                                       )
-                                      (set_local $$z$2
-                                        (get_local $$add$ptr205)
+                                      (set_local $53
+                                        (get_local $28)
                                       )
                                       (br $switch$24)
                                     )
-                                    (set_local $$a$1
+                                    (set_local $46
                                       (call $_strerror
                                         (i32.load
                                           (call $___errno_location)
                                         )
                                       )
                                     )
-                                    (set_local $label
+                                    (set_local $13
                                       (i32.const 82)
                                     )
                                     (br $switch$24)
                                   )
-                                  (set_local $$tobool349
+                                  (set_local $5
                                     (i32.ne
-                                      (set_local $$169
+                                      (set_local $1
                                         (i32.load
-                                          (get_local $$arg)
+                                          (get_local $18)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $$a$1
+                                  (set_local $46
                                     (select
-                                      (get_local $$169)
+                                      (get_local $1)
                                       (i32.const 4101)
-                                      (get_local $$tobool349)
+                                      (get_local $5)
                                     )
                                   )
-                                  (set_local $label
+                                  (set_local $13
                                     (i32.const 82)
                                   )
                                   (br $switch$24)
                                 )
-                                (set_local $$172
+                                (set_local $5
                                   (i32.load
-                                    (set_local $$170
-                                      (get_local $$arg)
+                                    (set_local $1
+                                      (get_local $18)
                                     )
                                   )
                                 )
                                 (i32.load offset=4
-                                  (get_local $$170)
+                                  (get_local $1)
                                 )
                                 (i32.store
-                                  (get_local $$wc)
-                                  (get_local $$172)
+                                  (get_local $75)
+                                  (get_local $5)
                                 )
                                 (i32.store
-                                  (get_local $$arrayidx370)
+                                  (get_local $77)
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $$arg)
-                                  (get_local $$wc)
+                                  (get_local $18)
+                                  (get_local $75)
                                 )
-                                (set_local $$p$4365
+                                (set_local $65
                                   (i32.const -1)
                                 )
-                                (set_local $label
+                                (set_local $13
                                   (i32.const 86)
                                 )
                                 (br $switch$24)
                               )
-                              (set_local $label
+                              (set_local $13
                                 (if
                                   (i32.eq
-                                    (get_local $$p$0)
+                                    (get_local $9)
                                     (i32.const 0)
                                   )
                                   (block
                                     (call $_pad
-                                      (get_local $$f)
+                                      (get_local $0)
                                       (i32.const 32)
-                                      (get_local $$w$1)
+                                      (get_local $16)
                                       (i32.const 0)
-                                      (get_local $$fl$1$and219)
+                                      (get_local $17)
                                     )
-                                    (set_local $$i$0$lcssa368
+                                    (set_local $37
                                       (i32.const 0)
                                     )
                                     (i32.const 98)
                                   )
                                   (block
-                                    (set_local $$p$4365
-                                      (get_local $$p$0)
+                                    (set_local $65
+                                      (get_local $9)
                                     )
                                     (i32.const 86)
                                   )
@@ -5821,27 +5277,27 @@
                   )
                 )
               )
-              (set_local $$181
+              (set_local $14
                 (f64.load
-                  (get_local $$arg)
+                  (get_local $18)
                 )
               )
               (i32.store
-                (get_local $$e2$i)
+                (get_local $25)
                 (i32.const 0)
               )
               (f64.store
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $$181)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
               )
-              (set_local $$pl$0$i
+              (set_local $50
                 (if
                   (i32.lt_s
                     (i32.load offset=4
@@ -5852,12 +5308,12 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$prefix$0$i
+                    (set_local $39
                       (i32.const 4108)
                     )
-                    (set_local $$y$addr$0$i
+                    (set_local $14
                       (f64.neg
-                        (get_local $$181)
+                        (get_local $14)
                       )
                     )
                     (i32.const 1)
@@ -5865,20 +5321,20 @@
                   (if
                     (i32.eq
                       (i32.and
-                        (get_local $$fl$1$and219)
+                        (get_local $17)
                         (i32.const 2048)
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$prefix$0$i
+                      (set_local $39
                         (select
                           (i32.const 4109)
                           (i32.const 4114)
                           (i32.eq
-                            (set_local $$and12$i
+                            (set_local $1
                               (i32.and
-                                (get_local $$fl$1$and219)
+                                (get_local $17)
                                 (i32.const 1)
                               )
                             )
@@ -5886,18 +5342,14 @@
                           )
                         )
                       )
-                      (set_local $$y$addr$0$i
-                        (get_local $$181)
-                      )
-                      (get_local $$and12$i)
+                      (get_local $14)
+                      (get_local $1)
                     )
                     (block
-                      (set_local $$prefix$0$i
+                      (set_local $39
                         (i32.const 4111)
                       )
-                      (set_local $$y$addr$0$i
-                        (get_local $$181)
-                      )
+                      (get_local $14)
                       (i32.const 1)
                     )
                   )
@@ -5907,19 +5359,19 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $$y$addr$0$i)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
               )
-              (set_local $$retval$0$i
+              (set_local $1
                 (block $do-once$56
                   (if
                     (i32.or
                       (i32.lt_u
-                        (set_local $$187
+                        (set_local $1
                           (i32.and
                             (i32.load offset=4
                               (i32.load
@@ -5933,7 +5385,7 @@
                       )
                       (i32.and
                         (i32.eq
-                          (get_local $$187)
+                          (get_local $1)
                           (i32.const 2146435072)
                         )
                         (i32.lt_s
@@ -5944,13 +5396,13 @@
                     )
                     (block
                       (if
-                        (set_local $$tobool56$i
+                        (set_local $5
                           (f64.ne
-                            (set_local $$mul$i$240
+                            (set_local $14
                               (f64.mul
                                 (call $_frexpl
-                                  (get_local $$y$addr$0$i)
-                                  (get_local $$e2$i)
+                                  (get_local $14)
+                                  (get_local $25)
                                 )
                                 (f64.const 2)
                               )
@@ -5959,10 +5411,10 @@
                           )
                         )
                         (i32.store
-                          (get_local $$e2$i)
+                          (get_local $25)
                           (i32.add
                             (i32.load
-                              (get_local $$e2$i)
+                              (get_local $25)
                             )
                             (i32.const -1)
                           )
@@ -5970,26 +5422,26 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $$or$i$241
+                          (set_local $15
                             (i32.or
-                              (get_local $$t$0)
+                              (get_local $33)
                               (i32.const 32)
                             )
                           )
                           (i32.const 97)
                         )
                         (block
-                          (set_local $$prefix$0$add$ptr65$i
+                          (set_local $10
                             (select
-                              (get_local $$prefix$0$i)
+                              (get_local $39)
                               (i32.add
-                                (get_local $$prefix$0$i)
+                                (get_local $39)
                                 (i32.const 9)
                               )
                               (i32.eq
-                                (set_local $$and62$i
+                                (set_local $6
                                   (i32.and
-                                    (get_local $$t$0)
+                                    (get_local $33)
                                     (i32.const 32)
                                   )
                                 )
@@ -5997,67 +5449,59 @@
                               )
                             )
                           )
-                          (set_local $$add67$i
+                          (set_local $7
                             (i32.or
-                              (get_local $$pl$0$i)
+                              (get_local $50)
                               (i32.const 2)
                             )
                           )
-                          (set_local $$y$addr$1$i
+                          (set_local $14
                             (if
                               (i32.or
                                 (i32.gt_u
-                                  (get_local $$p$0)
+                                  (get_local $9)
                                   (i32.const 11)
                                 )
                                 (i32.eq
-                                  (set_local $$sub74$i
+                                  (set_local $1
                                     (i32.sub
                                       (i32.const 12)
-                                      (get_local $$p$0)
+                                      (get_local $9)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                               )
-                              (get_local $$mul$i$240)
+                              (get_local $14)
                               (block
-                                (set_local $$re$1482$i
-                                  (get_local $$sub74$i)
-                                )
-                                (set_local $$round$0481$i
+                                (get_local $1)
+                                (set_local $22
                                   (f64.const 8)
                                 )
                                 (loop $while-out$60 $while-in$61
-                                  (set_local $$mul80$i
+                                  (set_local $22
                                     (f64.mul
-                                      (get_local $$round$0481$i)
+                                      (get_local $22)
                                       (f64.const 16)
                                     )
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $$dec78$i
+                                      (set_local $1
                                         (i32.add
-                                          (get_local $$re$1482$i)
+                                          (get_local $1)
                                           (i32.const -1)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                     (block
-                                      (set_local $$mul80$i$lcssa
-                                        (get_local $$mul80$i)
-                                      )
+                                      (get_local $22)
                                       (br $while-out$60)
                                     )
                                     (block
-                                      (set_local $$re$1482$i
-                                        (get_local $$dec78$i)
-                                      )
-                                      (set_local $$round$0481$i
-                                        (get_local $$mul80$i)
-                                      )
+                                      (get_local $1)
+                                      (get_local $22)
                                     )
                                   )
                                   (br $while-in$61)
@@ -6067,7 +5511,7 @@
                                     (i32.shr_s
                                       (i32.shl
                                         (i32.load8_s
-                                          (get_local $$prefix$0$add$ptr65$i)
+                                          (get_local $10)
                                         )
                                         (i32.const 24)
                                       )
@@ -6077,48 +5521,48 @@
                                   )
                                   (f64.neg
                                     (f64.add
-                                      (get_local $$mul80$i$lcssa)
+                                      (get_local $22)
                                       (f64.sub
                                         (f64.neg
-                                          (get_local $$mul$i$240)
+                                          (get_local $14)
                                         )
-                                        (get_local $$mul80$i$lcssa)
+                                        (get_local $22)
                                       )
                                     )
                                   )
                                   (f64.sub
                                     (f64.add
-                                      (get_local $$mul$i$240)
-                                      (get_local $$mul80$i$lcssa)
+                                      (get_local $14)
+                                      (get_local $22)
                                     )
-                                    (get_local $$mul80$i$lcssa)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $$cmp94$i
+                          (set_local $5
                             (i32.lt_s
-                              (set_local $$198
+                              (set_local $1
                                 (i32.load
-                                  (get_local $$e2$i)
+                                  (get_local $25)
                                 )
                               )
                               (i32.const 0)
                             )
                           )
-                          (set_local $$200
+                          (set_local $5
                             (i32.shr_s
                               (i32.shl
                                 (i32.lt_s
-                                  (set_local $$cond100$i
+                                  (set_local $8
                                     (select
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $$198)
+                                        (get_local $1)
                                       )
-                                      (get_local $$198)
-                                      (get_local $$cmp94$i)
+                                      (get_local $1)
+                                      (get_local $5)
                                     )
                                   )
                                   (i32.const 0)
@@ -6130,26 +5574,26 @@
                           )
                           (i32.store8
                             (i32.add
-                              (set_local $$estr$0$i
+                              (set_local $5
                                 (if
                                   (i32.eq
-                                    (set_local $$201
+                                    (set_local $5
                                       (call $_fmt_u
-                                        (get_local $$cond100$i)
-                                        (get_local $$200)
-                                        (get_local $$arrayidx$i$236)
+                                        (get_local $8)
+                                        (get_local $5)
+                                        (get_local $55)
                                       )
                                     )
-                                    (get_local $$arrayidx$i$236)
+                                    (get_local $55)
                                   )
                                   (block
                                     (i32.store8
-                                      (get_local $$incdec$ptr106$i)
+                                      (get_local $72)
                                       (i32.const 48)
                                     )
-                                    (get_local $$incdec$ptr106$i)
+                                    (get_local $72)
                                   )
-                                  (get_local $$201)
+                                  (get_local $5)
                                 )
                               )
                               (i32.const -1)
@@ -6158,7 +5602,7 @@
                               (i32.add
                                 (i32.and
                                   (i32.shr_s
-                                    (get_local $$198)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -6169,52 +5613,50 @@
                             )
                           )
                           (i32.store8
-                            (set_local $$incdec$ptr115$i
+                            (set_local $8
                               (i32.add
-                                (get_local $$estr$0$i)
+                                (get_local $5)
                                 (i32.const -2)
                               )
                             )
                             (i32.and
                               (i32.add
-                                (get_local $$t$0)
+                                (get_local $33)
                                 (i32.const 15)
                               )
                               (i32.const 255)
                             )
                           )
-                          (set_local $$notrhs$i
+                          (set_local $5
                             (i32.lt_s
-                              (get_local $$p$0)
+                              (get_local $9)
                               (i32.const 1)
                             )
                           )
-                          (set_local $$tobool135$i
+                          (set_local $12
                             (i32.eq
                               (i32.and
-                                (get_local $$fl$1$and219)
+                                (get_local $17)
                                 (i32.const 8)
                               )
                               (i32.const 0)
                             )
                           )
-                          (set_local $$s$0$i
-                            (get_local $$buf$i)
+                          (set_local $11
+                            (get_local $29)
                           )
-                          (set_local $$y$addr$2$i
-                            (get_local $$y$addr$1$i)
-                          )
+                          (get_local $14)
                           (loop $while-out$62 $while-in$63
                             (i32.store8
-                              (get_local $$s$0$i)
+                              (get_local $11)
                               (i32.and
                                 (i32.or
                                   (i32.and
                                     (i32.load8_s
                                       (i32.add
-                                        (set_local $$conv116$i
+                                        (set_local $1
                                           (i32.trunc_s/f64
-                                            (get_local $$y$addr$2$i)
+                                            (get_local $14)
                                           )
                                         )
                                         (i32.const 4075)
@@ -6222,194 +5664,188 @@
                                     )
                                     (i32.const 255)
                                   )
-                                  (get_local $$and62$i)
+                                  (get_local $6)
                                 )
                                 (i32.const 255)
                               )
                             )
-                            (set_local $$mul125$i
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $$y$addr$2$i)
+                                  (get_local $14)
                                   (f64.convert_s/i32
-                                    (get_local $$conv116$i)
+                                    (get_local $1)
                                   )
                                 )
                                 (f64.const 16)
                               )
                             )
-                            (set_local $$s$1$i
+                            (set_local $1
                               (block $do-once$64
                                 (if
                                   (i32.eq
                                     (i32.sub
-                                      (set_local $$incdec$ptr122$i
+                                      (set_local $1
                                         (i32.add
-                                          (get_local $$s$0$i)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
-                                      (get_local $$sub$ptr$rhs$cast$i)
+                                      (get_local $67)
                                     )
                                     (i32.const 1)
                                   )
                                   (block
                                     (if
                                       (i32.and
-                                        (get_local $$tobool135$i)
+                                        (get_local $12)
                                         (i32.and
-                                          (get_local $$notrhs$i)
+                                          (get_local $5)
                                           (f64.eq
-                                            (get_local $$mul125$i)
+                                            (get_local $14)
                                             (f64.const 0)
                                           )
                                         )
                                       )
                                       (br $do-once$64
-                                        (get_local $$incdec$ptr122$i)
+                                        (get_local $1)
                                       )
                                     )
                                     (i32.store8
-                                      (get_local $$incdec$ptr122$i)
+                                      (get_local $1)
                                       (i32.const 46)
                                     )
                                     (i32.add
-                                      (get_local $$s$0$i)
+                                      (get_local $11)
                                       (i32.const 2)
                                     )
                                   )
-                                  (get_local $$incdec$ptr122$i)
+                                  (get_local $1)
                                 )
                               )
                             )
                             (if
                               (f64.ne
-                                (get_local $$mul125$i)
+                                (get_local $14)
                                 (f64.const 0)
                               )
                               (block
-                                (set_local $$s$0$i
-                                  (get_local $$s$1$i)
+                                (set_local $11
+                                  (get_local $1)
                                 )
-                                (set_local $$y$addr$2$i
-                                  (get_local $$mul125$i)
-                                )
+                                (get_local $14)
                               )
                               (block
-                                (set_local $$s$1$i$lcssa
-                                  (get_local $$s$1$i)
-                                )
+                                (get_local $1)
                                 (br $while-out$62)
                               )
                             )
                             (br $while-in$63)
                           )
-                          (set_local $$or$cond384
+                          (set_local $5
                             (i32.and
                               (i32.ne
-                                (get_local $$p$0)
+                                (get_local $9)
                                 (i32.const 0)
                               )
                               (i32.lt_s
                                 (i32.add
-                                  (get_local $$sub$ptr$sub145$i)
-                                  (set_local $$$pre566$i
-                                    (get_local $$s$1$i$lcssa)
-                                  )
+                                  (get_local $81)
+                                  (get_local $1)
                                 )
-                                (get_local $$p$0)
+                                (get_local $9)
                               )
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 32)
-                            (get_local $$w$1)
-                            (set_local $$add165$i
+                            (get_local $16)
+                            (set_local $5
                               (i32.add
-                                (set_local $$l$0$i
+                                (set_local $6
                                   (select
                                     (i32.sub
                                       (i32.add
-                                        (get_local $$sub$ptr$sub153$i)
-                                        (get_local $$p$0)
+                                        (get_local $82)
+                                        (get_local $9)
                                       )
-                                      (get_local $$incdec$ptr115$i)
+                                      (get_local $8)
                                     )
                                     (i32.add
                                       (i32.sub
-                                        (get_local $$sub$ptr$sub159$i)
-                                        (get_local $$incdec$ptr115$i)
+                                        (get_local $83)
+                                        (get_local $8)
                                       )
-                                      (get_local $$$pre566$i)
+                                      (get_local $1)
                                     )
-                                    (get_local $$or$cond384)
+                                    (get_local $5)
                                   )
                                 )
-                                (get_local $$add67$i)
+                                (get_local $7)
                               )
                             )
-                            (get_local $$fl$1$and219)
+                            (get_local $17)
                           )
                           (if
                             (i32.eq
                               (i32.and
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $$prefix$0$add$ptr65$i)
-                              (get_local $$add67$i)
-                              (get_local $$f)
+                              (get_local $10)
+                              (get_local $7)
+                              (get_local $0)
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 48)
-                            (get_local $$w$1)
-                            (get_local $$add165$i)
+                            (get_local $16)
+                            (get_local $5)
                             (i32.xor
-                              (get_local $$fl$1$and219)
+                              (get_local $17)
                               (i32.const 65536)
                             )
                           )
-                          (set_local $$sub$ptr$sub172$i
+                          (set_local $1
                             (i32.sub
-                              (get_local $$$pre566$i)
-                              (get_local $$sub$ptr$rhs$cast$i)
+                              (get_local $1)
+                              (get_local $67)
                             )
                           )
                           (if
                             (i32.eq
                               (i32.and
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $$buf$i)
-                              (get_local $$sub$ptr$sub172$i)
-                              (get_local $$f)
+                              (get_local $29)
+                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 48)
                             (i32.sub
-                              (get_local $$l$0$i)
+                              (get_local $6)
                               (i32.add
-                                (get_local $$sub$ptr$sub172$i)
-                                (set_local $$sub$ptr$sub175$i
+                                (get_local $1)
+                                (set_local $1
                                   (i32.sub
-                                    (get_local $$sub$ptr$lhs$cast160$i)
-                                    (get_local $$incdec$ptr115$i)
+                                    (get_local $44)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -6421,124 +5857,120 @@
                             (i32.eq
                               (i32.and
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                                 (i32.const 32)
                               )
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $$incdec$ptr115$i)
-                              (get_local $$sub$ptr$sub175$i)
-                              (get_local $$f)
+                              (get_local $8)
+                              (get_local $1)
+                              (get_local $0)
                             )
                           )
                           (call $_pad
-                            (get_local $$f)
+                            (get_local $0)
                             (i32.const 32)
-                            (get_local $$w$1)
-                            (get_local $$add165$i)
+                            (get_local $16)
+                            (get_local $5)
                             (i32.xor
-                              (get_local $$fl$1$and219)
+                              (get_local $17)
                               (i32.const 8192)
                             )
                           )
                           (br $do-once$56
                             (select
-                              (get_local $$w$1)
-                              (get_local $$add165$i)
+                              (get_local $16)
+                              (get_local $5)
                               (i32.lt_s
-                                (get_local $$add165$i)
-                                (get_local $$w$1)
+                                (get_local $5)
+                                (get_local $16)
                               )
                             )
                           )
                         )
                       )
-                      (set_local $$$p$i
+                      (set_local $1
                         (select
                           (i32.const 6)
-                          (get_local $$p$0)
+                          (get_local $9)
                           (i32.lt_s
-                            (get_local $$p$0)
+                            (get_local $9)
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $$210
+                      (set_local $5
                         (if
-                          (get_local $$tobool56$i)
+                          (get_local $5)
                           (block
                             (i32.store
-                              (get_local $$e2$i)
-                              (set_local $$sub203$i
+                              (get_local $25)
+                              (set_local $5
                                 (i32.add
                                   (i32.load
-                                    (get_local $$e2$i)
+                                    (get_local $25)
                                   )
                                   (i32.const -28)
                                 )
                               )
                             )
-                            (set_local $$y$addr$3$i
+                            (set_local $14
                               (f64.mul
-                                (get_local $$mul$i$240)
+                                (get_local $14)
                                 (f64.const 268435456)
                               )
                             )
-                            (get_local $$sub203$i)
+                            (get_local $5)
                           )
                           (block
-                            (set_local $$y$addr$3$i
-                              (get_local $$mul$i$240)
-                            )
+                            (get_local $14)
                             (i32.load
-                              (get_local $$e2$i)
+                              (get_local $25)
                             )
                           )
                         )
                       )
-                      (set_local $$sub$ptr$rhs$cast345$i
-                        (set_local $$arraydecay208$add$ptr213$i
+                      (set_local $30
+                        (set_local $10
                           (select
-                            (get_local $$big$i)
-                            (get_local $$add$ptr213$i)
+                            (get_local $78)
+                            (get_local $76)
                             (i32.lt_s
-                              (get_local $$210)
+                              (get_local $5)
                               (i32.const 0)
                             )
                           )
                         )
                       )
-                      (set_local $$y$addr$4$i
-                        (get_local $$y$addr$3$i)
-                      )
-                      (set_local $$z$0$i
-                        (get_local $$arraydecay208$add$ptr213$i)
+                      (get_local $14)
+                      (set_local $7
+                        (get_local $10)
                       )
                       (loop $while-out$66 $while-in$67
                         (i32.store
-                          (get_local $$z$0$i)
-                          (set_local $$conv216$i
+                          (get_local $7)
+                          (set_local $5
                             (i32.trunc_s/f64
-                              (get_local $$y$addr$4$i)
+                              (get_local $14)
                             )
                           )
                         )
-                        (set_local $$incdec$ptr217$i
+                        (set_local $7
                           (i32.add
-                            (get_local $$z$0$i)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (if
                           (f64.ne
-                            (set_local $$mul220$i
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $$y$addr$4$i)
+                                  (get_local $14)
                                   (f64.convert_u/i32
-                                    (get_local $$conv216$i)
+                                    (get_local $5)
                                   )
                                 )
                                 (f64.const 1e9)
@@ -6547,16 +5979,12 @@
                             (f64.const 0)
                           )
                           (block
-                            (set_local $$y$addr$4$i
-                              (get_local $$mul220$i)
-                            )
-                            (set_local $$z$0$i
-                              (get_local $$incdec$ptr217$i)
-                            )
+                            (get_local $14)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$incdec$ptr217$i$lcssa
-                              (get_local $$incdec$ptr217$i)
+                            (set_local $6
+                              (get_local $7)
                             )
                             (br $while-out$66)
                           )
@@ -6565,74 +5993,72 @@
                       )
                       (if
                         (i32.gt_s
-                          (set_local $$$pr$i
+                          (set_local $5
                             (i32.load
-                              (get_local $$e2$i)
+                              (get_local $25)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$211
-                            (get_local $$$pr$i)
+                          (get_local $5)
+                          (set_local $8
+                            (get_local $10)
                           )
-                          (set_local $$a$1549$i
-                            (get_local $$arraydecay208$add$ptr213$i)
-                          )
-                          (set_local $$z$1548$i
-                            (get_local $$incdec$ptr217$i$lcssa)
+                          (set_local $9
+                            (get_local $6)
                           )
                           (loop $while-out$68 $while-in$69
-                            (set_local $$cond233$i
+                            (set_local $11
                               (select
                                 (i32.const 29)
-                                (get_local $$211)
+                                (get_local $5)
                                 (i32.gt_s
-                                  (get_local $$211)
+                                  (get_local $5)
                                   (i32.const 29)
                                 )
                               )
                             )
-                            (set_local $$a$2$ph$i
+                            (set_local $7
                               (block $do-once$70
                                 (if
                                   (i32.lt_u
-                                    (set_local $$d$0$542$i
+                                    (set_local $7
                                       (i32.add
-                                        (get_local $$z$1548$i)
+                                        (get_local $9)
                                         (i32.const -4)
                                       )
                                     )
-                                    (get_local $$a$1549$i)
+                                    (get_local $8)
                                   )
-                                  (get_local $$a$1549$i)
+                                  (get_local $8)
                                   (block
-                                    (set_local $$carry$0544$i
+                                    (set_local $5
                                       (i32.const 0)
                                     )
-                                    (set_local $$d$0545$i
-                                      (get_local $$d$0$542$i)
+                                    (set_local $12
+                                      (get_local $7)
                                     )
                                     (loop $while-out$72 $while-in$73
-                                      (set_local $$217
+                                      (set_local $6
                                         (call $___uremdi3
-                                          (set_local $$215
+                                          (set_local $5
                                             (call $_i64Add
                                               (call $_bitshift64Shl
                                                 (i32.load
-                                                  (get_local $$d$0545$i)
+                                                  (get_local $12)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $$cond233$i)
+                                                (get_local $11)
                                               )
                                               (i32.load
                                                 (i32.const 168)
                                               )
-                                              (get_local $$carry$0544$i)
+                                              (get_local $5)
                                               (i32.const 0)
                                             )
                                           )
-                                          (set_local $$216
+                                          (set_local $7
                                             (i32.load
                                               (i32.const 168)
                                             )
@@ -6645,13 +6071,13 @@
                                         (i32.const 168)
                                       )
                                       (i32.store
-                                        (get_local $$d$0545$i)
-                                        (get_local $$217)
+                                        (get_local $12)
+                                        (get_local $6)
                                       )
-                                      (set_local $$219
+                                      (set_local $5
                                         (call $___udivdi3
-                                          (get_local $$215)
-                                          (get_local $$216)
+                                          (get_local $5)
+                                          (get_local $7)
                                           (i32.const 1000000000)
                                           (i32.const 0)
                                         )
@@ -6661,26 +6087,22 @@
                                       )
                                       (if
                                         (i32.lt_u
-                                          (set_local $$d$0$i
+                                          (set_local $7
                                             (i32.add
-                                              (get_local $$d$0545$i)
+                                              (get_local $12)
                                               (i32.const -4)
                                             )
                                           )
-                                          (get_local $$a$1549$i)
+                                          (get_local $8)
                                         )
                                         (block
-                                          (set_local $$conv242$i$lcssa
-                                            (get_local $$219)
-                                          )
+                                          (get_local $5)
                                           (br $while-out$72)
                                         )
                                         (block
-                                          (set_local $$carry$0544$i
-                                            (get_local $$219)
-                                          )
-                                          (set_local $$d$0545$i
-                                            (get_local $$d$0$i)
+                                          (get_local $5)
+                                          (set_local $12
+                                            (get_local $7)
                                           )
                                         )
                                       )
@@ -6688,104 +6110,92 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (get_local $$conv242$i$lcssa)
+                                        (get_local $5)
                                         (i32.const 0)
                                       )
                                       (br $do-once$70
-                                        (get_local $$a$1549$i)
+                                        (get_local $8)
                                       )
                                     )
                                     (i32.store
-                                      (set_local $$incdec$ptr246$i
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $$a$1549$i)
+                                          (get_local $8)
                                           (i32.const -4)
                                         )
                                       )
-                                      (get_local $$conv242$i$lcssa)
+                                      (get_local $5)
                                     )
-                                    (get_local $$incdec$ptr246$i)
+                                    (get_local $7)
                                   )
                                 )
                               )
                             )
-                            (set_local $$z$2$i
-                              (get_local $$z$1548$i)
+                            (set_local $6
+                              (get_local $9)
                             )
                             (loop $while-out$74 $while-in$75
                               (if
                                 (i32.le_u
-                                  (get_local $$z$2$i)
-                                  (get_local $$a$2$ph$i)
+                                  (get_local $6)
+                                  (get_local $7)
                                 )
                                 (block
-                                  (set_local $$z$2$i$lcssa
-                                    (get_local $$z$2$i)
-                                  )
+                                  (get_local $6)
                                   (br $while-out$74)
                                 )
                               )
                               (if
                                 (i32.eq
                                   (i32.load
-                                    (set_local $$arrayidx251$i
+                                    (set_local $5
                                       (i32.add
-                                        (get_local $$z$2$i)
+                                        (get_local $6)
                                         (i32.const -4)
                                       )
                                     )
                                   )
                                   (i32.const 0)
                                 )
-                                (set_local $$z$2$i
-                                  (get_local $$arrayidx251$i)
+                                (set_local $6
+                                  (get_local $5)
                                 )
                                 (block
-                                  (set_local $$z$2$i$lcssa
-                                    (get_local $$z$2$i)
-                                  )
+                                  (get_local $6)
                                   (br $while-out$74)
                                 )
                               )
                               (br $while-in$75)
                             )
                             (i32.store
-                              (get_local $$e2$i)
-                              (set_local $$sub256$i
+                              (get_local $25)
+                              (set_local $5
                                 (i32.sub
                                   (i32.load
-                                    (get_local $$e2$i)
+                                    (get_local $25)
                                   )
-                                  (get_local $$cond233$i)
+                                  (get_local $11)
                                 )
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $$sub256$i)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$211
-                                  (get_local $$sub256$i)
+                                (get_local $5)
+                                (set_local $8
+                                  (get_local $7)
                                 )
-                                (set_local $$a$1549$i
-                                  (get_local $$a$2$ph$i)
-                                )
-                                (set_local $$z$1548$i
-                                  (get_local $$z$2$i$lcssa)
+                                (set_local $9
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $$$pr477$i
-                                  (get_local $$sub256$i)
-                                )
-                                (set_local $$a$1$lcssa$i
-                                  (get_local $$a$2$ph$i)
-                                )
-                                (set_local $$z$1$lcssa$i
-                                  (get_local $$z$2$i$lcssa)
-                                )
+                                (get_local $5)
+                                (get_local $7)
+                                (get_local $6)
                                 (br $while-out$68)
                               )
                             )
@@ -6793,29 +6203,25 @@
                           )
                         )
                         (block
-                          (set_local $$$pr477$i
-                            (get_local $$$pr$i)
+                          (get_local $5)
+                          (set_local $7
+                            (get_local $10)
                           )
-                          (set_local $$a$1$lcssa$i
-                            (get_local $$arraydecay208$add$ptr213$i)
-                          )
-                          (set_local $$z$1$lcssa$i
-                            (get_local $$incdec$ptr217$i$lcssa)
-                          )
+                          (get_local $6)
                         )
                       )
                       (if
                         (i32.lt_s
-                          (get_local $$$pr477$i)
+                          (get_local $5)
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$add275$i
+                          (set_local $8
                             (i32.add
                               (i32.and
                                 (i32.div_s
                                   (i32.add
-                                    (get_local $$$p$i)
+                                    (get_local $1)
                                     (i32.const 25)
                                   )
                                   (i32.const 9)
@@ -6825,133 +6231,127 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $$cmp299$i
+                          (set_local $12
                             (i32.eq
-                              (get_local $$or$i$241)
+                              (get_local $15)
                               (i32.const 102)
                             )
                           )
-                          (set_local $$223
-                            (get_local $$$pr477$i)
-                          )
-                          (set_local $$a$3539$i
-                            (get_local $$a$1$lcssa$i)
-                          )
-                          (set_local $$z$3538$i
-                            (get_local $$z$1$lcssa$i)
+                          (get_local $5)
+                          (get_local $7)
+                          (set_local $24
+                            (get_local $6)
                           )
                           (loop $while-out$76 $while-in$77
-                            (set_local $$cmp265$i
+                            (set_local $5
                               (i32.gt_s
-                                (set_local $$sub264$i
+                                (set_local $6
                                   (i32.sub
                                     (i32.const 0)
-                                    (get_local $$223)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 9)
                               )
                             )
-                            (set_local $$cond271$i
+                            (set_local $9
                               (select
                                 (i32.const 9)
-                                (get_local $$sub264$i)
-                                (get_local $$cmp265$i)
+                                (get_local $6)
+                                (get_local $5)
                               )
                             )
-                            (set_local $$incdec$ptr292$a$3573$i
+                            (set_local $11
                               (block $do-once$78
                                 (if
                                   (i32.lt_u
-                                    (get_local $$a$3539$i)
-                                    (get_local $$z$3538$i)
+                                    (get_local $7)
+                                    (get_local $24)
                                   )
                                   (block
-                                    (set_local $$sub281$i
+                                    (set_local $68
                                       (i32.add
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $$cond271$i)
+                                          (get_local $9)
                                         )
                                         (i32.const -1)
                                       )
                                     )
-                                    (set_local $$shr285$i
+                                    (set_local $27
                                       (i32.shr_u
                                         (i32.const 1000000000)
-                                        (get_local $$cond271$i)
+                                        (get_local $9)
                                       )
                                     )
-                                    (set_local $$carry262$0535$i
+                                    (set_local $11
                                       (i32.const 0)
                                     )
-                                    (set_local $$d$1534$i
-                                      (get_local $$a$3539$i)
+                                    (set_local $21
+                                      (get_local $7)
                                     )
                                     (loop $while-out$80 $while-in$81
-                                      (set_local $$and282$i
+                                      (set_local $6
                                         (i32.and
-                                          (set_local $$225
+                                          (set_local $5
                                             (i32.load
-                                              (get_local $$d$1534$i)
+                                              (get_local $21)
                                             )
                                           )
-                                          (get_local $$sub281$i)
+                                          (get_local $68)
                                         )
                                       )
                                       (i32.store
-                                        (get_local $$d$1534$i)
+                                        (get_local $21)
                                         (i32.add
                                           (i32.shr_u
-                                            (get_local $$225)
-                                            (get_local $$cond271$i)
+                                            (get_local $5)
+                                            (get_local $9)
                                           )
-                                          (get_local $$carry262$0535$i)
+                                          (get_local $11)
                                         )
                                       )
-                                      (set_local $$mul286$i
+                                      (set_local $6
                                         (i32.mul
-                                          (get_local $$and282$i)
-                                          (get_local $$shr285$i)
+                                          (get_local $6)
+                                          (get_local $27)
                                         )
                                       )
                                       (if
                                         (i32.lt_u
-                                          (set_local $$incdec$ptr288$i
+                                          (set_local $5
                                             (i32.add
-                                              (get_local $$d$1534$i)
+                                              (get_local $21)
                                               (i32.const 4)
                                             )
                                           )
-                                          (get_local $$z$3538$i)
+                                          (get_local $24)
                                         )
                                         (block
-                                          (set_local $$carry262$0535$i
-                                            (get_local $$mul286$i)
+                                          (set_local $11
+                                            (get_local $6)
                                           )
-                                          (set_local $$d$1534$i
-                                            (get_local $$incdec$ptr288$i)
+                                          (set_local $21
+                                            (get_local $5)
                                           )
                                         )
                                         (block
-                                          (set_local $$mul286$i$lcssa
-                                            (get_local $$mul286$i)
-                                          )
+                                          (get_local $6)
                                           (br $while-out$80)
                                         )
                                       )
                                       (br $while-in$81)
                                     )
-                                    (set_local $$incdec$ptr292$a$3$i
+                                    (set_local $5
                                       (select
                                         (i32.add
-                                          (get_local $$a$3539$i)
+                                          (get_local $7)
                                           (i32.const 4)
                                         )
-                                        (get_local $$a$3539$i)
+                                        (get_local $7)
                                         (i32.eq
                                           (i32.load
-                                            (get_local $$a$3539$i)
+                                            (get_local $7)
                                           )
                                           (i32.const 0)
                                         )
@@ -6959,43 +6359,43 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (get_local $$mul286$i$lcssa)
+                                        (get_local $6)
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $$z$4$i
-                                          (get_local $$z$3538$i)
+                                        (set_local $6
+                                          (get_local $24)
                                         )
                                         (br $do-once$78
-                                          (get_local $$incdec$ptr292$a$3$i)
+                                          (get_local $5)
                                         )
                                       )
                                     )
                                     (i32.store
-                                      (get_local $$z$3538$i)
-                                      (get_local $$mul286$i$lcssa)
+                                      (get_local $24)
+                                      (get_local $6)
                                     )
-                                    (set_local $$z$4$i
+                                    (set_local $6
                                       (i32.add
-                                        (get_local $$z$3538$i)
+                                        (get_local $24)
                                         (i32.const 4)
                                       )
                                     )
-                                    (get_local $$incdec$ptr292$a$3$i)
+                                    (get_local $5)
                                   )
                                   (block
-                                    (set_local $$z$4$i
-                                      (get_local $$z$3538$i)
+                                    (set_local $6
+                                      (get_local $24)
                                     )
                                     (select
                                       (i32.add
-                                        (get_local $$a$3539$i)
+                                        (get_local $7)
                                         (i32.const 4)
                                       )
-                                      (get_local $$a$3539$i)
+                                      (get_local $7)
                                       (i32.eq
                                         (i32.load
-                                          (get_local $$a$3539$i)
+                                          (get_local $7)
                                         )
                                         (i32.const 0)
                                       )
@@ -7004,70 +6404,68 @@
                                 )
                               )
                             )
-                            (set_local $$cmp308$i
+                            (set_local $5
                               (i32.gt_s
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $$z$4$i)
-                                    (set_local $$cond304$i
+                                    (get_local $6)
+                                    (set_local $7
                                       (select
-                                        (get_local $$arraydecay208$add$ptr213$i)
-                                        (get_local $$incdec$ptr292$a$3573$i)
-                                        (get_local $$cmp299$i)
+                                        (get_local $10)
+                                        (get_local $11)
+                                        (get_local $12)
                                       )
                                     )
                                   )
                                   (i32.const 2)
                                 )
-                                (get_local $$add275$i)
+                                (get_local $8)
                               )
                             )
-                            (set_local $$add$ptr311$z$4$i
+                            (set_local $6
                               (select
                                 (i32.add
-                                  (get_local $$cond304$i)
+                                  (get_local $7)
                                   (i32.shl
-                                    (get_local $$add275$i)
+                                    (get_local $8)
                                     (i32.const 2)
                                   )
                                 )
-                                (get_local $$z$4$i)
-                                (get_local $$cmp308$i)
+                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                             (i32.store
-                              (get_local $$e2$i)
-                              (set_local $$add313$i
+                              (get_local $25)
+                              (set_local $5
                                 (i32.add
                                   (i32.load
-                                    (get_local $$e2$i)
+                                    (get_local $25)
                                   )
-                                  (get_local $$cond271$i)
+                                  (get_local $9)
                                 )
                               )
                             )
                             (if
                               (i32.lt_s
-                                (get_local $$add313$i)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$223
-                                  (get_local $$add313$i)
+                                (get_local $5)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $$a$3539$i
-                                  (get_local $$incdec$ptr292$a$3573$i)
-                                )
-                                (set_local $$z$3538$i
-                                  (get_local $$add$ptr311$z$4$i)
+                                (set_local $24
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $$a$3$lcssa$i
-                                  (get_local $$incdec$ptr292$a$3573$i)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $$z$3$lcssa$i
-                                  (get_local $$add$ptr311$z$4$i)
+                                (set_local $27
+                                  (get_local $6)
                                 )
                                 (br $while-out$76)
                               )
@@ -7076,27 +6474,25 @@
                           )
                         )
                         (block
-                          (set_local $$a$3$lcssa$i
-                            (get_local $$a$1$lcssa$i)
-                          )
-                          (set_local $$z$3$lcssa$i
-                            (get_local $$z$1$lcssa$i)
+                          (get_local $7)
+                          (set_local $27
+                            (get_local $6)
                           )
                         )
                       )
                       (block $do-once$82
                         (if
                           (i32.lt_u
-                            (get_local $$a$3$lcssa$i)
-                            (get_local $$z$3$lcssa$i)
+                            (get_local $7)
+                            (get_local $27)
                           )
                           (block
-                            (set_local $$mul322$i
+                            (set_local $6
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $$sub$ptr$rhs$cast345$i)
-                                    (get_local $$a$3$lcssa$i)
+                                    (get_local $30)
+                                    (get_local $7)
                                   )
                                   (i32.const 2)
                                 )
@@ -7105,80 +6501,74 @@
                             )
                             (if
                               (i32.lt_u
-                                (set_local $$228
+                                (set_local $5
                                   (i32.load
-                                    (get_local $$a$3$lcssa$i)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 10)
                               )
                               (block
-                                (set_local $$e$1$i
-                                  (get_local $$mul322$i)
+                                (set_local $9
+                                  (get_local $6)
                                 )
                                 (br $do-once$82)
                               )
                               (block
-                                (set_local $$e$0531$i
-                                  (get_local $$mul322$i)
-                                )
-                                (set_local $$i$0530$i
+                                (get_local $6)
+                                (set_local $8
                                   (i32.const 10)
                                 )
                               )
                             )
                             (loop $while-out$84 $while-in$85
-                              (set_local $$inc$i
+                              (set_local $6
                                 (i32.add
-                                  (get_local $$e$0531$i)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$228)
-                                  (set_local $$mul328$i
+                                  (get_local $5)
+                                  (set_local $8
                                     (i32.mul
-                                      (get_local $$i$0530$i)
+                                      (get_local $8)
                                       (i32.const 10)
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $$e$1$i
-                                    (get_local $$inc$i)
+                                  (set_local $9
+                                    (get_local $6)
                                   )
                                   (br $while-out$84)
                                 )
                                 (block
-                                  (set_local $$e$0531$i
-                                    (get_local $$inc$i)
-                                  )
-                                  (set_local $$i$0530$i
-                                    (get_local $$mul328$i)
-                                  )
+                                  (get_local $6)
+                                  (get_local $8)
                                 )
                               )
                               (br $while-in$85)
                             )
                           )
-                          (set_local $$e$1$i
+                          (set_local $9
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $$a$9$ph$i
+                      (set_local $7
                         (if
                           (i32.lt_s
-                            (set_local $$sub343$i
+                            (set_local $5
                               (i32.add
                                 (i32.sub
-                                  (get_local $$$p$i)
+                                  (get_local $1)
                                   (select
-                                    (get_local $$e$1$i)
+                                    (get_local $9)
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $$or$i$241)
+                                      (get_local $15)
                                       (i32.const 102)
                                     )
                                   )
@@ -7186,15 +6576,15 @@
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.and
-                                      (set_local $$tobool341$i
+                                      (set_local $68
                                         (i32.ne
-                                          (get_local $$$p$i)
+                                          (get_local $1)
                                           (i32.const 0)
                                         )
                                       )
-                                      (set_local $$cmp338$i
+                                      (set_local $8
                                         (i32.eq
-                                          (get_local $$or$i$241)
+                                          (get_local $15)
                                           (i32.const 103)
                                         )
                                       )
@@ -7209,8 +6599,8 @@
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $$z$3$lcssa$i)
-                                    (get_local $$sub$ptr$rhs$cast345$i)
+                                    (get_local $27)
+                                    (get_local $30)
                                   )
                                   (i32.const 2)
                                 )
@@ -7220,19 +6610,19 @@
                             )
                           )
                           (block
-                            (set_local $$add$ptr358$i
+                            (set_local $6
                               (i32.add
                                 (i32.add
-                                  (get_local $$arraydecay208$add$ptr213$i)
+                                  (get_local $10)
                                   (i32.const 4)
                                 )
                                 (i32.shl
                                   (i32.add
                                     (i32.and
                                       (i32.div_s
-                                        (set_local $$add355$i
+                                        (set_local $5
                                           (i32.add
-                                            (get_local $$sub343$i)
+                                            (get_local $5)
                                             (i32.const 9216)
                                           )
                                         )
@@ -7248,11 +6638,11 @@
                             )
                             (if
                               (i32.lt_s
-                                (set_local $$j$0$524$i
+                                (set_local $11
                                   (i32.add
                                     (i32.and
                                       (i32.rem_s
-                                        (get_local $$add355$i)
+                                        (get_local $5)
                                         (i32.const 9)
                                       )
                                       (i32.const -1)
@@ -7263,73 +6653,67 @@
                                 (i32.const 9)
                               )
                               (block
-                                (set_local $$i$1526$i
+                                (set_local $5
                                   (i32.const 10)
                                 )
-                                (set_local $$j$0527$i
-                                  (get_local $$j$0$524$i)
-                                )
+                                (get_local $11)
                                 (loop $while-out$86 $while-in$87
-                                  (set_local $$mul367$i
+                                  (set_local $5
                                     (i32.mul
-                                      (get_local $$i$1526$i)
+                                      (get_local $5)
                                       (i32.const 10)
                                     )
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $$j$0$i
+                                      (set_local $11
                                         (i32.add
-                                          (get_local $$j$0527$i)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
                                       (i32.const 9)
                                     )
                                     (block
-                                      (set_local $$i$1$lcssa$i
-                                        (get_local $$mul367$i)
+                                      (set_local $21
+                                        (get_local $5)
                                       )
                                       (br $while-out$86)
                                     )
                                     (block
-                                      (set_local $$i$1526$i
-                                        (get_local $$mul367$i)
-                                      )
-                                      (set_local $$j$0527$i
-                                        (get_local $$j$0$i)
-                                      )
+                                      (get_local $5)
+                                      (get_local $11)
                                     )
                                   )
                                   (br $while-in$87)
                                 )
                               )
-                              (set_local $$i$1$lcssa$i
+                              (set_local $21
                                 (i32.const 10)
                               )
                             )
                             (block $do-once$88
                               (if
                                 (i32.and
-                                  (set_local $$cmp374$i
+                                  (set_local $11
                                     (i32.eq
                                       (i32.add
-                                        (get_local $$add$ptr358$i)
+                                        (get_local $6)
                                         (i32.const 4)
                                       )
-                                      (get_local $$z$3$lcssa$i)
+                                      (get_local $27)
                                     )
                                   )
                                   (i32.eq
-                                    (set_local $$rem370$i
+                                    (set_local $15
                                       (i32.and
                                         (i32.rem_u
-                                          (set_local $$231
+                                          (set_local $5
                                             (i32.load
-                                              (get_local $$add$ptr358$i)
+                                              (get_local $6)
                                             )
                                           )
-                                          (get_local $$i$1$lcssa$i)
+                                          (get_local $21)
                                         )
                                         (i32.const -1)
                                       )
@@ -7338,18 +6722,18 @@
                                   )
                                 )
                                 (block
-                                  (set_local $$a$8$i
-                                    (get_local $$a$3$lcssa$i)
+                                  (set_local $5
+                                    (get_local $7)
                                   )
-                                  (set_local $$d$4$i
-                                    (get_local $$add$ptr358$i)
+                                  (set_local $7
+                                    (get_local $6)
                                   )
-                                  (set_local $$e$4$i
-                                    (get_local $$e$1$i)
+                                  (set_local $11
+                                    (get_local $9)
                                   )
                                 )
                                 (block
-                                  (set_local $$$396$i
+                                  (set_local $14
                                     (select
                                       (f64.const 9007199254740992)
                                       (f64.const 9007199254740994)
@@ -7357,8 +6741,8 @@
                                         (i32.and
                                           (i32.and
                                             (i32.div_u
-                                              (get_local $$231)
-                                              (get_local $$i$1$lcssa$i)
+                                              (get_local $5)
+                                              (get_local $21)
                                             )
                                             (i32.const -1)
                                           )
@@ -7368,14 +6752,14 @@
                                       )
                                     )
                                   )
-                                  (set_local $$small$0$i
+                                  (set_local $22
                                     (if
                                       (i32.lt_u
-                                        (get_local $$rem370$i)
-                                        (set_local $$div384$i
+                                        (get_local $15)
+                                        (set_local $12
                                           (i32.and
                                             (i32.div_s
-                                              (get_local $$i$1$lcssa$i)
+                                              (get_local $21)
                                               (i32.const 2)
                                             )
                                             (i32.const -1)
@@ -7387,27 +6771,25 @@
                                         (f64.const 1)
                                         (f64.const 1.5)
                                         (i32.and
-                                          (get_local $$cmp374$i)
+                                          (get_local $11)
                                           (i32.eq
-                                            (get_local $$rem370$i)
-                                            (get_local $$div384$i)
+                                            (get_local $15)
+                                            (get_local $12)
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $$round377$1$i
+                                  (set_local $14
                                     (block $do-once$90
                                       (if
                                         (i32.eq
-                                          (get_local $$pl$0$i)
+                                          (get_local $50)
                                           (i32.const 0)
                                         )
                                         (block
-                                          (set_local $$small$1$i
-                                            (get_local $$small$0$i)
-                                          )
-                                          (get_local $$$396$i)
+                                          (get_local $22)
+                                          (get_local $14)
                                         )
                                         (block
                                           (if
@@ -7415,7 +6797,7 @@
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.load8_s
-                                                    (get_local $$prefix$0$i)
+                                                    (get_local $39)
                                                   )
                                                   (i32.const 24)
                                                 )
@@ -7424,114 +6806,112 @@
                                               (i32.const 45)
                                             )
                                             (block
-                                              (set_local $$small$1$i
-                                                (get_local $$small$0$i)
-                                              )
+                                              (get_local $22)
                                               (br $do-once$90
-                                                (get_local $$$396$i)
+                                                (get_local $14)
                                               )
                                             )
                                           )
-                                          (set_local $$small$1$i
+                                          (set_local $22
                                             (f64.neg
-                                              (get_local $$small$0$i)
+                                              (get_local $22)
                                             )
                                           )
                                           (f64.neg
-                                            (get_local $$$396$i)
+                                            (get_local $14)
                                           )
                                         )
                                       )
                                     )
                                   )
                                   (i32.store
-                                    (get_local $$add$ptr358$i)
-                                    (set_local $$sub409$i
+                                    (get_local $6)
+                                    (set_local $5
                                       (i32.sub
-                                        (get_local $$231)
-                                        (get_local $$rem370$i)
+                                        (get_local $5)
+                                        (get_local $15)
                                       )
                                     )
                                   )
                                   (if
                                     (f64.eq
                                       (f64.add
-                                        (get_local $$round377$1$i)
-                                        (get_local $$small$1$i)
+                                        (get_local $14)
+                                        (get_local $22)
                                       )
-                                      (get_local $$round377$1$i)
+                                      (get_local $14)
                                     )
                                     (block
-                                      (set_local $$a$8$i
-                                        (get_local $$a$3$lcssa$i)
+                                      (set_local $5
+                                        (get_local $7)
                                       )
-                                      (set_local $$d$4$i
-                                        (get_local $$add$ptr358$i)
+                                      (set_local $7
+                                        (get_local $6)
                                       )
-                                      (set_local $$e$4$i
-                                        (get_local $$e$1$i)
+                                      (set_local $11
+                                        (get_local $9)
                                       )
                                       (br $do-once$88)
                                     )
                                   )
                                   (i32.store
-                                    (get_local $$add$ptr358$i)
-                                    (set_local $$add414$i
+                                    (get_local $6)
+                                    (set_local $5
                                       (i32.add
-                                        (get_local $$sub409$i)
-                                        (get_local $$i$1$lcssa$i)
+                                        (get_local $5)
+                                        (get_local $21)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.gt_u
-                                      (get_local $$add414$i)
+                                      (get_local $5)
                                       (i32.const 999999999)
                                     )
                                     (block
-                                      (set_local $$a$5521$i
-                                        (get_local $$a$3$lcssa$i)
+                                      (set_local $5
+                                        (get_local $7)
                                       )
-                                      (set_local $$d$2520$i
-                                        (get_local $$add$ptr358$i)
+                                      (set_local $7
+                                        (get_local $6)
                                       )
                                       (loop $while-out$92 $while-in$93
                                         (i32.store
-                                          (get_local $$d$2520$i)
+                                          (get_local $7)
                                           (i32.const 0)
                                         )
-                                        (set_local $$a$6$i
+                                        (set_local $5
                                           (if
                                             (i32.lt_u
-                                              (set_local $$incdec$ptr419$i
+                                              (set_local $6
                                                 (i32.add
-                                                  (get_local $$d$2520$i)
+                                                  (get_local $7)
                                                   (i32.const -4)
                                                 )
                                               )
-                                              (get_local $$a$5521$i)
+                                              (get_local $5)
                                             )
                                             (block
                                               (i32.store
-                                                (set_local $$incdec$ptr423$i
+                                                (set_local $5
                                                   (i32.add
-                                                    (get_local $$a$5521$i)
+                                                    (get_local $5)
                                                     (i32.const -4)
                                                   )
                                                 )
                                                 (i32.const 0)
                                               )
-                                              (get_local $$incdec$ptr423$i)
+                                              (get_local $5)
                                             )
-                                            (get_local $$a$5521$i)
+                                            (get_local $5)
                                           )
                                         )
                                         (i32.store
-                                          (get_local $$incdec$ptr419$i)
-                                          (set_local $$inc425$i
+                                          (get_local $6)
+                                          (set_local $7
                                             (i32.add
                                               (i32.load
-                                                (get_local $$incdec$ptr419$i)
+                                                (get_local $6)
                                               )
                                               (i32.const 1)
                                             )
@@ -7539,24 +6919,20 @@
                                         )
                                         (if
                                           (i32.gt_u
-                                            (get_local $$inc425$i)
+                                            (get_local $7)
                                             (i32.const 999999999)
                                           )
                                           (block
-                                            (set_local $$a$5521$i
-                                              (get_local $$a$6$i)
-                                            )
-                                            (set_local $$d$2520$i
-                                              (get_local $$incdec$ptr419$i)
+                                            (get_local $5)
+                                            (set_local $7
+                                              (get_local $6)
                                             )
                                           )
                                           (block
-                                            (set_local $$a$5$lcssa$i
-                                              (get_local $$a$6$i)
+                                            (set_local $7
+                                              (get_local $5)
                                             )
-                                            (set_local $$d$2$lcssa$i
-                                              (get_local $$incdec$ptr419$i)
-                                            )
+                                            (get_local $6)
                                             (br $while-out$92)
                                           )
                                         )
@@ -7564,20 +6940,16 @@
                                       )
                                     )
                                     (block
-                                      (set_local $$a$5$lcssa$i
-                                        (get_local $$a$3$lcssa$i)
-                                      )
-                                      (set_local $$d$2$lcssa$i
-                                        (get_local $$add$ptr358$i)
-                                      )
+                                      (get_local $7)
+                                      (get_local $6)
                                     )
                                   )
-                                  (set_local $$mul431$i
+                                  (set_local $11
                                     (i32.mul
                                       (i32.shr_s
                                         (i32.sub
-                                          (get_local $$sub$ptr$rhs$cast345$i)
-                                          (get_local $$a$5$lcssa$i)
+                                          (get_local $30)
+                                          (get_local $7)
                                         )
                                         (i32.const 2)
                                       )
@@ -7586,70 +6958,60 @@
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $$234
+                                      (set_local $5
                                         (i32.load
-                                          (get_local $$a$5$lcssa$i)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 10)
                                     )
                                     (block
-                                      (set_local $$a$8$i
-                                        (get_local $$a$5$lcssa$i)
+                                      (set_local $5
+                                        (get_local $7)
                                       )
-                                      (set_local $$d$4$i
-                                        (get_local $$d$2$lcssa$i)
+                                      (set_local $7
+                                        (get_local $6)
                                       )
-                                      (set_local $$e$4$i
-                                        (get_local $$mul431$i)
-                                      )
+                                      (get_local $11)
                                       (br $do-once$88)
                                     )
                                     (block
-                                      (set_local $$e$2517$i
-                                        (get_local $$mul431$i)
-                                      )
-                                      (set_local $$i$2516$i
+                                      (get_local $11)
+                                      (set_local $12
                                         (i32.const 10)
                                       )
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
-                                    (set_local $$inc438$i
+                                    (set_local $11
                                       (i32.add
-                                        (get_local $$e$2517$i)
+                                        (get_local $11)
                                         (i32.const 1)
                                       )
                                     )
                                     (if
                                       (i32.lt_u
-                                        (get_local $$234)
-                                        (set_local $$mul437$i
+                                        (get_local $5)
+                                        (set_local $12
                                           (i32.mul
-                                            (get_local $$i$2516$i)
+                                            (get_local $12)
                                             (i32.const 10)
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $$a$8$i
-                                          (get_local $$a$5$lcssa$i)
+                                        (set_local $5
+                                          (get_local $7)
                                         )
-                                        (set_local $$d$4$i
-                                          (get_local $$d$2$lcssa$i)
+                                        (set_local $7
+                                          (get_local $6)
                                         )
-                                        (set_local $$e$4$i
-                                          (get_local $$inc438$i)
-                                        )
+                                        (get_local $11)
                                         (br $while-out$94)
                                       )
                                       (block
-                                        (set_local $$e$2517$i
-                                          (get_local $$inc438$i)
-                                        )
-                                        (set_local $$i$2516$i
-                                          (get_local $$mul437$i)
-                                        )
+                                        (get_local $11)
+                                        (get_local $12)
                                       )
                                     )
                                     (br $while-in$95)
@@ -7657,61 +7019,57 @@
                                 )
                               )
                             )
-                            (set_local $$cmp443$i
+                            (set_local $6
                               (i32.gt_u
-                                (get_local $$z$3$lcssa$i)
-                                (set_local $$add$ptr442$i
+                                (get_local $27)
+                                (set_local $7
                                   (i32.add
-                                    (get_local $$d$4$i)
+                                    (get_local $7)
                                     (i32.const 4)
                                   )
                                 )
                               )
                             )
-                            (set_local $$e$5$ph$i
-                              (get_local $$e$4$i)
+                            (set_local $9
+                              (get_local $11)
                             )
-                            (set_local $$z$7$ph$i
+                            (set_local $6
                               (select
-                                (get_local $$add$ptr442$i)
-                                (get_local $$z$3$lcssa$i)
-                                (get_local $$cmp443$i)
+                                (get_local $7)
+                                (get_local $27)
+                                (get_local $6)
                               )
                             )
-                            (get_local $$a$8$i)
+                            (get_local $5)
                           )
                           (block
-                            (set_local $$e$5$ph$i
-                              (get_local $$e$1$i)
+                            (get_local $9)
+                            (set_local $6
+                              (get_local $27)
                             )
-                            (set_local $$z$7$ph$i
-                              (get_local $$z$3$lcssa$i)
-                            )
-                            (get_local $$a$3$lcssa$i)
+                            (get_local $7)
                           )
                         )
                       )
-                      (set_local $$sub626$le$i
+                      (set_local $27
                         (i32.sub
                           (i32.const 0)
-                          (get_local $$e$5$ph$i)
+                          (get_local $9)
                         )
                       )
-                      (set_local $$z$7$i
-                        (get_local $$z$7$ph$i)
-                      )
+                      (get_local $6)
                       (loop $while-out$96 $while-in$97
                         (if
                           (i32.le_u
-                            (get_local $$z$7$i)
-                            (get_local $$a$9$ph$i)
+                            (get_local $6)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$cmp450$lcssa$i
+                            (set_local $11
                               (i32.const 0)
                             )
-                            (set_local $$z$7$i$lcssa
-                              (get_local $$z$7$i)
+                            (set_local $24
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
@@ -7719,82 +7077,82 @@
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $$arrayidx453$i
+                              (set_local $5
                                 (i32.add
-                                  (get_local $$z$7$i)
+                                  (get_local $6)
                                   (i32.const -4)
                                 )
                               )
                             )
                             (i32.const 0)
                           )
-                          (set_local $$z$7$i
-                            (get_local $$arrayidx453$i)
+                          (set_local $6
+                            (get_local $5)
                           )
                           (block
-                            (set_local $$cmp450$lcssa$i
+                            (set_local $11
                               (i32.const 1)
                             )
-                            (set_local $$z$7$i$lcssa
-                              (get_local $$z$7$i)
+                            (set_local $24
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
                         )
                         (br $while-in$97)
                       )
-                      (set_local $$and610$pre$phi$iZ2D
+                      (set_local $8
                         (block $do-once$98
                           (if
-                            (get_local $$cmp338$i)
+                            (get_local $8)
                             (block
-                              (set_local $$p$addr$2$i
+                              (set_local $8
                                 (if
                                   (i32.and
                                     (i32.gt_s
-                                      (set_local $$$p$inc468$i
+                                      (set_local $1
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $$tobool341$i)
+                                              (get_local $68)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $$$p$i)
+                                          (get_local $1)
                                         )
                                       )
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                     )
                                     (i32.gt_s
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                       (i32.const -5)
                                     )
                                   )
                                   (block
-                                    (set_local $$t$addr$0$i
+                                    (set_local $12
                                       (i32.add
-                                        (get_local $$t$0)
+                                        (get_local $33)
                                         (i32.const -1)
                                       )
                                     )
                                     (i32.sub
                                       (i32.add
-                                        (get_local $$$p$inc468$i)
+                                        (get_local $1)
                                         (i32.const -1)
                                       )
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                     )
                                   )
                                   (block
-                                    (set_local $$t$addr$0$i
+                                    (set_local $12
                                       (i32.add
-                                        (get_local $$t$0)
+                                        (get_local $33)
                                         (i32.const -2)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $$$p$inc468$i)
+                                      (get_local $1)
                                       (i32.const -1)
                                     )
                                   )
@@ -7802,36 +7160,36 @@
                               )
                               (if
                                 (i32.ne
-                                  (set_local $$and483$i
+                                  (set_local $1
                                     (i32.and
-                                      (get_local $$fl$1$and219)
+                                      (get_local $17)
                                       (i32.const 8)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$p$addr$3$i
-                                    (get_local $$p$addr$2$i)
+                                  (set_local $15
+                                    (get_local $8)
                                   )
-                                  (set_local $$t$addr$1$i
-                                    (get_local $$t$addr$0$i)
+                                  (set_local $30
+                                    (get_local $12)
                                   )
                                   (br $do-once$98
-                                    (get_local $$and483$i)
+                                    (get_local $1)
                                   )
                                 )
                               )
                               (block $do-once$100
                                 (if
-                                  (get_local $$cmp450$lcssa$i)
+                                  (get_local $11)
                                   (block
                                     (if
                                       (i32.eq
-                                        (set_local $$237
+                                        (set_local $1
                                           (i32.load
                                             (i32.add
-                                              (get_local $$z$7$i$lcssa)
+                                              (get_local $24)
                                               (i32.const -4)
                                             )
                                           )
@@ -7839,7 +7197,7 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $$j$2$i
+                                        (set_local $1
                                           (i32.const 9)
                                         )
                                         (br $do-once$100)
@@ -7849,7 +7207,7 @@
                                       (i32.eq
                                         (i32.and
                                           (i32.rem_u
-                                            (get_local $$237)
+                                            (get_local $1)
                                             (i32.const 10)
                                           )
                                           (i32.const -1)
@@ -7857,24 +7215,24 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $$i$3512$i
+                                        (set_local $5
                                           (i32.const 10)
                                         )
-                                        (set_local $$j$1513$i
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                       )
                                       (block
-                                        (set_local $$j$2$i
+                                        (set_local $1
                                           (i32.const 0)
                                         )
                                         (br $do-once$100)
                                       )
                                     )
                                     (loop $while-out$102 $while-in$103
-                                      (set_local $$inc500$i
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $$j$1513$i)
+                                          (get_local $6)
                                           (i32.const 1)
                                         )
                                       )
@@ -7882,10 +7240,10 @@
                                         (i32.eq
                                           (i32.and
                                             (i32.rem_u
-                                              (get_local $$237)
-                                              (set_local $$mul499$i
+                                              (get_local $1)
+                                              (set_local $5
                                                 (i32.mul
-                                                  (get_local $$i$3512$i)
+                                                  (get_local $5)
                                                   (i32.const 10)
                                                 )
                                               )
@@ -7895,16 +7253,12 @@
                                           (i32.const 0)
                                         )
                                         (block
-                                          (set_local $$i$3512$i
-                                            (get_local $$mul499$i)
-                                          )
-                                          (set_local $$j$1513$i
-                                            (get_local $$inc500$i)
-                                          )
+                                          (get_local $5)
+                                          (get_local $6)
                                         )
                                         (block
-                                          (set_local $$j$2$i
-                                            (get_local $$inc500$i)
+                                          (set_local $1
+                                            (get_local $6)
                                           )
                                           (br $while-out$102)
                                         )
@@ -7912,18 +7266,18 @@
                                       (br $while-in$103)
                                     )
                                   )
-                                  (set_local $$j$2$i
+                                  (set_local $1
                                     (i32.const 9)
                                   )
                                 )
                               )
-                              (set_local $$mul513$i
+                              (set_local $5
                                 (i32.add
                                   (i32.mul
                                     (i32.shr_s
                                       (i32.sub
-                                        (get_local $$z$7$i$lcssa)
-                                        (get_local $$sub$ptr$rhs$cast345$i)
+                                        (get_local $24)
+                                        (get_local $30)
                                       )
                                       (i32.const 2)
                                     )
@@ -7935,110 +7289,110 @@
                               (if
                                 (i32.eq
                                   (i32.or
-                                    (get_local $$t$addr$0$i)
+                                    (get_local $12)
                                     (i32.const 32)
                                   )
                                   (i32.const 102)
                                 )
                                 (block
-                                  (set_local $$cmp515$i
+                                  (set_local $1
                                     (i32.lt_s
-                                      (set_local $$sub514$i
+                                      (set_local $5
                                         (i32.sub
-                                          (get_local $$mul513$i)
-                                          (get_local $$j$2$i)
+                                          (get_local $5)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $$cmp528$i
+                                  (set_local $5
                                     (i32.lt_s
-                                      (get_local $$p$addr$2$i)
-                                      (set_local $$$sub514$i
+                                      (get_local $8)
+                                      (set_local $1
                                         (select
                                           (i32.const 0)
-                                          (get_local $$sub514$i)
-                                          (get_local $$cmp515$i)
+                                          (get_local $5)
+                                          (get_local $1)
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $$p$addr$3$i
+                                  (set_local $15
                                     (select
-                                      (get_local $$p$addr$2$i)
-                                      (get_local $$$sub514$i)
-                                      (get_local $$cmp528$i)
+                                      (get_local $8)
+                                      (get_local $1)
+                                      (get_local $5)
                                     )
                                   )
-                                  (set_local $$t$addr$1$i
-                                    (get_local $$t$addr$0$i)
+                                  (set_local $30
+                                    (get_local $12)
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$cmp563$i
+                                  (set_local $1
                                     (i32.lt_s
-                                      (set_local $$sub562$i
+                                      (set_local $5
                                         (i32.sub
                                           (i32.add
-                                            (get_local $$mul513$i)
-                                            (get_local $$e$5$ph$i)
+                                            (get_local $5)
+                                            (get_local $9)
                                           )
-                                          (get_local $$j$2$i)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $$cmp577$i
+                                  (set_local $5
                                     (i32.lt_s
-                                      (get_local $$p$addr$2$i)
-                                      (set_local $$$sub562$i
+                                      (get_local $8)
+                                      (set_local $1
                                         (select
                                           (i32.const 0)
-                                          (get_local $$sub562$i)
-                                          (get_local $$cmp563$i)
+                                          (get_local $5)
+                                          (get_local $1)
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $$p$addr$3$i
+                                  (set_local $15
                                     (select
-                                      (get_local $$p$addr$2$i)
-                                      (get_local $$$sub562$i)
-                                      (get_local $$cmp577$i)
+                                      (get_local $8)
+                                      (get_local $1)
+                                      (get_local $5)
                                     )
                                   )
-                                  (set_local $$t$addr$1$i
-                                    (get_local $$t$addr$0$i)
+                                  (set_local $30
+                                    (get_local $12)
                                   )
                                   (i32.const 0)
                                 )
                               )
                             )
                             (block
-                              (set_local $$p$addr$3$i
-                                (get_local $$$p$i)
+                              (set_local $15
+                                (get_local $1)
                               )
-                              (set_local $$t$addr$1$i
-                                (get_local $$t$0)
+                              (set_local $30
+                                (get_local $33)
                               )
                               (i32.and
-                                (get_local $$fl$1$and219)
+                                (get_local $17)
                                 (i32.const 8)
                               )
                             )
                           )
                         )
                       )
-                      (set_local $$lor$ext$i
+                      (set_local $21
                         (i32.and
                           (i32.ne
-                            (set_local $$239
+                            (set_local $1
                               (i32.or
-                                (get_local $$p$addr$3$i)
-                                (get_local $$and610$pre$phi$iZ2D)
+                                (get_local $15)
+                                (get_local $8)
                               )
                             )
                             (i32.const 0)
@@ -8046,24 +7400,24 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $$estr$2$i
+                      (set_local $9
                         (if
-                          (set_local $$cmp614$i
+                          (set_local $12
                             (i32.eq
                               (i32.or
-                                (get_local $$t$addr$1$i)
+                                (get_local $30)
                                 (i32.const 32)
                               )
                               (i32.const 102)
                             )
                           )
                           (block
-                            (set_local $$sub$ptr$sub650$pn$i
+                            (set_local $6
                               (select
-                                (get_local $$e$5$ph$i)
+                                (get_local $9)
                                 (i32.const 0)
                                 (i32.gt_s
-                                  (get_local $$e$5$ph$i)
+                                  (get_local $9)
                                   (i32.const 0)
                                 )
                               )
@@ -8071,16 +7425,16 @@
                             (i32.const 0)
                           )
                           (block
-                            (set_local $$242
+                            (set_local $5
                               (i32.shr_s
                                 (i32.shl
                                   (i32.lt_s
-                                    (set_local $$cond629$i
+                                    (set_local $6
                                       (select
-                                        (get_local $$sub626$le$i)
-                                        (get_local $$e$5$ph$i)
+                                        (get_local $27)
+                                        (get_local $9)
                                         (i32.lt_s
-                                          (get_local $$e$5$ph$i)
+                                          (get_local $9)
                                           (i32.const 0)
                                         )
                                       )
@@ -8095,26 +7449,24 @@
                             (if
                               (i32.lt_s
                                 (i32.sub
-                                  (get_local $$sub$ptr$lhs$cast160$i)
-                                  (set_local $$243
+                                  (get_local $44)
+                                  (set_local $5
                                     (call $_fmt_u
-                                      (get_local $$cond629$i)
-                                      (get_local $$242)
-                                      (get_local $$arrayidx$i$236)
+                                      (get_local $6)
+                                      (get_local $5)
+                                      (get_local $55)
                                     )
                                   )
                                 )
                                 (i32.const 2)
                               )
                               (block
-                                (set_local $$estr$1507$i
-                                  (get_local $$243)
-                                )
+                                (get_local $5)
                                 (loop $while-out$104 $while-in$105
                                   (i32.store8
-                                    (set_local $$incdec$ptr639$i
+                                    (set_local $5
                                       (i32.add
-                                        (get_local $$estr$1507$i)
+                                        (get_local $5)
                                         (i32.const -1)
                                       )
                                     )
@@ -8123,38 +7475,32 @@
                                   (if
                                     (i32.lt_s
                                       (i32.sub
-                                        (get_local $$sub$ptr$lhs$cast160$i)
-                                        (get_local $$incdec$ptr639$i)
+                                        (get_local $44)
+                                        (get_local $5)
                                       )
                                       (i32.const 2)
                                     )
-                                    (set_local $$estr$1507$i
-                                      (get_local $$incdec$ptr639$i)
-                                    )
+                                    (get_local $5)
                                     (block
-                                      (set_local $$estr$1$lcssa$i
-                                        (get_local $$incdec$ptr639$i)
-                                      )
+                                      (get_local $5)
                                       (br $while-out$104)
                                     )
                                   )
                                   (br $while-in$105)
                                 )
                               )
-                              (set_local $$estr$1$lcssa$i
-                                (get_local $$243)
-                              )
+                              (get_local $5)
                             )
                             (i32.store8
                               (i32.add
-                                (get_local $$estr$1$lcssa$i)
+                                (get_local $5)
                                 (i32.const -1)
                               )
                               (i32.and
                                 (i32.add
                                   (i32.and
                                     (i32.shr_s
-                                      (get_local $$e$5$ph$i)
+                                      (get_local $9)
                                       (i32.const 31)
                                     )
                                     (i32.const 2)
@@ -8165,148 +7511,142 @@
                               )
                             )
                             (i32.store8
-                              (set_local $$incdec$ptr647$i
+                              (set_local $5
                                 (i32.add
-                                  (get_local $$estr$1$lcssa$i)
+                                  (get_local $5)
                                   (i32.const -2)
                                 )
                               )
                               (i32.and
-                                (get_local $$t$addr$1$i)
+                                (get_local $30)
                                 (i32.const 255)
                               )
                             )
-                            (set_local $$sub$ptr$sub650$pn$i
+                            (set_local $6
                               (i32.sub
-                                (get_local $$sub$ptr$lhs$cast160$i)
-                                (get_local $$incdec$ptr647$i)
+                                (get_local $44)
+                                (get_local $5)
                               )
                             )
-                            (get_local $$incdec$ptr647$i)
+                            (get_local $5)
                           )
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (set_local $$add653$i
+                        (get_local $16)
+                        (set_local $6
                           (i32.add
                             (i32.add
                               (i32.add
                                 (i32.add
-                                  (get_local $$pl$0$i)
+                                  (get_local $50)
                                   (i32.const 1)
                                 )
-                                (get_local $$p$addr$3$i)
+                                (get_local $15)
                               )
-                              (get_local $$lor$ext$i)
+                              (get_local $21)
                             )
-                            (get_local $$sub$ptr$sub650$pn$i)
+                            (get_local $6)
                           )
                         )
-                        (get_local $$fl$1$and219)
+                        (get_local $17)
                       )
                       (if
                         (i32.eq
                           (i32.and
                             (i32.load
-                              (get_local $$f)
+                              (get_local $0)
                             )
                             (i32.const 32)
                           )
                           (i32.const 0)
                         )
                         (call $___fwritex
-                          (get_local $$prefix$0$i)
-                          (get_local $$pl$0$i)
-                          (get_local $$f)
+                          (get_local $39)
+                          (get_local $50)
+                          (get_local $0)
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 48)
-                        (get_local $$w$1)
-                        (get_local $$add653$i)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $$fl$1$and219)
+                          (get_local $17)
                           (i32.const 65536)
                         )
                       )
                       (block $do-once$106
                         (if
-                          (get_local $$cmp614$i)
+                          (get_local $12)
                           (block
-                            (set_local $$d$5494$i
-                              (set_local $$r$0$a$9$i
+                            (set_local $7
+                              (set_local $8
                                 (select
-                                  (get_local $$arraydecay208$add$ptr213$i)
-                                  (get_local $$a$9$ph$i)
+                                  (get_local $10)
+                                  (get_local $7)
                                   (i32.gt_u
-                                    (get_local $$a$9$ph$i)
-                                    (get_local $$arraydecay208$add$ptr213$i)
+                                    (get_local $7)
+                                    (get_local $10)
                                   )
                                 )
                               )
                             )
                             (loop $while-out$108 $while-in$109
-                              (set_local $$249
+                              (set_local $5
                                 (call $_fmt_u
                                   (i32.load
-                                    (get_local $$d$5494$i)
+                                    (get_local $7)
                                   )
                                   (i32.const 0)
-                                  (get_local $$add$ptr671$i)
+                                  (get_local $48)
                                 )
                               )
                               (block $do-once$110
                                 (if
                                   (i32.eq
-                                    (get_local $$d$5494$i)
-                                    (get_local $$r$0$a$9$i)
+                                    (get_local $7)
+                                    (get_local $8)
                                   )
                                   (block
                                     (if
                                       (i32.ne
-                                        (get_local $$249)
-                                        (get_local $$add$ptr671$i)
+                                        (get_local $5)
+                                        (get_local $48)
                                       )
                                       (block
-                                        (set_local $$s668$1$i
-                                          (get_local $$249)
-                                        )
+                                        (get_local $5)
                                         (br $do-once$110)
                                       )
                                     )
                                     (i32.store8
-                                      (get_local $$incdec$ptr689$i)
+                                      (get_local $57)
                                       (i32.const 48)
                                     )
-                                    (set_local $$s668$1$i
-                                      (get_local $$incdec$ptr689$i)
+                                    (set_local $5
+                                      (get_local $57)
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.gt_u
-                                        (get_local $$249)
-                                        (get_local $$buf$i)
+                                        (get_local $5)
+                                        (get_local $29)
                                       )
-                                      (set_local $$s668$0492$i
-                                        (get_local $$249)
-                                      )
+                                      (get_local $5)
                                       (block
-                                        (set_local $$s668$1$i
-                                          (get_local $$249)
-                                        )
+                                        (get_local $5)
                                         (br $do-once$110)
                                       )
                                     )
                                     (loop $while-out$112 $while-in$113
                                       (i32.store8
-                                        (set_local $$incdec$ptr681$i
+                                        (set_local $5
                                           (i32.add
-                                            (get_local $$s668$0492$i)
+                                            (get_local $5)
                                             (i32.const -1)
                                           )
                                         )
@@ -8314,16 +7654,12 @@
                                       )
                                       (if
                                         (i32.gt_u
-                                          (get_local $$incdec$ptr681$i)
-                                          (get_local $$buf$i)
+                                          (get_local $5)
+                                          (get_local $29)
                                         )
-                                        (set_local $$s668$0492$i
-                                          (get_local $$incdec$ptr681$i)
-                                        )
+                                        (get_local $5)
                                         (block
-                                          (set_local $$s668$1$i
-                                            (get_local $$incdec$ptr681$i)
-                                          )
+                                          (get_local $5)
                                           (br $while-out$112)
                                         )
                                       )
@@ -8336,39 +7672,37 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                     (i32.const 32)
                                   )
                                   (i32.const 0)
                                 )
                                 (call $___fwritex
-                                  (get_local $$s668$1$i)
+                                  (get_local $5)
                                   (i32.sub
-                                    (get_local $$sub$ptr$lhs$cast694$i)
-                                    (get_local $$s668$1$i)
+                                    (get_local $74)
+                                    (get_local $5)
                                   )
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                               )
                               (if
                                 (i32.gt_u
-                                  (set_local $$incdec$ptr698$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$d$5494$i)
+                                      (get_local $7)
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $$arraydecay208$add$ptr213$i)
+                                  (get_local $10)
                                 )
                                 (block
-                                  (set_local $$incdec$ptr698$i$lcssa
-                                    (get_local $$incdec$ptr698$i)
-                                  )
+                                  (get_local $5)
                                   (br $while-out$108)
                                 )
-                                (set_local $$d$5494$i
-                                  (get_local $$incdec$ptr698$i)
+                                (set_local $7
+                                  (get_local $5)
                                 )
                               )
                               (br $while-in$109)
@@ -8376,7 +7710,7 @@
                             (block $do-once$114
                               (if
                                 (i32.ne
-                                  (get_local $$239)
+                                  (get_local $1)
                                   (i32.const 0)
                                 )
                                 (block
@@ -8384,7 +7718,7 @@
                                     (i32.ne
                                       (i32.and
                                         (i32.load
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
                                         (i32.const 32)
                                       )
@@ -8394,7 +7728,7 @@
                                   (call $___fwritex
                                     (i32.const 4143)
                                     (i32.const 1)
-                                    (get_local $$f)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -8402,44 +7736,40 @@
                             (if
                               (i32.and
                                 (i32.gt_s
-                                  (get_local $$p$addr$3$i)
+                                  (get_local $15)
                                   (i32.const 0)
                                 )
                                 (i32.lt_u
-                                  (get_local $$incdec$ptr698$i$lcssa)
-                                  (get_local $$z$7$i$lcssa)
+                                  (get_local $5)
+                                  (get_local $24)
                                 )
                               )
                               (block
-                                (set_local $$d$6488$i
-                                  (get_local $$incdec$ptr698$i$lcssa)
-                                )
-                                (set_local $$p$addr$4489$i
-                                  (get_local $$p$addr$3$i)
+                                (get_local $5)
+                                (set_local $7
+                                  (get_local $15)
                                 )
                                 (loop $while-out$116 $while-in$117
                                   (if
                                     (i32.gt_u
-                                      (set_local $$255
+                                      (set_local $1
                                         (call $_fmt_u
                                           (i32.load
-                                            (get_local $$d$6488$i)
+                                            (get_local $5)
                                           )
                                           (i32.const 0)
-                                          (get_local $$add$ptr671$i)
+                                          (get_local $48)
                                         )
                                       )
-                                      (get_local $$buf$i)
+                                      (get_local $29)
                                     )
                                     (block
-                                      (set_local $$s715$0484$i
-                                        (get_local $$255)
-                                      )
+                                      (get_local $1)
                                       (loop $while-out$118 $while-in$119
                                         (i32.store8
-                                          (set_local $$incdec$ptr725$i
+                                          (set_local $1
                                             (i32.add
-                                              (get_local $$s715$0484$i)
+                                              (get_local $1)
                                               (i32.const -1)
                                             )
                                           )
@@ -8447,82 +7777,76 @@
                                         )
                                         (if
                                           (i32.gt_u
-                                            (get_local $$incdec$ptr725$i)
-                                            (get_local $$buf$i)
+                                            (get_local $1)
+                                            (get_local $29)
                                           )
-                                          (set_local $$s715$0484$i
-                                            (get_local $$incdec$ptr725$i)
-                                          )
+                                          (get_local $1)
                                           (block
-                                            (set_local $$s715$0$lcssa$i
-                                              (get_local $$incdec$ptr725$i)
-                                            )
+                                            (get_local $1)
                                             (br $while-out$118)
                                           )
                                         )
                                         (br $while-in$119)
                                       )
                                     )
-                                    (set_local $$s715$0$lcssa$i
-                                      (get_local $$255)
-                                    )
+                                    (get_local $1)
                                   )
                                   (if
                                     (i32.eq
                                       (i32.and
                                         (i32.load
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
                                         (i32.const 32)
                                       )
                                       (i32.const 0)
                                     )
                                     (call $___fwritex
-                                      (get_local $$s715$0$lcssa$i)
+                                      (get_local $1)
                                       (select
                                         (i32.const 9)
-                                        (get_local $$p$addr$4489$i)
+                                        (get_local $7)
                                         (i32.gt_s
-                                          (get_local $$p$addr$4489$i)
+                                          (get_local $7)
                                           (i32.const 9)
                                         )
                                       )
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                   )
-                                  (set_local $$sub735$i
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $$p$addr$4489$i)
+                                      (get_local $7)
                                       (i32.const -9)
                                     )
                                   )
                                   (if
                                     (i32.and
                                       (i32.gt_s
-                                        (get_local $$p$addr$4489$i)
+                                        (get_local $7)
                                         (i32.const 9)
                                       )
                                       (i32.lt_u
-                                        (set_local $$incdec$ptr734$i
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $$d$6488$i)
+                                            (get_local $5)
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $$z$7$i$lcssa)
+                                        (get_local $24)
                                       )
                                     )
                                     (block
-                                      (set_local $$d$6488$i
-                                        (get_local $$incdec$ptr734$i)
+                                      (set_local $5
+                                        (get_local $1)
                                       )
-                                      (set_local $$p$addr$4489$i
-                                        (get_local $$sub735$i)
+                                      (set_local $7
+                                        (get_local $8)
                                       )
                                     )
                                     (block
-                                      (set_local $$p$addr$4$lcssa$i
-                                        (get_local $$sub735$i)
+                                      (set_local $1
+                                        (get_local $8)
                                       )
                                       (br $while-out$116)
                                     )
@@ -8530,15 +7854,15 @@
                                   (br $while-in$117)
                                 )
                               )
-                              (set_local $$p$addr$4$lcssa$i
-                                (get_local $$p$addr$3$i)
+                              (set_local $1
+                                (get_local $15)
                               )
                             )
                             (call $_pad
-                              (get_local $$f)
+                              (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $$p$addr$4$lcssa$i)
+                                (get_local $1)
                                 (i32.const 9)
                               )
                               (i32.const 9)
@@ -8546,69 +7870,69 @@
                             )
                           )
                           (block
-                            (set_local $$z$7$add$ptr742$i
+                            (set_local $12
                               (select
-                                (get_local $$z$7$i$lcssa)
+                                (get_local $24)
                                 (i32.add
-                                  (get_local $$a$9$ph$i)
+                                  (get_local $7)
                                   (i32.const 4)
                                 )
-                                (get_local $$cmp450$lcssa$i)
+                                (get_local $11)
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $$p$addr$3$i)
+                                (get_local $15)
                                 (i32.const -1)
                               )
                               (block
-                                (set_local $$tobool781$i
+                                (set_local $11
                                   (i32.eq
-                                    (get_local $$and610$pre$phi$iZ2D)
+                                    (get_local $8)
                                     (i32.const 0)
                                   )
                                 )
-                                (set_local $$d$7500$i
-                                  (get_local $$a$9$ph$i)
+                                (set_local $5
+                                  (get_local $7)
                                 )
-                                (set_local $$p$addr$5501$i
-                                  (get_local $$p$addr$3$i)
+                                (set_local $8
+                                  (get_local $15)
                                 )
                                 (loop $while-out$120 $while-in$121
-                                  (set_local $$s753$0$i
+                                  (set_local $10
                                     (if
                                       (i32.eq
-                                        (set_local $$259
+                                        (set_local $1
                                           (call $_fmt_u
                                             (i32.load
-                                              (get_local $$d$7500$i)
+                                              (get_local $5)
                                             )
                                             (i32.const 0)
-                                            (get_local $$add$ptr671$i)
+                                            (get_local $48)
                                           )
                                         )
-                                        (get_local $$add$ptr671$i)
+                                        (get_local $48)
                                       )
                                       (block
                                         (i32.store8
-                                          (get_local $$incdec$ptr689$i)
+                                          (get_local $57)
                                           (i32.const 48)
                                         )
-                                        (get_local $$incdec$ptr689$i)
+                                        (get_local $57)
                                       )
-                                      (get_local $$259)
+                                      (get_local $1)
                                     )
                                   )
                                   (block $do-once$122
                                     (if
                                       (i32.eq
-                                        (get_local $$d$7500$i)
-                                        (get_local $$a$9$ph$i)
+                                        (get_local $5)
+                                        (get_local $7)
                                       )
                                       (block
-                                        (set_local $$incdec$ptr776$i
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $$s753$0$i)
+                                            (get_local $10)
                                             (i32.const 1)
                                           )
                                         )
@@ -8616,30 +7940,28 @@
                                           (i32.eq
                                             (i32.and
                                               (i32.load
-                                                (get_local $$f)
+                                                (get_local $0)
                                               )
                                               (i32.const 32)
                                             )
                                             (i32.const 0)
                                           )
                                           (call $___fwritex
-                                            (get_local $$s753$0$i)
+                                            (get_local $10)
                                             (i32.const 1)
-                                            (get_local $$f)
+                                            (get_local $0)
                                           )
                                         )
                                         (if
                                           (i32.and
-                                            (get_local $$tobool781$i)
+                                            (get_local $11)
                                             (i32.lt_s
-                                              (get_local $$p$addr$5501$i)
+                                              (get_local $8)
                                               (i32.const 1)
                                             )
                                           )
                                           (block
-                                            (set_local $$s753$2$i
-                                              (get_local $$incdec$ptr776$i)
-                                            )
+                                            (get_local $1)
                                             (br $do-once$122)
                                           )
                                         )
@@ -8647,49 +7969,45 @@
                                           (i32.ne
                                             (i32.and
                                               (i32.load
-                                                (get_local $$f)
+                                                (get_local $0)
                                               )
                                               (i32.const 32)
                                             )
                                             (i32.const 0)
                                           )
                                           (block
-                                            (set_local $$s753$2$i
-                                              (get_local $$incdec$ptr776$i)
-                                            )
+                                            (get_local $1)
                                             (br $do-once$122)
                                           )
                                         )
                                         (call $___fwritex
                                           (i32.const 4143)
                                           (i32.const 1)
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
-                                        (set_local $$s753$2$i
-                                          (get_local $$incdec$ptr776$i)
-                                        )
+                                        (get_local $1)
                                       )
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $$s753$0$i)
-                                            (get_local $$buf$i)
+                                            (get_local $10)
+                                            (get_local $29)
                                           )
-                                          (set_local $$s753$1496$i
-                                            (get_local $$s753$0$i)
+                                          (set_local $1
+                                            (get_local $10)
                                           )
                                           (block
-                                            (set_local $$s753$2$i
-                                              (get_local $$s753$0$i)
+                                            (set_local $1
+                                              (get_local $10)
                                             )
                                             (br $do-once$122)
                                           )
                                         )
                                         (loop $while-out$124 $while-in$125
                                           (i32.store8
-                                            (set_local $$incdec$ptr773$i
+                                            (set_local $1
                                               (i32.add
-                                                (get_local $$s753$1496$i)
+                                                (get_local $1)
                                                 (i32.const -1)
                                               )
                                             )
@@ -8697,16 +8015,12 @@
                                           )
                                           (if
                                             (i32.gt_u
-                                              (get_local $$incdec$ptr773$i)
-                                              (get_local $$buf$i)
+                                              (get_local $1)
+                                              (get_local $29)
                                             )
-                                            (set_local $$s753$1496$i
-                                              (get_local $$incdec$ptr773$i)
-                                            )
+                                            (get_local $1)
                                             (block
-                                              (set_local $$s753$2$i
-                                                (get_local $$incdec$ptr773$i)
-                                              )
+                                              (get_local $1)
                                               (br $while-out$124)
                                             )
                                           )
@@ -8715,67 +8029,65 @@
                                       )
                                     )
                                   )
-                                  (set_local $$sub$ptr$sub789$i
+                                  (set_local $10
                                     (i32.sub
-                                      (get_local $$sub$ptr$lhs$cast694$i)
-                                      (get_local $$s753$2$i)
+                                      (get_local $74)
+                                      (get_local $1)
                                     )
                                   )
                                   (if
                                     (i32.eq
                                       (i32.and
                                         (i32.load
-                                          (get_local $$f)
+                                          (get_local $0)
                                         )
                                         (i32.const 32)
                                       )
                                       (i32.const 0)
                                     )
                                     (call $___fwritex
-                                      (get_local $$s753$2$i)
+                                      (get_local $1)
                                       (select
-                                        (get_local $$sub$ptr$sub789$i)
-                                        (get_local $$p$addr$5501$i)
+                                        (get_local $10)
+                                        (get_local $8)
                                         (i32.gt_s
-                                          (get_local $$p$addr$5501$i)
-                                          (get_local $$sub$ptr$sub789$i)
+                                          (get_local $8)
+                                          (get_local $10)
                                         )
                                       )
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                   )
                                   (if
                                     (i32.and
                                       (i32.lt_u
-                                        (set_local $$incdec$ptr808$i
+                                        (set_local $1
                                           (i32.add
-                                            (get_local $$d$7500$i)
+                                            (get_local $5)
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $$z$7$add$ptr742$i)
+                                        (get_local $12)
                                       )
                                       (i32.gt_s
-                                        (set_local $$sub806$i
+                                        (set_local $8
                                           (i32.sub
-                                            (get_local $$p$addr$5501$i)
-                                            (get_local $$sub$ptr$sub789$i)
+                                            (get_local $8)
+                                            (get_local $10)
                                           )
                                         )
                                         (i32.const -1)
                                       )
                                     )
                                     (block
-                                      (set_local $$d$7500$i
-                                        (get_local $$incdec$ptr808$i)
+                                      (set_local $5
+                                        (get_local $1)
                                       )
-                                      (set_local $$p$addr$5501$i
-                                        (get_local $$sub806$i)
-                                      )
+                                      (get_local $8)
                                     )
                                     (block
-                                      (set_local $$p$addr$5$lcssa$i
-                                        (get_local $$sub806$i)
+                                      (set_local $1
+                                        (get_local $8)
                                       )
                                       (br $while-out$120)
                                     )
@@ -8783,15 +8095,15 @@
                                   (br $while-in$121)
                                 )
                               )
-                              (set_local $$p$addr$5$lcssa$i
-                                (get_local $$p$addr$3$i)
+                              (set_local $1
+                                (get_local $15)
                               )
                             )
                             (call $_pad
-                              (get_local $$f)
+                              (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $$p$addr$5$lcssa$i)
+                                (get_local $1)
                                 (i32.const 18)
                               )
                               (i32.const 18)
@@ -8801,7 +8113,7 @@
                               (i32.ne
                                 (i32.and
                                   (i32.load
-                                    (get_local $$f)
+                                    (get_local $0)
                                   )
                                   (i32.const 32)
                                 )
@@ -8809,44 +8121,44 @@
                               )
                             )
                             (call $___fwritex
-                              (get_local $$estr$2$i)
+                              (get_local $9)
                               (i32.sub
-                                (get_local $$sub$ptr$lhs$cast160$i)
-                                (get_local $$estr$2$i)
+                                (get_local $44)
+                                (get_local $9)
                               )
-                              (get_local $$f)
+                              (get_local $0)
                             )
                           )
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (get_local $$add653$i)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $$fl$1$and219)
+                          (get_local $17)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $$w$1)
-                        (get_local $$add653$i)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.lt_s
-                          (get_local $$add653$i)
-                          (get_local $$w$1)
+                          (get_local $6)
+                          (get_local $16)
                         )
                       )
                     )
                     (block
-                      (set_local $$cond$i
+                      (set_local $5
                         (select
                           (i32.const 4127)
                           (i32.const 4131)
-                          (set_local $$tobool37$i
+                          (set_local $8
                             (i32.ne
                               (i32.and
-                                (get_local $$t$0)
+                                (get_local $33)
                                 (i32.const 32)
                               )
                               (i32.const 0)
@@ -8854,15 +8166,15 @@
                           )
                         )
                       )
-                      (set_local $$pl$1$i
+                      (set_local $7
                         (select
                           (i32.const 0)
-                          (get_local $$pl$0$i)
-                          (set_local $$cmp38$i
+                          (get_local $50)
+                          (set_local $1
                             (i32.or
                               (f64.ne
-                                (get_local $$y$addr$0$i)
-                                (get_local $$y$addr$0$i)
+                                (get_local $14)
+                                (get_local $14)
                               )
                               (f64.ne
                                 (f64.const 0)
@@ -8872,28 +8184,28 @@
                           )
                         )
                       )
-                      (set_local $$s35$0$i
+                      (set_local $8
                         (select
                           (select
                             (i32.const 4135)
                             (i32.const 4139)
-                            (get_local $$tobool37$i)
+                            (get_local $8)
                           )
-                          (get_local $$cond$i)
-                          (get_local $$cmp38$i)
+                          (get_local $5)
+                          (get_local $1)
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (set_local $$add$i$239
+                        (get_local $16)
+                        (set_local $5
                           (i32.add
-                            (get_local $$pl$1$i)
+                            (get_local $7)
                             (i32.const 3)
                           )
                         )
-                        (get_local $$and219)
+                        (get_local $6)
                       )
                       (if
                         (i32.eq
@@ -8901,9 +8213,9 @@
                             (if
                               (i32.eq
                                 (i32.and
-                                  (set_local $$193
+                                  (set_local $1
                                     (i32.load
-                                      (get_local $$f)
+                                      (get_local $0)
                                     )
                                   )
                                   (i32.const 32)
@@ -8912,79 +8224,77 @@
                               )
                               (block
                                 (call $___fwritex
-                                  (get_local $$prefix$0$i)
-                                  (get_local $$pl$1$i)
-                                  (get_local $$f)
+                                  (get_local $39)
+                                  (get_local $7)
+                                  (get_local $0)
                                 )
                                 (i32.load
-                                  (get_local $$f)
+                                  (get_local $0)
                                 )
                               )
-                              (get_local $$193)
+                              (get_local $1)
                             )
                             (i32.const 32)
                           )
                           (i32.const 0)
                         )
                         (call $___fwritex
-                          (get_local $$s35$0$i)
+                          (get_local $8)
                           (i32.const 3)
-                          (get_local $$f)
+                          (get_local $0)
                         )
                       )
                       (call $_pad
-                        (get_local $$f)
+                        (get_local $0)
                         (i32.const 32)
-                        (get_local $$w$1)
-                        (get_local $$add$i$239)
+                        (get_local $16)
+                        (get_local $5)
                         (i32.xor
-                          (get_local $$fl$1$and219)
+                          (get_local $17)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $$w$1)
-                        (get_local $$add$i$239)
+                        (get_local $16)
+                        (get_local $5)
                         (i32.lt_s
-                          (get_local $$add$i$239)
-                          (get_local $$w$1)
+                          (get_local $5)
+                          (get_local $16)
                         )
                       )
                     )
                   )
                 )
               )
-              (set_local $$cnt$0
-                (get_local $$cnt$1)
+              (set_local $5
+                (get_local $19)
               )
-              (set_local $$incdec$ptr169275
-                (get_local $$incdec$ptr169$lcssa)
+              (set_local $12
+                (get_local $26)
               )
-              (set_local $$l$0
-                (get_local $$retval$0$i)
-              )
-              (set_local $$l10n$0
-                (get_local $$l10n$3)
+              (get_local $1)
+              (set_local $8
+                (get_local $20)
               )
               (br $label$continue$L1)
             )
-            (set_local $$a$2
-              (get_local $$incdec$ptr169275)
+            (set_local $47
+              (get_local $12)
             )
-            (set_local $$fl$6
-              (get_local $$fl$1$and219)
+            (set_local $36
+              (get_local $17)
             )
-            (set_local $$p$5
-              (get_local $$p$0)
+            (set_local $42
+              (get_local $9)
             )
-            (set_local $$pl$2
+            (set_local $43
               (i32.const 0)
             )
-            (set_local $$prefix$2
+            (set_local $51
               (i32.const 4091)
             )
-            (set_local $$z$2
-              (get_local $$add$ptr205)
+            (set_local $53
+              (get_local $28)
             )
           )
         )
@@ -8992,74 +8302,68 @@
       (block $label$break$L308
         (if
           (i32.eq
-            (get_local $label)
+            (get_local $13)
             (i32.const 64)
           )
           (block
-            (set_local $label
-              (i32.const 0)
-            )
-            (set_local $$and249
+            (i32.const 0)
+            (set_local $7
               (i32.and
-                (get_local $$t$1)
+                (get_local $69)
                 (i32.const 32)
               )
             )
-            (set_local $$a$0
+            (set_local $34
               (if
                 (i32.and
                   (i32.eq
-                    (set_local $$92
+                    (set_local $5
                       (i32.load
-                        (set_local $$90
-                          (get_local $$arg)
+                        (set_local $1
+                          (get_local $18)
                         )
                       )
                     )
                     (i32.const 0)
                   )
                   (i32.eq
-                    (set_local $$95
+                    (set_local $1
                       (i32.load offset=4
-                        (get_local $$90)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                   )
                 )
                 (block
-                  (set_local $$fl$4
-                    (get_local $$fl$3)
+                  (set_local $35
+                    (get_local $49)
                   )
-                  (set_local $$p$2
-                    (get_local $$p$1)
+                  (set_local $31
+                    (get_local $58)
                   )
-                  (set_local $$pl$1
+                  (set_local $38
                     (i32.const 0)
                   )
-                  (set_local $$prefix$1
+                  (set_local $40
                     (i32.const 4091)
                   )
-                  (set_local $label
+                  (set_local $13
                     (i32.const 77)
                   )
-                  (get_local $$add$ptr205)
+                  (get_local $28)
                 )
                 (block
-                  (set_local $$101
-                    (get_local $$95)
-                  )
-                  (set_local $$99
-                    (get_local $$92)
-                  )
-                  (set_local $$s$addr$06$i
-                    (get_local $$add$ptr205)
+                  (get_local $1)
+                  (get_local $5)
+                  (set_local $6
+                    (get_local $28)
                   )
                   (loop $while-out$129 $while-in$130
                     (i32.store8
-                      (set_local $$incdec$ptr$i$212
+                      (set_local $6
                         (i32.add
-                          (get_local $$s$addr$06$i)
+                          (get_local $6)
                           (i32.const -1)
                         )
                       )
@@ -9069,7 +8373,7 @@
                             (i32.load8_s
                               (i32.add
                                 (i32.and
-                                  (get_local $$99)
+                                  (get_local $5)
                                   (i32.const 15)
                                 )
                                 (i32.const 4075)
@@ -9077,7 +8381,7 @@
                             )
                             (i32.const 255)
                           )
-                          (get_local $$and249)
+                          (get_local $7)
                         )
                         (i32.const 255)
                       )
@@ -9085,17 +8389,17 @@
                     (if
                       (i32.and
                         (i32.eq
-                          (set_local $$102
+                          (set_local $5
                             (call $_bitshift64Lshr
-                              (get_local $$99)
-                              (get_local $$101)
+                              (get_local $5)
+                              (get_local $1)
                               (i32.const 4)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.eq
-                          (set_local $$103
+                          (set_local $1
                             (i32.load
                               (i32.const 168)
                             )
@@ -9104,21 +8408,15 @@
                         )
                       )
                       (block
-                        (set_local $$incdec$ptr$i$212$lcssa
-                          (get_local $$incdec$ptr$i$212)
+                        (set_local $5
+                          (get_local $6)
                         )
                         (br $while-out$129)
                       )
                       (block
-                        (set_local $$101
-                          (get_local $$103)
-                        )
-                        (set_local $$99
-                          (get_local $$102)
-                        )
-                        (set_local $$s$addr$06$i
-                          (get_local $$incdec$ptr$i$212)
-                        )
+                        (get_local $1)
+                        (get_local $5)
+                        (get_local $6)
                       )
                     )
                     (br $while-in$130)
@@ -9127,7 +8425,7 @@
                     (i32.or
                       (i32.eq
                         (i32.and
-                          (get_local $$fl$3)
+                          (get_local $49)
                           (i32.const 8)
                         )
                         (i32.const 0)
@@ -9135,61 +8433,61 @@
                       (i32.and
                         (i32.eq
                           (i32.load
-                            (set_local $$107
-                              (get_local $$arg)
+                            (set_local $1
+                              (get_local $18)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.eq
                           (i32.load offset=4
-                            (get_local $$107)
+                            (get_local $1)
                           )
                           (i32.const 0)
                         )
                       )
                     )
                     (block
-                      (set_local $$fl$4
-                        (get_local $$fl$3)
+                      (set_local $35
+                        (get_local $49)
                       )
-                      (set_local $$p$2
-                        (get_local $$p$1)
+                      (set_local $31
+                        (get_local $58)
                       )
-                      (set_local $$pl$1
+                      (set_local $38
                         (i32.const 0)
                       )
-                      (set_local $$prefix$1
+                      (set_local $40
                         (i32.const 4091)
                       )
-                      (set_local $label
+                      (set_local $13
                         (i32.const 77)
                       )
-                      (get_local $$incdec$ptr$i$212$lcssa)
+                      (get_local $5)
                     )
                     (block
-                      (set_local $$fl$4
-                        (get_local $$fl$3)
+                      (set_local $35
+                        (get_local $49)
                       )
-                      (set_local $$p$2
-                        (get_local $$p$1)
+                      (set_local $31
+                        (get_local $58)
                       )
-                      (set_local $$pl$1
+                      (set_local $38
                         (i32.const 2)
                       )
-                      (set_local $$prefix$1
+                      (set_local $40
                         (i32.add
                           (i32.const 4091)
                           (i32.shr_s
-                            (get_local $$t$1)
+                            (get_local $69)
                             (i32.const 4)
                           )
                         )
                       )
-                      (set_local $label
+                      (set_local $13
                         (i32.const 77)
                       )
-                      (get_local $$incdec$ptr$i$212$lcssa)
+                      (get_local $5)
                     )
                   )
                 )
@@ -9198,124 +8496,122 @@
           )
           (if
             (i32.eq
-              (get_local $label)
+              (get_local $13)
               (i32.const 76)
             )
             (block
               (i32.const 0)
-              (set_local $$a$0
+              (set_local $34
                 (call $_fmt_u
-                  (get_local $$148)
-                  (get_local $$149)
-                  (get_local $$add$ptr205)
+                  (get_local $45)
+                  (get_local $54)
+                  (get_local $28)
                 )
               )
-              (set_local $$fl$4
-                (get_local $$fl$1$and219)
+              (set_local $35
+                (get_local $17)
               )
-              (set_local $$p$2
-                (get_local $$p$0)
+              (set_local $31
+                (get_local $9)
               )
-              (set_local $$pl$1
-                (get_local $$pl$0)
+              (set_local $38
+                (get_local $59)
               )
-              (set_local $$prefix$1
-                (get_local $$prefix$0)
+              (set_local $40
+                (get_local $60)
               )
-              (set_local $label
+              (set_local $13
                 (i32.const 77)
               )
             )
             (if
               (i32.eq
-                (get_local $label)
+                (get_local $13)
                 (i32.const 82)
               )
               (block
-                (set_local $label
+                (set_local $13
                   (i32.const 0)
                 )
-                (set_local $$tobool357
+                (set_local $5
                   (i32.eq
-                    (set_local $$call356
+                    (set_local $1
                       (call $_memchr
-                        (get_local $$a$1)
+                        (get_local $46)
                         (i32.const 0)
-                        (get_local $$p$0)
+                        (get_local $9)
                       )
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $$a$2
-                  (get_local $$a$1)
+                (set_local $47
+                  (get_local $46)
                 )
-                (set_local $$fl$6
-                  (get_local $$and219)
+                (set_local $36
+                  (get_local $6)
                 )
-                (set_local $$p$5
+                (set_local $42
                   (select
-                    (get_local $$p$0)
+                    (get_local $9)
                     (i32.sub
-                      (get_local $$call356)
-                      (get_local $$a$1)
+                      (get_local $1)
+                      (get_local $46)
                     )
-                    (get_local $$tobool357)
+                    (get_local $5)
                   )
                 )
-                (set_local $$pl$2
+                (set_local $43
                   (i32.const 0)
                 )
-                (set_local $$prefix$2
+                (set_local $51
                   (i32.const 4091)
                 )
-                (set_local $$z$2
+                (set_local $53
                   (select
                     (i32.add
-                      (get_local $$a$1)
-                      (get_local $$p$0)
+                      (get_local $46)
+                      (get_local $9)
                     )
-                    (get_local $$call356)
-                    (get_local $$tobool357)
+                    (get_local $1)
+                    (get_local $5)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (get_local $label)
+                  (get_local $13)
                   (i32.const 86)
                 )
                 (block
-                  (set_local $label
+                  (set_local $13
                     (i32.const 0)
                   )
-                  (set_local $$i$0316
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $$l$1315
+                  (set_local $5
                     (i32.const 0)
                   )
-                  (set_local $$ws$0317
+                  (set_local $6
                     (i32.load
-                      (get_local $$arg)
+                      (get_local $18)
                     )
                   )
                   (loop $while-out$131 $while-in$132
                     (if
                       (i32.eq
-                        (set_local $$177
+                        (set_local $1
                           (i32.load
-                            (get_local $$ws$0317)
+                            (get_local $6)
                           )
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$i$0$lcssa
-                          (get_local $$i$0316)
-                        )
-                        (set_local $$l$2
-                          (get_local $$l$1315)
+                        (get_local $7)
+                        (set_local $1
+                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
@@ -9323,65 +8619,59 @@
                     (if
                       (i32.or
                         (i32.lt_s
-                          (set_local $$call384
+                          (set_local $5
                             (call $_wctomb
-                              (get_local $$mb)
-                              (get_local $$177)
+                              (get_local $64)
+                              (get_local $1)
                             )
                           )
                           (i32.const 0)
                         )
                         (i32.gt_u
-                          (get_local $$call384)
+                          (get_local $5)
                           (i32.sub
-                            (get_local $$p$4365)
-                            (get_local $$i$0316)
+                            (get_local $65)
+                            (get_local $7)
                           )
                         )
                       )
                       (block
-                        (set_local $$i$0$lcssa
-                          (get_local $$i$0316)
-                        )
-                        (set_local $$l$2
-                          (get_local $$call384)
+                        (get_local $7)
+                        (set_local $1
+                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
                     )
-                    (set_local $$incdec$ptr383
+                    (set_local $6
                       (i32.add
-                        (get_local $$ws$0317)
+                        (get_local $6)
                         (i32.const 4)
                       )
                     )
                     (if
                       (i32.gt_u
-                        (get_local $$p$4365)
-                        (set_local $$add395
+                        (get_local $65)
+                        (set_local $1
                           (i32.add
-                            (get_local $$call384)
-                            (get_local $$i$0316)
+                            (get_local $5)
+                            (get_local $7)
                           )
                         )
                       )
                       (block
-                        (set_local $$i$0316
-                          (get_local $$add395)
+                        (set_local $7
+                          (get_local $1)
                         )
-                        (set_local $$l$1315
-                          (get_local $$call384)
-                        )
-                        (set_local $$ws$0317
-                          (get_local $$incdec$ptr383)
-                        )
+                        (get_local $5)
+                        (get_local $6)
                       )
                       (block
-                        (set_local $$i$0$lcssa
-                          (get_local $$add395)
+                        (set_local $7
+                          (get_local $1)
                         )
-                        (set_local $$l$2
-                          (get_local $$call384)
+                        (set_local $1
+                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
@@ -9390,91 +8680,91 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $$l$2)
+                      (get_local $1)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$retval$0
+                      (set_local $23
                         (i32.const -1)
                       )
                       (br $label$break$L1)
                     )
                   )
                   (call $_pad
-                    (get_local $$f)
+                    (get_local $0)
                     (i32.const 32)
-                    (get_local $$w$1)
-                    (get_local $$i$0$lcssa)
-                    (get_local $$fl$1$and219)
+                    (get_local $16)
+                    (get_local $7)
+                    (get_local $17)
                   )
                   (if
                     (i32.eq
-                      (get_local $$i$0$lcssa)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$i$0$lcssa368
+                      (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $label
+                      (set_local $13
                         (i32.const 98)
                       )
                     )
                     (block
-                      (set_local $$i$1325
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $$ws$1326
+                      (set_local $5
                         (i32.load
-                          (get_local $$arg)
+                          (get_local $18)
                         )
                       )
                       (loop $while-out$133 $while-in$134
                         (if
                           (i32.eq
-                            (set_local $$179
+                            (set_local $1
                               (i32.load
-                                (get_local $$ws$1326)
+                                (get_local $5)
                               )
                             )
                             (i32.const 0)
                           )
                           (block
-                            (set_local $$i$0$lcssa368
-                              (get_local $$i$0$lcssa)
+                            (set_local $37
+                              (get_local $7)
                             )
-                            (set_local $label
+                            (set_local $13
                               (i32.const 98)
                             )
                             (br $label$break$L308)
                           )
                         )
-                        (set_local $$incdec$ptr410
+                        (set_local $8
                           (i32.add
-                            (get_local $$ws$1326)
+                            (get_local $5)
                             (i32.const 4)
                           )
                         )
                         (if
                           (i32.gt_s
-                            (set_local $$add412
+                            (set_local $1
                               (i32.add
-                                (set_local $$call411
+                                (set_local $5
                                   (call $_wctomb
-                                    (get_local $$mb)
-                                    (get_local $$179)
+                                    (get_local $64)
+                                    (get_local $1)
                                   )
                                 )
-                                (get_local $$i$1325)
+                                (get_local $6)
                               )
                             )
-                            (get_local $$i$0$lcssa)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$i$0$lcssa368
-                              (get_local $$i$0$lcssa)
+                            (set_local $37
+                              (get_local $7)
                             )
-                            (set_local $label
+                            (set_local $13
                               (i32.const 98)
                             )
                             (br $label$break$L308)
@@ -9484,36 +8774,36 @@
                           (i32.eq
                             (i32.and
                               (i32.load
-                                (get_local $$f)
+                                (get_local $0)
                               )
                               (i32.const 32)
                             )
                             (i32.const 0)
                           )
                           (call $___fwritex
-                            (get_local $$mb)
-                            (get_local $$call411)
-                            (get_local $$f)
+                            (get_local $64)
+                            (get_local $5)
+                            (get_local $0)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $$add412)
-                            (get_local $$i$0$lcssa)
+                            (get_local $1)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $$i$1325
-                              (get_local $$add412)
+                            (set_local $6
+                              (get_local $1)
                             )
-                            (set_local $$ws$1326
-                              (get_local $$incdec$ptr410)
+                            (set_local $5
+                              (get_local $8)
                             )
                           )
                           (block
-                            (set_local $$i$0$lcssa368
-                              (get_local $$i$0$lcssa)
+                            (set_local $37
+                              (get_local $7)
                             )
-                            (set_local $label
+                            (set_local $13
                               (i32.const 98)
                             )
                             (br $while-out$133)
@@ -9531,87 +8821,87 @@
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 98)
         )
         (block
-          (set_local $label
+          (set_local $13
             (i32.const 0)
           )
           (call $_pad
-            (get_local $$f)
+            (get_local $0)
             (i32.const 32)
-            (get_local $$w$1)
-            (get_local $$i$0$lcssa368)
+            (get_local $16)
+            (get_local $37)
             (i32.xor
-              (get_local $$fl$1$and219)
+              (get_local $17)
               (i32.const 8192)
             )
           )
-          (set_local $$cnt$0
-            (get_local $$cnt$1)
+          (set_local $5
+            (get_local $19)
           )
-          (set_local $$incdec$ptr169275
-            (get_local $$incdec$ptr169$lcssa)
+          (set_local $12
+            (get_local $26)
           )
-          (set_local $$l$0
+          (set_local $1
             (select
-              (get_local $$w$1)
-              (get_local $$i$0$lcssa368)
+              (get_local $16)
+              (get_local $37)
               (i32.gt_s
-                (get_local $$w$1)
-                (get_local $$i$0$lcssa368)
+                (get_local $16)
+                (get_local $37)
               )
             )
           )
-          (set_local $$l10n$0
-            (get_local $$l10n$3)
+          (set_local $8
+            (get_local $20)
           )
           (br $label$continue$L1)
         )
       )
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 77)
         )
         (block
-          (set_local $label
+          (set_local $13
             (i32.const 0)
           )
-          (set_local $$and309$fl$4
+          (set_local $5
             (select
               (i32.and
-                (get_local $$fl$4)
+                (get_local $35)
                 (i32.const -65537)
               )
-              (get_local $$fl$4)
+              (get_local $35)
               (i32.gt_s
-                (get_local $$p$2)
+                (get_local $31)
                 (i32.const -1)
               )
             )
           )
-          (set_local $$a$2
+          (set_local $47
             (if
               (i32.or
                 (i32.ne
-                  (get_local $$p$2)
+                  (get_local $31)
                   (i32.const 0)
                 )
-                (set_local $$159
+                (set_local $1
                   (i32.or
                     (i32.ne
                       (i32.load
-                        (set_local $$151
-                          (get_local $$arg)
+                        (set_local $1
+                          (get_local $18)
                         )
                       )
                       (i32.const 0)
                     )
                     (i32.ne
                       (i32.load offset=4
-                        (get_local $$151)
+                        (get_local $1)
                       )
                       (i32.const 0)
                     )
@@ -9619,91 +8909,91 @@
                 )
               )
               (block
-                (set_local $$cmp323
+                (set_local $7
                   (i32.gt_s
-                    (get_local $$p$2)
-                    (set_local $$add322
+                    (get_local $31)
+                    (set_local $1
                       (i32.add
                         (i32.xor
                           (i32.and
-                            (get_local $$159)
+                            (get_local $1)
                             (i32.const 1)
                           )
                           (i32.const 1)
                         )
                         (i32.sub
-                          (get_local $$sub$ptr$lhs$cast317)
-                          (get_local $$a$0)
+                          (get_local $73)
+                          (get_local $34)
                         )
                       )
                     )
                   )
                 )
-                (set_local $$fl$6
-                  (get_local $$and309$fl$4)
+                (set_local $36
+                  (get_local $5)
                 )
-                (set_local $$p$5
+                (set_local $42
                   (select
-                    (get_local $$p$2)
-                    (get_local $$add322)
-                    (get_local $$cmp323)
+                    (get_local $31)
+                    (get_local $1)
+                    (get_local $7)
                   )
                 )
-                (set_local $$pl$2
-                  (get_local $$pl$1)
+                (set_local $43
+                  (get_local $38)
                 )
-                (set_local $$prefix$2
-                  (get_local $$prefix$1)
+                (set_local $51
+                  (get_local $40)
                 )
-                (set_local $$z$2
-                  (get_local $$add$ptr205)
+                (set_local $53
+                  (get_local $28)
                 )
-                (get_local $$a$0)
+                (get_local $34)
               )
               (block
-                (set_local $$fl$6
-                  (get_local $$and309$fl$4)
+                (set_local $36
+                  (get_local $5)
                 )
-                (set_local $$p$5
+                (set_local $42
                   (i32.const 0)
                 )
-                (set_local $$pl$2
-                  (get_local $$pl$1)
+                (set_local $43
+                  (get_local $38)
                 )
-                (set_local $$prefix$2
-                  (get_local $$prefix$1)
+                (set_local $51
+                  (get_local $40)
                 )
-                (set_local $$z$2
-                  (get_local $$add$ptr205)
+                (set_local $53
+                  (get_local $28)
                 )
-                (get_local $$add$ptr205)
+                (get_local $28)
               )
             )
           )
         )
       )
-      (set_local $$cmp434
+      (set_local $1
         (i32.lt_s
-          (get_local $$p$5)
-          (set_local $$sub$ptr$sub433
+          (get_local $42)
+          (set_local $7
             (i32.sub
-              (get_local $$z$2)
-              (get_local $$a$2)
+              (get_local $53)
+              (get_local $47)
             )
           )
         )
       )
-      (set_local $$cmp442
+      (set_local $5
         (i32.lt_s
-          (get_local $$w$1)
-          (set_local $$add441
+          (get_local $16)
+          (set_local $1
             (i32.add
-              (get_local $$pl$2)
-              (set_local $$sub$ptr$sub433$p$5
+              (get_local $43)
+              (set_local $6
                 (select
-                  (get_local $$sub$ptr$sub433)
-                  (get_local $$p$5)
-                  (get_local $$cmp434)
+                  (get_local $7)
+                  (get_local $42)
+                  (get_local $1)
                 )
               )
             )
@@ -9711,123 +9001,123 @@
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 32)
-        (set_local $$w$2
+        (set_local $8
           (select
-            (get_local $$add441)
-            (get_local $$w$1)
-            (get_local $$cmp442)
+            (get_local $1)
+            (get_local $16)
+            (get_local $5)
           )
         )
-        (get_local $$add441)
-        (get_local $$fl$6)
+        (get_local $1)
+        (get_local $36)
       )
       (if
         (i32.eq
           (i32.and
             (i32.load
-              (get_local $$f)
+              (get_local $0)
             )
             (i32.const 32)
           )
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $$prefix$2)
-          (get_local $$pl$2)
-          (get_local $$f)
+          (get_local $51)
+          (get_local $43)
+          (get_local $0)
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 48)
-        (get_local $$w$2)
-        (get_local $$add441)
+        (get_local $8)
+        (get_local $1)
         (i32.xor
-          (get_local $$fl$6)
+          (get_local $36)
           (i32.const 65536)
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 48)
-        (get_local $$sub$ptr$sub433$p$5)
-        (get_local $$sub$ptr$sub433)
+        (get_local $6)
+        (get_local $7)
         (i32.const 0)
       )
       (if
         (i32.eq
           (i32.and
             (i32.load
-              (get_local $$f)
+              (get_local $0)
             )
             (i32.const 32)
           )
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $$a$2)
-          (get_local $$sub$ptr$sub433)
-          (get_local $$f)
+          (get_local $47)
+          (get_local $7)
+          (get_local $0)
         )
       )
       (call $_pad
-        (get_local $$f)
+        (get_local $0)
         (i32.const 32)
-        (get_local $$w$2)
-        (get_local $$add441)
+        (get_local $8)
+        (get_local $1)
         (i32.xor
-          (get_local $$fl$6)
+          (get_local $36)
           (i32.const 8192)
         )
       )
-      (set_local $$cnt$0
-        (get_local $$cnt$1)
+      (set_local $5
+        (get_local $19)
       )
-      (set_local $$incdec$ptr169275
-        (get_local $$incdec$ptr169$lcssa)
+      (set_local $12
+        (get_local $26)
       )
-      (set_local $$l$0
-        (get_local $$w$2)
+      (set_local $1
+        (get_local $8)
       )
-      (set_local $$l10n$0
-        (get_local $$l10n$3)
+      (set_local $8
+        (get_local $20)
       )
       (br $label$continue$L1)
     )
     (block $label$break$L343
       (if
         (i32.eq
-          (get_local $label)
+          (get_local $13)
           (i32.const 242)
         )
         (if
           (i32.eq
-            (get_local $$f)
+            (get_local $0)
             (i32.const 0)
           )
           (if
             (i32.eq
-              (get_local $$l10n$0$lcssa)
+              (get_local $80)
               (i32.const 0)
             )
-            (set_local $$retval$0
+            (set_local $23
               (i32.const 0)
             )
             (block
-              (set_local $$i$2299
+              (set_local $1
                 (i32.const 1)
               )
               (loop $while-out$136 $while-in$137
                 (if
                   (i32.eq
-                    (set_local $$267
+                    (set_local $0
                       (i32.load
                         (i32.add
-                          (get_local $$nl_type)
+                          (get_local $4)
                           (i32.shl
-                            (get_local $$i$2299)
+                            (get_local $1)
                             (i32.const 2)
                           )
                         )
@@ -9836,38 +9126,38 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$i$2299$lcssa
-                      (get_local $$i$2299)
+                    (set_local $0
+                      (get_local $1)
                     )
                     (br $while-out$136)
                   )
                 )
                 (call $_pop_arg_336
                   (i32.add
-                    (get_local $$nl_arg)
+                    (get_local $3)
                     (i32.shl
-                      (get_local $$i$2299)
+                      (get_local $1)
                       (i32.const 3)
                     )
                   )
-                  (get_local $$267)
-                  (get_local $$ap)
+                  (get_local $0)
+                  (get_local $2)
                 )
                 (if
                   (i32.lt_s
-                    (set_local $$inc
+                    (set_local $0
                       (i32.add
-                        (get_local $$i$2299)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
                     (i32.const 10)
                   )
-                  (set_local $$i$2299
-                    (get_local $$inc)
+                  (set_local $1
+                    (get_local $0)
                   )
                   (block
-                    (set_local $$retval$0
+                    (set_local $23
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -9877,17 +9167,15 @@
               )
               (if
                 (i32.lt_s
-                  (get_local $$i$2299$lcssa)
+                  (get_local $0)
                   (i32.const 10)
                 )
                 (block
-                  (set_local $$i$3296
-                    (get_local $$i$2299$lcssa)
-                  )
+                  (get_local $0)
                   (loop $while-out$138 $while-in$139
-                    (set_local $$inc488
+                    (set_local $1
                       (i32.add
-                        (get_local $$i$3296)
+                        (get_local $0)
                         (i32.const 1)
                       )
                     )
@@ -9895,9 +9183,9 @@
                       (i32.ne
                         (i32.load
                           (i32.add
-                            (get_local $$nl_type)
+                            (get_local $4)
                             (i32.shl
-                              (get_local $$i$3296)
+                              (get_local $0)
                               (i32.const 2)
                             )
                           )
@@ -9905,7 +9193,7 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$retval$0
+                        (set_local $23
                           (i32.const -1)
                         )
                         (br $label$break$L343)
@@ -9913,14 +9201,14 @@
                     )
                     (if
                       (i32.lt_s
-                        (get_local $$inc488)
+                        (get_local $1)
                         (i32.const 10)
                       )
-                      (set_local $$i$3296
-                        (get_local $$inc488)
+                      (set_local $0
+                        (get_local $1)
                       )
                       (block
-                        (set_local $$retval$0
+                        (set_local $23
                           (i32.const 1)
                         )
                         (br $while-out$138)
@@ -9929,65 +9217,35 @@
                     (br $while-in$139)
                   )
                 )
-                (set_local $$retval$0
+                (set_local $23
                   (i32.const 1)
                 )
               )
             )
           )
-          (set_local $$retval$0
-            (get_local $$cnt$1$lcssa)
+          (set_local $23
+            (get_local $79)
           )
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $32)
     )
-    (get_local $$retval$0)
+    (get_local $23)
   )
-  (func $_pop_arg_336 (param $$arg i32) (param $$type i32) (param $$ap i32)
-    (local $$13 i32)
-    (local $$102 i32)
-    (local $$103 f64)
-    (local $$109 i32)
-    (local $$110 f64)
-    (local $$12 i32)
-    (local $$16 i32)
-    (local $$25 i32)
-    (local $$26 i32)
-    (local $$27 i32)
-    (local $$36 i32)
-    (local $$37 i32)
-    (local $$39 i32)
-    (local $$42 i32)
-    (local $$43 i32)
-    (local $$5 i32)
-    (local $$52 i32)
-    (local $$53 i32)
-    (local $$54 i32)
-    (local $$56 i32)
-    (local $$57 i32)
-    (local $$6 i32)
-    (local $$66 i32)
-    (local $$67 i32)
-    (local $$68 i32)
-    (local $$77 i32)
-    (local $$78 i32)
-    (local $$79 i32)
-    (local $$81 i32)
-    (local $$82 i32)
-    (local $$91 i32)
-    (local $$92 i32)
-    (local $$93 i32)
+  (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
+    (local $3 i32)
+    (local $4 f64)
+    (local $5 i32)
     (i32.load
       (i32.const 8)
     )
     (block $label$break$L1
       (if
         (i32.le_u
-          (get_local $$type)
+          (get_local $1)
           (i32.const 20)
         )
         (block $switch$3
@@ -10005,18 +9263,18 @@
                                 (block $switch-case$4
                                   (br_table $switch-case$4 $switch-case$5 $switch-case$6 $switch-case$7 $switch-case$8 $switch-case$9 $switch-case$10 $switch-case$11 $switch-case$12 $switch-case$13 $switch-default$14
                                     (i32.sub
-                                      (get_local $$type)
+                                      (get_local $1)
                                       (i32.const 9)
                                     )
                                   )
                                 )
-                                (set_local $$6
+                                (set_local $3
                                   (i32.load
-                                    (set_local $$5
+                                    (set_local $1
                                       (i32.and
                                         (i32.add
                                           (i32.load
-                                            (get_local $$ap)
+                                            (get_local $2)
                                           )
                                           (i32.sub
                                             (i32.add
@@ -10041,25 +9299,25 @@
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$ap)
+                                  (get_local $2)
                                   (i32.add
-                                    (get_local $$5)
+                                    (get_local $1)
                                     (i32.const 4)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$arg)
-                                  (get_local $$6)
+                                  (get_local $0)
+                                  (get_local $3)
                                 )
                                 (br $label$break$L1)
                               )
-                              (set_local $$13
+                              (set_local $3
                                 (i32.load
-                                  (set_local $$12
+                                  (set_local $1
                                     (i32.and
                                       (i32.add
                                         (i32.load
-                                          (get_local $$ap)
+                                          (get_local $2)
                                         )
                                         (i32.sub
                                           (i32.add
@@ -10084,24 +9342,22 @@
                                 )
                               )
                               (i32.store
-                                (get_local $$ap)
+                                (get_local $2)
                                 (i32.add
-                                  (get_local $$12)
+                                  (get_local $1)
                                   (i32.const 4)
                                 )
                               )
                               (i32.store
-                                (set_local $$16
-                                  (get_local $$arg)
-                                )
-                                (get_local $$13)
+                                (get_local $0)
+                                (get_local $3)
                               )
                               (i32.store offset=4
-                                (get_local $$16)
+                                (get_local $0)
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.lt_s
-                                      (get_local $$13)
+                                      (get_local $3)
                                       (i32.const 0)
                                     )
                                     (i32.const 31)
@@ -10111,13 +9367,13 @@
                               )
                               (br $label$break$L1)
                             )
-                            (set_local $$26
+                            (set_local $3
                               (i32.load
-                                (set_local $$25
+                                (set_local $1
                                   (i32.and
                                     (i32.add
                                       (i32.load
-                                        (get_local $$ap)
+                                        (get_local $2)
                                       )
                                       (i32.sub
                                         (i32.add
@@ -10142,32 +9398,30 @@
                               )
                             )
                             (i32.store
-                              (get_local $$ap)
+                              (get_local $2)
                               (i32.add
-                                (get_local $$25)
+                                (get_local $1)
                                 (i32.const 4)
                               )
                             )
                             (i32.store
-                              (set_local $$27
-                                (get_local $$arg)
-                              )
-                              (get_local $$26)
+                              (get_local $0)
+                              (get_local $3)
                             )
                             (i32.store offset=4
-                              (get_local $$27)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (br $label$break$L1)
                           )
-                          (set_local $$39
+                          (set_local $5
                             (i32.load
-                              (set_local $$37
-                                (set_local $$36
+                              (set_local $3
+                                (set_local $1
                                   (i32.and
                                     (i32.add
                                       (i32.load
-                                        (get_local $$ap)
+                                        (get_local $2)
                                       )
                                       (i32.sub
                                         (i32.add
@@ -10192,37 +9446,35 @@
                               )
                             )
                           )
-                          (set_local $$42
+                          (set_local $3
                             (i32.load offset=4
-                              (get_local $$37)
+                              (get_local $3)
                             )
                           )
                           (i32.store
-                            (get_local $$ap)
+                            (get_local $2)
                             (i32.add
-                              (get_local $$36)
+                              (get_local $1)
                               (i32.const 8)
                             )
                           )
                           (i32.store
-                            (set_local $$43
-                              (get_local $$arg)
-                            )
-                            (get_local $$39)
+                            (get_local $0)
+                            (get_local $5)
                           )
                           (i32.store offset=4
-                            (get_local $$43)
-                            (get_local $$42)
+                            (get_local $0)
+                            (get_local $3)
                           )
                           (br $label$break$L1)
                         )
-                        (set_local $$53
+                        (set_local $3
                           (i32.load
-                            (set_local $$52
+                            (set_local $1
                               (i32.and
                                 (i32.add
                                   (i32.load
-                                    (get_local $$ap)
+                                    (get_local $2)
                                   )
                                   (i32.sub
                                     (i32.add
@@ -10247,21 +9499,21 @@
                           )
                         )
                         (i32.store
-                          (get_local $$ap)
+                          (get_local $2)
                           (i32.add
-                            (get_local $$52)
+                            (get_local $1)
                             (i32.const 4)
                           )
                         )
-                        (set_local $$56
+                        (set_local $2
                           (i32.shr_s
                             (i32.shl
                               (i32.lt_s
-                                (set_local $$54
+                                (set_local $1
                                   (i32.shr_s
                                     (i32.shl
                                       (i32.and
-                                        (get_local $$53)
+                                        (get_local $3)
                                         (i32.const 65535)
                                       )
                                       (i32.const 16)
@@ -10277,24 +9529,22 @@
                           )
                         )
                         (i32.store
-                          (set_local $$57
-                            (get_local $$arg)
-                          )
-                          (get_local $$54)
+                          (get_local $0)
+                          (get_local $1)
                         )
                         (i32.store offset=4
-                          (get_local $$57)
-                          (get_local $$56)
+                          (get_local $0)
+                          (get_local $2)
                         )
                         (br $label$break$L1)
                       )
-                      (set_local $$67
+                      (set_local $3
                         (i32.load
-                          (set_local $$66
+                          (set_local $1
                             (i32.and
                               (i32.add
                                 (i32.load
-                                  (get_local $$ap)
+                                  (get_local $2)
                                 )
                                 (i32.sub
                                   (i32.add
@@ -10319,34 +9569,32 @@
                         )
                       )
                       (i32.store
-                        (get_local $$ap)
+                        (get_local $2)
                         (i32.add
-                          (get_local $$66)
+                          (get_local $1)
                           (i32.const 4)
                         )
                       )
                       (i32.store
-                        (set_local $$68
-                          (get_local $$arg)
-                        )
+                        (get_local $0)
                         (i32.and
-                          (get_local $$67)
+                          (get_local $3)
                           (i32.const 65535)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $$68)
+                        (get_local $0)
                         (i32.const 0)
                       )
                       (br $label$break$L1)
                     )
-                    (set_local $$78
+                    (set_local $3
                       (i32.load
-                        (set_local $$77
+                        (set_local $1
                           (i32.and
                             (i32.add
                               (i32.load
-                                (get_local $$ap)
+                                (get_local $2)
                               )
                               (i32.sub
                                 (i32.add
@@ -10371,21 +9619,21 @@
                       )
                     )
                     (i32.store
-                      (get_local $$ap)
+                      (get_local $2)
                       (i32.add
-                        (get_local $$77)
+                        (get_local $1)
                         (i32.const 4)
                       )
                     )
-                    (set_local $$81
+                    (set_local $2
                       (i32.shr_s
                         (i32.shl
                           (i32.lt_s
-                            (set_local $$79
+                            (set_local $1
                               (i32.shr_s
                                 (i32.shl
                                   (i32.and
-                                    (get_local $$78)
+                                    (get_local $3)
                                     (i32.const 255)
                                   )
                                   (i32.const 24)
@@ -10401,24 +9649,22 @@
                       )
                     )
                     (i32.store
-                      (set_local $$82
-                        (get_local $$arg)
-                      )
-                      (get_local $$79)
+                      (get_local $0)
+                      (get_local $1)
                     )
                     (i32.store offset=4
-                      (get_local $$82)
-                      (get_local $$81)
+                      (get_local $0)
+                      (get_local $2)
                     )
                     (br $label$break$L1)
                   )
-                  (set_local $$92
+                  (set_local $3
                     (i32.load
-                      (set_local $$91
+                      (set_local $1
                         (i32.and
                           (i32.add
                             (i32.load
-                              (get_local $$ap)
+                              (get_local $2)
                             )
                             (i32.sub
                               (i32.add
@@ -10443,34 +9689,32 @@
                     )
                   )
                   (i32.store
-                    (get_local $$ap)
+                    (get_local $2)
                     (i32.add
-                      (get_local $$91)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
                   (i32.store
-                    (set_local $$93
-                      (get_local $$arg)
-                    )
+                    (get_local $0)
                     (i32.and
-                      (get_local $$92)
+                      (get_local $3)
                       (i32.const 255)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$93)
+                    (get_local $0)
                     (i32.const 0)
                   )
                   (br $label$break$L1)
                 )
-                (set_local $$103
+                (set_local $4
                   (f64.load
-                    (set_local $$102
+                    (set_local $1
                       (i32.and
                         (i32.add
                           (i32.load
-                            (get_local $$ap)
+                            (get_local $2)
                           )
                           (i32.sub
                             (i32.add
@@ -10495,25 +9739,25 @@
                   )
                 )
                 (i32.store
-                  (get_local $$ap)
+                  (get_local $2)
                   (i32.add
-                    (get_local $$102)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (f64.store
-                  (get_local $$arg)
-                  (get_local $$103)
+                  (get_local $0)
+                  (get_local $4)
                 )
                 (br $label$break$L1)
               )
-              (set_local $$110
+              (set_local $4
                 (f64.load
-                  (set_local $$109
+                  (set_local $1
                     (i32.and
                       (i32.add
                         (i32.load
-                          (get_local $$ap)
+                          (get_local $2)
                         )
                         (i32.sub
                           (i32.add
@@ -10538,15 +9782,15 @@
                 )
               )
               (i32.store
-                (get_local $$ap)
+                (get_local $2)
                 (i32.add
-                  (get_local $$109)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (f64.store
-                (get_local $$arg)
-                (get_local $$110)
+                (get_local $0)
+                (get_local $4)
               )
             )
           )
@@ -10554,59 +9798,45 @@
       )
     )
   )
-  (func $_fmt_u (param $$0 i32) (param $$1 i32) (param $$s i32) (result i32)
-    (local $$8 i32)
-    (local $$7 i32)
-    (local $$y$010 i32)
-    (local $$x$addr$0$lcssa$off0 i32)
-    (local $$13 i32)
-    (local $$14 i32)
-    (local $$incdec$ptr i32)
-    (local $$incdec$ptr7 i32)
-    (local $$s$addr$0$lcssa i32)
-    (local $$s$addr$013 i32)
-    (local $$s$addr$1$lcssa i32)
-    (local $$s$addr$19 i32)
-    (local $$21 i32)
-    (local $$9 i32)
-    (local $$div9 i32)
-    (local $$incdec$ptr$lcssa i32)
+  (func $_fmt_u (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
     (i32.load
       (i32.const 8)
     )
-    (set_local $$s$addr$0$lcssa
+    (set_local $0
       (if
         (i32.or
           (i32.gt_u
-            (get_local $$1)
+            (get_local $1)
             (i32.const 0)
           )
           (i32.and
             (i32.eq
-              (get_local $$1)
+              (get_local $1)
               (i32.const 0)
             )
             (i32.gt_u
-              (get_local $$0)
+              (get_local $0)
               (i32.const -1)
             )
           )
         )
         (block
-          (set_local $$7
-            (get_local $$0)
+          (set_local $3
+            (get_local $0)
           )
-          (set_local $$8
-            (get_local $$1)
+          (set_local $4
+            (get_local $1)
           )
-          (set_local $$s$addr$013
-            (get_local $$s)
+          (set_local $1
+            (get_local $2)
           )
           (loop $while-out$0 $while-in$1
-            (set_local $$9
+            (set_local $0
               (call $___uremdi3
-                (get_local $$7)
-                (get_local $$8)
+                (get_local $3)
+                (get_local $4)
                 (i32.const 10)
                 (i32.const 0)
               )
@@ -10615,29 +9845,29 @@
               (i32.const 168)
             )
             (i32.store8
-              (set_local $$incdec$ptr
+              (set_local $2
                 (i32.add
-                  (get_local $$s$addr$013)
+                  (get_local $1)
                   (i32.const -1)
                 )
               )
               (i32.and
                 (i32.or
-                  (get_local $$9)
+                  (get_local $0)
                   (i32.const 48)
                 )
                 (i32.const 255)
               )
             )
-            (set_local $$13
+            (set_local $0
               (call $___udivdi3
-                (get_local $$7)
-                (get_local $$8)
+                (get_local $3)
+                (get_local $4)
                 (i32.const 10)
                 (i32.const 0)
               )
             )
-            (set_local $$14
+            (set_local $1
               (i32.load
                 (i32.const 168)
               )
@@ -10645,77 +9875,73 @@
             (if
               (i32.or
                 (i32.gt_u
-                  (get_local $$8)
+                  (get_local $4)
                   (i32.const 9)
                 )
                 (i32.and
                   (i32.eq
-                    (get_local $$8)
+                    (get_local $4)
                     (i32.const 9)
                   )
                   (i32.gt_u
-                    (get_local $$7)
+                    (get_local $3)
                     (i32.const -1)
                   )
                 )
               )
               (block
-                (set_local $$7
-                  (get_local $$13)
+                (set_local $3
+                  (get_local $0)
                 )
-                (set_local $$8
-                  (get_local $$14)
+                (set_local $4
+                  (get_local $1)
                 )
-                (set_local $$s$addr$013
-                  (get_local $$incdec$ptr)
+                (set_local $1
+                  (get_local $2)
                 )
               )
               (block
-                (set_local $$21
-                  (get_local $$13)
-                )
-                (get_local $$14)
-                (set_local $$incdec$ptr$lcssa
-                  (get_local $$incdec$ptr)
+                (get_local $0)
+                (get_local $1)
+                (set_local $1
+                  (get_local $2)
                 )
                 (br $while-out$0)
               )
             )
             (br $while-in$1)
           )
-          (set_local $$x$addr$0$lcssa$off0
-            (get_local $$21)
+          (set_local $3
+            (get_local $0)
           )
-          (get_local $$incdec$ptr$lcssa)
+          (get_local $1)
         )
         (block
-          (set_local $$x$addr$0$lcssa$off0
-            (get_local $$0)
+          (set_local $3
+            (get_local $0)
           )
-          (get_local $$s)
+          (get_local $2)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $$x$addr$0$lcssa$off0)
+        (get_local $3)
         (i32.const 0)
       )
-      (set_local $$s$addr$1$lcssa
-        (get_local $$s$addr$0$lcssa)
-      )
+      (get_local $0)
       (block
-        (set_local $$s$addr$19
-          (get_local $$s$addr$0$lcssa)
+        (set_local $1
+          (get_local $0)
         )
-        (set_local $$y$010
-          (get_local $$x$addr$0$lcssa$off0)
+        (set_local $2
+          (get_local $3)
         )
         (loop $while-out$2 $while-in$3
           (i32.store8
-            (set_local $$incdec$ptr7
+            (set_local $1
               (i32.add
-                (get_local $$s$addr$19)
+                (get_local $1)
                 (i32.const -1)
               )
             )
@@ -10723,7 +9949,7 @@
               (i32.or
                 (i32.and
                   (i32.rem_u
-                    (get_local $$y$010)
+                    (get_local $2)
                     (i32.const 10)
                   )
                   (i32.const -1)
@@ -10733,10 +9959,10 @@
               (i32.const 255)
             )
           )
-          (set_local $$div9
+          (set_local $0
             (i32.and
               (i32.div_u
-                (get_local $$y$010)
+                (get_local $2)
                 (i32.const 10)
               )
               (i32.const -1)
@@ -10744,21 +9970,19 @@
           )
           (if
             (i32.lt_u
-              (get_local $$y$010)
+              (get_local $2)
               (i32.const 10)
             )
             (block
-              (set_local $$s$addr$1$lcssa
-                (get_local $$incdec$ptr7)
+              (set_local $0
+                (get_local $1)
               )
               (br $while-out$2)
             )
             (block
-              (set_local $$s$addr$19
-                (get_local $$incdec$ptr7)
-              )
-              (set_local $$y$010
-                (get_local $$div9)
+              (get_local $1)
+              (set_local $2
+                (get_local $0)
               )
             )
           )
@@ -10766,25 +9990,13 @@
         )
       )
     )
-    (get_local $$s$addr$1$lcssa)
+    (get_local $0)
   )
-  (func $_pad (param $$f i32) (param $$c i32) (param $$w i32) (param $$l i32) (param $$fl i32)
-    (local $$sub i32)
-    (local $$pad i32)
-    (local $$4 i32)
-    (local $$l$addr$0$lcssa21 i32)
-    (local $$l$addr$017 i32)
-    (local $$tobool$i i32)
-    (local $$tobool$i$16 i32)
-    (local $$tobool$i18 i32)
-    (local $sp i32)
-    (local $$0 i32)
-    (local $$1 i32)
-    (local $$2 i32)
-    (local $$3 i32)
-    (local $$cmp1 i32)
-    (local $$sub5 i32)
-    (set_local $sp
+  (func $_pad (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (set_local $7
       (i32.load
         (i32.const 8)
       )
@@ -10809,51 +10021,51 @@
       )
       (call_import $abort)
     )
-    (set_local $$pad
-      (get_local $sp)
+    (set_local $6
+      (get_local $7)
     )
     (block $do-once$0
       (if
         (i32.and
           (i32.gt_s
-            (get_local $$w)
-            (get_local $$l)
+            (get_local $2)
+            (get_local $3)
           )
           (i32.eq
             (i32.and
-              (get_local $$fl)
+              (get_local $4)
               (i32.const 73728)
             )
             (i32.const 0)
           )
         )
         (block
-          (set_local $$cmp1
+          (set_local $4
             (i32.gt_u
-              (set_local $$sub
+              (set_local $5
                 (i32.sub
-                  (get_local $$w)
-                  (get_local $$l)
+                  (get_local $2)
+                  (get_local $3)
                 )
               )
               (i32.const 256)
             )
           )
           (call $_memset
-            (get_local $$pad)
-            (get_local $$c)
+            (get_local $6)
+            (get_local $1)
             (select
               (i32.const 256)
-              (get_local $$sub)
-              (get_local $$cmp1)
+              (get_local $5)
+              (get_local $4)
             )
           )
-          (set_local $$tobool$i$16
+          (set_local $4
             (i32.eq
               (i32.and
-                (set_local $$0
+                (set_local $1
                   (i32.load
-                    (get_local $$f)
+                    (get_local $0)
                   )
                 )
                 (i32.const 32)
@@ -10863,43 +10075,39 @@
           )
           (if
             (i32.gt_u
-              (get_local $$sub)
+              (get_local $5)
               (i32.const 255)
             )
             (block
-              (set_local $$1
+              (set_local $2
                 (i32.sub
-                  (get_local $$w)
-                  (get_local $$l)
+                  (get_local $2)
+                  (get_local $3)
                 )
               )
-              (set_local $$4
-                (get_local $$0)
+              (get_local $1)
+              (set_local $3
+                (get_local $5)
               )
-              (set_local $$l$addr$017
-                (get_local $$sub)
-              )
-              (set_local $$tobool$i18
-                (get_local $$tobool$i$16)
-              )
+              (get_local $4)
               (loop $while-out$2 $while-in$3
-                (set_local $$tobool$i
+                (set_local $4
                   (i32.eq
                     (i32.and
-                      (set_local $$2
+                      (set_local $1
                         (if
-                          (get_local $$tobool$i18)
+                          (get_local $4)
                           (block
                             (call $___fwritex
-                              (get_local $$pad)
+                              (get_local $6)
                               (i32.const 256)
-                              (get_local $$f)
+                              (get_local $0)
                             )
                             (i32.load
-                              (get_local $$f)
+                              (get_local $0)
                             )
                           )
-                          (get_local $$4)
+                          (get_local $1)
                         )
                       )
                       (i32.const 32)
@@ -10909,547 +10117,137 @@
                 )
                 (if
                   (i32.gt_u
-                    (set_local $$sub5
+                    (set_local $3
                       (i32.add
-                        (get_local $$l$addr$017)
+                        (get_local $3)
                         (i32.const -256)
                       )
                     )
                     (i32.const 255)
                   )
                   (block
-                    (set_local $$4
-                      (get_local $$2)
-                    )
-                    (set_local $$l$addr$017
-                      (get_local $$sub5)
-                    )
-                    (set_local $$tobool$i18
-                      (get_local $$tobool$i)
-                    )
+                    (get_local $1)
+                    (get_local $3)
+                    (get_local $4)
                   )
                   (br $while-out$2)
                 )
                 (br $while-in$3)
               )
-              (set_local $$3
+              (set_local $1
                 (i32.and
-                  (get_local $$1)
+                  (get_local $2)
                   (i32.const 255)
                 )
               )
               (if
-                (get_local $$tobool$i)
-                (set_local $$l$addr$0$lcssa21
-                  (get_local $$3)
-                )
+                (get_local $4)
+                (get_local $1)
                 (br $do-once$0)
               )
             )
             (if
-              (get_local $$tobool$i$16)
-              (set_local $$l$addr$0$lcssa21
-                (get_local $$sub)
+              (get_local $4)
+              (set_local $1
+                (get_local $5)
               )
               (br $do-once$0)
             )
           )
           (call $___fwritex
-            (get_local $$pad)
-            (get_local $$l$addr$0$lcssa21)
-            (get_local $$f)
+            (get_local $6)
+            (get_local $1)
+            (get_local $0)
           )
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $sp)
+      (get_local $7)
     )
   )
-  (func $_malloc (param $$bytes i32) (result i32)
-    (local $$119 i32)
-    (local $label i32)
-    (local $$add$ptr17$i$i i32)
-    (local $$nb$0 i32)
-    (local $$add$ptr$i$161 i32)
-    (local $$v$4$lcssa$i i32)
-    (local $$add$ptr16$i$i i32)
-    (local $$tbase$796$i i32)
-    (local $$v$0$i$lcssa i32)
-    (local $$and145 i32)
-    (local $$rsize$4$lcssa$i i32)
-    (local $$R$3$i i32)
-    (local $$R$3$i$171 i32)
-    (local $$R$3$i$i i32)
-    (local $$tsize$795$i i32)
-    (local $$cond i32)
-    (local $$qsize$0$i$i i32)
-    (local $$ssize$2$ph$i i32)
-    (local $$sub$ptr$sub$i$i i32)
-    (local $$t$0$i$151 i32)
-    (local $$t$48$i i32)
-    (local $$149 i32)
-    (local $$R$1$i i32)
-    (local $$R$1$i$168 i32)
-    (local $$R$1$i$i i32)
-    (local $$rsize$0$i$lcssa i32)
-    (local $$ssize$0$i i32)
-    (local $$148 i32)
-    (local $$154 i32)
-    (local $$26 i32)
-    (local $$63 i32)
-    (local $$95 i32)
-    (local $$T$0$i i32)
-    (local $$T$0$i$58$i i32)
-    (local $$T$0$i$i i32)
-    (local $$add$ptr14$i$i i32)
-    (local $$and11$i i32)
-    (local $$cond13$i$i i32)
-    (local $$rsize$49$i i32)
-    (local $$sp$0$i$i i32)
-    (local $$sp$0$i$i$i i32)
-    (local $$sp$0108$i i32)
-    (local $$sp$1107$i i32)
-    (local $$10 i32)
-    (local $$14 i32)
-    (local $$150 i32)
-    (local $$3 i32)
-    (local $$46 i32)
-    (local $$I252$0$i$i i32)
-    (local $$I316$0$i i32)
-    (local $$I57$0$i$i i32)
-    (local $$RP$1$i i32)
-    (local $$RP$1$i$167 i32)
-    (local $$RP$1$i$i i32)
-    (local $$arrayidx$i$20$i i32)
-    (local $$arrayidx103 i32)
-    (local $$arrayidx196$i i32)
-    (local $$arrayidx223$i$i i32)
-    (local $$arrayidx289$i i32)
-    (local $$br$2$ph$i i32)
-    (local $$cond4$i i32)
-    (local $$rsize$0$i i32)
-    (local $$sub160 i32)
-    (local $$sub18$i$i i32)
-    (local $$v$3$i i32)
-    (local $$v$410$i i32)
-    (local $$13 i32)
-    (local $$147 i32)
-    (local $$155 i32)
-    (local $$169 i32)
-    (local $$170 i32)
-    (local $$2 i32)
-    (local $$27 i32)
-    (local $$41 i32)
-    (local $$42 i32)
-    (local $$64 i32)
-    (local $$78 i32)
-    (local $$79 i32)
-    (local $$9 i32)
-    (local $$94 i32)
-    (local $$F$0$i$i i32)
-    (local $$F104$0 i32)
-    (local $$F197$0$i i32)
-    (local $$F224$0$i$i i32)
-    (local $$F290$0$i i32)
-    (local $$K105$0$i$i i32)
-    (local $$K305$0$i$i i32)
-    (local $$K373$0$i i32)
-    (local $$T$0$i$58$i$lcssa i32)
-    (local $$T$0$i$i$lcssa i32)
-    (local $$T$0$i$lcssa i32)
-    (local $$add$ptr$i i32)
-    (local $$add$ptr227$i i32)
-    (local $$add$ptr4$i$26$i i32)
-    (local $$add$ptr4$i$37$i i32)
-    (local $$add26$i$i i32)
-    (local $$and80$i i32)
-    (local $$arrayidx$i$i i32)
-    (local $$arrayidx287$i$i i32)
-    (local $$arrayidx355$i i32)
-    (local $$arrayidx91$i$i i32)
-    (local $$call$i$i i32)
-    (local $$call131$i i32)
-    (local $$call37$i i32)
-    (local $$call83$i i32)
-    (local $$i$01$i$i i32)
-    (local $$idx$0$i i32)
-    (local $$rsize$0$i$152 i32)
-    (local $$rsize$1$i i32)
-    (local $$rsize$3$i i32)
-    (local $$shr i32)
-    (local $$shr3 i32)
-    (local $$sizebits$0$i i32)
-    (local $$ssize$5$i i32)
-    (local $$sub101$rsize$4$i i32)
-    (local $$sub5$i$27$i i32)
-    (local $$sub91 i32)
-    (local $$t$0$i i32)
-    (local $$t$2$i i32)
-    (local $$t$4$v$4$i i32)
-    (local $$v$0$i i32)
-    (local $$v$1$i i32)
-    (local $$$pre$phi$i$178Z2D i32)
-    (local $$$pre$phi$i$57$iZ2D i32)
-    (local $$$pre$phi$i$iZ2D i32)
-    (local $$$pre$phi$iZ2D i32)
-    (local $$$pre$phiZ2D i32)
-    (local $$0 i32)
-    (local $$104 i32)
-    (local $$108 i32)
-    (local $$156 i32)
-    (local $$182 i32)
-    (local $$19 i32)
-    (local $$20 i32)
-    (local $$204 i32)
-    (local $$208 i32)
-    (local $$25 i32)
-    (local $$28 i32)
-    (local $$54 i32)
-    (local $$55 i32)
-    (local $$62 i32)
-    (local $$65 i32)
-    (local $$91 i32)
-    (local $$98 i32)
-    (local $$RP$1$i$167$lcssa i32)
-    (local $$RP$1$i$i$lcssa i32)
-    (local $$RP$1$i$lcssa i32)
-    (local $$add$ptr$i$i$i$lcssa i32)
-    (local $$add$ptr166 i32)
-    (local $$add$ptr24$i$i i32)
-    (local $$add$ptr4$i$i i32)
-    (local $$add$ptr4$i$i$i i32)
-    (local $$add$ptr95 i32)
-    (local $$add150$i i32)
-    (local $$add54$i i32)
-    (local $$add64 i32)
-    (local $$add8 i32)
-    (local $$and104$i i32)
-    (local $$and3$i i32)
-    (local $$and37$i$i i32)
-    (local $$and46 i32)
-    (local $$and64$i i32)
-    (local $$and73$i i32)
-    (local $$arrayidx i32)
-    (local $$arrayidx126$i$i$lcssa i32)
-    (local $$arrayidx325$i$i$lcssa i32)
-    (local $$arrayidx394$i$lcssa i32)
-    (local $$arrayidx66 i32)
-    (local $$call132$i i32)
-    (local $$child$i$i i32)
-    (local $$cmp102$i i32)
-    (local $$cmp32$i i32)
-    (local $$fd68$pre$phi$i$iZ2D i32)
-    (local $$head$i$17$i i32)
-    (local $$p$0$i$i i32)
-    (local $$rst$0$i i32)
-    (local $$rst$1$i i32)
-    (local $$shr$i$139 i32)
-    (local $$shr$i$45$i i32)
-    (local $$shr$i$i i32)
-    (local $$shr214$i$i i32)
-    (local $$shr253$i$i i32)
-    (local $$shr283$i i32)
-    (local $$shr318$i i32)
-    (local $$shr58$i$i i32)
-    (local $$sp$1107$i$lcssa i32)
-    (local $$sub$i$138 i32)
-    (local $$sub33$i i32)
-    (local $$sub5$i$i i32)
-    (local $$sub5$i$i$i i32)
-    (local $$v$0$i$153 i32)
-    (local $$$lcssa i32)
-    (local $$$lcssa290 i32)
-    (local $$1 i32)
-    (local $$100 i32)
-    (local $$101 i32)
-    (local $$102 i32)
-    (local $$105 i32)
-    (local $$107 i32)
-    (local $$109 i32)
-    (local $$110 i32)
-    (local $$111 i32)
-    (local $$115 i32)
-    (local $$120 i32)
-    (local $$124 i32)
-    (local $$127 i32)
-    (local $$128 i32)
-    (local $$129 i32)
-    (local $$132 i32)
-    (local $$135 i32)
-    (local $$137 i32)
-    (local $$140 i32)
-    (local $$142 i32)
-    (local $$15 i32)
-    (local $$159 i32)
-    (local $$16 i32)
-    (local $$160 i32)
-    (local $$161 i32)
-    (local $$162 i32)
-    (local $$163 i32)
-    (local $$168 i32)
-    (local $$17 i32)
-    (local $$173 i32)
-    (local $$174 i32)
-    (local $$175 i32)
-    (local $$177 i32)
-    (local $$180 i32)
-    (local $$183 i32)
-    (local $$185 i32)
-    (local $$188 i32)
-    (local $$190 i32)
-    (local $$195 i32)
-    (local $$196 i32)
-    (local $$197 i32)
-    (local $$199 i32)
-    (local $$202 i32)
-    (local $$205 i32)
-    (local $$207 i32)
-    (local $$22 i32)
-    (local $$23 i32)
-    (local $$31 i32)
-    (local $$32 i32)
-    (local $$33 i32)
-    (local $$34 i32)
-    (local $$35 i32)
-    (local $$40 i32)
-    (local $$45 i32)
-    (local $$47 i32)
-    (local $$48 i32)
-    (local $$49 i32)
-    (local $$51 i32)
-    (local $$52 i32)
-    (local $$59 i32)
-    (local $$60 i32)
-    (local $$68 i32)
-    (local $$69 i32)
-    (local $$7 i32)
-    (local $$70 i32)
-    (local $$71 i32)
-    (local $$72 i32)
-    (local $$77 i32)
-    (local $$8 i32)
-    (local $$82 i32)
-    (local $$83 i32)
-    (local $$84 i32)
-    (local $$86 i32)
-    (local $$89 i32)
-    (local $$92 i32)
-    (local $$97 i32)
-    (local $$R$1$i$168$lcssa i32)
-    (local $$R$1$i$i$lcssa i32)
-    (local $$R$1$i$lcssa i32)
-    (local $$T$0$i$58$i$lcssa283 i32)
-    (local $$T$0$i$i$lcssa284 i32)
-    (local $$T$0$i$lcssa293 i32)
-    (local $$add$i$180 i32)
-    (local $$add$i$i i32)
-    (local $$add$ptr$i$i$i i32)
-    (local $$add$ptr193 i32)
-    (local $$add$ptr2$i$i i32)
-    (local $$add$ptr262$i i32)
-    (local $$add$ptr7$i$i i32)
-    (local $$add$ptr8$i122$i i32)
-    (local $$add144 i32)
-    (local $$add17$i i32)
-    (local $$add17$i$183 i32)
-    (local $$add177$i i32)
-    (local $$add246$i i32)
-    (local $$add268$i i32)
-    (local $$add278$i$i i32)
-    (local $$add346$i i32)
-    (local $$add83$i$i i32)
-    (local $$add9$i i32)
-    (local $$and$i$143 i32)
-    (local $$and12$i i32)
-    (local $$and13$i i32)
-    (local $$and17$i i32)
-    (local $$and209$i$i i32)
-    (local $$and264$i$i i32)
-    (local $$and268$i$i i32)
-    (local $$and273$i$i i32)
-    (local $$and32$i i32)
-    (local $$and331$i i32)
-    (local $$and336$i i32)
-    (local $$and341$i i32)
-    (local $$and41 i32)
-    (local $$and49 i32)
-    (local $$and53 i32)
-    (local $$and57 i32)
-    (local $$and6$i i32)
-    (local $$and61 i32)
-    (local $$and69$i$i i32)
-    (local $$and73$i$i i32)
-    (local $$and77$i i32)
-    (local $$and78$i$i i32)
-    (local $$and8$i i32)
-    (local $$and81$i i32)
-    (local $$and85$i i32)
-    (local $$and89$i i32)
-    (local $$and9$i i32)
-    (local $$arrayidx$i$48$i i32)
-    (local $$arrayidx103$i$i i32)
-    (local $$arrayidx107$i$i i32)
-    (local $$arrayidx113$i i32)
-    (local $$arrayidx123$i$i i32)
-    (local $$arrayidx126$i$i i32)
-    (local $$arrayidx143$i$i i32)
-    (local $$arrayidx151$i i32)
-    (local $$arrayidx155$i i32)
-    (local $$arrayidx161$i i32)
-    (local $$arrayidx165$i$169 i32)
-    (local $$arrayidx184$i i32)
-    (local $$arrayidx204$i i32)
-    (local $$arrayidx325$i$i i32)
-    (local $$arrayidx394$i i32)
-    (local $$arrayidx61$i i32)
-    (local $$arrayidx65$i i32)
-    (local $$arrayidx71$i i32)
-    (local $$arrayidx75$i i32)
-    (local $$arrayidx94$i i32)
-    (local $$arrayidx96$i$i i32)
-    (local $$base$i$i$lcssa i32)
-    (local $$base226$i$lcssa i32)
-    (local $$bk i32)
-    (local $$bk136$i i32)
-    (local $$bk47$i i32)
-    (local $$bk78 i32)
-    (local $$bk82$i$i i32)
-    (local $$call68$i i32)
-    (local $$child166$i$i i32)
-    (local $$child289$i$i i32)
-    (local $$child357$i i32)
-    (local $$cmp$i$13$i i32)
-    (local $$cmp$i$15$i i32)
-    (local $$cmp$i$2$i$i i32)
-    (local $$cmp$i$23$i i32)
-    (local $$cmp$i$34$i i32)
-    (local $$cmp45$i$155 i32)
-    (local $$cmp49$i i32)
-    (local $$cmp7$i$i i32)
-    (local $$cmp9$i$i i32)
-    (local $$cond$i$25$i i32)
-    (local $$cond$i$i i32)
-    (local $$cond$i$i$i i32)
-    (local $$fd139$i i32)
-    (local $$fd148$i$i i32)
-    (local $$fd344$i$i i32)
-    (local $$fd416$i i32)
-    (local $$fd50$i i32)
-    (local $$fd59$i$i i32)
-    (local $$fd69 i32)
-    (local $$fd85$i$i i32)
-    (local $$fd9 i32)
-    (local $$head179 i32)
-    (local $$head182$i i32)
-    (local $$head208$i$i i32)
-    (local $$head25 i32)
-    (local $$head274$i i32)
-    (local $$inc$i$i i32)
-    (local $$neg$i$182 i32)
-    (local $$or$cond4$i i32)
-    (local $$or180 i32)
-    (local $$or183$i i32)
-    (local $$or26 i32)
-    (local $$or275$i i32)
-    (local $$shl$i$144 i32)
-    (local $$shl105 i32)
-    (local $$shl127$i$i i32)
-    (local $$shl18$i i32)
-    (local $$shl198$i i32)
-    (local $$shl22 i32)
-    (local $$shl226$i$i i32)
-    (local $$shl265$i$i i32)
-    (local $$shl270$i$i i32)
-    (local $$shl279$i$i i32)
-    (local $$shl291$i i32)
-    (local $$shl294$i$i i32)
-    (local $$shl326$i$i i32)
-    (local $$shl333$i i32)
-    (local $$shl338$i i32)
-    (local $$shl347$i i32)
-    (local $$shl362$i i32)
-    (local $$shl37 i32)
-    (local $$shl39$i$i i32)
-    (local $$shl395$i i32)
-    (local $$shl60$i i32)
-    (local $$shl70$i$i i32)
-    (local $$shl75$i$i i32)
-    (local $$shl84$i$i i32)
-    (local $$shl9$i i32)
-    (local $$shl95$i$i i32)
-    (local $$shr101 i32)
-    (local $$shr11$i i32)
-    (local $$shr15$i i32)
-    (local $$shr194$i i32)
-    (local $$shr4$i i32)
-    (local $$shr47 i32)
-    (local $$shr51 i32)
-    (local $$shr55 i32)
-    (local $$shr59 i32)
-    (local $$shr7$i i32)
-    (local $$shr75$i i32)
-    (local $$shr79$i i32)
-    (local $$shr83$i i32)
-    (local $$shr87$i i32)
-    (local $$size$i$i i32)
-    (local $$size$i$i$lcssa i32)
-    (local $$size188$i i32)
-    (local $$size188$i$lcssa i32)
-    (local $$size245$i i32)
-    (local $$sizebits$0$shl52$i i32)
-    (local $$sp$0108$i$lcssa i32)
-    (local $$sub i32)
-    (local $$sub$i$181 i32)
-    (local $$sub$ptr$sub$i i32)
-    (local $$sub$ptr$sub$i$41$i i32)
-    (local $$sub101$i i32)
-    (local $$sub112$i i32)
-    (local $$sub190 i32)
-    (local $$sub2$i i32)
-    (local $$sub260$i i32)
-    (local $$sub31$i i32)
-    (local $$sub41$i i32)
-    (local $$sub42 i32)
-    (local $$sub44 i32)
-    (local $$sub63$i i32)
-    (local $$sub70$i i32)
-    (local $$t$4$ph$i i32)
+  (func $_malloc (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 i32)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
     (i32.load
       (i32.const 8)
     )
     (block $do-once$0
       (if
         (i32.lt_u
-          (get_local $$bytes)
+          (get_local $0)
           (i32.const 245)
         )
         (block
           (if
             (i32.ne
               (i32.and
-                (set_local $$shr3
+                (set_local $25
                   (i32.shr_u
-                    (set_local $$0
+                    (set_local $4
                       (i32.load
                         (i32.const 176)
                       )
                     )
-                    (set_local $$shr
+                    (set_local $22
                       (i32.shr_u
-                        (set_local $$cond
+                        (set_local $12
                           (select
                             (i32.const 16)
                             (i32.and
                               (i32.add
-                                (get_local $$bytes)
+                                (get_local $0)
                                 (i32.const 11)
                               )
                               (i32.const -8)
                             )
                             (i32.lt_u
-                              (get_local $$bytes)
+                              (get_local $0)
                               (i32.const 11)
                             )
                           )
@@ -11464,29 +10262,29 @@
               (i32.const 0)
             )
             (block
-              (set_local $$3
+              (set_local $2
                 (i32.load
-                  (set_local $$fd9
+                  (set_local $3
                     (i32.add
-                      (set_local $$2
+                      (set_local $1
                         (i32.load
-                          (set_local $$1
+                          (set_local $0
                             (i32.add
-                              (set_local $$arrayidx
+                              (set_local $8
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $$add8
+                                      (set_local $7
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $$shr3)
+                                              (get_local $25)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $$shr)
+                                          (get_local $22)
                                         )
                                       )
                                       (i32.const 1)
@@ -11507,17 +10305,17 @@
               )
               (if
                 (i32.eq
-                  (get_local $$arrayidx)
-                  (get_local $$3)
+                  (get_local $8)
+                  (get_local $2)
                 )
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $$0)
+                    (get_local $4)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $$add8)
+                        (get_local $7)
                       )
                       (i32.const -1)
                     )
@@ -11526,7 +10324,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$3)
+                      (get_local $2)
                       (i32.load
                         (i32.const 192)
                       )
@@ -11536,23 +10334,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$bk
+                        (set_local $4
                           (i32.add
-                            (get_local $$3)
+                            (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $$2)
+                      (get_local $1)
                     )
                     (block
                       (i32.store
-                        (get_local $$bk)
-                        (get_local $$arrayidx)
+                        (get_local $4)
+                        (get_local $8)
                       )
                       (i32.store
-                        (get_local $$1)
-                        (get_local $$3)
+                        (get_local $0)
+                        (get_local $2)
                       )
                     )
                     (call_import $_abort)
@@ -11560,25 +10358,25 @@
                 )
               )
               (i32.store offset=4
-                (get_local $$2)
+                (get_local $1)
                 (i32.or
-                  (set_local $$shl22
+                  (set_local $0
                     (i32.shl
-                      (get_local $$add8)
+                      (get_local $7)
                       (i32.const 3)
                     )
                   )
                   (i32.const 3)
                 )
               )
-              (set_local $$or26
+              (set_local $1
                 (i32.or
                   (i32.load
-                    (set_local $$head25
+                    (set_local $0
                       (i32.add
                         (i32.add
-                          (get_local $$2)
-                          (get_local $$shl22)
+                          (get_local $1)
+                          (get_local $0)
                         )
                         (i32.const 4)
                       )
@@ -11588,18 +10386,18 @@
                 )
               )
               (i32.store
-                (get_local $$head25)
-                (get_local $$or26)
+                (get_local $0)
+                (get_local $1)
               )
               (return
-                (get_local $$fd9)
+                (get_local $3)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $$cond)
-              (set_local $$7
+              (get_local $12)
+              (set_local $11
                 (i32.load
                   (i32.const 184)
                 )
@@ -11608,46 +10406,46 @@
             (block
               (if
                 (i32.ne
-                  (get_local $$shr3)
+                  (get_local $25)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$sub
+                  (set_local $1
                     (i32.sub
                       (i32.const 0)
-                      (set_local $$shl37
+                      (set_local $0
                         (i32.shl
                           (i32.const 2)
-                          (get_local $$shr)
+                          (get_local $22)
                         )
                       )
                     )
                   )
-                  (set_local $$sub42
+                  (set_local $1
                     (i32.sub
                       (i32.const 0)
-                      (set_local $$and41
+                      (set_local $0
                         (i32.and
                           (i32.shl
-                            (get_local $$shr3)
-                            (get_local $$shr)
+                            (get_local $25)
+                            (get_local $22)
                           )
                           (i32.or
-                            (get_local $$shl37)
-                            (get_local $$sub)
+                            (get_local $0)
+                            (get_local $1)
                           )
                         )
                       )
                     )
                   )
-                  (set_local $$and46
+                  (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (set_local $$sub44
+                        (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $$and41)
-                              (get_local $$sub42)
+                              (get_local $0)
+                              (get_local $1)
                             )
                             (i32.const -1)
                           )
@@ -11657,32 +10455,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $$10
+                  (set_local $0
                     (i32.load
-                      (set_local $$fd69
+                      (set_local $3
                         (i32.add
-                          (set_local $$9
+                          (set_local $2
                             (i32.load
-                              (set_local $$8
+                              (set_local $1
                                 (i32.add
-                                  (set_local $$arrayidx66
+                                  (set_local $8
                                     (i32.add
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $$add64
+                                          (set_local $7
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $$and49
+                                                      (set_local $1
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $$shr47
+                                                            (set_local $2
                                                               (i32.shr_u
-                                                                (get_local $$sub44)
-                                                                (get_local $$and46)
+                                                                (get_local $1)
+                                                                (get_local $0)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -11690,15 +10488,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $$and46)
+                                                      (get_local $0)
                                                     )
-                                                    (set_local $$and53
+                                                    (set_local $0
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $$shr51
+                                                          (set_local $1
                                                             (i32.shr_u
-                                                              (get_local $$shr47)
-                                                              (get_local $$and49)
+                                                              (get_local $2)
+                                                              (get_local $1)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -11707,13 +10505,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $$and57
+                                                  (set_local $0
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $$shr55
+                                                        (set_local $1
                                                           (i32.shr_u
-                                                            (get_local $$shr51)
-                                                            (get_local $$and53)
+                                                            (get_local $1)
+                                                            (get_local $0)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -11722,13 +10520,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $$and61
+                                                (set_local $0
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $$shr59
+                                                      (set_local $1
                                                         (i32.shr_u
-                                                          (get_local $$shr55)
-                                                          (get_local $$and57)
+                                                          (get_local $1)
+                                                          (get_local $0)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -11738,8 +10536,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $$shr59)
-                                                (get_local $$and61)
+                                                (get_local $1)
+                                                (get_local $0)
                                               )
                                             )
                                           )
@@ -11761,31 +10559,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $$arrayidx66)
-                      (get_local $$10)
+                      (get_local $8)
+                      (get_local $0)
                     )
                     (block
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $$0)
+                          (get_local $4)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $$add64)
+                              (get_local $7)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $$13
-                        (get_local $$7)
+                      (set_local $6
+                        (get_local $11)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $$10)
+                          (get_local $0)
                           (i32.load
                             (i32.const 192)
                           )
@@ -11795,25 +10593,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $$bk78
+                            (set_local $4
                               (i32.add
-                                (get_local $$10)
+                                (get_local $0)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $$9)
+                          (get_local $2)
                         )
                         (block
                           (i32.store
-                            (get_local $$bk78)
-                            (get_local $$arrayidx66)
+                            (get_local $4)
+                            (get_local $8)
                           )
                           (i32.store
-                            (get_local $$8)
-                            (get_local $$10)
+                            (get_local $1)
+                            (get_local $0)
                           )
-                          (set_local $$13
+                          (set_local $6
                             (i32.load
                               (i32.const 184)
                             )
@@ -11824,27 +10622,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$9)
+                    (get_local $2)
                     (i32.or
-                      (get_local $$cond)
+                      (get_local $12)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $$add$ptr95
+                    (set_local $4
                       (i32.add
-                        (get_local $$9)
-                        (get_local $$cond)
+                        (get_local $2)
+                        (get_local $12)
                       )
                     )
                     (i32.or
-                      (set_local $$sub91
+                      (set_local $8
                         (i32.sub
                           (i32.shl
-                            (get_local $$add64)
+                            (get_local $7)
                             (i32.const 3)
                           )
-                          (get_local $$cond)
+                          (get_local $12)
                         )
                       )
                       (i32.const 1)
@@ -11852,30 +10650,30 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $$add$ptr95)
-                      (get_local $$sub91)
+                      (get_local $4)
+                      (get_local $8)
                     )
-                    (get_local $$sub91)
+                    (get_local $8)
                   )
                   (if
                     (i32.ne
-                      (get_local $$13)
+                      (get_local $6)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$14
+                      (set_local $0
                         (i32.load
                           (i32.const 196)
                         )
                       )
-                      (set_local $$arrayidx103
+                      (set_local $7
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (set_local $$shr101
+                              (set_local $2
                                 (i32.shr_u
-                                  (get_local $$13)
+                                  (get_local $6)
                                   (i32.const 3)
                                 )
                               )
@@ -11888,15 +10686,15 @@
                       (if
                         (i32.eq
                           (i32.and
-                            (set_local $$15
+                            (set_local $1
                               (i32.load
                                 (i32.const 176)
                               )
                             )
-                            (set_local $$shl105
+                            (set_local $2
                               (i32.shl
                                 (i32.const 1)
-                                (get_local $$shr101)
+                                (get_local $2)
                               )
                             )
                           )
@@ -11906,27 +10704,27 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $$15)
-                              (get_local $$shl105)
+                              (get_local $1)
+                              (get_local $2)
                             )
                           )
-                          (set_local $$$pre$phiZ2D
+                          (set_local $5
                             (i32.add
-                              (get_local $$arrayidx103)
+                              (get_local $7)
                               (i32.const 8)
                             )
                           )
-                          (set_local $$F104$0
-                            (get_local $$arrayidx103)
+                          (set_local $9
+                            (get_local $7)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $$17
+                            (set_local $2
                               (i32.load
-                                (set_local $$16
+                                (set_local $1
                                   (i32.add
-                                    (get_local $$arrayidx103)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
@@ -11938,69 +10736,69 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $$$pre$phiZ2D
-                              (get_local $$16)
+                            (set_local $5
+                              (get_local $1)
                             )
-                            (set_local $$F104$0
-                              (get_local $$17)
+                            (set_local $9
+                              (get_local $2)
                             )
                           )
                         )
                       )
                       (i32.store
-                        (get_local $$$pre$phiZ2D)
-                        (get_local $$14)
+                        (get_local $5)
+                        (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $$F104$0)
-                        (get_local $$14)
+                        (get_local $9)
+                        (get_local $0)
                       )
                       (i32.store offset=8
-                        (get_local $$14)
-                        (get_local $$F104$0)
+                        (get_local $0)
+                        (get_local $9)
                       )
                       (i32.store offset=12
-                        (get_local $$14)
-                        (get_local $$arrayidx103)
+                        (get_local $0)
+                        (get_local $7)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $$sub91)
+                    (get_local $8)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $$add$ptr95)
+                    (get_local $4)
                   )
                   (return
-                    (get_local $$fd69)
+                    (get_local $3)
                   )
                 )
               )
               (if
                 (i32.eq
-                  (set_local $$19
+                  (set_local $0
                     (i32.load
                       (i32.const 180)
                     )
                   )
                   (i32.const 0)
                 )
-                (set_local $$nb$0
-                  (get_local $$cond)
+                (set_local $9
+                  (get_local $12)
                 )
                 (block
-                  (set_local $$and3$i
+                  (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (set_local $$sub2$i
+                        (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $$19)
+                              (get_local $0)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $$19)
+                                (get_local $0)
                               )
                             )
                             (i32.const -1)
@@ -12011,11 +10809,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $$rsize$0$i
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $$20
+                          (set_local $0
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -12023,13 +10821,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $$and6$i
+                                          (set_local $1
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $$shr4$i
+                                                (set_local $2
                                                   (i32.shr_u
-                                                    (get_local $$sub2$i)
-                                                    (get_local $$and3$i)
+                                                    (get_local $1)
+                                                    (get_local $0)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -12037,15 +10835,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $$and3$i)
+                                          (get_local $0)
                                         )
-                                        (set_local $$and9$i
+                                        (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $$shr7$i
+                                              (set_local $1
                                                 (i32.shr_u
-                                                  (get_local $$shr4$i)
-                                                  (get_local $$and6$i)
+                                                  (get_local $2)
+                                                  (get_local $1)
                                                 )
                                               )
                                               (i32.const 2)
@@ -12054,13 +10852,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $$and13$i
+                                      (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $$shr11$i
+                                            (set_local $1
                                               (i32.shr_u
-                                                (get_local $$shr7$i)
-                                                (get_local $$and9$i)
+                                                (get_local $1)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -12069,13 +10867,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $$and17$i
+                                    (set_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $$shr15$i
+                                          (set_local $1
                                             (i32.shr_u
-                                              (get_local $$shr11$i)
-                                              (get_local $$and13$i)
+                                              (get_local $1)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -12085,8 +10883,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $$shr15$i)
-                                    (get_local $$and17$i)
+                                    (get_local $1)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 2)
@@ -12096,90 +10894,90 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $$cond)
+                      (get_local $12)
                     )
                   )
-                  (set_local $$t$0$i
-                    (get_local $$20)
+                  (set_local $4
+                    (get_local $0)
                   )
-                  (set_local $$v$0$i
-                    (get_local $$20)
+                  (set_local $7
+                    (get_local $0)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
                       (i32.eq
-                        (set_local $$22
+                        (set_local $0
                           (i32.load offset=16
-                            (get_local $$t$0$i)
+                            (get_local $4)
                           )
                         )
                         (i32.const 0)
                       )
                       (if
                         (i32.eq
-                          (set_local $$23
+                          (set_local $0
                             (i32.load offset=20
-                              (get_local $$t$0$i)
+                              (get_local $4)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$rsize$0$i$lcssa
-                            (get_local $$rsize$0$i)
+                          (set_local $6
+                            (get_local $2)
                           )
-                          (set_local $$v$0$i$lcssa
-                            (get_local $$v$0$i)
+                          (set_local $11
+                            (get_local $7)
                           )
                           (br $while-out$6)
                         )
-                        (set_local $$cond4$i
-                          (get_local $$23)
+                        (set_local $1
+                          (get_local $0)
                         )
                       )
-                      (set_local $$cond4$i
-                        (get_local $$22)
+                      (set_local $1
+                        (get_local $0)
                       )
                     )
-                    (set_local $$cmp32$i
+                    (set_local $0
                       (i32.lt_u
-                        (set_local $$sub31$i
+                        (set_local $4
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $$cond4$i)
+                                (get_local $1)
                               )
                               (i32.const -8)
                             )
-                            (get_local $$cond)
+                            (get_local $12)
                           )
                         )
-                        (get_local $$rsize$0$i)
+                        (get_local $2)
                       )
                     )
-                    (set_local $$rsize$0$i
+                    (set_local $2
                       (select
-                        (get_local $$sub31$i)
-                        (get_local $$rsize$0$i)
-                        (get_local $$cmp32$i)
+                        (get_local $4)
+                        (get_local $2)
+                        (get_local $0)
                       )
                     )
-                    (set_local $$t$0$i
-                      (get_local $$cond4$i)
+                    (set_local $4
+                      (get_local $1)
                     )
-                    (set_local $$v$0$i
+                    (set_local $7
                       (select
-                        (get_local $$cond4$i)
-                        (get_local $$v$0$i)
-                        (get_local $$cmp32$i)
+                        (get_local $1)
+                        (get_local $7)
+                        (get_local $0)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$v$0$i$lcssa)
-                      (set_local $$25
+                      (get_local $11)
+                      (set_local $0
                         (i32.load
                           (i32.const 192)
                         )
@@ -12189,39 +10987,39 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $$v$0$i$lcssa)
-                      (set_local $$add$ptr$i
+                      (get_local $11)
+                      (set_local $8
                         (i32.add
-                          (get_local $$v$0$i$lcssa)
-                          (get_local $$cond)
+                          (get_local $11)
+                          (get_local $12)
                         )
                       )
                     )
                     (call_import $_abort)
                   )
-                  (set_local $$26
+                  (set_local $1
                     (i32.load offset=24
-                      (get_local $$v$0$i$lcssa)
+                      (get_local $11)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $$27
+                        (set_local $2
                           (i32.load offset=12
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                           )
                         )
-                        (get_local $$v$0$i$lcssa)
+                        (get_local $11)
                       )
                       (block
                         (if
                           (i32.eq
-                            (set_local $$31
+                            (set_local $2
                               (i32.load
-                                (set_local $$arrayidx61$i
+                                (set_local $7
                                   (i32.add
-                                    (get_local $$v$0$i$lcssa)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
@@ -12231,11 +11029,11 @@
                           )
                           (if
                             (i32.eq
-                              (set_local $$32
+                              (set_local $2
                                 (i32.load
-                                  (set_local $$arrayidx65$i
+                                  (set_local $7
                                     (i32.add
-                                      (get_local $$v$0$i$lcssa)
+                                      (get_local $11)
                                       (i32.const 16)
                                     )
                                   )
@@ -12244,37 +11042,33 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $$R$3$i
+                              (set_local $14
                                 (i32.const 0)
                               )
                               (br $do-once$8)
                             )
                             (block
-                              (set_local $$R$1$i
-                                (get_local $$32)
+                              (set_local $4
+                                (get_local $2)
                               )
-                              (set_local $$RP$1$i
-                                (get_local $$arrayidx65$i)
-                              )
+                              (get_local $7)
                             )
                           )
                           (block
-                            (set_local $$R$1$i
-                              (get_local $$31)
+                            (set_local $4
+                              (get_local $2)
                             )
-                            (set_local $$RP$1$i
-                              (get_local $$arrayidx61$i)
-                            )
+                            (get_local $7)
                           )
                         )
                         (loop $while-out$10 $while-in$11
                           (if
                             (i32.ne
-                              (set_local $$33
+                              (set_local $2
                                 (i32.load
-                                  (set_local $$arrayidx71$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$R$1$i)
+                                      (get_local $4)
                                       (i32.const 20)
                                     )
                                   )
@@ -12283,22 +11077,22 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $$R$1$i
-                                (get_local $$33)
+                              (set_local $4
+                                (get_local $2)
                               )
-                              (set_local $$RP$1$i
-                                (get_local $$arrayidx71$i)
+                              (set_local $7
+                                (get_local $5)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
                             (i32.eq
-                              (set_local $$34
+                              (set_local $2
                                 (i32.load
-                                  (set_local $$arrayidx75$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$R$1$i)
+                                      (get_local $4)
                                       (i32.const 16)
                                     )
                                   )
@@ -12307,20 +11101,20 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $$R$1$i$lcssa
-                                (get_local $$R$1$i)
+                              (set_local $2
+                                (get_local $4)
                               )
-                              (set_local $$RP$1$i$lcssa
-                                (get_local $$RP$1$i)
+                              (set_local $4
+                                (get_local $7)
                               )
                               (br $while-out$10)
                             )
                             (block
-                              (set_local $$R$1$i
-                                (get_local $$34)
+                              (set_local $4
+                                (get_local $2)
                               )
-                              (set_local $$RP$1$i
-                                (get_local $$arrayidx75$i)
+                              (set_local $7
+                                (get_local $5)
                               )
                             )
                           )
@@ -12328,17 +11122,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $$RP$1$i$lcssa)
-                            (get_local $$25)
+                            (get_local $4)
+                            (get_local $0)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $$RP$1$i$lcssa)
+                              (get_local $4)
                               (i32.const 0)
                             )
-                            (set_local $$R$3$i
-                              (get_local $$R$1$i$lcssa)
+                            (set_local $14
+                              (get_local $2)
                             )
                           )
                         )
@@ -12346,52 +11140,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $$28
+                            (set_local $4
                               (i32.load offset=8
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                             )
-                            (get_local $$25)
+                            (get_local $0)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $$bk47$i
+                              (set_local $0
                                 (i32.add
-                                  (get_local $$28)
+                                  (get_local $4)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                           )
                           (call_import $_abort)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $$fd50$i
+                              (set_local $7
                                 (i32.add
-                                  (get_local $$27)
+                                  (get_local $2)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                           )
                           (block
                             (i32.store
-                              (get_local $$bk47$i)
-                              (get_local $$27)
+                              (get_local $0)
+                              (get_local $2)
                             )
                             (i32.store
-                              (get_local $$fd50$i)
-                              (get_local $$28)
+                              (get_local $7)
+                              (get_local $4)
                             )
-                            (set_local $$R$3$i
-                              (get_local $$27)
+                            (set_local $14
+                              (get_local $2)
                             )
                           )
                           (call_import $_abort)
@@ -12402,21 +11196,21 @@
                   (block $do-once$12
                     (if
                       (i32.ne
-                        (get_local $$26)
+                        (get_local $1)
                         (i32.const 0)
                       )
                       (block
                         (if
                           (i32.eq
-                            (get_local $$v$0$i$lcssa)
+                            (get_local $11)
                             (i32.load
-                              (set_local $$arrayidx94$i
+                              (set_local $2
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (set_local $$35
+                                    (set_local $0
                                       (i32.load offset=28
-                                        (get_local $$v$0$i$lcssa)
+                                        (get_local $11)
                                       )
                                     )
                                     (i32.const 2)
@@ -12427,12 +11221,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $$arrayidx94$i)
-                              (get_local $$R$3$i)
+                              (get_local $2)
+                              (get_local $14)
                             )
                             (if
                               (i32.eq
-                                (get_local $$R$3$i)
+                                (get_local $14)
                                 (i32.const 0)
                               )
                               (block
@@ -12445,7 +11239,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $$35)
+                                        (get_local $0)
                                       )
                                       (i32.const -1)
                                     )
@@ -12458,7 +11252,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $$26)
+                                (get_local $1)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -12468,27 +11262,27 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $$arrayidx113$i
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $$26)
+                                      (get_local $1)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                               (i32.store
-                                (get_local $$arrayidx113$i)
-                                (get_local $$R$3$i)
+                                (get_local $0)
+                                (get_local $14)
                               )
                               (i32.store offset=20
-                                (get_local $$26)
-                                (get_local $$R$3$i)
+                                (get_local $1)
+                                (get_local $14)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eq
-                                (get_local $$R$3$i)
+                                (get_local $14)
                                 (i32.const 0)
                               )
                             )
@@ -12496,8 +11290,8 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $$R$3$i)
-                            (set_local $$40
+                            (get_local $14)
+                            (set_local $0
                               (i32.load
                                 (i32.const 192)
                               )
@@ -12506,48 +11300,48 @@
                           (call_import $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $$R$3$i)
-                          (get_local $$26)
+                          (get_local $14)
+                          (get_local $1)
                         )
                         (if
                           (i32.ne
-                            (set_local $$41
+                            (set_local $1
                               (i32.load offset=16
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                             )
                             (i32.const 0)
                           )
                           (if
                             (i32.lt_u
-                              (get_local $$41)
-                              (get_local $$40)
+                              (get_local $1)
+                              (get_local $0)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $$R$3$i)
-                                (get_local $$41)
+                                (get_local $14)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $$41)
-                                (get_local $$R$3$i)
+                                (get_local $1)
+                                (get_local $14)
                               )
                             )
                           )
                         )
                         (if
                           (i32.ne
-                            (set_local $$42
+                            (set_local $0
                               (i32.load offset=20
-                                (get_local $$v$0$i$lcssa)
+                                (get_local $11)
                               )
                             )
                             (i32.const 0)
                           )
                           (if
                             (i32.lt_u
-                              (get_local $$42)
+                              (get_local $0)
                               (i32.load
                                 (i32.const 192)
                               )
@@ -12555,12 +11349,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $$R$3$i)
-                                (get_local $$42)
+                                (get_local $14)
+                                (get_local $0)
                               )
                               (i32.store offset=24
-                                (get_local $$42)
-                                (get_local $$R$3$i)
+                                (get_local $0)
+                                (get_local $14)
                               )
                             )
                           )
@@ -12570,30 +11364,30 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$rsize$0$i$lcssa)
+                      (get_local $6)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $$v$0$i$lcssa)
+                        (get_local $11)
                         (i32.or
-                          (set_local $$add177$i
+                          (set_local $0
                             (i32.add
-                              (get_local $$rsize$0$i$lcssa)
-                              (get_local $$cond)
+                              (get_local $6)
+                              (get_local $12)
                             )
                           )
                           (i32.const 3)
                         )
                       )
-                      (set_local $$or183$i
+                      (set_local $1
                         (i32.or
                           (i32.load
-                            (set_local $$head182$i
+                            (set_local $0
                               (i32.add
                                 (i32.add
-                                  (get_local $$v$0$i$lcssa)
-                                  (get_local $$add177$i)
+                                  (get_local $11)
+                                  (get_local $0)
                                 )
                                 (i32.const 4)
                               )
@@ -12603,35 +11397,35 @@
                         )
                       )
                       (i32.store
-                        (get_local $$head182$i)
-                        (get_local $$or183$i)
+                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $$v$0$i$lcssa)
+                        (get_local $11)
                         (i32.or
-                          (get_local $$cond)
+                          (get_local $12)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $$add$ptr$i)
+                        (get_local $8)
                         (i32.or
-                          (get_local $$rsize$0$i$lcssa)
+                          (get_local $6)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $$add$ptr$i)
-                          (get_local $$rsize$0$i$lcssa)
+                          (get_local $8)
+                          (get_local $6)
                         )
-                        (get_local $$rsize$0$i$lcssa)
+                        (get_local $6)
                       )
                       (if
                         (i32.ne
-                          (set_local $$45
+                          (set_local $0
                             (i32.load
                               (i32.const 184)
                             )
@@ -12639,19 +11433,19 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$46
+                          (set_local $1
                             (i32.load
                               (i32.const 196)
                             )
                           )
-                          (set_local $$arrayidx196$i
+                          (set_local $4
                             (i32.add
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $$shr194$i
+                                  (set_local $2
                                     (i32.shr_u
-                                      (get_local $$45)
+                                      (get_local $0)
                                       (i32.const 3)
                                     )
                                   )
@@ -12664,15 +11458,15 @@
                           (if
                             (i32.eq
                               (i32.and
-                                (set_local $$47
+                                (set_local $0
                                   (i32.load
                                     (i32.const 176)
                                   )
                                 )
-                                (set_local $$shl198$i
+                                (set_local $2
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $$shr194$i)
+                                    (get_local $2)
                                   )
                                 )
                               )
@@ -12682,27 +11476,27 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $$47)
-                                  (get_local $$shl198$i)
+                                  (get_local $0)
+                                  (get_local $2)
                                 )
                               )
-                              (set_local $$$pre$phi$iZ2D
+                              (set_local $3
                                 (i32.add
-                                  (get_local $$arrayidx196$i)
+                                  (get_local $4)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $$F197$0$i
-                                (get_local $$arrayidx196$i)
+                              (set_local $13
+                                (get_local $4)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $$49
+                                (set_local $2
                                   (i32.load
-                                    (set_local $$48
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $$arrayidx196$i)
+                                        (get_local $4)
                                         (i32.const 8)
                                       )
                                     )
@@ -12714,71 +11508,71 @@
                               )
                               (call_import $_abort)
                               (block
-                                (set_local $$$pre$phi$iZ2D
-                                  (get_local $$48)
+                                (set_local $3
+                                  (get_local $0)
                                 )
-                                (set_local $$F197$0$i
-                                  (get_local $$49)
+                                (set_local $13
+                                  (get_local $2)
                                 )
                               )
                             )
                           )
                           (i32.store
-                            (get_local $$$pre$phi$iZ2D)
-                            (get_local $$46)
+                            (get_local $3)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $$F197$0$i)
-                            (get_local $$46)
+                            (get_local $13)
+                            (get_local $1)
                           )
                           (i32.store offset=8
-                            (get_local $$46)
-                            (get_local $$F197$0$i)
+                            (get_local $1)
+                            (get_local $13)
                           )
                           (i32.store offset=12
-                            (get_local $$46)
-                            (get_local $$arrayidx196$i)
+                            (get_local $1)
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $$rsize$0$i$lcssa)
+                        (get_local $6)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $$add$ptr$i)
+                        (get_local $8)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $$v$0$i$lcssa)
+                      (get_local $11)
                       (i32.const 8)
                     )
                   )
                 )
               )
             )
-            (set_local $$nb$0
-              (get_local $$cond)
+            (set_local $9
+              (get_local $12)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $$bytes)
+            (get_local $0)
             (i32.const -65)
           )
-          (set_local $$nb$0
+          (set_local $9
             (i32.const -1)
           )
           (block
-            (set_local $$and145
+            (set_local $5
               (i32.and
-                (set_local $$add144
+                (set_local $3
                   (i32.add
-                    (get_local $$bytes)
+                    (get_local $0)
                     (i32.const 11)
                   )
                 )
@@ -12787,35 +11581,35 @@
             )
             (if
               (i32.eq
-                (set_local $$51
+                (set_local $0
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (i32.const 0)
               )
-              (set_local $$nb$0
-                (get_local $$and145)
+              (set_local $9
+                (get_local $5)
               )
               (block
-                (set_local $$sub$i$138
+                (set_local $13
                   (i32.sub
                     (i32.const 0)
-                    (get_local $$and145)
+                    (get_local $5)
                   )
                 )
                 (block $label$break$L123
                   (if
                     (i32.eq
-                      (set_local $$52
+                      (set_local $3
                         (i32.load offset=480
                           (i32.shl
-                            (set_local $$idx$0$i
+                            (set_local $9
                               (if
                                 (i32.eq
-                                  (set_local $$shr$i$139
+                                  (set_local $3
                                     (i32.shr_u
-                                      (get_local $$add144)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
@@ -12824,31 +11618,31 @@
                                 (i32.const 0)
                                 (if
                                   (i32.gt_u
-                                    (get_local $$and145)
+                                    (get_local $5)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (block
-                                    (set_local $$shl18$i
+                                    (set_local $6
                                       (i32.shl
-                                        (set_local $$add17$i
+                                        (set_local $3
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (set_local $$and8$i
+                                                  (set_local $6
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $$shl$i$144
+                                                          (set_local $9
                                                             (i32.shl
-                                                              (get_local $$shr$i$139)
-                                                              (set_local $$and$i$143
+                                                              (get_local $3)
+                                                              (set_local $3
                                                                 (i32.and
                                                                   (i32.shr_u
                                                                     (i32.add
-                                                                      (get_local $$shr$i$139)
+                                                                      (get_local $3)
                                                                       (i32.const 1048320)
                                                                     )
                                                                     (i32.const 16)
@@ -12865,16 +11659,16 @@
                                                       (i32.const 4)
                                                     )
                                                   )
-                                                  (get_local $$and$i$143)
+                                                  (get_local $3)
                                                 )
-                                                (set_local $$and12$i
+                                                (set_local $3
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $$shl9$i
+                                                        (set_local $6
                                                           (i32.shl
-                                                            (get_local $$shl$i$144)
-                                                            (get_local $$and8$i)
+                                                            (get_local $9)
+                                                            (get_local $6)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -12888,8 +11682,8 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $$shl9$i)
-                                                (get_local $$and12$i)
+                                                (get_local $6)
+                                                (get_local $3)
                                               )
                                               (i32.const 15)
                                             )
@@ -12901,15 +11695,15 @@
                                     (i32.or
                                       (i32.and
                                         (i32.shr_u
-                                          (get_local $$and145)
+                                          (get_local $5)
                                           (i32.add
-                                            (get_local $$add17$i)
+                                            (get_local $3)
                                             (i32.const 7)
                                           )
                                         )
                                         (i32.const 1)
                                       )
-                                      (get_local $$shl18$i)
+                                      (get_local $6)
                                     )
                                   )
                                 )
@@ -12922,135 +11716,131 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$rsize$3$i
-                        (get_local $$sub$i$138)
+                      (set_local $35
+                        (get_local $13)
                       )
-                      (set_local $$t$2$i
+                      (set_local $36
                         (i32.const 0)
                       )
-                      (set_local $$v$3$i
+                      (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $label
+                      (set_local $10
                         (i32.const 86)
                       )
                     )
                     (block
-                      (set_local $$rsize$0$i$152
-                        (get_local $$sub$i$138)
+                      (set_local $6
+                        (get_local $13)
                       )
-                      (set_local $$rst$0$i
+                      (set_local $14
                         (i32.const 0)
                       )
-                      (set_local $$sizebits$0$i
+                      (set_local $10
                         (i32.shl
-                          (get_local $$and145)
+                          (get_local $5)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $$idx$0$i)
+                                (get_local $9)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $$idx$0$i)
+                              (get_local $9)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $$t$0$i$151
-                        (get_local $$52)
+                      (set_local $23
+                        (get_local $3)
                       )
-                      (set_local $$v$0$i$153
+                      (set_local $29
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $$sub33$i
+                            (set_local $13
                               (i32.sub
-                                (set_local $$and32$i
+                                (set_local $3
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $$t$0$i$151)
+                                      (get_local $23)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $$and145)
+                                (get_local $5)
                               )
                             )
-                            (get_local $$rsize$0$i$152)
+                            (get_local $6)
                           )
                           (if
                             (i32.eq
-                              (get_local $$and32$i)
-                              (get_local $$and145)
+                              (get_local $3)
+                              (get_local $5)
                             )
                             (block
-                              (set_local $$rsize$49$i
-                                (get_local $$sub33$i)
+                              (set_local $26
+                                (get_local $13)
                               )
-                              (set_local $$t$48$i
-                                (get_local $$t$0$i$151)
+                              (set_local $24
+                                (get_local $23)
                               )
-                              (set_local $$v$410$i
-                                (get_local $$t$0$i$151)
+                              (set_local $31
+                                (get_local $23)
                               )
-                              (set_local $label
+                              (set_local $10
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $$rsize$1$i
-                                (get_local $$sub33$i)
-                              )
-                              (set_local $$v$1$i
-                                (get_local $$t$0$i$151)
+                              (get_local $13)
+                              (set_local $29
+                                (get_local $23)
                               )
                             )
                           )
                           (block
-                            (set_local $$rsize$1$i
-                              (get_local $$rsize$0$i$152)
+                            (set_local $13
+                              (get_local $6)
                             )
-                            (set_local $$v$1$i
-                              (get_local $$v$0$i$153)
-                            )
+                            (get_local $29)
                           )
                         )
-                        (set_local $$cmp45$i$155
+                        (set_local $6
                           (i32.eq
-                            (set_local $$54
+                            (set_local $3
                               (i32.load offset=20
-                                (get_local $$t$0$i$151)
+                                (get_local $23)
                               )
                             )
                             (i32.const 0)
                           )
                         )
-                        (set_local $$rst$1$i
+                        (set_local $14
                           (select
-                            (get_local $$rst$0$i)
-                            (get_local $$54)
+                            (get_local $14)
+                            (get_local $3)
                             (i32.or
-                              (get_local $$cmp45$i$155)
+                              (get_local $6)
                               (i32.eq
-                                (get_local $$54)
-                                (set_local $$55
+                                (get_local $3)
+                                (set_local $3
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $$t$0$i$151)
+                                        (get_local $23)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $$sizebits$0$i)
+                                          (get_local $10)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -13062,14 +11852,14 @@
                             )
                           )
                         )
-                        (set_local $$sizebits$0$shl52$i
+                        (set_local $10
                           (i32.shl
-                            (get_local $$sizebits$0$i)
+                            (get_local $10)
                             (i32.xor
                               (i32.and
-                                (set_local $$cmp49$i
+                                (set_local $6
                                   (i32.eq
-                                    (get_local $$55)
+                                    (get_local $3)
                                     (i32.const 0)
                                   )
                                 )
@@ -13080,38 +11870,32 @@
                           )
                         )
                         (if
-                          (get_local $$cmp49$i)
+                          (get_local $6)
                           (block
-                            (set_local $$rsize$3$i
-                              (get_local $$rsize$1$i)
+                            (set_local $35
+                              (get_local $13)
                             )
-                            (set_local $$t$2$i
-                              (get_local $$rst$1$i)
+                            (set_local $36
+                              (get_local $14)
                             )
-                            (set_local $$v$3$i
-                              (get_local $$v$1$i)
+                            (set_local $30
+                              (get_local $29)
                             )
-                            (set_local $label
+                            (set_local $10
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $$rsize$0$i$152
-                              (get_local $$rsize$1$i)
+                            (set_local $6
+                              (get_local $13)
                             )
-                            (set_local $$rst$0$i
-                              (get_local $$rst$1$i)
+                            (get_local $14)
+                            (get_local $10)
+                            (set_local $23
+                              (get_local $3)
                             )
-                            (set_local $$sizebits$0$i
-                              (get_local $$sizebits$0$shl52$i)
-                            )
-                            (set_local $$t$0$i$151
-                              (get_local $$55)
-                            )
-                            (set_local $$v$0$i$153
-                              (get_local $$v$1$i)
-                            )
+                            (get_local $29)
                           )
                         )
                         (br $while-in$18)
@@ -13121,65 +11905,65 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $label)
+                    (get_local $10)
                     (i32.const 86)
                   )
                   (if
                     (i32.eq
-                      (set_local $$t$4$ph$i
+                      (set_local $0
                         (if
                           (i32.and
                             (i32.eq
-                              (get_local $$t$2$i)
+                              (get_local $36)
                               (i32.const 0)
                             )
                             (i32.eq
-                              (get_local $$v$3$i)
+                              (get_local $30)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $$sub63$i
+                            (set_local $6
                               (i32.sub
                                 (i32.const 0)
-                                (set_local $$shl60$i
+                                (set_local $3
                                   (i32.shl
                                     (i32.const 2)
-                                    (get_local $$idx$0$i)
+                                    (get_local $9)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$and64$i
+                                (set_local $0
                                   (i32.and
-                                    (get_local $$51)
+                                    (get_local $0)
                                     (i32.or
-                                      (get_local $$shl60$i)
-                                      (get_local $$sub63$i)
+                                      (get_local $3)
+                                      (get_local $6)
                                     )
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$nb$0
-                                  (get_local $$and145)
+                                (set_local $9
+                                  (get_local $5)
                                 )
                                 (br $do-once$0)
                               )
                             )
-                            (set_local $$and73$i
+                            (set_local $0
                               (i32.and
                                 (i32.shr_u
-                                  (set_local $$sub70$i
+                                  (set_local $3
                                     (i32.add
                                       (i32.and
-                                        (get_local $$and64$i)
+                                        (get_local $0)
                                         (i32.sub
                                           (i32.const 0)
-                                          (get_local $$and64$i)
+                                          (get_local $0)
                                         )
                                       )
                                       (i32.const -1)
@@ -13197,13 +11981,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $$and77$i
+                                          (set_local $3
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $$shr75$i
+                                                (set_local $6
                                                   (i32.shr_u
-                                                    (get_local $$sub70$i)
-                                                    (get_local $$and73$i)
+                                                    (get_local $3)
+                                                    (get_local $0)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -13211,15 +11995,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $$and73$i)
+                                          (get_local $0)
                                         )
-                                        (set_local $$and81$i
+                                        (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $$shr79$i
+                                              (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $$shr75$i)
-                                                  (get_local $$and77$i)
+                                                  (get_local $6)
+                                                  (get_local $3)
                                                 )
                                               )
                                               (i32.const 2)
@@ -13228,13 +12012,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $$and85$i
+                                      (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $$shr83$i
+                                            (set_local $3
                                               (i32.shr_u
-                                                (get_local $$shr79$i)
-                                                (get_local $$and81$i)
+                                                (get_local $3)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -13243,13 +12027,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $$and89$i
+                                    (set_local $0
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $$shr87$i
+                                          (set_local $3
                                             (i32.shr_u
-                                              (get_local $$shr83$i)
-                                              (get_local $$and85$i)
+                                              (get_local $3)
+                                              (get_local $0)
                                             )
                                           )
                                           (i32.const 1)
@@ -13259,38 +12043,38 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $$shr87$i)
-                                    (get_local $$and89$i)
+                                    (get_local $3)
+                                    (get_local $0)
                                   )
                                 )
                                 (i32.const 2)
                               )
                             )
                           )
-                          (get_local $$t$2$i)
+                          (get_local $36)
                         )
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$rsize$4$lcssa$i
-                        (get_local $$rsize$3$i)
+                      (set_local $17
+                        (get_local $35)
                       )
-                      (set_local $$v$4$lcssa$i
-                        (get_local $$v$3$i)
+                      (set_local $15
+                        (get_local $30)
                       )
                     )
                     (block
-                      (set_local $$rsize$49$i
-                        (get_local $$rsize$3$i)
+                      (set_local $26
+                        (get_local $35)
                       )
-                      (set_local $$t$48$i
-                        (get_local $$t$4$ph$i)
+                      (set_local $24
+                        (get_local $0)
                       )
-                      (set_local $$v$410$i
-                        (get_local $$v$3$i)
+                      (set_local $31
+                        (get_local $30)
                       )
-                      (set_local $label
+                      (set_local $10
                         (i32.const 90)
                       )
                     )
@@ -13298,99 +12082,95 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $label)
+                    (get_local $10)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $label
+                    (set_local $10
                       (i32.const 0)
                     )
-                    (set_local $$cmp102$i
+                    (set_local $0
                       (i32.lt_u
-                        (set_local $$sub101$i
+                        (set_local $3
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $$t$48$i)
+                                (get_local $24)
                               )
                               (i32.const -8)
                             )
-                            (get_local $$and145)
+                            (get_local $5)
                           )
                         )
-                        (get_local $$rsize$49$i)
+                        (get_local $26)
                       )
                     )
-                    (set_local $$sub101$rsize$4$i
+                    (set_local $3
                       (select
-                        (get_local $$sub101$i)
-                        (get_local $$rsize$49$i)
-                        (get_local $$cmp102$i)
+                        (get_local $3)
+                        (get_local $26)
+                        (get_local $0)
                       )
                     )
-                    (set_local $$t$4$v$4$i
+                    (set_local $6
                       (select
-                        (get_local $$t$48$i)
-                        (get_local $$v$410$i)
-                        (get_local $$cmp102$i)
+                        (get_local $24)
+                        (get_local $31)
+                        (get_local $0)
                       )
                     )
                     (if
                       (i32.ne
-                        (set_local $$59
+                        (set_local $0
                           (i32.load offset=16
-                            (get_local $$t$48$i)
+                            (get_local $24)
                           )
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$rsize$49$i
-                          (get_local $$sub101$rsize$4$i)
+                        (set_local $26
+                          (get_local $3)
                         )
-                        (set_local $$t$48$i
-                          (get_local $$59)
+                        (set_local $24
+                          (get_local $0)
                         )
-                        (set_local $$v$410$i
-                          (get_local $$t$4$v$4$i)
+                        (set_local $31
+                          (get_local $6)
                         )
-                        (set_local $label
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                         (br $while-in$20)
                       )
                     )
                     (if
                       (i32.eq
-                        (set_local $$60
+                        (set_local $0
                           (i32.load offset=20
-                            (get_local $$t$48$i)
+                            (get_local $24)
                           )
                         )
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$rsize$4$lcssa$i
-                          (get_local $$sub101$rsize$4$i)
+                        (set_local $17
+                          (get_local $3)
                         )
-                        (set_local $$v$4$lcssa$i
-                          (get_local $$t$4$v$4$i)
+                        (set_local $15
+                          (get_local $6)
                         )
                         (br $while-out$19)
                       )
                       (block
-                        (set_local $$rsize$49$i
-                          (get_local $$sub101$rsize$4$i)
+                        (set_local $26
+                          (get_local $3)
                         )
-                        (set_local $$t$48$i
-                          (get_local $$60)
+                        (set_local $24
+                          (get_local $0)
                         )
-                        (set_local $$v$410$i
-                          (get_local $$t$4$v$4$i)
+                        (set_local $31
+                          (get_local $6)
                         )
-                        (set_local $label
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                       )
                     )
                     (br $while-in$20)
@@ -13398,27 +12178,27 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $$v$4$lcssa$i)
+                    (get_local $15)
                     (i32.const 0)
                   )
-                  (set_local $$nb$0
-                    (get_local $$and145)
+                  (set_local $9
+                    (get_local $5)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$rsize$4$lcssa$i)
+                      (get_local $17)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
                         )
-                        (get_local $$and145)
+                        (get_local $5)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $$v$4$lcssa$i)
-                          (set_local $$62
+                          (get_local $15)
+                          (set_local $0
                             (i32.load
                               (i32.const 192)
                             )
@@ -13428,39 +12208,39 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $$v$4$lcssa$i)
-                          (set_local $$add$ptr$i$161
+                          (get_local $15)
+                          (set_local $3
                             (i32.add
-                              (get_local $$v$4$lcssa$i)
-                              (get_local $$and145)
+                              (get_local $15)
+                              (get_local $5)
                             )
                           )
                         )
                         (call_import $_abort)
                       )
-                      (set_local $$63
+                      (set_local $1
                         (i32.load offset=24
-                          (get_local $$v$4$lcssa$i)
+                          (get_local $15)
                         )
                       )
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $$64
+                            (set_local $2
                               (i32.load offset=12
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                               )
                             )
-                            (get_local $$v$4$lcssa$i)
+                            (get_local $15)
                           )
                           (block
                             (if
                               (i32.eq
-                                (set_local $$68
+                                (set_local $2
                                   (i32.load
-                                    (set_local $$arrayidx151$i
+                                    (set_local $8
                                       (i32.add
-                                        (get_local $$v$4$lcssa$i)
+                                        (get_local $15)
                                         (i32.const 20)
                                       )
                                     )
@@ -13470,11 +12250,11 @@
                               )
                               (if
                                 (i32.eq
-                                  (set_local $$69
+                                  (set_local $2
                                     (i32.load
-                                      (set_local $$arrayidx155$i
+                                      (set_local $8
                                         (i32.add
-                                          (get_local $$v$4$lcssa$i)
+                                          (get_local $15)
                                           (i32.const 16)
                                         )
                                       )
@@ -13483,37 +12263,33 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$R$3$i$171
+                                  (set_local $12
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168
-                                    (get_local $$69)
+                                  (set_local $7
+                                    (get_local $2)
                                   )
-                                  (set_local $$RP$1$i$167
-                                    (get_local $$arrayidx155$i)
-                                  )
+                                  (get_local $8)
                                 )
                               )
                               (block
-                                (set_local $$R$1$i$168
-                                  (get_local $$68)
+                                (set_local $7
+                                  (get_local $2)
                                 )
-                                (set_local $$RP$1$i$167
-                                  (get_local $$arrayidx151$i)
-                                )
+                                (get_local $8)
                               )
                             )
                             (loop $while-out$23 $while-in$24
                               (if
                                 (i32.ne
-                                  (set_local $$70
+                                  (set_local $2
                                     (i32.load
-                                      (set_local $$arrayidx161$i
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $$R$1$i$168)
+                                          (get_local $7)
                                           (i32.const 20)
                                         )
                                       )
@@ -13522,22 +12298,22 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168
-                                    (get_local $$70)
+                                  (set_local $7
+                                    (get_local $2)
                                   )
-                                  (set_local $$RP$1$i$167
-                                    (get_local $$arrayidx161$i)
+                                  (set_local $8
+                                    (get_local $6)
                                   )
                                   (br $while-in$24)
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (set_local $$71
+                                  (set_local $2
                                     (i32.load
-                                      (set_local $$arrayidx165$i$169
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $$R$1$i$168)
+                                          (get_local $7)
                                           (i32.const 16)
                                         )
                                       )
@@ -13546,20 +12322,20 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168$lcssa
-                                    (get_local $$R$1$i$168)
+                                  (set_local $2
+                                    (get_local $7)
                                   )
-                                  (set_local $$RP$1$i$167$lcssa
-                                    (get_local $$RP$1$i$167)
+                                  (set_local $7
+                                    (get_local $8)
                                   )
                                   (br $while-out$23)
                                 )
                                 (block
-                                  (set_local $$R$1$i$168
-                                    (get_local $$71)
+                                  (set_local $7
+                                    (get_local $2)
                                   )
-                                  (set_local $$RP$1$i$167
-                                    (get_local $$arrayidx165$i$169)
+                                  (set_local $8
+                                    (get_local $6)
                                   )
                                 )
                               )
@@ -13567,17 +12343,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$RP$1$i$167$lcssa)
-                                (get_local $$62)
+                                (get_local $7)
+                                (get_local $0)
                               )
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $$RP$1$i$167$lcssa)
+                                  (get_local $7)
                                   (i32.const 0)
                                 )
-                                (set_local $$R$3$i$171
-                                  (get_local $$R$1$i$168$lcssa)
+                                (set_local $12
+                                  (get_local $2)
                                 )
                               )
                             )
@@ -13585,52 +12361,52 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $$65
+                                (set_local $7
                                   (i32.load offset=8
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                 )
-                                (get_local $$62)
+                                (get_local $0)
                               )
                               (call_import $_abort)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (set_local $$bk136$i
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $$65)
+                                      (get_local $7)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                               )
                               (call_import $_abort)
                             )
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $$fd139$i
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $$64)
+                                      (get_local $2)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                               )
                               (block
                                 (i32.store
-                                  (get_local $$bk136$i)
-                                  (get_local $$64)
+                                  (get_local $0)
+                                  (get_local $2)
                                 )
                                 (i32.store
-                                  (get_local $$fd139$i)
-                                  (get_local $$65)
+                                  (get_local $8)
+                                  (get_local $7)
                                 )
-                                (set_local $$R$3$i$171
-                                  (get_local $$64)
+                                (set_local $12
+                                  (get_local $2)
                                 )
                               )
                               (call_import $_abort)
@@ -13641,21 +12417,21 @@
                       (block $do-once$25
                         (if
                           (i32.ne
-                            (get_local $$63)
+                            (get_local $1)
                             (i32.const 0)
                           )
                           (block
                             (if
                               (i32.eq
-                                (get_local $$v$4$lcssa$i)
+                                (get_local $15)
                                 (i32.load
-                                  (set_local $$arrayidx184$i
+                                  (set_local $2
                                     (i32.add
                                       (i32.const 480)
                                       (i32.shl
-                                        (set_local $$72
+                                        (set_local $0
                                           (i32.load offset=28
-                                            (get_local $$v$4$lcssa$i)
+                                            (get_local $15)
                                           )
                                         )
                                         (i32.const 2)
@@ -13666,12 +12442,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $$arrayidx184$i)
-                                  (get_local $$R$3$i$171)
+                                  (get_local $2)
+                                  (get_local $12)
                                 )
                                 (if
                                   (i32.eq
-                                    (get_local $$R$3$i$171)
+                                    (get_local $12)
                                     (i32.const 0)
                                   )
                                   (block
@@ -13684,7 +12460,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $$72)
+                                            (get_local $0)
                                           )
                                           (i32.const -1)
                                         )
@@ -13697,7 +12473,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $$63)
+                                    (get_local $1)
                                     (i32.load
                                       (i32.const 192)
                                     )
@@ -13707,27 +12483,27 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $$arrayidx204$i
+                                      (set_local $0
                                         (i32.add
-                                          (get_local $$63)
+                                          (get_local $1)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                   (i32.store
-                                    (get_local $$arrayidx204$i)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $0)
+                                    (get_local $12)
                                   )
                                   (i32.store offset=20
-                                    (get_local $$63)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $1)
+                                    (get_local $12)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eq
-                                    (get_local $$R$3$i$171)
+                                    (get_local $12)
                                     (i32.const 0)
                                   )
                                 )
@@ -13735,8 +12511,8 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$R$3$i$171)
-                                (set_local $$77
+                                (get_local $12)
+                                (set_local $0
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -13745,48 +12521,48 @@
                               (call_import $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $$R$3$i$171)
-                              (get_local $$63)
+                              (get_local $12)
+                              (get_local $1)
                             )
                             (if
                               (i32.ne
-                                (set_local $$78
+                                (set_local $1
                                   (i32.load offset=16
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$78)
-                                  (get_local $$77)
+                                  (get_local $1)
+                                  (get_local $0)
                                 )
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $$R$3$i$171)
-                                    (get_local $$78)
+                                    (get_local $12)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$78)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $1)
+                                    (get_local $12)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.ne
-                                (set_local $$79
+                                (set_local $0
                                   (i32.load offset=20
-                                    (get_local $$v$4$lcssa$i)
+                                    (get_local $15)
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$79)
+                                  (get_local $0)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -13794,12 +12570,12 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $$R$3$i$171)
-                                    (get_local $$79)
+                                    (get_local $12)
+                                    (get_local $0)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$79)
-                                    (get_local $$R$3$i$171)
+                                    (get_local $0)
+                                    (get_local $12)
                                   )
                                 )
                               )
@@ -13810,30 +12586,30 @@
                       (block $do-once$29
                         (if
                           (i32.lt_u
-                            (get_local $$rsize$4$lcssa$i)
+                            (get_local $17)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $$v$4$lcssa$i)
+                              (get_local $15)
                               (i32.or
-                                (set_local $$add268$i
+                                (set_local $0
                                   (i32.add
-                                    (get_local $$rsize$4$lcssa$i)
-                                    (get_local $$and145)
+                                    (get_local $17)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 3)
                               )
                             )
-                            (set_local $$or275$i
+                            (set_local $1
                               (i32.or
                                 (i32.load
-                                  (set_local $$head274$i
+                                  (set_local $0
                                     (i32.add
                                       (i32.add
-                                        (get_local $$v$4$lcssa$i)
-                                        (get_local $$add268$i)
+                                        (get_local $15)
+                                        (get_local $0)
                                       )
                                       (i32.const 4)
                                     )
@@ -13843,50 +12619,50 @@
                               )
                             )
                             (i32.store
-                              (get_local $$head274$i)
-                              (get_local $$or275$i)
+                              (get_local $0)
+                              (get_local $1)
                             )
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $$v$4$lcssa$i)
+                              (get_local $15)
                               (i32.or
-                                (get_local $$and145)
+                                (get_local $5)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $$add$ptr$i$161)
+                              (get_local $3)
                               (i32.or
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $$add$ptr$i$161)
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $3)
+                                (get_local $17)
                               )
-                              (get_local $$rsize$4$lcssa$i)
+                              (get_local $17)
                             )
-                            (set_local $$shr283$i
+                            (set_local $1
                               (i32.shr_u
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $$arrayidx289$i
+                                (set_local $2
                                   (i32.add
                                     (i32.const 216)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $$shr283$i)
+                                        (get_local $1)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -13896,15 +12672,15 @@
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $$82
+                                      (set_local $0
                                         (i32.load
                                           (i32.const 176)
                                         )
                                       )
-                                      (set_local $$shl291$i
+                                      (set_local $1
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $$shr283$i)
+                                          (get_local $1)
                                         )
                                       )
                                     )
@@ -13914,27 +12690,27 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $$82)
-                                        (get_local $$shl291$i)
+                                        (get_local $0)
+                                        (get_local $1)
                                       )
                                     )
-                                    (set_local $$$pre$phi$i$178Z2D
+                                    (set_local $4
                                       (i32.add
-                                        (get_local $$arrayidx289$i)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $$F290$0$i
-                                      (get_local $$arrayidx289$i)
+                                    (set_local $11
+                                      (get_local $2)
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $$84
+                                      (set_local $1
                                         (i32.load
-                                          (set_local $$83
+                                          (set_local $0
                                             (i32.add
-                                              (get_local $$arrayidx289$i)
+                                              (get_local $2)
                                               (i32.const 8)
                                             )
                                           )
@@ -13946,44 +12722,44 @@
                                     )
                                     (call_import $_abort)
                                     (block
-                                      (set_local $$$pre$phi$i$178Z2D
-                                        (get_local $$83)
+                                      (set_local $4
+                                        (get_local $0)
                                       )
-                                      (set_local $$F290$0$i
-                                        (get_local $$84)
+                                      (set_local $11
+                                        (get_local $1)
                                       )
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$$pre$phi$i$178Z2D)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $4)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$F290$0$i)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $11)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$F290$0$i)
+                                  (get_local $3)
+                                  (get_local $11)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$arrayidx289$i)
+                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $$arrayidx355$i
+                            (set_local $2
                               (i32.add
                                 (i32.const 480)
                                 (i32.shl
-                                  (set_local $$I316$0$i
+                                  (set_local $1
                                     (if
                                       (i32.eq
-                                        (set_local $$shr318$i
+                                        (set_local $0
                                           (i32.shr_u
-                                            (get_local $$rsize$4$lcssa$i)
+                                            (get_local $17)
                                             (i32.const 8)
                                           )
                                         )
@@ -13992,31 +12768,31 @@
                                       (i32.const 0)
                                       (if
                                         (i32.gt_u
-                                          (get_local $$rsize$4$lcssa$i)
+                                          (get_local $17)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (block
-                                          (set_local $$shl347$i
+                                          (set_local $1
                                             (i32.shl
-                                              (set_local $$add346$i
+                                              (set_local $0
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
                                                     (i32.or
                                                       (i32.or
-                                                        (set_local $$and336$i
+                                                        (set_local $1
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $$shl333$i
+                                                                (set_local $2
                                                                   (i32.shl
-                                                                    (get_local $$shr318$i)
-                                                                    (set_local $$and331$i
+                                                                    (get_local $0)
+                                                                    (set_local $0
                                                                       (i32.and
                                                                         (i32.shr_u
                                                                           (i32.add
-                                                                            (get_local $$shr318$i)
+                                                                            (get_local $0)
                                                                             (i32.const 1048320)
                                                                           )
                                                                           (i32.const 16)
@@ -14033,16 +12809,16 @@
                                                             (i32.const 4)
                                                           )
                                                         )
-                                                        (get_local $$and331$i)
+                                                        (get_local $0)
                                                       )
-                                                      (set_local $$and341$i
+                                                      (set_local $0
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $$shl338$i
+                                                              (set_local $1
                                                                 (i32.shl
-                                                                  (get_local $$shl333$i)
-                                                                  (get_local $$and336$i)
+                                                                  (get_local $2)
+                                                                  (get_local $1)
                                                                 )
                                                               )
                                                               (i32.const 245760)
@@ -14056,8 +12832,8 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $$shl338$i)
-                                                      (get_local $$and341$i)
+                                                      (get_local $1)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const 15)
                                                   )
@@ -14069,15 +12845,15 @@
                                           (i32.or
                                             (i32.and
                                               (i32.shr_u
-                                                (get_local $$rsize$4$lcssa$i)
+                                                (get_local $17)
                                                 (i32.add
-                                                  (get_local $$add346$i)
+                                                  (get_local $0)
                                                   (i32.const 7)
                                                 )
                                               )
                                               (i32.const 1)
                                             )
-                                            (get_local $$shl347$i)
+                                            (get_local $1)
                                           )
                                         )
                                       )
@@ -14088,34 +12864,34 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $$add$ptr$i$161)
-                              (get_local $$I316$0$i)
+                              (get_local $3)
+                              (get_local $1)
                             )
                             (i32.store offset=4
-                              (set_local $$child357$i
+                              (set_local $0
                                 (i32.add
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $3)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $$child357$i)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (if
                               (i32.eq
                                 (i32.and
-                                  (set_local $$86
+                                  (set_local $0
                                     (i32.load
                                       (i32.const 180)
                                     )
                                   )
-                                  (set_local $$shl362$i
+                                  (set_local $4
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $$I316$0$i)
+                                      (get_local $1)
                                     )
                                   )
                                 )
@@ -14125,51 +12901,51 @@
                                 (i32.store
                                   (i32.const 180)
                                   (i32.or
-                                    (get_local $$86)
-                                    (get_local $$shl362$i)
+                                    (get_local $0)
+                                    (get_local $4)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$arrayidx355$i)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $2)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=24
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$arrayidx355$i)
+                                  (get_local $3)
+                                  (get_local $2)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (i32.store offset=8
-                                  (get_local $$add$ptr$i$161)
-                                  (get_local $$add$ptr$i$161)
+                                  (get_local $3)
+                                  (get_local $3)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $$K373$0$i
+                            (set_local $1
                               (i32.shl
-                                (get_local $$rsize$4$lcssa$i)
+                                (get_local $17)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $$I316$0$i)
+                                      (get_local $1)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $$I316$0$i)
+                                    (get_local $1)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $$T$0$i
+                            (set_local $2
                               (i32.load
-                                (get_local $$arrayidx355$i)
+                                (get_local $2)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -14177,41 +12953,41 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $$T$0$i)
+                                      (get_local $2)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $$rsize$4$lcssa$i)
+                                  (get_local $17)
                                 )
                                 (block
-                                  (set_local $$T$0$i$lcssa
-                                    (get_local $$T$0$i)
+                                  (set_local $22
+                                    (get_local $2)
                                   )
-                                  (set_local $label
+                                  (set_local $10
                                     (i32.const 148)
                                   )
                                   (br $while-out$31)
                                 )
                               )
-                              (set_local $$shl395$i
+                              (set_local $4
                                 (i32.shl
-                                  (get_local $$K373$0$i)
+                                  (get_local $1)
                                   (i32.const 1)
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (set_local $$89
+                                  (set_local $0
                                     (i32.load
-                                      (set_local $$arrayidx394$i
+                                      (set_local $1
                                         (i32.add
                                           (i32.add
-                                            (get_local $$T$0$i)
+                                            (get_local $2)
                                             (i32.const 16)
                                           )
                                           (i32.shl
                                             (i32.shr_u
-                                              (get_local $$K373$0$i)
+                                              (get_local $1)
                                               (i32.const 31)
                                             )
                                             (i32.const 2)
@@ -14223,23 +12999,23 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $$T$0$i$lcssa293
-                                    (get_local $$T$0$i)
+                                  (set_local $25
+                                    (get_local $2)
                                   )
-                                  (set_local $$arrayidx394$i$lcssa
-                                    (get_local $$arrayidx394$i)
+                                  (set_local $39
+                                    (get_local $1)
                                   )
-                                  (set_local $label
+                                  (set_local $10
                                     (i32.const 145)
                                   )
                                   (br $while-out$31)
                                 )
                                 (block
-                                  (set_local $$K373$0$i
-                                    (get_local $$shl395$i)
+                                  (set_local $1
+                                    (get_local $4)
                                   )
-                                  (set_local $$T$0$i
-                                    (get_local $$89)
+                                  (set_local $2
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -14247,12 +13023,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $label)
+                                (get_local $10)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $$arrayidx394$i$lcssa)
+                                  (get_local $39)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -14260,71 +13036,71 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store
-                                    (get_local $$arrayidx394$i$lcssa)
-                                    (get_local $$add$ptr$i$161)
+                                    (get_local $39)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$add$ptr$i$161)
-                                    (get_local $$T$0$i$lcssa293)
+                                    (get_local $3)
+                                    (get_local $25)
                                   )
                                   (i32.store offset=12
-                                    (get_local $$add$ptr$i$161)
-                                    (get_local $$add$ptr$i$161)
+                                    (get_local $3)
+                                    (get_local $3)
                                   )
                                   (i32.store offset=8
-                                    (get_local $$add$ptr$i$161)
-                                    (get_local $$add$ptr$i$161)
+                                    (get_local $3)
+                                    (get_local $3)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $label)
+                                  (get_local $10)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (set_local $$91
+                                      (set_local $0
                                         (i32.load
-                                          (set_local $$fd416$i
+                                          (set_local $2
                                             (i32.add
-                                              (get_local $$T$0$i$lcssa)
+                                              (get_local $22)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $$92
+                                      (set_local $1
                                         (i32.load
                                           (i32.const 192)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $$T$0$i$lcssa)
-                                      (get_local $$92)
+                                      (get_local $22)
+                                      (get_local $1)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $$91)
-                                      (get_local $$add$ptr$i$161)
+                                      (get_local $0)
+                                      (get_local $3)
                                     )
                                     (i32.store
-                                      (get_local $$fd416$i)
-                                      (get_local $$add$ptr$i$161)
+                                      (get_local $2)
+                                      (get_local $3)
                                     )
                                     (i32.store offset=8
-                                      (get_local $$add$ptr$i$161)
-                                      (get_local $$91)
+                                      (get_local $3)
+                                      (get_local $0)
                                     )
                                     (i32.store offset=12
-                                      (get_local $$add$ptr$i$161)
-                                      (get_local $$T$0$i$lcssa)
+                                      (get_local $3)
+                                      (get_local $22)
                                     )
                                     (i32.store offset=24
-                                      (get_local $$add$ptr$i$161)
+                                      (get_local $3)
                                       (i32.const 0)
                                     )
                                   )
@@ -14337,13 +13113,13 @@
                       )
                       (return
                         (i32.add
-                          (get_local $$v$4$lcssa$i)
+                          (get_local $15)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $$nb$0
-                      (get_local $$and145)
+                    (set_local $9
+                      (get_local $5)
                     )
                   )
                 )
@@ -14355,25 +13131,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $$94
+        (set_local $0
           (i32.load
             (i32.const 184)
           )
         )
-        (get_local $$nb$0)
+        (get_local $9)
       )
       (block
-        (set_local $$95
+        (set_local $1
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (set_local $$sub160
+            (set_local $2
               (i32.sub
-                (get_local $$94)
-                (get_local $$nb$0)
+                (get_local $0)
+                (get_local $9)
               )
             )
             (i32.const 15)
@@ -14381,35 +13157,35 @@
           (block
             (i32.store
               (i32.const 196)
-              (set_local $$add$ptr166
+              (set_local $0
                 (i32.add
-                  (get_local $$95)
-                  (get_local $$nb$0)
+                  (get_local $1)
+                  (get_local $9)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $$sub160)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $$add$ptr166)
+              (get_local $0)
               (i32.or
-                (get_local $$sub160)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $$add$ptr166)
-                (get_local $$sub160)
+                (get_local $0)
+                (get_local $2)
               )
-              (get_local $$sub160)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $$95)
+              (get_local $1)
               (i32.or
-                (get_local $$nb$0)
+                (get_local $9)
                 (i32.const 3)
               )
             )
@@ -14424,20 +13200,20 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $$95)
+              (get_local $1)
               (i32.or
-                (get_local $$94)
+                (get_local $0)
                 (i32.const 3)
               )
             )
-            (set_local $$or180
+            (set_local $2
               (i32.or
                 (i32.load
-                  (set_local $$head179
+                  (set_local $0
                     (i32.add
                       (i32.add
-                        (get_local $$95)
-                        (get_local $$94)
+                        (get_local $1)
+                        (get_local $0)
                       )
                       (i32.const 4)
                     )
@@ -14447,14 +13223,14 @@
               )
             )
             (i32.store
-              (get_local $$head179)
-              (get_local $$or180)
+              (get_local $0)
+              (get_local $2)
             )
           )
         )
         (return
           (i32.add
-            (get_local $$95)
+            (get_local $1)
             (i32.const 8)
           )
         )
@@ -14462,53 +13238,53 @@
     )
     (if
       (i32.gt_u
-        (set_local $$97
+        (set_local $0
           (i32.load
             (i32.const 188)
           )
         )
-        (get_local $$nb$0)
+        (get_local $9)
       )
       (block
         (i32.store
           (i32.const 188)
-          (set_local $$sub190
+          (set_local $2
             (i32.sub
-              (get_local $$97)
-              (get_local $$nb$0)
+              (get_local $0)
+              (get_local $9)
             )
           )
         )
         (i32.store
           (i32.const 200)
-          (set_local $$add$ptr193
+          (set_local $1
             (i32.add
-              (set_local $$98
+              (set_local $0
                 (i32.load
                   (i32.const 200)
                 )
               )
-              (get_local $$nb$0)
+              (get_local $9)
             )
           )
         )
         (i32.store offset=4
-          (get_local $$add$ptr193)
+          (get_local $1)
           (i32.or
-            (get_local $$sub190)
+            (get_local $2)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $$98)
+          (get_local $0)
           (i32.or
-            (get_local $$nb$0)
+            (get_local $9)
             (i32.const 3)
           )
         )
         (return
           (i32.add
-            (get_local $$98)
+            (get_local $0)
             (i32.const 8)
           )
         )
@@ -14525,25 +13301,25 @@
         (i32.eq
           (i32.and
             (i32.add
-              (set_local $$call$i$i
+              (set_local $0
                 (call_import $_sysconf
                   (i32.const 30)
                 )
               )
               (i32.const -1)
             )
-            (get_local $$call$i$i)
+            (get_local $0)
           )
           (i32.const 0)
         )
         (block
           (i32.store
             (i32.const 656)
-            (get_local $$call$i$i)
+            (get_local $0)
           )
           (i32.store
             (i32.const 652)
-            (get_local $$call$i$i)
+            (get_local $0)
           )
           (i32.store
             (i32.const 660)
@@ -14577,40 +13353,40 @@
         (call_import $_abort)
       )
     )
-    (set_local $$add$i$180
+    (set_local $3
       (i32.add
-        (get_local $$nb$0)
+        (get_local $9)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $$and11$i
+        (set_local $11
           (i32.and
-            (set_local $$add9$i
+            (set_local $6
               (i32.add
-                (set_local $$100
+                (set_local $0
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (set_local $$sub$i$181
+                (set_local $12
                   (i32.add
-                    (get_local $$nb$0)
+                    (get_local $9)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $$neg$i$182
+            (set_local $13
               (i32.sub
                 (i32.const 0)
-                (get_local $$100)
+                (get_local $0)
               )
             )
           )
         )
-        (get_local $$nb$0)
+        (get_local $9)
       )
       (return
         (i32.const 0)
@@ -14618,7 +13394,7 @@
     )
     (if
       (i32.ne
-        (set_local $$101
+        (set_local $0
           (i32.load
             (i32.const 616)
           )
@@ -14628,21 +13404,21 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $$add17$i$183
+            (set_local $5
               (i32.add
-                (set_local $$102
+                (set_local $4
                   (i32.load
                     (i32.const 608)
                   )
                 )
-                (get_local $$and11$i)
+                (get_local $11)
               )
             )
-            (get_local $$102)
+            (get_local $4)
           )
           (i32.gt_u
-            (get_local $$add17$i$183)
-            (get_local $$101)
+            (get_local $5)
+            (get_local $0)
           )
         )
         (return
@@ -14652,7 +13428,7 @@
     )
     (if
       (i32.eq
-        (set_local $label
+        (set_local $10
           (block $label$break$L257
             (if
               (i32.eq
@@ -14668,51 +13444,51 @@
                 (block $label$break$L259
                   (if
                     (i32.eq
-                      (set_local $$104
+                      (set_local $0
                         (i32.load
                           (i32.const 200)
                         )
                       )
                       (i32.const 0)
                     )
-                    (set_local $label
+                    (set_local $10
                       (i32.const 173)
                     )
                     (block
-                      (set_local $$sp$0$i$i
+                      (set_local $14
                         (i32.const 624)
                       )
                       (loop $while-out$37 $while-in$38
                         (if
                           (i32.le_u
-                            (set_local $$105
+                            (set_local $4
                               (i32.load
-                                (get_local $$sp$0$i$i)
+                                (get_local $14)
                               )
                             )
-                            (get_local $$104)
+                            (get_local $0)
                           )
                           (if
                             (i32.gt_u
                               (i32.add
-                                (get_local $$105)
+                                (get_local $4)
                                 (i32.load
-                                  (set_local $$size$i$i
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $$sp$0$i$i)
+                                      (get_local $14)
                                       (i32.const 4)
                                     )
                                   )
                                 )
                               )
-                              (get_local $$104)
+                              (get_local $0)
                             )
                             (block
-                              (set_local $$base$i$i$lcssa
-                                (get_local $$sp$0$i$i)
+                              (set_local $4
+                                (get_local $14)
                               )
-                              (set_local $$size$i$i$lcssa
-                                (get_local $$size$i$i)
+                              (set_local $14
+                                (get_local $5)
                               )
                               (br $while-out$37)
                             )
@@ -14720,67 +13496,67 @@
                         )
                         (if
                           (i32.eq
-                            (set_local $$107
+                            (set_local $4
                               (i32.load offset=8
-                                (get_local $$sp$0$i$i)
+                                (get_local $14)
                               )
                             )
                             (i32.const 0)
                           )
                           (block
-                            (set_local $label
+                            (set_local $10
                               (i32.const 173)
                             )
                             (br $label$break$L259)
                           )
-                          (set_local $$sp$0$i$i
-                            (get_local $$107)
+                          (set_local $14
+                            (get_local $4)
                           )
                         )
                         (br $while-in$38)
                       )
                       (if
                         (i32.lt_u
-                          (set_local $$and80$i
+                          (set_local $0
                             (i32.and
                               (i32.sub
-                                (get_local $$add9$i)
+                                (get_local $6)
                                 (i32.load
                                   (i32.const 188)
                                 )
                               )
-                              (get_local $$neg$i$182)
+                              (get_local $13)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $$call83$i
+                            (set_local $5
                               (call_import $_sbrk
-                                (get_local $$and80$i)
+                                (get_local $0)
                               )
                             )
                             (i32.add
                               (i32.load
-                                (get_local $$base$i$i$lcssa)
+                                (get_local $4)
                               )
                               (i32.load
-                                (get_local $$size$i$i$lcssa)
+                                (get_local $14)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $$call83$i)
+                              (get_local $5)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $$tbase$796$i
-                                (get_local $$call83$i)
+                              (set_local $16
+                                (get_local $5)
                               )
-                              (set_local $$tsize$795$i
-                                (get_local $$and80$i)
+                              (set_local $19
+                                (get_local $0)
                               )
                               (br $label$break$L257
                                 (i32.const 193)
@@ -14788,13 +13564,13 @@
                             )
                           )
                           (block
-                            (set_local $$br$2$ph$i
-                              (get_local $$call83$i)
+                            (set_local $28
+                              (get_local $5)
                             )
-                            (set_local $$ssize$2$ph$i
-                              (get_local $$and80$i)
+                            (set_local $21
+                              (get_local $0)
                             )
-                            (set_local $label
+                            (set_local $10
                               (i32.const 183)
                             )
                           )
@@ -14806,12 +13582,12 @@
                 (block $do-once$39
                   (if
                     (i32.eq
-                      (get_local $label)
+                      (get_local $10)
                       (i32.const 173)
                     )
                     (if
                       (i32.ne
-                        (set_local $$call37$i
+                        (set_local $6
                           (call_import $_sbrk
                             (i32.const 0)
                           )
@@ -14819,13 +13595,13 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $$ssize$0$i
+                        (set_local $13
                           (if
                             (i32.eq
                               (i32.and
-                                (set_local $$sub41$i
+                                (set_local $5
                                   (i32.add
-                                    (set_local $$109
+                                    (set_local $4
                                       (i32.load
                                         (i32.const 652)
                                       )
@@ -14833,56 +13609,56 @@
                                     (i32.const -1)
                                   )
                                 )
-                                (set_local $$108
-                                  (get_local $$call37$i)
+                                (set_local $0
+                                  (get_local $6)
                                 )
                               )
                               (i32.const 0)
                             )
-                            (get_local $$and11$i)
+                            (get_local $11)
                             (i32.add
                               (i32.sub
-                                (get_local $$and11$i)
-                                (get_local $$108)
+                                (get_local $11)
+                                (get_local $0)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $$sub41$i)
-                                  (get_local $$108)
+                                  (get_local $5)
+                                  (get_local $0)
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$109)
+                                  (get_local $4)
                                 )
                               )
                             )
                           )
                         )
-                        (set_local $$add54$i
+                        (set_local $5
                           (i32.add
-                            (set_local $$110
+                            (set_local $0
                               (i32.load
                                 (i32.const 608)
                               )
                             )
-                            (get_local $$ssize$0$i)
+                            (get_local $13)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $$ssize$0$i)
-                              (get_local $$nb$0)
+                              (get_local $13)
+                              (get_local $9)
                             )
                             (i32.lt_u
-                              (get_local $$ssize$0$i)
+                              (get_local $13)
                               (i32.const 2147483647)
                             )
                           )
                           (block
                             (if
                               (i32.ne
-                                (set_local $$111
+                                (set_local $4
                                   (i32.load
                                     (i32.const 616)
                                   )
@@ -14892,44 +13668,44 @@
                               (br_if $do-once$39
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $$add54$i)
-                                    (get_local $$110)
+                                    (get_local $5)
+                                    (get_local $0)
                                   )
                                   (i32.gt_u
-                                    (get_local $$add54$i)
-                                    (get_local $$111)
+                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$call68$i
+                                (set_local $0
                                   (call_import $_sbrk
-                                    (get_local $$ssize$0$i)
+                                    (get_local $13)
                                   )
                                 )
-                                (get_local $$call37$i)
+                                (get_local $6)
                               )
                               (block
-                                (set_local $$tbase$796$i
-                                  (get_local $$call37$i)
+                                (set_local $16
+                                  (get_local $6)
                                 )
-                                (set_local $$tsize$795$i
-                                  (get_local $$ssize$0$i)
+                                (set_local $19
+                                  (get_local $13)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
                                 )
                               )
                               (block
-                                (set_local $$br$2$ph$i
-                                  (get_local $$call68$i)
+                                (set_local $28
+                                  (get_local $0)
                                 )
-                                (set_local $$ssize$2$ph$i
-                                  (get_local $$ssize$0$i)
+                                (set_local $21
+                                  (get_local $13)
                                 )
-                                (set_local $label
+                                (set_local $10
                                   (i32.const 183)
                                 )
                               )
@@ -14943,43 +13719,43 @@
                 (block $label$break$L279
                   (if
                     (i32.eq
-                      (get_local $label)
+                      (get_local $10)
                       (i32.const 183)
                     )
                     (block
-                      (set_local $$sub112$i
+                      (set_local $4
                         (i32.sub
                           (i32.const 0)
-                          (get_local $$ssize$2$ph$i)
+                          (get_local $21)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $$add$i$180)
-                            (get_local $$ssize$2$ph$i)
+                            (get_local $3)
+                            (get_local $21)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $$ssize$2$ph$i)
+                              (get_local $21)
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $$br$2$ph$i)
+                              (get_local $28)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $$and104$i
+                            (set_local $0
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $$sub$i$181)
-                                    (get_local $$ssize$2$ph$i)
+                                    (get_local $12)
+                                    (get_local $21)
                                   )
-                                  (set_local $$115
+                                  (set_local $0
                                     (i32.load
                                       (i32.const 656)
                                     )
@@ -14987,7 +13763,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$115)
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -14996,42 +13772,42 @@
                           (if
                             (i32.eq
                               (call_import $_sbrk
-                                (get_local $$and104$i)
+                                (get_local $0)
                               )
                               (i32.const -1)
                             )
                             (block
                               (call_import $_sbrk
-                                (get_local $$sub112$i)
+                                (get_local $4)
                               )
                               (br $label$break$L279)
                             )
-                            (set_local $$ssize$5$i
+                            (set_local $0
                               (i32.add
-                                (get_local $$and104$i)
-                                (get_local $$ssize$2$ph$i)
+                                (get_local $0)
+                                (get_local $21)
                               )
                             )
                           )
-                          (set_local $$ssize$5$i
-                            (get_local $$ssize$2$ph$i)
+                          (set_local $0
+                            (get_local $21)
                           )
                         )
-                        (set_local $$ssize$5$i
-                          (get_local $$ssize$2$ph$i)
+                        (set_local $0
+                          (get_local $21)
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $$br$2$ph$i)
+                          (get_local $28)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $$tbase$796$i
-                            (get_local $$br$2$ph$i)
+                          (set_local $16
+                            (get_local $28)
                           )
-                          (set_local $$tsize$795$i
-                            (get_local $$ssize$5$i)
+                          (set_local $19
+                            (get_local $0)
                           )
                           (br $label$break$L257
                             (i32.const 193)
@@ -15060,22 +13836,22 @@
       )
       (if
         (i32.lt_u
-          (get_local $$and11$i)
+          (get_local $11)
           (i32.const 2147483647)
         )
         (block
-          (set_local $$or$cond4$i
+          (set_local $3
             (i32.and
               (i32.ne
-                (set_local $$call131$i
+                (set_local $0
                   (call_import $_sbrk
-                    (get_local $$and11$i)
+                    (get_local $11)
                   )
                 )
                 (i32.const -1)
               )
               (i32.ne
-                (set_local $$call132$i
+                (set_local $4
                   (call_import $_sbrk
                     (i32.const 0)
                   )
@@ -15087,32 +13863,32 @@
           (if
             (i32.and
               (i32.lt_u
-                (get_local $$call131$i)
-                (get_local $$call132$i)
+                (get_local $0)
+                (get_local $4)
               )
-              (get_local $$or$cond4$i)
+              (get_local $3)
             )
             (if
               (i32.gt_u
-                (set_local $$sub$ptr$sub$i
+                (set_local $4
                   (i32.sub
-                    (get_local $$call132$i)
-                    (get_local $$call131$i)
+                    (get_local $4)
+                    (get_local $0)
                   )
                 )
                 (i32.add
-                  (get_local $$nb$0)
+                  (get_local $9)
                   (i32.const 40)
                 )
               )
               (block
-                (set_local $$tbase$796$i
-                  (get_local $$call131$i)
+                (set_local $16
+                  (get_local $0)
                 )
-                (set_local $$tsize$795$i
-                  (get_local $$sub$ptr$sub$i)
+                (set_local $19
+                  (get_local $4)
                 )
-                (set_local $label
+                (set_local $10
                   (i32.const 193)
                 )
               )
@@ -15123,37 +13899,37 @@
     )
     (if
       (i32.eq
-        (get_local $label)
+        (get_local $10)
         (i32.const 193)
       )
       (block
         (i32.store
           (i32.const 608)
-          (set_local $$add150$i
+          (set_local $0
             (i32.add
               (i32.load
                 (i32.const 608)
               )
-              (get_local $$tsize$795$i)
+              (get_local $19)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $$add150$i)
+            (get_local $0)
             (i32.load
               (i32.const 612)
             )
           )
           (i32.store
             (i32.const 612)
-            (get_local $$add150$i)
+            (get_local $0)
           )
         )
         (block $do-once$44
           (if
             (i32.eq
-              (set_local $$119
+              (set_local $0
                 (i32.load
                   (i32.const 200)
                 )
@@ -15164,7 +13940,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $$120
+                    (set_local $0
                       (i32.load
                         (i32.const 192)
                       )
@@ -15172,22 +13948,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $$tbase$796$i)
-                    (get_local $$120)
+                    (get_local $16)
+                    (get_local $0)
                   )
                 )
                 (i32.store
                   (i32.const 192)
-                  (get_local $$tbase$796$i)
+                  (get_local $16)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $$tbase$796$i)
+                (get_local $16)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $$tsize$795$i)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 636)
@@ -15203,52 +13979,52 @@
                 (i32.const 208)
                 (i32.const -1)
               )
-              (set_local $$i$01$i$i
+              (set_local $1
                 (i32.const 0)
               )
               (loop $while-out$46 $while-in$47
                 (i32.store offset=12
-                  (set_local $$arrayidx$i$i
+                  (set_local $0
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $$i$01$i$i)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $$arrayidx$i$i)
+                  (get_local $0)
                 )
                 (i32.store offset=8
-                  (get_local $$arrayidx$i$i)
-                  (get_local $$arrayidx$i$i)
+                  (get_local $0)
+                  (get_local $0)
                 )
                 (if
                   (i32.eq
-                    (set_local $$inc$i$i
+                    (set_local $0
                       (i32.add
-                        (get_local $$i$01$i$i)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
                     (i32.const 32)
                   )
                   (br $while-out$46)
-                  (set_local $$i$01$i$i
-                    (get_local $$inc$i$i)
+                  (set_local $1
+                    (get_local $0)
                   )
                 )
                 (br $while-in$47)
               )
-              (set_local $$cmp$i$13$i
+              (set_local $1
                 (i32.eq
                   (i32.and
-                    (set_local $$124
+                    (set_local $0
                       (i32.add
-                        (get_local $$tbase$796$i)
+                        (get_local $16)
                         (i32.const 8)
                       )
                     )
@@ -15259,20 +14035,20 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $$add$ptr4$i$i
+                (set_local $0
                   (i32.add
-                    (get_local $$tbase$796$i)
-                    (set_local $$cond$i$i
+                    (get_local $16)
+                    (set_local $1
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (get_local $$124)
+                            (get_local $0)
                           )
                           (i32.const 7)
                         )
-                        (get_local $$cmp$i$13$i)
+                        (get_local $1)
                       )
                     )
                   )
@@ -15280,27 +14056,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $$sub5$i$i
+                (set_local $1
                   (i32.sub
                     (i32.add
-                      (get_local $$tsize$795$i)
+                      (get_local $19)
                       (i32.const -40)
                     )
-                    (get_local $$cond$i$i)
+                    (get_local $1)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr4$i$i)
+                (get_local $0)
                 (i32.or
-                  (get_local $$sub5$i$i)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $$add$ptr4$i$i)
-                  (get_local $$sub5$i$i)
+                  (get_local $0)
+                  (get_local $1)
                 )
                 (i32.const 40)
               )
@@ -15312,24 +14088,24 @@
               )
             )
             (block
-              (set_local $$sp$0108$i
+              (set_local $6
                 (i32.const 624)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
-                    (get_local $$tbase$796$i)
+                    (get_local $16)
                     (i32.add
-                      (set_local $$127
+                      (set_local $4
                         (i32.load
-                          (get_local $$sp$0108$i)
+                          (get_local $6)
                         )
                       )
-                      (set_local $$128
+                      (set_local $3
                         (i32.load
-                          (set_local $$size188$i
+                          (set_local $5
                             (i32.add
-                              (get_local $$sp$0108$i)
+                              (get_local $6)
                               (i32.const 4)
                             )
                           )
@@ -15338,19 +14114,19 @@
                     )
                   )
                   (block
-                    (set_local $$$lcssa
-                      (get_local $$127)
+                    (set_local $1
+                      (get_local $4)
                     )
-                    (set_local $$$lcssa290
-                      (get_local $$128)
+                    (set_local $2
+                      (get_local $3)
                     )
-                    (set_local $$size188$i$lcssa
-                      (get_local $$size188$i)
+                    (set_local $45
+                      (get_local $5)
                     )
-                    (set_local $$sp$0108$i$lcssa
-                      (get_local $$sp$0108$i)
+                    (set_local $46
+                      (get_local $6)
                     )
-                    (set_local $label
+                    (set_local $10
                       (i32.const 203)
                     )
                     (br $while-out$48)
@@ -15358,30 +14134,30 @@
                 )
                 (if
                   (i32.eq
-                    (set_local $$129
+                    (set_local $4
                       (i32.load offset=8
-                        (get_local $$sp$0108$i)
+                        (get_local $6)
                       )
                     )
                     (i32.const 0)
                   )
                   (br $while-out$48)
-                  (set_local $$sp$0108$i
-                    (get_local $$129)
+                  (set_local $6
+                    (get_local $4)
                   )
                 )
                 (br $while-in$49)
               )
               (if
                 (i32.eq
-                  (get_local $label)
+                  (get_local $10)
                   (i32.const 203)
                 )
                 (if
                   (i32.eq
                     (i32.and
                       (i32.load offset=12
-                        (get_local $$sp$0108$i$lcssa)
+                        (get_local $46)
                       )
                       (i32.const 8)
                     )
@@ -15390,28 +14166,28 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $$119)
-                        (get_local $$tbase$796$i)
+                        (get_local $0)
+                        (get_local $16)
                       )
                       (i32.ge_u
-                        (get_local $$119)
-                        (get_local $$$lcssa)
+                        (get_local $0)
+                        (get_local $1)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $$size188$i$lcssa)
+                        (get_local $45)
                         (i32.add
-                          (get_local $$$lcssa290)
-                          (get_local $$tsize$795$i)
+                          (get_local $2)
+                          (get_local $19)
                         )
                       )
-                      (set_local $$cmp$i$23$i
+                      (set_local $2
                         (i32.eq
                           (i32.and
-                            (set_local $$132
+                            (set_local $1
                               (i32.add
-                                (get_local $$119)
+                                (get_local $0)
                                 (i32.const 8)
                               )
                             )
@@ -15420,29 +14196,29 @@
                           (i32.const 0)
                         )
                       )
-                      (set_local $$add$ptr4$i$26$i
+                      (set_local $0
                         (i32.add
-                          (get_local $$119)
-                          (set_local $$cond$i$25$i
+                          (get_local $0)
+                          (set_local $1
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$132)
+                                  (get_local $1)
                                 )
                                 (i32.const 7)
                               )
-                              (get_local $$cmp$i$23$i)
+                              (get_local $2)
                             )
                           )
                         )
                       )
-                      (set_local $$sub5$i$27$i
+                      (set_local $1
                         (i32.add
                           (i32.sub
-                            (get_local $$tsize$795$i)
-                            (get_local $$cond$i$25$i)
+                            (get_local $19)
+                            (get_local $1)
                           )
                           (i32.load
                             (i32.const 188)
@@ -15451,23 +14227,23 @@
                       )
                       (i32.store
                         (i32.const 200)
-                        (get_local $$add$ptr4$i$26$i)
+                        (get_local $0)
                       )
                       (i32.store
                         (i32.const 188)
-                        (get_local $$sub5$i$27$i)
+                        (get_local $1)
                       )
                       (i32.store offset=4
-                        (get_local $$add$ptr4$i$26$i)
+                        (get_local $0)
                         (i32.or
-                          (get_local $$sub5$i$27$i)
+                          (get_local $1)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $$add$ptr4$i$26$i)
-                          (get_local $$sub5$i$27$i)
+                          (get_local $0)
+                          (get_local $1)
                         )
                         (i32.const 40)
                       )
@@ -15482,11 +14258,11 @@
                   )
                 )
               )
-              (set_local $$150
+              (set_local $4
                 (if
                   (i32.lt_u
-                    (get_local $$tbase$796$i)
-                    (set_local $$135
+                    (get_local $16)
+                    (set_local $1
                       (i32.load
                         (i32.const 192)
                       )
@@ -15495,38 +14271,38 @@
                   (block
                     (i32.store
                       (i32.const 192)
-                      (get_local $$tbase$796$i)
+                      (get_local $16)
                     )
-                    (get_local $$tbase$796$i)
+                    (get_local $16)
                   )
-                  (get_local $$135)
+                  (get_local $1)
                 )
               )
-              (set_local $$add$ptr227$i
+              (set_local $3
                 (i32.add
-                  (get_local $$tbase$796$i)
-                  (get_local $$tsize$795$i)
+                  (get_local $16)
+                  (get_local $19)
                 )
               )
-              (set_local $$sp$1107$i
+              (set_local $1
                 (i32.const 624)
               )
               (loop $while-out$50 $while-in$51
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $$sp$1107$i)
+                      (get_local $1)
                     )
-                    (get_local $$add$ptr227$i)
+                    (get_local $3)
                   )
                   (block
-                    (set_local $$base226$i$lcssa
-                      (get_local $$sp$1107$i)
+                    (set_local $44
+                      (get_local $1)
                     )
-                    (set_local $$sp$1107$i$lcssa
-                      (get_local $$sp$1107$i)
+                    (set_local $41
+                      (get_local $1)
                     )
-                    (set_local $label
+                    (set_local $10
                       (i32.const 211)
                     )
                     (br $while-out$50)
@@ -15534,35 +14310,33 @@
                 )
                 (if
                   (i32.eq
-                    (set_local $$137
+                    (set_local $1
                       (i32.load offset=8
-                        (get_local $$sp$1107$i)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
                   )
                   (block
-                    (set_local $$sp$0$i$i$i
+                    (set_local $27
                       (i32.const 624)
                     )
                     (br $while-out$50)
                   )
-                  (set_local $$sp$1107$i
-                    (get_local $$137)
-                  )
+                  (get_local $1)
                 )
                 (br $while-in$51)
               )
               (if
                 (i32.eq
-                  (get_local $label)
+                  (get_local $10)
                   (i32.const 211)
                 )
                 (if
                   (i32.eq
                     (i32.and
                       (i32.load offset=12
-                        (get_local $$sp$1107$i$lcssa)
+                        (get_local $41)
                       )
                       (i32.const 8)
                     )
@@ -15570,32 +14344,32 @@
                   )
                   (block
                     (i32.store
-                      (get_local $$base226$i$lcssa)
-                      (get_local $$tbase$796$i)
+                      (get_local $44)
+                      (get_local $16)
                     )
-                    (set_local $$add246$i
+                    (set_local $1
                       (i32.add
                         (i32.load
-                          (set_local $$size245$i
+                          (set_local $2
                             (i32.add
-                              (get_local $$sp$1107$i$lcssa)
+                              (get_local $41)
                               (i32.const 4)
                             )
                           )
                         )
-                        (get_local $$tsize$795$i)
+                        (get_local $19)
                       )
                     )
                     (i32.store
-                      (get_local $$size245$i)
-                      (get_local $$add246$i)
+                      (get_local $2)
+                      (get_local $1)
                     )
-                    (set_local $$cmp$i$34$i
+                    (set_local $8
                       (i32.eq
                         (i32.and
-                          (set_local $$140
+                          (set_local $1
                             (i32.add
-                              (get_local $$tbase$796$i)
+                              (get_local $16)
                               (i32.const 8)
                             )
                           )
@@ -15604,12 +14378,12 @@
                         (i32.const 0)
                       )
                     )
-                    (set_local $$cmp7$i$i
+                    (set_local $5
                       (i32.eq
                         (i32.and
-                          (set_local $$142
+                          (set_local $2
                             (i32.add
-                              (get_local $$add$ptr227$i)
+                              (get_local $3)
                               (i32.const 8)
                             )
                           )
@@ -15618,87 +14392,87 @@
                         (i32.const 0)
                       )
                     )
-                    (set_local $$sub$ptr$sub$i$41$i
+                    (set_local $1
                       (i32.sub
-                        (set_local $$add$ptr16$i$i
+                        (set_local $3
                           (i32.add
-                            (get_local $$add$ptr227$i)
+                            (get_local $3)
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$142)
+                                  (get_local $2)
                                 )
                                 (i32.const 7)
                               )
-                              (get_local $$cmp7$i$i)
+                              (get_local $5)
                             )
                           )
                         )
-                        (set_local $$add$ptr4$i$37$i
+                        (set_local $6
                           (i32.add
-                            (get_local $$tbase$796$i)
+                            (get_local $16)
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $$140)
+                                  (get_local $1)
                                 )
                                 (i32.const 7)
                               )
-                              (get_local $$cmp$i$34$i)
+                              (get_local $8)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $$add$ptr17$i$i
+                    (set_local $5
                       (i32.add
-                        (get_local $$add$ptr4$i$37$i)
-                        (get_local $$nb$0)
+                        (get_local $6)
+                        (get_local $9)
                       )
                     )
-                    (set_local $$sub18$i$i
+                    (set_local $13
                       (i32.sub
-                        (get_local $$sub$ptr$sub$i$41$i)
-                        (get_local $$nb$0)
+                        (get_local $1)
+                        (get_local $9)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $$add$ptr4$i$37$i)
+                      (get_local $6)
                       (i32.or
-                        (get_local $$nb$0)
+                        (get_local $9)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$52
                       (if
                         (i32.eq
-                          (get_local $$add$ptr16$i$i)
-                          (get_local $$119)
+                          (get_local $3)
+                          (get_local $0)
                         )
                         (block
                           (i32.store
                             (i32.const 188)
-                            (set_local $$add$i$i
+                            (set_local $0
                               (i32.add
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $$sub18$i$i)
+                                (get_local $13)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 200)
-                            (get_local $$add$ptr17$i$i)
+                            (get_local $5)
                           )
                           (i32.store offset=4
-                            (get_local $$add$ptr17$i$i)
+                            (get_local $5)
                             (i32.or
-                              (get_local $$add$i$i)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
@@ -15706,7 +14480,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $$add$ptr16$i$i)
+                              (get_local $3)
                               (i32.load
                                 (i32.const 196)
                               )
@@ -15714,47 +14488,47 @@
                             (block
                               (i32.store
                                 (i32.const 184)
-                                (set_local $$add26$i$i
+                                (set_local $0
                                   (i32.add
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $$sub18$i$i)
+                                    (get_local $13)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 196)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
                               )
                               (i32.store offset=4
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
                                 (i32.or
-                                  (get_local $$add26$i$i)
+                                  (get_local $0)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$add26$i$i)
+                                  (get_local $5)
+                                  (get_local $0)
                                 )
-                                (get_local $$add26$i$i)
+                                (get_local $0)
                               )
                               (br $do-once$52)
                             )
                           )
-                          (set_local $$and209$i$i
+                          (set_local $0
                             (i32.and
                               (i32.load
-                                (set_local $$head208$i$i
+                                (set_local $1
                                   (i32.add
                                     (if
                                       (i32.eq
                                         (i32.and
-                                          (set_local $$147
+                                          (set_local $0
                                             (i32.load offset=4
-                                              (get_local $$add$ptr16$i$i)
+                                              (get_local $3)
                                             )
                                           )
                                           (i32.const 3)
@@ -15762,44 +14536,44 @@
                                         (i32.const 1)
                                       )
                                       (block
-                                        (set_local $$and37$i$i
+                                        (set_local $11
                                           (i32.and
-                                            (get_local $$147)
+                                            (get_local $0)
                                             (i32.const -8)
                                           )
                                         )
-                                        (set_local $$shr$i$45$i
+                                        (set_local $8
                                           (i32.shr_u
-                                            (get_local $$147)
+                                            (get_local $0)
                                             (i32.const 3)
                                           )
                                         )
                                         (block $label$break$L331
                                           (if
                                             (i32.lt_u
-                                              (get_local $$147)
+                                              (get_local $0)
                                               (i32.const 256)
                                             )
                                             (block
-                                              (set_local $$149
+                                              (set_local $1
                                                 (i32.load offset=12
-                                                  (get_local $$add$ptr16$i$i)
+                                                  (get_local $3)
                                                 )
                                               )
                                               (block $do-once$55
                                                 (if
                                                   (i32.ne
-                                                    (set_local $$148
+                                                    (set_local $0
                                                       (i32.load offset=8
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                     )
-                                                    (set_local $$arrayidx$i$48$i
+                                                    (set_local $2
                                                       (i32.add
                                                         (i32.const 216)
                                                         (i32.shl
                                                           (i32.shl
-                                                            (get_local $$shr$i$45$i)
+                                                            (get_local $8)
                                                             (i32.const 1)
                                                           )
                                                           (i32.const 2)
@@ -15810,17 +14584,17 @@
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$148)
-                                                        (get_local $$150)
+                                                        (get_local $0)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (br_if $do-once$55
                                                       (i32.eq
                                                         (i32.load offset=12
-                                                          (get_local $$148)
+                                                          (get_local $0)
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                     )
                                                     (call_import $_abort)
@@ -15829,8 +14603,8 @@
                                               )
                                               (if
                                                 (i32.eq
-                                                  (get_local $$149)
-                                                  (get_local $$148)
+                                                  (get_local $1)
+                                                  (get_local $0)
                                                 )
                                                 (block
                                                   (i32.store
@@ -15842,7 +14616,7 @@
                                                       (i32.xor
                                                         (i32.shl
                                                           (i32.const 1)
-                                                          (get_local $$shr$i$45$i)
+                                                          (get_local $8)
                                                         )
                                                         (i32.const -1)
                                                       )
@@ -15854,38 +14628,38 @@
                                               (block $do-once$57
                                                 (if
                                                   (i32.eq
-                                                    (get_local $$149)
-                                                    (get_local $$arrayidx$i$48$i)
+                                                    (get_local $1)
+                                                    (get_local $2)
                                                   )
-                                                  (set_local $$fd68$pre$phi$i$iZ2D
+                                                  (set_local $40
                                                     (i32.add
-                                                      (get_local $$149)
+                                                      (get_local $1)
                                                       (i32.const 8)
                                                     )
                                                   )
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$149)
-                                                        (get_local $$150)
+                                                        (get_local $1)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (if
                                                       (i32.eq
                                                         (i32.load
-                                                          (set_local $$fd59$i$i
+                                                          (set_local $2
                                                             (i32.add
-                                                              (get_local $$149)
+                                                              (get_local $1)
                                                               (i32.const 8)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (block
-                                                        (set_local $$fd68$pre$phi$i$iZ2D
-                                                          (get_local $$fd59$i$i)
+                                                        (set_local $40
+                                                          (get_local $2)
                                                         )
                                                         (br $do-once$57)
                                                       )
@@ -15895,40 +14669,40 @@
                                                 )
                                               )
                                               (i32.store offset=12
-                                                (get_local $$148)
-                                                (get_local $$149)
+                                                (get_local $0)
+                                                (get_local $1)
                                               )
                                               (i32.store
-                                                (get_local $$fd68$pre$phi$i$iZ2D)
-                                                (get_local $$148)
+                                                (get_local $40)
+                                                (get_local $0)
                                               )
                                             )
                                             (block
-                                              (set_local $$154
+                                              (set_local $0
                                                 (i32.load offset=24
-                                                  (get_local $$add$ptr16$i$i)
+                                                  (get_local $3)
                                                 )
                                               )
                                               (block $do-once$59
                                                 (if
                                                   (i32.eq
-                                                    (set_local $$155
+                                                    (set_local $1
                                                       (i32.load offset=12
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                     )
-                                                    (get_local $$add$ptr16$i$i)
+                                                    (get_local $3)
                                                   )
                                                   (block
                                                     (if
                                                       (i32.eq
-                                                        (set_local $$159
+                                                        (set_local $1
                                                           (i32.load
-                                                            (set_local $$arrayidx96$i$i
+                                                            (set_local $8
                                                               (i32.add
-                                                                (set_local $$child$i$i
+                                                                (set_local $20
                                                                   (i32.add
-                                                                    (get_local $$add$ptr16$i$i)
+                                                                    (get_local $3)
                                                                     (i32.const 16)
                                                                   )
                                                                 )
@@ -15941,45 +14715,43 @@
                                                       )
                                                       (if
                                                         (i32.eq
-                                                          (set_local $$160
+                                                          (set_local $1
                                                             (i32.load
-                                                              (get_local $$child$i$i)
+                                                              (get_local $20)
                                                             )
                                                           )
                                                           (i32.const 0)
                                                         )
                                                         (block
-                                                          (set_local $$R$3$i$i
+                                                          (set_local $18
                                                             (i32.const 0)
                                                           )
                                                           (br $do-once$59)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i
-                                                            (get_local $$160)
+                                                          (set_local $2
+                                                            (get_local $1)
                                                           )
-                                                          (set_local $$RP$1$i$i
-                                                            (get_local $$child$i$i)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                         )
                                                       )
                                                       (block
-                                                        (set_local $$R$1$i$i
-                                                          (get_local $$159)
+                                                        (set_local $2
+                                                          (get_local $1)
                                                         )
-                                                        (set_local $$RP$1$i$i
-                                                          (get_local $$arrayidx96$i$i)
-                                                        )
+                                                        (get_local $8)
                                                       )
                                                     )
                                                     (loop $while-out$61 $while-in$62
                                                       (if
                                                         (i32.ne
-                                                          (set_local $$161
+                                                          (set_local $1
                                                             (i32.load
-                                                              (set_local $$arrayidx103$i$i
+                                                              (set_local $20
                                                                 (i32.add
-                                                                  (get_local $$R$1$i$i)
+                                                                  (get_local $2)
                                                                   (i32.const 20)
                                                                 )
                                                               )
@@ -15988,22 +14760,22 @@
                                                           (i32.const 0)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i
-                                                            (get_local $$161)
+                                                          (set_local $2
+                                                            (get_local $1)
                                                           )
-                                                          (set_local $$RP$1$i$i
-                                                            (get_local $$arrayidx103$i$i)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                           (br $while-in$62)
                                                         )
                                                       )
                                                       (if
                                                         (i32.eq
-                                                          (set_local $$162
+                                                          (set_local $1
                                                             (i32.load
-                                                              (set_local $$arrayidx107$i$i
+                                                              (set_local $20
                                                                 (i32.add
-                                                                  (get_local $$R$1$i$i)
+                                                                  (get_local $2)
                                                                   (i32.const 16)
                                                                 )
                                                               )
@@ -16012,20 +14784,20 @@
                                                           (i32.const 0)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i$lcssa
-                                                            (get_local $$R$1$i$i)
+                                                          (set_local $1
+                                                            (get_local $2)
                                                           )
-                                                          (set_local $$RP$1$i$i$lcssa
-                                                            (get_local $$RP$1$i$i)
+                                                          (set_local $2
+                                                            (get_local $8)
                                                           )
                                                           (br $while-out$61)
                                                         )
                                                         (block
-                                                          (set_local $$R$1$i$i
-                                                            (get_local $$162)
+                                                          (set_local $2
+                                                            (get_local $1)
                                                           )
-                                                          (set_local $$RP$1$i$i
-                                                            (get_local $$arrayidx107$i$i)
+                                                          (set_local $8
+                                                            (get_local $20)
                                                           )
                                                         )
                                                       )
@@ -16033,17 +14805,17 @@
                                                     )
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$RP$1$i$i$lcssa)
-                                                        (get_local $$150)
+                                                        (get_local $2)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                       (block
                                                         (i32.store
-                                                          (get_local $$RP$1$i$i$lcssa)
+                                                          (get_local $2)
                                                           (i32.const 0)
                                                         )
-                                                        (set_local $$R$3$i$i
-                                                          (get_local $$R$1$i$i$lcssa)
+                                                        (set_local $18
+                                                          (get_local $1)
                                                         )
                                                       )
                                                     )
@@ -16051,52 +14823,52 @@
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (set_local $$156
+                                                        (set_local $2
                                                           (i32.load offset=8
-                                                            (get_local $$add$ptr16$i$i)
+                                                            (get_local $3)
                                                           )
                                                         )
-                                                        (get_local $$150)
+                                                        (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (if
                                                       (i32.ne
                                                         (i32.load
-                                                          (set_local $$bk82$i$i
+                                                          (set_local $4
                                                             (i32.add
-                                                              (get_local $$156)
+                                                              (get_local $2)
                                                               (i32.const 12)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (call_import $_abort)
                                                     )
                                                     (if
                                                       (i32.eq
                                                         (i32.load
-                                                          (set_local $$fd85$i$i
+                                                          (set_local $8
                                                             (i32.add
-                                                              (get_local $$155)
+                                                              (get_local $1)
                                                               (i32.const 8)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (block
                                                         (i32.store
-                                                          (get_local $$bk82$i$i)
-                                                          (get_local $$155)
+                                                          (get_local $4)
+                                                          (get_local $1)
                                                         )
                                                         (i32.store
-                                                          (get_local $$fd85$i$i)
-                                                          (get_local $$156)
+                                                          (get_local $8)
+                                                          (get_local $2)
                                                         )
-                                                        (set_local $$R$3$i$i
-                                                          (get_local $$155)
+                                                        (set_local $18
+                                                          (get_local $1)
                                                         )
                                                       )
                                                       (call_import $_abort)
@@ -16106,22 +14878,22 @@
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eq
-                                                  (get_local $$154)
+                                                  (get_local $0)
                                                   (i32.const 0)
                                                 )
                                               )
                                               (block $do-once$63
                                                 (if
                                                   (i32.eq
-                                                    (get_local $$add$ptr16$i$i)
+                                                    (get_local $3)
                                                     (i32.load
-                                                      (set_local $$arrayidx123$i$i
+                                                      (set_local $2
                                                         (i32.add
                                                           (i32.const 480)
                                                           (i32.shl
-                                                            (set_local $$163
+                                                            (set_local $1
                                                               (i32.load offset=28
-                                                                (get_local $$add$ptr16$i$i)
+                                                                (get_local $3)
                                                               )
                                                             )
                                                             (i32.const 2)
@@ -16132,12 +14904,12 @@
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $$arrayidx123$i$i)
-                                                      (get_local $$R$3$i$i)
+                                                      (get_local $2)
+                                                      (get_local $18)
                                                     )
                                                     (br_if $do-once$63
                                                       (i32.ne
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $18)
                                                         (i32.const 0)
                                                       )
                                                     )
@@ -16150,7 +14922,7 @@
                                                         (i32.xor
                                                           (i32.shl
                                                             (i32.const 1)
-                                                            (get_local $$163)
+                                                            (get_local $1)
                                                           )
                                                           (i32.const -1)
                                                         )
@@ -16161,7 +14933,7 @@
                                                   (block
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $$154)
+                                                        (get_local $0)
                                                         (i32.load
                                                           (i32.const 192)
                                                         )
@@ -16171,27 +14943,27 @@
                                                     (if
                                                       (i32.eq
                                                         (i32.load
-                                                          (set_local $$arrayidx143$i$i
+                                                          (set_local $1
                                                             (i32.add
-                                                              (get_local $$154)
+                                                              (get_local $0)
                                                               (i32.const 16)
                                                             )
                                                           )
                                                         )
-                                                        (get_local $$add$ptr16$i$i)
+                                                        (get_local $3)
                                                       )
                                                       (i32.store
-                                                        (get_local $$arrayidx143$i$i)
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $1)
+                                                        (get_local $18)
                                                       )
                                                       (i32.store offset=20
-                                                        (get_local $$154)
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $0)
+                                                        (get_local $18)
                                                       )
                                                     )
                                                     (br_if $label$break$L331
                                                       (i32.eq
-                                                        (get_local $$R$3$i$i)
+                                                        (get_local $18)
                                                         (i32.const 0)
                                                       )
                                                     )
@@ -16200,8 +14972,8 @@
                                               )
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $$R$3$i$i)
-                                                  (set_local $$168
+                                                  (get_local $18)
+                                                  (set_local $1
                                                     (i32.load
                                                       (i32.const 192)
                                                     )
@@ -16210,16 +14982,16 @@
                                                 (call_import $_abort)
                                               )
                                               (i32.store offset=24
-                                                (get_local $$R$3$i$i)
-                                                (get_local $$154)
+                                                (get_local $18)
+                                                (get_local $0)
                                               )
                                               (if
                                                 (i32.ne
-                                                  (set_local $$169
+                                                  (set_local $0
                                                     (i32.load
-                                                      (set_local $$child166$i$i
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $$add$ptr16$i$i)
+                                                          (get_local $3)
                                                           (i32.const 16)
                                                         )
                                                       )
@@ -16229,27 +15001,27 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $$169)
-                                                    (get_local $$168)
+                                                    (get_local $0)
+                                                    (get_local $1)
                                                   )
                                                   (call_import $_abort)
                                                   (block
                                                     (i32.store offset=16
-                                                      (get_local $$R$3$i$i)
-                                                      (get_local $$169)
+                                                      (get_local $18)
+                                                      (get_local $0)
                                                     )
                                                     (i32.store offset=24
-                                                      (get_local $$169)
-                                                      (get_local $$R$3$i$i)
+                                                      (get_local $0)
+                                                      (get_local $18)
                                                     )
                                                   )
                                                 )
                                               )
                                               (br_if $label$break$L331
                                                 (i32.eq
-                                                  (set_local $$170
+                                                  (set_local $0
                                                     (i32.load offset=4
-                                                      (get_local $$child166$i$i)
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (i32.const 0)
@@ -16257,7 +15029,7 @@
                                               )
                                               (if
                                                 (i32.lt_u
-                                                  (get_local $$170)
+                                                  (get_local $0)
                                                   (i32.load
                                                     (i32.const 192)
                                                   )
@@ -16265,34 +15037,34 @@
                                                 (call_import $_abort)
                                                 (block
                                                   (i32.store offset=20
-                                                    (get_local $$R$3$i$i)
-                                                    (get_local $$170)
+                                                    (get_local $18)
+                                                    (get_local $0)
                                                   )
                                                   (i32.store offset=24
-                                                    (get_local $$170)
-                                                    (get_local $$R$3$i$i)
+                                                    (get_local $0)
+                                                    (get_local $18)
                                                   )
                                                 )
                                               )
                                             )
                                           )
                                         )
-                                        (set_local $$qsize$0$i$i
+                                        (set_local $4
                                           (i32.add
-                                            (get_local $$and37$i$i)
-                                            (get_local $$sub18$i$i)
+                                            (get_local $11)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.add
-                                          (get_local $$add$ptr16$i$i)
-                                          (get_local $$and37$i$i)
+                                          (get_local $3)
+                                          (get_local $11)
                                         )
                                       )
                                       (block
-                                        (set_local $$qsize$0$i$i
-                                          (get_local $$sub18$i$i)
+                                        (set_local $4
+                                          (get_local $13)
                                         )
-                                        (get_local $$add$ptr16$i$i)
+                                        (get_local $3)
                                       )
                                     )
                                     (i32.const 4)
@@ -16303,41 +15075,41 @@
                             )
                           )
                           (i32.store
-                            (get_local $$head208$i$i)
-                            (get_local $$and209$i$i)
+                            (get_local $1)
+                            (get_local $0)
                           )
                           (i32.store offset=4
-                            (get_local $$add$ptr17$i$i)
+                            (get_local $5)
                             (i32.or
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $$add$ptr17$i$i)
-                              (get_local $$qsize$0$i$i)
+                              (get_local $5)
+                              (get_local $4)
                             )
-                            (get_local $$qsize$0$i$i)
+                            (get_local $4)
                           )
-                          (set_local $$shr214$i$i
+                          (set_local $1
                             (i32.shr_u
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $$arrayidx223$i$i
+                              (set_local $2
                                 (i32.add
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $$shr214$i$i)
+                                      (get_local $1)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -16348,15 +15120,15 @@
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $$173
+                                      (set_local $0
                                         (i32.load
                                           (i32.const 176)
                                         )
                                       )
-                                      (set_local $$shl226$i$i
+                                      (set_local $1
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $$shr214$i$i)
+                                          (get_local $1)
                                         )
                                       )
                                     )
@@ -16366,28 +15138,28 @@
                                     (i32.store
                                       (i32.const 176)
                                       (i32.or
-                                        (get_local $$173)
-                                        (get_local $$shl226$i$i)
+                                        (get_local $0)
+                                        (get_local $1)
                                       )
                                     )
-                                    (set_local $$$pre$phi$i$57$iZ2D
+                                    (set_local $7
                                       (i32.add
-                                        (get_local $$arrayidx223$i$i)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $$F224$0$i$i
-                                      (get_local $$arrayidx223$i$i)
+                                    (set_local $32
+                                      (get_local $2)
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $$175
+                                        (set_local $1
                                           (i32.load
-                                            (set_local $$174
+                                            (set_local $0
                                               (i32.add
-                                                (get_local $$arrayidx223$i$i)
+                                                (get_local $2)
                                                 (i32.const 8)
                                               )
                                             )
@@ -16398,11 +15170,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $$$pre$phi$i$57$iZ2D
-                                          (get_local $$174)
+                                        (set_local $7
+                                          (get_local $0)
                                         )
-                                        (set_local $$F224$0$i$i
-                                          (get_local $$175)
+                                        (set_local $32
+                                          (get_local $1)
                                         )
                                         (br $do-once$67)
                                       )
@@ -16412,35 +15184,35 @@
                                 )
                               )
                               (i32.store
-                                (get_local $$$pre$phi$i$57$iZ2D)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $7)
+                                (get_local $5)
                               )
                               (i32.store offset=12
-                                (get_local $$F224$0$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $32)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$F224$0$i$i)
+                                (get_local $5)
+                                (get_local $32)
                               )
                               (i32.store offset=12
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$arrayidx223$i$i)
+                                (get_local $5)
+                                (get_local $2)
                               )
                               (br $do-once$52)
                             )
                           )
-                          (set_local $$arrayidx287$i$i
+                          (set_local $2
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $$I252$0$i$i
+                                (set_local $1
                                   (block $do-once$69
                                     (if
                                       (i32.eq
-                                        (set_local $$shr253$i$i
+                                        (set_local $0
                                           (i32.shr_u
-                                            (get_local $$qsize$0$i$i)
+                                            (get_local $4)
                                             (i32.const 8)
                                           )
                                         )
@@ -16450,33 +15222,33 @@
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $$qsize$0$i$i)
+                                            (get_local $4)
                                             (i32.const 16777215)
                                           )
                                           (br $do-once$69
                                             (i32.const 31)
                                           )
                                         )
-                                        (set_local $$shl279$i$i
+                                        (set_local $1
                                           (i32.shl
-                                            (set_local $$add278$i$i
+                                            (set_local $0
                                               (i32.add
                                                 (i32.sub
                                                   (i32.const 14)
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $$and268$i$i
+                                                      (set_local $1
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $$shl265$i$i
+                                                              (set_local $2
                                                                 (i32.shl
-                                                                  (get_local $$shr253$i$i)
-                                                                  (set_local $$and264$i$i
+                                                                  (get_local $0)
+                                                                  (set_local $0
                                                                     (i32.and
                                                                       (i32.shr_u
                                                                         (i32.add
-                                                                          (get_local $$shr253$i$i)
+                                                                          (get_local $0)
                                                                           (i32.const 1048320)
                                                                         )
                                                                         (i32.const 16)
@@ -16493,16 +15265,16 @@
                                                           (i32.const 4)
                                                         )
                                                       )
-                                                      (get_local $$and264$i$i)
+                                                      (get_local $0)
                                                     )
-                                                    (set_local $$and273$i$i
+                                                    (set_local $0
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $$shl270$i$i
+                                                            (set_local $1
                                                               (i32.shl
-                                                                (get_local $$shl265$i$i)
-                                                                (get_local $$and268$i$i)
+                                                                (get_local $2)
+                                                                (get_local $1)
                                                               )
                                                             )
                                                             (i32.const 245760)
@@ -16516,8 +15288,8 @@
                                                 )
                                                 (i32.shr_u
                                                   (i32.shl
-                                                    (get_local $$shl270$i$i)
-                                                    (get_local $$and273$i$i)
+                                                    (get_local $1)
+                                                    (get_local $0)
                                                   )
                                                   (i32.const 15)
                                                 )
@@ -16529,15 +15301,15 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $$qsize$0$i$i)
+                                              (get_local $4)
                                               (i32.add
-                                                (get_local $$add278$i$i)
+                                                (get_local $0)
                                                 (i32.const 7)
                                               )
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $$shl279$i$i)
+                                          (get_local $1)
                                         )
                                       )
                                     )
@@ -16548,34 +15320,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $$add$ptr17$i$i)
-                            (get_local $$I252$0$i$i)
+                            (get_local $5)
+                            (get_local $1)
                           )
                           (i32.store offset=4
-                            (set_local $$child289$i$i
+                            (set_local $0
                               (i32.add
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $$child289$i$i)
+                            (get_local $0)
                             (i32.const 0)
                           )
                           (if
                             (i32.eq
                               (i32.and
-                                (set_local $$177
+                                (set_local $0
                                   (i32.load
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $$shl294$i$i
+                                (set_local $7
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $$I252$0$i$i)
+                                    (get_local $1)
                                   )
                                 )
                               )
@@ -16585,51 +15357,51 @@
                               (i32.store
                                 (i32.const 180)
                                 (i32.or
-                                  (get_local $$177)
-                                  (get_local $$shl294$i$i)
+                                  (get_local $0)
+                                  (get_local $7)
                                 )
                               )
                               (i32.store
-                                (get_local $$arrayidx287$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $2)
+                                (get_local $5)
                               )
                               (i32.store offset=24
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$arrayidx287$i$i)
+                                (get_local $5)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $$add$ptr17$i$i)
-                                (get_local $$add$ptr17$i$i)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (br $do-once$52)
                             )
                           )
-                          (set_local $$K305$0$i$i
+                          (set_local $1
                             (i32.shl
-                              (get_local $$qsize$0$i$i)
+                              (get_local $4)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $$I252$0$i$i)
+                                    (get_local $1)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $$I252$0$i$i)
+                                  (get_local $1)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $$T$0$i$58$i
+                          (set_local $2
                             (i32.load
-                              (get_local $$arrayidx287$i$i)
+                              (get_local $2)
                             )
                           )
                           (loop $while-out$71 $while-in$72
@@ -16637,41 +15409,41 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $$T$0$i$58$i)
+                                    (get_local $2)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $$qsize$0$i$i)
+                                (get_local $4)
                               )
                               (block
-                                (set_local $$T$0$i$58$i$lcssa
-                                  (get_local $$T$0$i$58$i)
+                                (set_local $33
+                                  (get_local $2)
                                 )
-                                (set_local $label
+                                (set_local $10
                                   (i32.const 281)
                                 )
                                 (br $while-out$71)
                               )
                             )
-                            (set_local $$shl326$i$i
+                            (set_local $7
                               (i32.shl
-                                (get_local $$K305$0$i$i)
+                                (get_local $1)
                                 (i32.const 1)
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$180
+                                (set_local $0
                                   (i32.load
-                                    (set_local $$arrayidx325$i$i
+                                    (set_local $1
                                       (i32.add
                                         (i32.add
-                                          (get_local $$T$0$i$58$i)
+                                          (get_local $2)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $$K305$0$i$i)
+                                            (get_local $1)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -16683,23 +15455,23 @@
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $$T$0$i$58$i$lcssa283
-                                  (get_local $$T$0$i$58$i)
+                                (set_local $42
+                                  (get_local $2)
                                 )
-                                (set_local $$arrayidx325$i$i$lcssa
-                                  (get_local $$arrayidx325$i$i)
+                                (set_local $38
+                                  (get_local $1)
                                 )
-                                (set_local $label
+                                (set_local $10
                                   (i32.const 278)
                                 )
                                 (br $while-out$71)
                               )
                               (block
-                                (set_local $$K305$0$i$i
-                                  (get_local $$shl326$i$i)
+                                (set_local $1
+                                  (get_local $7)
                                 )
-                                (set_local $$T$0$i$58$i
-                                  (get_local $$180)
+                                (set_local $2
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -16707,12 +15479,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $label)
+                              (get_local $10)
                               (i32.const 278)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $$arrayidx325$i$i$lcssa)
+                                (get_local $38)
                                 (i32.load
                                   (i32.const 192)
                                 )
@@ -16720,71 +15492,71 @@
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $$arrayidx325$i$i$lcssa)
-                                  (get_local $$add$ptr17$i$i)
+                                  (get_local $38)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$T$0$i$58$i$lcssa283)
+                                  (get_local $5)
+                                  (get_local $42)
                                 )
                                 (i32.store offset=12
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$add$ptr17$i$i)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $$add$ptr17$i$i)
-                                  (get_local $$add$ptr17$i$i)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $label)
+                                (get_local $10)
                                 (i32.const 281)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $$182
+                                    (set_local $0
                                       (i32.load
-                                        (set_local $$fd344$i$i
+                                        (set_local $2
                                           (i32.add
-                                            (get_local $$T$0$i$58$i$lcssa)
+                                            (get_local $33)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $$183
+                                    (set_local $1
                                       (i32.load
                                         (i32.const 192)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $$T$0$i$58$i$lcssa)
-                                    (get_local $$183)
+                                    (get_local $33)
+                                    (get_local $1)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $$182)
-                                    (get_local $$add$ptr17$i$i)
+                                    (get_local $0)
+                                    (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $$fd344$i$i)
-                                    (get_local $$add$ptr17$i$i)
+                                    (get_local $2)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $$add$ptr17$i$i)
-                                    (get_local $$182)
+                                    (get_local $5)
+                                    (get_local $0)
                                   )
                                   (i32.store offset=12
-                                    (get_local $$add$ptr17$i$i)
-                                    (get_local $$T$0$i$58$i$lcssa)
+                                    (get_local $5)
+                                    (get_local $33)
                                   )
                                   (i32.store offset=24
-                                    (get_local $$add$ptr17$i$i)
+                                    (get_local $5)
                                     (i32.const 0)
                                   )
                                 )
@@ -16797,12 +15569,12 @@
                     )
                     (return
                       (i32.add
-                        (get_local $$add$ptr4$i$37$i)
+                        (get_local $6)
                         (i32.const 8)
                       )
                     )
                   )
-                  (set_local $$sp$0$i$i$i
+                  (set_local $27
                     (i32.const 624)
                   )
                 )
@@ -16810,48 +15582,48 @@
               (loop $while-out$73 $while-in$74
                 (if
                   (i32.le_u
-                    (set_local $$185
+                    (set_local $1
                       (i32.load
-                        (get_local $$sp$0$i$i$i)
+                        (get_local $27)
                       )
                     )
-                    (get_local $$119)
+                    (get_local $0)
                   )
                   (if
                     (i32.gt_u
-                      (set_local $$add$ptr$i$i$i
+                      (set_local $1
                         (i32.add
-                          (get_local $$185)
+                          (get_local $1)
                           (i32.load offset=4
-                            (get_local $$sp$0$i$i$i)
+                            (get_local $27)
                           )
                         )
                       )
-                      (get_local $$119)
+                      (get_local $0)
                     )
                     (block
-                      (set_local $$add$ptr$i$i$i$lcssa
-                        (get_local $$add$ptr$i$i$i)
+                      (set_local $2
+                        (get_local $1)
                       )
                       (br $while-out$73)
                     )
                   )
                 )
-                (set_local $$sp$0$i$i$i
+                (set_local $27
                   (i32.load offset=8
-                    (get_local $$sp$0$i$i$i)
+                    (get_local $27)
                   )
                 )
                 (br $while-in$74)
               )
-              (set_local $$cmp$i$15$i
+              (set_local $7
                 (i32.eq
                   (i32.and
-                    (set_local $$188
+                    (set_local $1
                       (i32.add
-                        (set_local $$add$ptr2$i$i
+                        (set_local $4
                           (i32.add
-                            (get_local $$add$ptr$i$i$i$lcssa)
+                            (get_local $2)
                             (i32.const -47)
                           )
                         )
@@ -16863,50 +15635,50 @@
                   (i32.const 0)
                 )
               )
-              (set_local $$cmp9$i$i
+              (set_local $4
                 (i32.lt_u
-                  (set_local $$add$ptr7$i$i
+                  (set_local $1
                     (i32.add
-                      (get_local $$add$ptr2$i$i)
+                      (get_local $4)
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (get_local $$188)
+                            (get_local $1)
                           )
                           (i32.const 7)
                         )
-                        (get_local $$cmp$i$15$i)
+                        (get_local $7)
                       )
                     )
                   )
-                  (set_local $$add$ptr8$i122$i
+                  (set_local $7
                     (i32.add
-                      (get_local $$119)
+                      (get_local $0)
                       (i32.const 16)
                     )
                   )
                 )
               )
-              (set_local $$add$ptr14$i$i
+              (set_local $4
                 (i32.add
-                  (set_local $$cond13$i$i
+                  (set_local $5
                     (select
-                      (get_local $$119)
-                      (get_local $$add$ptr7$i$i)
-                      (get_local $$cmp9$i$i)
+                      (get_local $0)
+                      (get_local $1)
+                      (get_local $4)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $$cmp$i$2$i$i
+              (set_local $3
                 (i32.eq
                   (i32.and
-                    (set_local $$190
+                    (set_local $1
                       (i32.add
-                        (get_local $$tbase$796$i)
+                        (get_local $16)
                         (i32.const 8)
                       )
                     )
@@ -16917,20 +15689,20 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $$add$ptr4$i$i$i
+                (set_local $1
                   (i32.add
-                    (get_local $$tbase$796$i)
-                    (set_local $$cond$i$i$i
+                    (get_local $16)
+                    (set_local $3
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (get_local $$190)
+                            (get_local $1)
                           )
                           (i32.const 7)
                         )
-                        (get_local $$cmp$i$2$i$i)
+                        (get_local $3)
                       )
                     )
                   )
@@ -16938,27 +15710,27 @@
               )
               (i32.store
                 (i32.const 188)
-                (set_local $$sub5$i$i$i
+                (set_local $3
                   (i32.sub
                     (i32.add
-                      (get_local $$tsize$795$i)
+                      (get_local $19)
                       (i32.const -40)
                     )
-                    (get_local $$cond$i$i$i)
+                    (get_local $3)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr4$i$i$i)
+                (get_local $1)
                 (i32.or
-                  (get_local $$sub5$i$i$i)
+                  (get_local $3)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $$add$ptr4$i$i$i)
-                  (get_local $$sub5$i$i$i)
+                  (get_local $1)
+                  (get_local $3)
                 )
                 (i32.const 40)
               )
@@ -16969,45 +15741,45 @@
                 )
               )
               (i32.store
-                (set_local $$head$i$17$i
+                (set_local $3
                   (i32.add
-                    (get_local $$cond13$i$i)
+                    (get_local $5)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load
                   (i32.const 624)
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load offset=4
                   (i32.const 624)
                 )
               )
               (i32.store offset=8
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load offset=8
                   (i32.const 624)
                 )
               )
               (i32.store offset=12
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
                 (i32.load offset=12
                   (i32.const 624)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $$tbase$796$i)
+                (get_local $16)
               )
               (i32.store
                 (i32.const 628)
-                (get_local $$tsize$795$i)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 636)
@@ -17015,19 +15787,19 @@
               )
               (i32.store
                 (i32.const 632)
-                (get_local $$add$ptr14$i$i)
+                (get_local $4)
               )
-              (set_local $$p$0$i$i
+              (set_local $1
                 (i32.add
-                  (get_local $$cond13$i$i)
+                  (get_local $5)
                   (i32.const 24)
                 )
               )
               (loop $while-out$75 $while-in$76
                 (i32.store
-                  (set_local $$add$ptr24$i$i
+                  (set_local $1
                     (i32.add
-                      (get_local $$p$0$i$i)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
@@ -17036,67 +15808,65 @@
                 (if
                   (i32.lt_u
                     (i32.add
-                      (get_local $$add$ptr24$i$i)
+                      (get_local $1)
                       (i32.const 4)
                     )
-                    (get_local $$add$ptr$i$i$i$lcssa)
+                    (get_local $2)
                   )
-                  (set_local $$p$0$i$i
-                    (get_local $$add$ptr24$i$i)
-                  )
+                  (get_local $1)
                   (br $while-out$75)
                 )
                 (br $while-in$76)
               )
               (if
                 (i32.ne
-                  (get_local $$cond13$i$i)
-                  (get_local $$119)
+                  (get_local $5)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
-                    (get_local $$head$i$17$i)
+                    (get_local $3)
                     (i32.and
                       (i32.load
-                        (get_local $$head$i$17$i)
+                        (get_local $3)
                       )
                       (i32.const -2)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$119)
+                    (get_local $0)
                     (i32.or
-                      (set_local $$sub$ptr$sub$i$i
+                      (set_local $3
                         (i32.sub
-                          (get_local $$cond13$i$i)
-                          (get_local $$119)
+                          (get_local $5)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $$cond13$i$i)
-                    (get_local $$sub$ptr$sub$i$i)
+                    (get_local $5)
+                    (get_local $3)
                   )
-                  (set_local $$shr$i$i
+                  (set_local $2
                     (i32.shr_u
-                      (get_local $$sub$ptr$sub$i$i)
+                      (get_local $3)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$sub$ptr$sub$i$i)
+                      (get_local $3)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $$arrayidx$i$20$i
+                      (set_local $4
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (get_local $$shr$i$i)
+                              (get_local $2)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -17106,15 +15876,15 @@
                       (if
                         (i32.eq
                           (i32.and
-                            (set_local $$195
+                            (set_local $1
                               (i32.load
                                 (i32.const 176)
                               )
                             )
-                            (set_local $$shl39$i$i
+                            (set_local $2
                               (i32.shl
                                 (i32.const 1)
-                                (get_local $$shr$i$i)
+                                (get_local $2)
                               )
                             )
                           )
@@ -17124,27 +15894,27 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $$195)
-                              (get_local $$shl39$i$i)
+                              (get_local $1)
+                              (get_local $2)
                             )
                           )
-                          (set_local $$$pre$phi$i$iZ2D
+                          (set_local $8
                             (i32.add
-                              (get_local $$arrayidx$i$20$i)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
-                          (set_local $$F$0$i$i
-                            (get_local $$arrayidx$i$20$i)
+                          (set_local $20
+                            (get_local $4)
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $$197
+                            (set_local $2
                               (i32.load
-                                (set_local $$196
+                                (set_local $1
                                   (i32.add
-                                    (get_local $$arrayidx$i$20$i)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -17156,44 +15926,44 @@
                           )
                           (call_import $_abort)
                           (block
-                            (set_local $$$pre$phi$i$iZ2D
-                              (get_local $$196)
+                            (set_local $8
+                              (get_local $1)
                             )
-                            (set_local $$F$0$i$i
-                              (get_local $$197)
+                            (set_local $20
+                              (get_local $2)
                             )
                           )
                         )
                       )
                       (i32.store
-                        (get_local $$$pre$phi$i$iZ2D)
-                        (get_local $$119)
+                        (get_local $8)
+                        (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $$F$0$i$i)
-                        (get_local $$119)
+                        (get_local $20)
+                        (get_local $0)
                       )
                       (i32.store offset=8
-                        (get_local $$119)
-                        (get_local $$F$0$i$i)
+                        (get_local $0)
+                        (get_local $20)
                       )
                       (i32.store offset=12
-                        (get_local $$119)
-                        (get_local $$arrayidx$i$20$i)
+                        (get_local $0)
+                        (get_local $4)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $$arrayidx91$i$i
+                  (set_local $4
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (set_local $$I57$0$i$i
+                        (set_local $2
                           (if
                             (i32.eq
-                              (set_local $$shr58$i$i
+                              (set_local $1
                                 (i32.shr_u
-                                  (get_local $$sub$ptr$sub$i$i)
+                                  (get_local $3)
                                   (i32.const 8)
                                 )
                               )
@@ -17202,31 +15972,31 @@
                             (i32.const 0)
                             (if
                               (i32.gt_u
-                                (get_local $$sub$ptr$sub$i$i)
+                                (get_local $3)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (block
-                                (set_local $$shl84$i$i
+                                (set_local $2
                                   (i32.shl
-                                    (set_local $$add83$i$i
+                                    (set_local $1
                                       (i32.add
                                         (i32.sub
                                           (i32.const 14)
                                           (i32.or
                                             (i32.or
-                                              (set_local $$and73$i$i
+                                              (set_local $2
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $$shl70$i$i
+                                                      (set_local $4
                                                         (i32.shl
-                                                          (get_local $$shr58$i$i)
-                                                          (set_local $$and69$i$i
+                                                          (get_local $1)
+                                                          (set_local $1
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (get_local $$shr58$i$i)
+                                                                  (get_local $1)
                                                                   (i32.const 1048320)
                                                                 )
                                                                 (i32.const 16)
@@ -17243,16 +16013,16 @@
                                                   (i32.const 4)
                                                 )
                                               )
-                                              (get_local $$and69$i$i)
+                                              (get_local $1)
                                             )
-                                            (set_local $$and78$i$i
+                                            (set_local $1
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (set_local $$shl75$i$i
+                                                    (set_local $2
                                                       (i32.shl
-                                                        (get_local $$shl70$i$i)
-                                                        (get_local $$and73$i$i)
+                                                        (get_local $4)
+                                                        (get_local $2)
                                                       )
                                                     )
                                                     (i32.const 245760)
@@ -17266,8 +16036,8 @@
                                         )
                                         (i32.shr_u
                                           (i32.shl
-                                            (get_local $$shl75$i$i)
-                                            (get_local $$and78$i$i)
+                                            (get_local $2)
+                                            (get_local $1)
                                           )
                                           (i32.const 15)
                                         )
@@ -17279,15 +16049,15 @@
                                 (i32.or
                                   (i32.and
                                     (i32.shr_u
-                                      (get_local $$sub$ptr$sub$i$i)
+                                      (get_local $3)
                                       (i32.add
-                                        (get_local $$add83$i$i)
+                                        (get_local $1)
                                         (i32.const 7)
                                       )
                                     )
                                     (i32.const 1)
                                   )
-                                  (get_local $$shl84$i$i)
+                                  (get_local $2)
                                 )
                               )
                             )
@@ -17298,29 +16068,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $$119)
-                    (get_local $$I57$0$i$i)
+                    (get_local $0)
+                    (get_local $2)
                   )
                   (i32.store offset=20
-                    (get_local $$119)
+                    (get_local $0)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $$add$ptr8$i122$i)
+                    (get_local $7)
                     (i32.const 0)
                   )
                   (if
                     (i32.eq
                       (i32.and
-                        (set_local $$199
+                        (set_local $1
                           (i32.load
                             (i32.const 180)
                           )
                         )
-                        (set_local $$shl95$i$i
+                        (set_local $7
                           (i32.shl
                             (i32.const 1)
-                            (get_local $$I57$0$i$i)
+                            (get_local $2)
                           )
                         )
                       )
@@ -17330,51 +16100,51 @@
                       (i32.store
                         (i32.const 180)
                         (i32.or
-                          (get_local $$199)
-                          (get_local $$shl95$i$i)
+                          (get_local $1)
+                          (get_local $7)
                         )
                       )
                       (i32.store
-                        (get_local $$arrayidx91$i$i)
-                        (get_local $$119)
+                        (get_local $4)
+                        (get_local $0)
                       )
                       (i32.store offset=24
-                        (get_local $$119)
-                        (get_local $$arrayidx91$i$i)
+                        (get_local $0)
+                        (get_local $4)
                       )
                       (i32.store offset=12
-                        (get_local $$119)
-                        (get_local $$119)
+                        (get_local $0)
+                        (get_local $0)
                       )
                       (i32.store offset=8
-                        (get_local $$119)
-                        (get_local $$119)
+                        (get_local $0)
+                        (get_local $0)
                       )
                       (br $do-once$44)
                     )
                   )
-                  (set_local $$K105$0$i$i
+                  (set_local $2
                     (i32.shl
-                      (get_local $$sub$ptr$sub$i$i)
+                      (get_local $3)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $$I57$0$i$i)
+                            (get_local $2)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $$I57$0$i$i)
+                          (get_local $2)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $$T$0$i$i
+                  (set_local $4
                     (i32.load
-                      (get_local $$arrayidx91$i$i)
+                      (get_local $4)
                     )
                   )
                   (loop $while-out$77 $while-in$78
@@ -17382,41 +16152,41 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $$T$0$i$i)
+                            (get_local $4)
                           )
                           (i32.const -8)
                         )
-                        (get_local $$sub$ptr$sub$i$i)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $$T$0$i$i$lcssa
-                          (get_local $$T$0$i$i)
+                        (set_local $34
+                          (get_local $4)
                         )
-                        (set_local $label
+                        (set_local $10
                           (i32.const 307)
                         )
                         (br $while-out$77)
                       )
                     )
-                    (set_local $$shl127$i$i
+                    (set_local $7
                       (i32.shl
-                        (get_local $$K105$0$i$i)
+                        (get_local $2)
                         (i32.const 1)
                       )
                     )
                     (if
                       (i32.eq
-                        (set_local $$202
+                        (set_local $1
                           (i32.load
-                            (set_local $$arrayidx126$i$i
+                            (set_local $2
                               (i32.add
                                 (i32.add
-                                  (get_local $$T$0$i$i)
+                                  (get_local $4)
                                   (i32.const 16)
                                 )
                                 (i32.shl
                                   (i32.shr_u
-                                    (get_local $$K105$0$i$i)
+                                    (get_local $2)
                                     (i32.const 31)
                                   )
                                   (i32.const 2)
@@ -17428,23 +16198,23 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $$T$0$i$i$lcssa284
-                          (get_local $$T$0$i$i)
+                        (set_local $43
+                          (get_local $4)
                         )
-                        (set_local $$arrayidx126$i$i$lcssa
-                          (get_local $$arrayidx126$i$i)
+                        (set_local $37
+                          (get_local $2)
                         )
-                        (set_local $label
+                        (set_local $10
                           (i32.const 304)
                         )
                         (br $while-out$77)
                       )
                       (block
-                        (set_local $$K105$0$i$i
-                          (get_local $$shl127$i$i)
+                        (set_local $2
+                          (get_local $7)
                         )
-                        (set_local $$T$0$i$i
-                          (get_local $$202)
+                        (set_local $4
+                          (get_local $1)
                         )
                       )
                     )
@@ -17452,12 +16222,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $label)
+                      (get_local $10)
                       (i32.const 304)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$arrayidx126$i$i$lcssa)
+                        (get_local $37)
                         (i32.load
                           (i32.const 192)
                         )
@@ -17465,71 +16235,71 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $$arrayidx126$i$i$lcssa)
-                          (get_local $$119)
+                          (get_local $37)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $$119)
-                          (get_local $$T$0$i$i$lcssa284)
+                          (get_local $0)
+                          (get_local $43)
                         )
                         (i32.store offset=12
-                          (get_local $$119)
-                          (get_local $$119)
+                          (get_local $0)
+                          (get_local $0)
                         )
                         (i32.store offset=8
-                          (get_local $$119)
-                          (get_local $$119)
+                          (get_local $0)
+                          (get_local $0)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $label)
+                        (get_local $10)
                         (i32.const 307)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $$204
+                            (set_local $1
                               (i32.load
-                                (set_local $$fd148$i$i
+                                (set_local $4
                                   (i32.add
-                                    (get_local $$T$0$i$i$lcssa)
+                                    (get_local $34)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $$205
+                            (set_local $2
                               (i32.load
                                 (i32.const 192)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $$T$0$i$i$lcssa)
-                            (get_local $$205)
+                            (get_local $34)
+                            (get_local $2)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $$204)
-                            (get_local $$119)
+                            (get_local $1)
+                            (get_local $0)
                           )
                           (i32.store
-                            (get_local $$fd148$i$i)
-                            (get_local $$119)
+                            (get_local $4)
+                            (get_local $0)
                           )
                           (i32.store offset=8
-                            (get_local $$119)
-                            (get_local $$204)
+                            (get_local $0)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $$119)
-                            (get_local $$T$0$i$i$lcssa)
+                            (get_local $0)
+                            (get_local $34)
                           )
                           (i32.store offset=24
-                            (get_local $$119)
+                            (get_local $0)
                             (i32.const 0)
                           )
                         )
@@ -17544,53 +16314,53 @@
         )
         (if
           (i32.gt_u
-            (set_local $$207
+            (set_local $0
               (i32.load
                 (i32.const 188)
               )
             )
-            (get_local $$nb$0)
+            (get_local $9)
           )
           (block
             (i32.store
               (i32.const 188)
-              (set_local $$sub260$i
+              (set_local $2
                 (i32.sub
-                  (get_local $$207)
-                  (get_local $$nb$0)
+                  (get_local $0)
+                  (get_local $9)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (set_local $$add$ptr262$i
+              (set_local $1
                 (i32.add
-                  (set_local $$208
+                  (set_local $0
                     (i32.load
                       (i32.const 200)
                     )
                   )
-                  (get_local $$nb$0)
+                  (get_local $9)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $$add$ptr262$i)
+              (get_local $1)
               (i32.or
-                (get_local $$sub260$i)
+                (get_local $2)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $$208)
+              (get_local $0)
               (i32.or
-                (get_local $$nb$0)
+                (get_local $9)
                 (i32.const 3)
               )
             )
             (return
               (i32.add
-                (get_local $$208)
+                (get_local $0)
                 (i32.const 8)
               )
             )
@@ -17604,144 +16374,44 @@
     )
     (i32.const 0)
   )
-  (func $_free (param $$mem i32)
-    (local $$p$1 i32)
-    (local $$add$ptr16 i32)
-    (local $$add$ptr6 i32)
-    (local $$psize$1 i32)
-    (local $$R$3 i32)
-    (local $$R332$3 i32)
-    (local $$add17 i32)
-    (local $$psize$2 i32)
-    (local $$35 i32)
-    (local $$5 i32)
-    (local $$R$1 i32)
-    (local $$R332$1 i32)
-    (local $$0 i32)
-    (local $$28 i32)
-    (local $$34 i32)
-    (local $$4 i32)
-    (local $$41 i32)
-    (local $$9 i32)
-    (local $$T$0 i32)
-    (local $$add267 i32)
-    (local $$2 i32)
-    (local $$I534$0 i32)
-    (local $$RP$1 i32)
-    (local $$RP360$1 i32)
-    (local $$add$ptr i32)
-    (local $$arrayidx509 i32)
-    (local $$10 i32)
-    (local $$24 i32)
-    (local $$25 i32)
-    (local $$42 i32)
-    (local $$58 i32)
-    (local $$59 i32)
-    (local $$F510$0 i32)
-    (local $$K583$0 i32)
-    (local $$T$0$lcssa i32)
-    (local $$add258 i32)
-    (local $$arrayidx567 i32)
-    (local $label i32)
-    (local $$$pre$phiZ2D i32)
-    (local $$1 i32)
-    (local $$11 i32)
-    (local $$43 i32)
-    (local $$71 i32)
-    (local $$RP$1$lcssa i32)
-    (local $$RP360$1$lcssa i32)
-    (local $$and5 i32)
-    (local $$arrayidx599$lcssa i32)
-    (local $$child i32)
-    (local $$child361 i32)
-    (local $$fd322$pre$phiZ2D i32)
-    (local $$fd67$pre$phiZ2D i32)
-    (local $$shr i32)
-    (local $$shr268 i32)
-    (local $$shr501 i32)
-    (local $$shr535 i32)
-    (local $$sp$0$in$i i32)
-    (local $$14 i32)
-    (local $$15 i32)
-    (local $$16 i32)
-    (local $$17 i32)
-    (local $$18 i32)
-    (local $$23 i32)
-    (local $$27 i32)
-    (local $$47 i32)
-    (local $$48 i32)
-    (local $$49 i32)
-    (local $$50 i32)
-    (local $$52 i32)
-    (local $$57 i32)
-    (local $$62 i32)
-    (local $$63 i32)
-    (local $$64 i32)
-    (local $$66 i32)
-    (local $$69 i32)
-    (local $$72 i32)
-    (local $$R$1$lcssa i32)
-    (local $$R332$1$lcssa i32)
-    (local $$T$0$lcssa319 i32)
-    (local $$add246 i32)
-    (local $$add559 i32)
-    (local $$and i32)
-    (local $$and545 i32)
-    (local $$and549 i32)
-    (local $$and554 i32)
-    (local $$arrayidx i32)
-    (local $$arrayidx108 i32)
-    (local $$arrayidx113 i32)
-    (local $$arrayidx130 i32)
-    (local $$arrayidx149 i32)
-    (local $$arrayidx279 i32)
-    (local $$arrayidx362 i32)
-    (local $$arrayidx374 i32)
-    (local $$arrayidx379 i32)
-    (local $$arrayidx400 i32)
-    (local $$arrayidx419 i32)
-    (local $$arrayidx599 i32)
-    (local $$arrayidx99 i32)
-    (local $$bk343 i32)
-    (local $$bk82 i32)
-    (local $$child171 i32)
-    (local $$child443 i32)
-    (local $$cmp$i i32)
-    (local $$dec i32)
-    (local $$fd311 i32)
-    (local $$fd347 i32)
-    (local $$fd56 i32)
-    (local $$fd620 i32)
-    (local $$fd86 i32)
-    (local $$head209 i32)
-    (local $$head231 i32)
-    (local $$next4$i i32)
-    (local $$shl511 i32)
-    (local $$shl546 i32)
-    (local $$shl551 i32)
-    (local $$shl560 i32)
-    (local $$shl573 i32)
-    (local $$shl600 i32)
-    (local $$sp$0$i i32)
+  (func $_free (param $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
     (i32.load
       (i32.const 8)
     )
     (if
       (i32.eq
-        (get_local $$mem)
+        (get_local $0)
         (i32.const 0)
       )
       (return)
     )
     (if
       (i32.lt_u
-        (set_local $$add$ptr
+        (set_local $2
           (i32.add
-            (get_local $$mem)
+            (get_local $0)
             (i32.const -8)
           )
         )
-        (set_local $$0
+        (set_local $1
           (i32.load
             (i32.const 192)
           )
@@ -17751,12 +16421,12 @@
     )
     (if
       (i32.eq
-        (set_local $$and
+        (set_local $6
           (i32.and
-            (set_local $$1
+            (set_local $0
               (i32.load
                 (i32.add
-                  (get_local $$mem)
+                  (get_local $0)
                   (i32.const -4)
                 )
               )
@@ -17768,12 +16438,12 @@
       )
       (call_import $_abort)
     )
-    (set_local $$add$ptr6
+    (set_local $8
       (i32.add
-        (get_local $$add$ptr)
-        (set_local $$and5
+        (get_local $2)
+        (set_local $7
           (i32.and
-            (get_local $$1)
+            (get_local $0)
             (i32.const -8)
           )
         )
@@ -17783,48 +16453,48 @@
       (if
         (i32.eq
           (i32.and
-            (get_local $$1)
+            (get_local $0)
             (i32.const 1)
           )
           (i32.const 0)
         )
         (block
-          (set_local $$2
+          (set_local $0
             (i32.load
-              (get_local $$add$ptr)
+              (get_local $2)
             )
           )
           (if
             (i32.eq
-              (get_local $$and)
+              (get_local $6)
               (i32.const 0)
             )
             (return)
           )
-          (set_local $$add17
+          (set_local $12
             (i32.add
-              (get_local $$2)
-              (get_local $$and5)
+              (get_local $0)
+              (get_local $7)
             )
           )
           (if
             (i32.lt_u
-              (set_local $$add$ptr16
+              (set_local $4
                 (i32.add
-                  (get_local $$add$ptr)
+                  (get_local $2)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $$2)
+                    (get_local $0)
                   )
                 )
               )
-              (get_local $$0)
+              (get_local $1)
             )
             (call_import $_abort)
           )
           (if
             (i32.eq
-              (get_local $$add$ptr16)
+              (get_local $4)
               (i32.load
                 (i32.const 196)
               )
@@ -17833,11 +16503,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $$27
+                    (set_local $0
                       (i32.load
-                        (set_local $$head209
+                        (set_local $1
                           (i32.add
-                            (get_local $$add$ptr6)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -17848,73 +16518,73 @@
                   (i32.const 3)
                 )
                 (block
-                  (set_local $$p$1
-                    (get_local $$add$ptr16)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $$psize$1
-                    (get_local $$add17)
+                  (set_local $10
+                    (get_local $12)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 184)
-                (get_local $$add17)
+                (get_local $12)
               )
               (i32.store
-                (get_local $$head209)
+                (get_local $1)
                 (i32.and
-                  (get_local $$27)
+                  (get_local $0)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $$add$ptr16)
+                (get_local $4)
                 (i32.or
-                  (get_local $$add17)
+                  (get_local $12)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $$add$ptr16)
-                  (get_local $$add17)
+                  (get_local $4)
+                  (get_local $12)
                 )
-                (get_local $$add17)
+                (get_local $12)
               )
               (return)
             )
           )
-          (set_local $$shr
+          (set_local $7
             (i32.shr_u
-              (get_local $$2)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $$2)
+              (get_local $0)
               (i32.const 256)
             )
             (block
-              (set_local $$5
+              (set_local $2
                 (i32.load offset=12
-                  (get_local $$add$ptr16)
+                  (get_local $4)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $$4
+                  (set_local $0
                     (i32.load offset=8
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
                   )
-                  (set_local $$arrayidx
+                  (set_local $6
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $$shr)
+                          (get_local $7)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -17925,17 +16595,17 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$4)
-                      (get_local $$0)
+                      (get_local $0)
+                      (get_local $1)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $$4)
+                        (get_local $0)
                       )
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
                     (call_import $_abort)
                   )
@@ -17943,8 +16613,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $$5)
-                  (get_local $$4)
+                  (get_local $2)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
@@ -17956,101 +16626,101 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $$shr)
+                          (get_local $7)
                         )
                         (i32.const -1)
                       )
                     )
                   )
-                  (set_local $$p$1
-                    (get_local $$add$ptr16)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $$psize$1
-                    (get_local $$add17)
+                  (set_local $10
+                    (get_local $12)
                   )
                   (br $do-once$0)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $$5)
-                  (get_local $$arrayidx)
+                  (get_local $2)
+                  (get_local $6)
                 )
-                (set_local $$fd67$pre$phiZ2D
+                (set_local $13
                   (i32.add
-                    (get_local $$5)
+                    (get_local $2)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$5)
-                      (get_local $$0)
+                      (get_local $2)
+                      (get_local $1)
                     )
                     (call_import $_abort)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$fd56
+                        (set_local $1
                           (i32.add
-                            (get_local $$5)
+                            (get_local $2)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
-                    (set_local $$fd67$pre$phiZ2D
-                      (get_local $$fd56)
+                    (set_local $13
+                      (get_local $1)
                     )
                     (call_import $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $$4)
-                (get_local $$5)
+                (get_local $0)
+                (get_local $2)
               )
               (i32.store
-                (get_local $$fd67$pre$phiZ2D)
-                (get_local $$4)
+                (get_local $13)
+                (get_local $0)
               )
-              (set_local $$p$1
-                (get_local $$add$ptr16)
+              (set_local $3
+                (get_local $4)
               )
-              (set_local $$psize$1
-                (get_local $$add17)
+              (set_local $10
+                (get_local $12)
               )
               (br $do-once$0)
             )
           )
-          (set_local $$9
+          (set_local $6
             (i32.load offset=24
-              (get_local $$add$ptr16)
+              (get_local $4)
             )
           )
           (block $do-once$2
             (if
               (i32.eq
-                (set_local $$10
+                (set_local $0
                   (i32.load offset=12
-                    (get_local $$add$ptr16)
+                    (get_local $4)
                   )
                 )
-                (get_local $$add$ptr16)
+                (get_local $4)
               )
               (block
                 (if
                   (i32.eq
-                    (set_local $$14
+                    (set_local $0
                       (i32.load
-                        (set_local $$arrayidx99
+                        (set_local $7
                           (i32.add
-                            (set_local $$child
+                            (set_local $13
                               (i32.add
-                                (get_local $$add$ptr16)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
@@ -18063,45 +16733,43 @@
                   )
                   (if
                     (i32.eq
-                      (set_local $$15
+                      (set_local $0
                         (i32.load
-                          (get_local $$child)
+                          (get_local $13)
                         )
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$R$3
+                      (set_local $9
                         (i32.const 0)
                       )
                       (br $do-once$2)
                     )
                     (block
-                      (set_local $$R$1
-                        (get_local $$15)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $$RP$1
-                        (get_local $$child)
+                      (set_local $7
+                        (get_local $13)
                       )
                     )
                   )
                   (block
-                    (set_local $$R$1
-                      (get_local $$14)
+                    (set_local $2
+                      (get_local $0)
                     )
-                    (set_local $$RP$1
-                      (get_local $$arrayidx99)
-                    )
+                    (get_local $7)
                   )
                 )
                 (loop $while-out$4 $while-in$5
                   (if
                     (i32.ne
-                      (set_local $$16
+                      (set_local $0
                         (i32.load
-                          (set_local $$arrayidx108
+                          (set_local $13
                             (i32.add
-                              (get_local $$R$1)
+                              (get_local $2)
                               (i32.const 20)
                             )
                           )
@@ -18110,22 +16778,22 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$R$1
-                        (get_local $$16)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $$RP$1
-                        (get_local $$arrayidx108)
+                      (set_local $7
+                        (get_local $13)
                       )
                       (br $while-in$5)
                     )
                   )
                   (if
                     (i32.eq
-                      (set_local $$17
+                      (set_local $0
                         (i32.load
-                          (set_local $$arrayidx113
+                          (set_local $13
                             (i32.add
-                              (get_local $$R$1)
+                              (get_local $2)
                               (i32.const 16)
                             )
                           )
@@ -18134,20 +16802,20 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$R$1$lcssa
-                        (get_local $$R$1)
+                      (set_local $0
+                        (get_local $2)
                       )
-                      (set_local $$RP$1$lcssa
-                        (get_local $$RP$1)
+                      (set_local $2
+                        (get_local $7)
                       )
                       (br $while-out$4)
                     )
                     (block
-                      (set_local $$R$1
-                        (get_local $$17)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $$RP$1
-                        (get_local $$arrayidx113)
+                      (set_local $7
+                        (get_local $13)
                       )
                     )
                   )
@@ -18155,17 +16823,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $$RP$1$lcssa)
-                    (get_local $$0)
+                    (get_local $2)
+                    (get_local $1)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store
-                      (get_local $$RP$1$lcssa)
+                      (get_local $2)
                       (i32.const 0)
                     )
-                    (set_local $$R$3
-                      (get_local $$R$1$lcssa)
+                    (set_local $9
+                      (get_local $0)
                     )
                   )
                 )
@@ -18173,52 +16841,52 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $$11
+                    (set_local $2
                       (i32.load offset=8
-                        (get_local $$add$ptr16)
+                        (get_local $4)
                       )
                     )
-                    (get_local $$0)
+                    (get_local $1)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.ne
                     (i32.load
-                      (set_local $$bk82
+                      (set_local $1
                         (i32.add
-                          (get_local $$11)
+                          (get_local $2)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $$add$ptr16)
+                    (get_local $4)
                   )
                   (call_import $_abort)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $$fd86
+                      (set_local $7
                         (i32.add
-                          (get_local $$10)
+                          (get_local $0)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $$add$ptr16)
+                    (get_local $4)
                   )
                   (block
                     (i32.store
-                      (get_local $$bk82)
-                      (get_local $$10)
+                      (get_local $1)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $$fd86)
-                      (get_local $$11)
+                      (get_local $7)
+                      (get_local $2)
                     )
-                    (set_local $$R$3
-                      (get_local $$10)
+                    (set_local $9
+                      (get_local $0)
                     )
                   )
                   (call_import $_abort)
@@ -18228,29 +16896,29 @@
           )
           (if
             (i32.eq
-              (get_local $$9)
+              (get_local $6)
               (i32.const 0)
             )
             (block
-              (set_local $$p$1
-                (get_local $$add$ptr16)
+              (set_local $3
+                (get_local $4)
               )
-              (set_local $$psize$1
-                (get_local $$add17)
+              (set_local $10
+                (get_local $12)
               )
             )
             (block
               (if
                 (i32.eq
-                  (get_local $$add$ptr16)
+                  (get_local $4)
                   (i32.load
-                    (set_local $$arrayidx130
+                    (set_local $1
                       (i32.add
                         (i32.const 480)
                         (i32.shl
-                          (set_local $$18
+                          (set_local $0
                             (i32.load offset=28
-                              (get_local $$add$ptr16)
+                              (get_local $4)
                             )
                           )
                           (i32.const 2)
@@ -18261,12 +16929,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $$arrayidx130)
-                    (get_local $$R$3)
+                    (get_local $1)
+                    (get_local $9)
                   )
                   (if
                     (i32.eq
-                      (get_local $$R$3)
+                      (get_local $9)
                       (i32.const 0)
                     )
                     (block
@@ -18279,17 +16947,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $$18)
+                              (get_local $0)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $$p$1
-                        (get_local $$add$ptr16)
+                      (set_local $3
+                        (get_local $4)
                       )
-                      (set_local $$psize$1
-                        (get_local $$add17)
+                      (set_local $10
+                        (get_local $12)
                       )
                       (br $do-once$0)
                     )
@@ -18298,7 +16966,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$9)
+                      (get_local $6)
                       (i32.load
                         (i32.const 192)
                       )
@@ -18308,35 +16976,35 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$arrayidx149
+                        (set_local $0
                           (i32.add
-                            (get_local $$9)
+                            (get_local $6)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $$add$ptr16)
+                      (get_local $4)
                     )
                     (i32.store
-                      (get_local $$arrayidx149)
-                      (get_local $$R$3)
+                      (get_local $0)
+                      (get_local $9)
                     )
                     (i32.store offset=20
-                      (get_local $$9)
-                      (get_local $$R$3)
+                      (get_local $6)
+                      (get_local $9)
                     )
                   )
                   (if
                     (i32.eq
-                      (get_local $$R$3)
+                      (get_local $9)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $$p$1
-                        (get_local $$add$ptr16)
+                      (set_local $3
+                        (get_local $4)
                       )
-                      (set_local $$psize$1
-                        (get_local $$add17)
+                      (set_local $10
+                        (get_local $12)
                       )
                       (br $do-once$0)
                     )
@@ -18345,8 +17013,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $$R$3)
-                  (set_local $$23
+                  (get_local $9)
+                  (set_local $0
                     (i32.load
                       (i32.const 192)
                     )
@@ -18355,16 +17023,16 @@
                 (call_import $_abort)
               )
               (i32.store offset=24
-                (get_local $$R$3)
-                (get_local $$9)
+                (get_local $9)
+                (get_local $6)
               )
               (if
                 (i32.ne
-                  (set_local $$24
+                  (set_local $1
                     (i32.load
-                      (set_local $$child171
+                      (set_local $2
                         (i32.add
-                          (get_local $$add$ptr16)
+                          (get_local $4)
                           (i32.const 16)
                         )
                       )
@@ -18374,42 +17042,42 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $$24)
-                    (get_local $$23)
+                    (get_local $1)
+                    (get_local $0)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $$R$3)
-                      (get_local $$24)
+                      (get_local $9)
+                      (get_local $1)
                     )
                     (i32.store offset=24
-                      (get_local $$24)
-                      (get_local $$R$3)
+                      (get_local $1)
+                      (get_local $9)
                     )
                   )
                 )
               )
               (if
                 (i32.eq
-                  (set_local $$25
+                  (set_local $0
                     (i32.load offset=4
-                      (get_local $$child171)
+                      (get_local $2)
                     )
                   )
                   (i32.const 0)
                 )
                 (block
-                  (set_local $$p$1
-                    (get_local $$add$ptr16)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $$psize$1
-                    (get_local $$add17)
+                  (set_local $10
+                    (get_local $12)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $$25)
+                    (get_local $0)
                     (i32.load
                       (i32.const 192)
                     )
@@ -18417,18 +17085,18 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $$R$3)
-                      (get_local $$25)
+                      (get_local $9)
+                      (get_local $0)
                     )
                     (i32.store offset=24
-                      (get_local $$25)
-                      (get_local $$R$3)
+                      (get_local $0)
+                      (get_local $9)
                     )
-                    (set_local $$p$1
-                      (get_local $$add$ptr16)
+                    (set_local $3
+                      (get_local $4)
                     )
-                    (set_local $$psize$1
-                      (get_local $$add17)
+                    (set_local $10
+                      (get_local $12)
                     )
                   )
                 )
@@ -18437,30 +17105,30 @@
           )
         )
         (block
-          (set_local $$p$1
-            (get_local $$add$ptr)
+          (set_local $3
+            (get_local $2)
           )
-          (set_local $$psize$1
-            (get_local $$and5)
+          (set_local $10
+            (get_local $7)
           )
         )
       )
     )
     (if
       (i32.ge_u
-        (get_local $$p$1)
-        (get_local $$add$ptr6)
+        (get_local $3)
+        (get_local $8)
       )
       (call_import $_abort)
     )
     (if
       (i32.eq
         (i32.and
-          (set_local $$28
+          (set_local $0
             (i32.load
-              (set_local $$head231
+              (set_local $1
                 (i32.add
-                  (get_local $$add$ptr6)
+                  (get_local $8)
                   (i32.const 4)
                 )
               )
@@ -18475,7 +17143,7 @@
     (if
       (i32.eq
         (i32.and
-          (get_local $$28)
+          (get_local $0)
           (i32.const 2)
         )
         (i32.const 0)
@@ -18483,7 +17151,7 @@
       (block
         (if
           (i32.eq
-            (get_local $$add$ptr6)
+            (get_local $8)
             (i32.load
               (i32.const 200)
             )
@@ -18491,29 +17159,29 @@
           (block
             (i32.store
               (i32.const 188)
-              (set_local $$add246
+              (set_local $0
                 (i32.add
                   (i32.load
                     (i32.const 188)
                   )
-                  (get_local $$psize$1)
+                  (get_local $10)
                 )
               )
             )
             (i32.store
               (i32.const 200)
-              (get_local $$p$1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $$p$1)
+              (get_local $3)
               (i32.or
-                (get_local $$add246)
+                (get_local $0)
                 (i32.const 1)
               )
             )
             (if
               (i32.ne
-                (get_local $$p$1)
+                (get_local $3)
                 (i32.load
                   (i32.const 196)
                 )
@@ -18533,7 +17201,7 @@
         )
         (if
           (i32.eq
-            (get_local $$add$ptr6)
+            (get_local $8)
             (i32.load
               (i32.const 196)
             )
@@ -18541,76 +17209,76 @@
           (block
             (i32.store
               (i32.const 184)
-              (set_local $$add258
+              (set_local $0
                 (i32.add
                   (i32.load
                     (i32.const 184)
                   )
-                  (get_local $$psize$1)
+                  (get_local $10)
                 )
               )
             )
             (i32.store
               (i32.const 196)
-              (get_local $$p$1)
+              (get_local $3)
             )
             (i32.store offset=4
-              (get_local $$p$1)
+              (get_local $3)
               (i32.or
-                (get_local $$add258)
+                (get_local $0)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $$p$1)
-                (get_local $$add258)
+                (get_local $3)
+                (get_local $0)
               )
-              (get_local $$add258)
+              (get_local $0)
             )
             (return)
           )
         )
-        (set_local $$add267
+        (set_local $9
           (i32.add
             (i32.and
-              (get_local $$28)
+              (get_local $0)
               (i32.const -8)
             )
-            (get_local $$psize$1)
+            (get_local $10)
           )
         )
-        (set_local $$shr268
+        (set_local $6
           (i32.shr_u
-            (get_local $$28)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (block $do-once$8
           (if
             (i32.lt_u
-              (get_local $$28)
+              (get_local $0)
               (i32.const 256)
             )
             (block
-              (set_local $$35
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $$add$ptr6)
+                  (get_local $8)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $$34
+                  (set_local $0
                     (i32.load offset=8
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                     )
                   )
-                  (set_local $$arrayidx279
+                  (set_local $2
                     (i32.add
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $$shr268)
+                          (get_local $6)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -18621,7 +17289,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$34)
+                      (get_local $0)
                       (i32.load
                         (i32.const 192)
                       )
@@ -18631,9 +17299,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $$34)
+                        (get_local $0)
                       )
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                     )
                     (call_import $_abort)
                   )
@@ -18641,8 +17309,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $$35)
-                  (get_local $$34)
+                  (get_local $1)
+                  (get_local $0)
                 )
                 (block
                   (i32.store
@@ -18654,7 +17322,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $$shr268)
+                          (get_local $6)
                         )
                         (i32.const -1)
                       )
@@ -18665,19 +17333,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $$35)
-                  (get_local $$arrayidx279)
+                  (get_local $1)
+                  (get_local $2)
                 )
-                (set_local $$fd322$pre$phiZ2D
+                (set_local $17
                   (i32.add
-                    (get_local $$35)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $$35)
+                      (get_local $1)
                       (i32.load
                         (i32.const 192)
                       )
@@ -18687,57 +17355,57 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $$fd311
+                        (set_local $2
                           (i32.add
-                            (get_local $$35)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                     )
-                    (set_local $$fd322$pre$phiZ2D
-                      (get_local $$fd311)
+                    (set_local $17
+                      (get_local $2)
                     )
                     (call_import $_abort)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $$34)
-                (get_local $$35)
+                (get_local $0)
+                (get_local $1)
               )
               (i32.store
-                (get_local $$fd322$pre$phiZ2D)
-                (get_local $$34)
+                (get_local $17)
+                (get_local $0)
               )
             )
             (block
-              (set_local $$41
+              (set_local $0
                 (i32.load offset=24
-                  (get_local $$add$ptr6)
+                  (get_local $8)
                 )
               )
               (block $do-once$10
                 (if
                   (i32.eq
-                    (set_local $$42
+                    (set_local $1
                       (i32.load offset=12
-                        (get_local $$add$ptr6)
+                        (get_local $8)
                       )
                     )
-                    (get_local $$add$ptr6)
+                    (get_local $8)
                   )
                   (block
                     (if
                       (i32.eq
-                        (set_local $$47
+                        (set_local $1
                           (i32.load
-                            (set_local $$arrayidx362
+                            (set_local $6
                               (i32.add
-                                (set_local $$child361
+                                (set_local $7
                                   (i32.add
-                                    (get_local $$add$ptr6)
+                                    (get_local $8)
                                     (i32.const 16)
                                   )
                                 )
@@ -18750,45 +17418,43 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $$48
+                          (set_local $1
                             (i32.load
-                              (get_local $$child361)
+                              (get_local $7)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$R332$3
+                          (set_local $11
                             (i32.const 0)
                           )
                           (br $do-once$10)
                         )
                         (block
-                          (set_local $$R332$1
-                            (get_local $$48)
+                          (set_local $2
+                            (get_local $1)
                           )
-                          (set_local $$RP360$1
-                            (get_local $$child361)
+                          (set_local $6
+                            (get_local $7)
                           )
                         )
                       )
                       (block
-                        (set_local $$R332$1
-                          (get_local $$47)
+                        (set_local $2
+                          (get_local $1)
                         )
-                        (set_local $$RP360$1
-                          (get_local $$arrayidx362)
-                        )
+                        (get_local $6)
                       )
                     )
                     (loop $while-out$12 $while-in$13
                       (if
                         (i32.ne
-                          (set_local $$49
+                          (set_local $1
                             (i32.load
-                              (set_local $$arrayidx374
+                              (set_local $7
                                 (i32.add
-                                  (get_local $$R332$1)
+                                  (get_local $2)
                                   (i32.const 20)
                                 )
                               )
@@ -18797,22 +17463,22 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$R332$1
-                            (get_local $$49)
+                          (set_local $2
+                            (get_local $1)
                           )
-                          (set_local $$RP360$1
-                            (get_local $$arrayidx374)
+                          (set_local $6
+                            (get_local $7)
                           )
                           (br $while-in$13)
                         )
                       )
                       (if
                         (i32.eq
-                          (set_local $$50
+                          (set_local $1
                             (i32.load
-                              (set_local $$arrayidx379
+                              (set_local $7
                                 (i32.add
-                                  (get_local $$R332$1)
+                                  (get_local $2)
                                   (i32.const 16)
                                 )
                               )
@@ -18821,20 +17487,20 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $$R332$1$lcssa
-                            (get_local $$R332$1)
+                          (set_local $1
+                            (get_local $2)
                           )
-                          (set_local $$RP360$1$lcssa
-                            (get_local $$RP360$1)
+                          (set_local $2
+                            (get_local $6)
                           )
                           (br $while-out$12)
                         )
                         (block
-                          (set_local $$R332$1
-                            (get_local $$50)
+                          (set_local $2
+                            (get_local $1)
                           )
-                          (set_local $$RP360$1
-                            (get_local $$arrayidx379)
+                          (set_local $6
+                            (get_local $7)
                           )
                         )
                       )
@@ -18842,7 +17508,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$RP360$1$lcssa)
+                        (get_local $2)
                         (i32.load
                           (i32.const 192)
                         )
@@ -18850,11 +17516,11 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $$RP360$1$lcssa)
+                          (get_local $2)
                           (i32.const 0)
                         )
-                        (set_local $$R332$3
-                          (get_local $$R332$1$lcssa)
+                        (set_local $11
+                          (get_local $1)
                         )
                       )
                     )
@@ -18862,9 +17528,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (set_local $$43
+                        (set_local $2
                           (i32.load offset=8
-                            (get_local $$add$ptr6)
+                            (get_local $8)
                           )
                         )
                         (i32.load
@@ -18876,40 +17542,40 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $$bk343
+                          (set_local $6
                             (i32.add
-                              (get_local $$43)
+                              (get_local $2)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $$add$ptr6)
+                        (get_local $8)
                       )
                       (call_import $_abort)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $$fd347
+                          (set_local $7
                             (i32.add
-                              (get_local $$42)
+                              (get_local $1)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $$add$ptr6)
+                        (get_local $8)
                       )
                       (block
                         (i32.store
-                          (get_local $$bk343)
-                          (get_local $$42)
+                          (get_local $6)
+                          (get_local $1)
                         )
                         (i32.store
-                          (get_local $$fd347)
-                          (get_local $$43)
+                          (get_local $7)
+                          (get_local $2)
                         )
-                        (set_local $$R332$3
-                          (get_local $$42)
+                        (set_local $11
+                          (get_local $1)
                         )
                       )
                       (call_import $_abort)
@@ -18919,21 +17585,21 @@
               )
               (if
                 (i32.ne
-                  (get_local $$41)
+                  (get_local $0)
                   (i32.const 0)
                 )
                 (block
                   (if
                     (i32.eq
-                      (get_local $$add$ptr6)
+                      (get_local $8)
                       (i32.load
-                        (set_local $$arrayidx400
+                        (set_local $2
                           (i32.add
                             (i32.const 480)
                             (i32.shl
-                              (set_local $$52
+                              (set_local $1
                                 (i32.load offset=28
-                                  (get_local $$add$ptr6)
+                                  (get_local $8)
                                 )
                               )
                               (i32.const 2)
@@ -18944,12 +17610,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $$arrayidx400)
-                        (get_local $$R332$3)
+                        (get_local $2)
+                        (get_local $11)
                       )
                       (if
                         (i32.eq
-                          (get_local $$R332$3)
+                          (get_local $11)
                           (i32.const 0)
                         )
                         (block
@@ -18962,7 +17628,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $$52)
+                                  (get_local $1)
                                 )
                                 (i32.const -1)
                               )
@@ -18975,7 +17641,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $$41)
+                          (get_local $0)
                           (i32.load
                             (i32.const 192)
                           )
@@ -18985,27 +17651,27 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $$arrayidx419
+                            (set_local $1
                               (i32.add
-                                (get_local $$41)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $$add$ptr6)
+                          (get_local $8)
                         )
                         (i32.store
-                          (get_local $$arrayidx419)
-                          (get_local $$R332$3)
+                          (get_local $1)
+                          (get_local $11)
                         )
                         (i32.store offset=20
-                          (get_local $$41)
-                          (get_local $$R332$3)
+                          (get_local $0)
+                          (get_local $11)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eq
-                          (get_local $$R332$3)
+                          (get_local $11)
                           (i32.const 0)
                         )
                       )
@@ -19013,8 +17679,8 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $$R332$3)
-                      (set_local $$57
+                      (get_local $11)
+                      (set_local $1
                         (i32.load
                           (i32.const 192)
                         )
@@ -19023,16 +17689,16 @@
                     (call_import $_abort)
                   )
                   (i32.store offset=24
-                    (get_local $$R332$3)
-                    (get_local $$41)
+                    (get_local $11)
+                    (get_local $0)
                   )
                   (if
                     (i32.ne
-                      (set_local $$58
+                      (set_local $0
                         (i32.load
-                          (set_local $$child443
+                          (set_local $2
                             (i32.add
-                              (get_local $$add$ptr6)
+                              (get_local $8)
                               (i32.const 16)
                             )
                           )
@@ -19042,34 +17708,34 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$58)
-                        (get_local $$57)
+                        (get_local $0)
+                        (get_local $1)
                       )
                       (call_import $_abort)
                       (block
                         (i32.store offset=16
-                          (get_local $$R332$3)
-                          (get_local $$58)
+                          (get_local $11)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $$58)
-                          (get_local $$R332$3)
+                          (get_local $0)
+                          (get_local $11)
                         )
                       )
                     )
                   )
                   (if
                     (i32.ne
-                      (set_local $$59
+                      (set_local $0
                         (i32.load offset=4
-                          (get_local $$child443)
+                          (get_local $2)
                         )
                       )
                       (i32.const 0)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $$59)
+                        (get_local $0)
                         (i32.load
                           (i32.const 192)
                         )
@@ -19077,12 +17743,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=20
-                          (get_local $$R332$3)
-                          (get_local $$59)
+                          (get_local $11)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $$59)
-                          (get_local $$R332$3)
+                          (get_local $0)
+                          (get_local $11)
                         )
                       )
                     )
@@ -19093,22 +17759,22 @@
           )
         )
         (i32.store offset=4
-          (get_local $$p$1)
+          (get_local $3)
           (i32.or
-            (get_local $$add267)
+            (get_local $9)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $$p$1)
-            (get_local $$add267)
+            (get_local $3)
+            (get_local $9)
           )
-          (get_local $$add267)
+          (get_local $9)
         )
         (if
           (i32.eq
-            (get_local $$p$1)
+            (get_local $3)
             (i32.load
               (i32.const 196)
             )
@@ -19116,60 +17782,60 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $$add267)
+              (get_local $9)
             )
             (return)
           )
-          (set_local $$psize$2
-            (get_local $$add267)
+          (set_local $2
+            (get_local $9)
           )
         )
       )
       (block
         (i32.store
-          (get_local $$head231)
+          (get_local $1)
           (i32.and
-            (get_local $$28)
+            (get_local $0)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $$p$1)
+          (get_local $3)
           (i32.or
-            (get_local $$psize$1)
+            (get_local $10)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $$p$1)
-            (get_local $$psize$1)
+            (get_local $3)
+            (get_local $10)
           )
-          (get_local $$psize$1)
+          (get_local $10)
         )
-        (set_local $$psize$2
-          (get_local $$psize$1)
+        (set_local $2
+          (get_local $10)
         )
       )
     )
-    (set_local $$shr501
+    (set_local $1
       (i32.shr_u
-        (get_local $$psize$2)
+        (get_local $2)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $$psize$2)
+        (get_local $2)
         (i32.const 256)
       )
       (block
-        (set_local $$arrayidx509
+        (set_local $2
           (i32.add
             (i32.const 216)
             (i32.shl
               (i32.shl
-                (get_local $$shr501)
+                (get_local $1)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -19179,15 +17845,15 @@
         (if
           (i32.eq
             (i32.and
-              (set_local $$62
+              (set_local $0
                 (i32.load
                   (i32.const 176)
                 )
               )
-              (set_local $$shl511
+              (set_local $1
                 (i32.shl
                   (i32.const 1)
-                  (get_local $$shr501)
+                  (get_local $1)
                 )
               )
             )
@@ -19197,27 +17863,27 @@
             (i32.store
               (i32.const 176)
               (i32.or
-                (get_local $$62)
-                (get_local $$shl511)
+                (get_local $0)
+                (get_local $1)
               )
             )
-            (set_local $$$pre$phiZ2D
+            (set_local $5
               (i32.add
-                (get_local $$arrayidx509)
+                (get_local $2)
                 (i32.const 8)
               )
             )
-            (set_local $$F510$0
-              (get_local $$arrayidx509)
+            (set_local $14
+              (get_local $2)
             )
           )
           (if
             (i32.lt_u
-              (set_local $$64
+              (set_local $1
                 (i32.load
-                  (set_local $$63
+                  (set_local $0
                     (i32.add
-                      (get_local $$arrayidx509)
+                      (get_local $2)
                       (i32.const 8)
                     )
                   )
@@ -19229,44 +17895,44 @@
             )
             (call_import $_abort)
             (block
-              (set_local $$$pre$phiZ2D
-                (get_local $$63)
+              (set_local $5
+                (get_local $0)
               )
-              (set_local $$F510$0
-                (get_local $$64)
+              (set_local $14
+                (get_local $1)
               )
             )
           )
         )
         (i32.store
-          (get_local $$$pre$phiZ2D)
-          (get_local $$p$1)
+          (get_local $5)
+          (get_local $3)
         )
         (i32.store offset=12
-          (get_local $$F510$0)
-          (get_local $$p$1)
+          (get_local $14)
+          (get_local $3)
         )
         (i32.store offset=8
-          (get_local $$p$1)
-          (get_local $$F510$0)
+          (get_local $3)
+          (get_local $14)
         )
         (i32.store offset=12
-          (get_local $$p$1)
-          (get_local $$arrayidx509)
+          (get_local $3)
+          (get_local $2)
         )
         (return)
       )
     )
-    (set_local $$arrayidx567
+    (set_local $1
       (i32.add
         (i32.const 480)
         (i32.shl
-          (set_local $$I534$0
+          (set_local $5
             (if
               (i32.eq
-                (set_local $$shr535
+                (set_local $0
                   (i32.shr_u
-                    (get_local $$psize$2)
+                    (get_local $2)
                     (i32.const 8)
                   )
                 )
@@ -19275,31 +17941,31 @@
               (i32.const 0)
               (if
                 (i32.gt_u
-                  (get_local $$psize$2)
+                  (get_local $2)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (block
-                  (set_local $$shl560
+                  (set_local $5
                     (i32.shl
-                      (set_local $$add559
+                      (set_local $0
                         (i32.add
                           (i32.sub
                             (i32.const 14)
                             (i32.or
                               (i32.or
-                                (set_local $$and549
+                                (set_local $5
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $$shl546
+                                        (set_local $1
                                           (i32.shl
-                                            (get_local $$shr535)
-                                            (set_local $$and545
+                                            (get_local $0)
+                                            (set_local $0
                                               (i32.and
                                                 (i32.shr_u
                                                   (i32.add
-                                                    (get_local $$shr535)
+                                                    (get_local $0)
                                                     (i32.const 1048320)
                                                   )
                                                   (i32.const 16)
@@ -19316,16 +17982,16 @@
                                     (i32.const 4)
                                   )
                                 )
-                                (get_local $$and545)
+                                (get_local $0)
                               )
-                              (set_local $$and554
+                              (set_local $0
                                 (i32.and
                                   (i32.shr_u
                                     (i32.add
-                                      (set_local $$shl551
+                                      (set_local $5
                                         (i32.shl
-                                          (get_local $$shl546)
-                                          (get_local $$and549)
+                                          (get_local $1)
+                                          (get_local $5)
                                         )
                                       )
                                       (i32.const 245760)
@@ -19339,8 +18005,8 @@
                           )
                           (i32.shr_u
                             (i32.shl
-                              (get_local $$shl551)
-                              (get_local $$and554)
+                              (get_local $5)
+                              (get_local $0)
                             )
                             (i32.const 15)
                           )
@@ -19352,15 +18018,15 @@
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $$psize$2)
+                        (get_local $2)
                         (i32.add
-                          (get_local $$add559)
+                          (get_local $0)
                           (i32.const 7)
                         )
                       )
                       (i32.const 1)
                     )
-                    (get_local $$shl560)
+                    (get_local $5)
                   )
                 )
               )
@@ -19371,29 +18037,29 @@
       )
     )
     (i32.store offset=28
-      (get_local $$p$1)
-      (get_local $$I534$0)
+      (get_local $3)
+      (get_local $5)
     )
     (i32.store offset=20
-      (get_local $$p$1)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $$p$1)
+      (get_local $3)
       (i32.const 0)
     )
     (if
       (i32.eq
         (i32.and
-          (set_local $$66
+          (set_local $0
             (i32.load
               (i32.const 180)
             )
           )
-          (set_local $$shl573
+          (set_local $6
             (i32.shl
               (i32.const 1)
-              (get_local $$I534$0)
+              (get_local $5)
             )
           )
         )
@@ -19403,50 +18069,50 @@
         (i32.store
           (i32.const 180)
           (i32.or
-            (get_local $$66)
-            (get_local $$shl573)
+            (get_local $0)
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $$arrayidx567)
-          (get_local $$p$1)
+          (get_local $1)
+          (get_local $3)
         )
         (i32.store offset=24
-          (get_local $$p$1)
-          (get_local $$arrayidx567)
+          (get_local $3)
+          (get_local $1)
         )
         (i32.store offset=12
-          (get_local $$p$1)
-          (get_local $$p$1)
+          (get_local $3)
+          (get_local $3)
         )
         (i32.store offset=8
-          (get_local $$p$1)
-          (get_local $$p$1)
+          (get_local $3)
+          (get_local $3)
         )
       )
       (block
-        (set_local $$K583$0
+        (set_local $5
           (i32.shl
-            (get_local $$psize$2)
+            (get_local $2)
             (select
               (i32.const 0)
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $$I534$0)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $$I534$0)
+                (get_local $5)
                 (i32.const 31)
               )
             )
           )
         )
-        (set_local $$T$0
+        (set_local $1
           (i32.load
-            (get_local $$arrayidx567)
+            (get_local $1)
           )
         )
         (loop $while-out$18 $while-in$19
@@ -19454,41 +18120,41 @@
             (i32.eq
               (i32.and
                 (i32.load offset=4
-                  (get_local $$T$0)
+                  (get_local $1)
                 )
                 (i32.const -8)
               )
-              (get_local $$psize$2)
+              (get_local $2)
             )
             (block
-              (set_local $$T$0$lcssa
-                (get_local $$T$0)
+              (set_local $15
+                (get_local $1)
               )
-              (set_local $label
+              (set_local $0
                 (i32.const 130)
               )
               (br $while-out$18)
             )
           )
-          (set_local $$shl600
+          (set_local $6
             (i32.shl
-              (get_local $$K583$0)
+              (get_local $5)
               (i32.const 1)
             )
           )
           (if
             (i32.eq
-              (set_local $$69
+              (set_local $0
                 (i32.load
-                  (set_local $$arrayidx599
+                  (set_local $5
                     (i32.add
                       (i32.add
-                        (get_local $$T$0)
+                        (get_local $1)
                         (i32.const 16)
                       )
                       (i32.shl
                         (i32.shr_u
-                          (get_local $$K583$0)
+                          (get_local $5)
                           (i32.const 31)
                         )
                         (i32.const 2)
@@ -19500,23 +18166,23 @@
               (i32.const 0)
             )
             (block
-              (set_local $$T$0$lcssa319
-                (get_local $$T$0)
+              (set_local $18
+                (get_local $1)
               )
-              (set_local $$arrayidx599$lcssa
-                (get_local $$arrayidx599)
+              (set_local $16
+                (get_local $5)
               )
-              (set_local $label
+              (set_local $0
                 (i32.const 127)
               )
               (br $while-out$18)
             )
             (block
-              (set_local $$K583$0
-                (get_local $$shl600)
+              (set_local $5
+                (get_local $6)
               )
-              (set_local $$T$0
-                (get_local $$69)
+              (set_local $1
+                (get_local $0)
               )
             )
           )
@@ -19524,12 +18190,12 @@
         )
         (if
           (i32.eq
-            (get_local $label)
+            (get_local $0)
             (i32.const 127)
           )
           (if
             (i32.lt_u
-              (get_local $$arrayidx599$lcssa)
+              (get_local $16)
               (i32.load
                 (i32.const 192)
               )
@@ -19537,71 +18203,71 @@
             (call_import $_abort)
             (block
               (i32.store
-                (get_local $$arrayidx599$lcssa)
-                (get_local $$p$1)
+                (get_local $16)
+                (get_local $3)
               )
               (i32.store offset=24
-                (get_local $$p$1)
-                (get_local $$T$0$lcssa319)
+                (get_local $3)
+                (get_local $18)
               )
               (i32.store offset=12
-                (get_local $$p$1)
-                (get_local $$p$1)
+                (get_local $3)
+                (get_local $3)
               )
               (i32.store offset=8
-                (get_local $$p$1)
-                (get_local $$p$1)
+                (get_local $3)
+                (get_local $3)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $label)
+              (get_local $0)
               (i32.const 130)
             )
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $$71
+                  (set_local $0
                     (i32.load
-                      (set_local $$fd620
+                      (set_local $1
                         (i32.add
-                          (get_local $$T$0$lcssa)
+                          (get_local $15)
                           (i32.const 8)
                         )
                       )
                     )
                   )
-                  (set_local $$72
+                  (set_local $5
                     (i32.load
                       (i32.const 192)
                     )
                   )
                 )
                 (i32.ge_u
-                  (get_local $$T$0$lcssa)
-                  (get_local $$72)
+                  (get_local $15)
+                  (get_local $5)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $$71)
-                  (get_local $$p$1)
+                  (get_local $0)
+                  (get_local $3)
                 )
                 (i32.store
-                  (get_local $$fd620)
-                  (get_local $$p$1)
+                  (get_local $1)
+                  (get_local $3)
                 )
                 (i32.store offset=8
-                  (get_local $$p$1)
-                  (get_local $$71)
+                  (get_local $3)
+                  (get_local $0)
                 )
                 (i32.store offset=12
-                  (get_local $$p$1)
-                  (get_local $$T$0$lcssa)
+                  (get_local $3)
+                  (get_local $15)
                 )
                 (i32.store offset=24
-                  (get_local $$p$1)
+                  (get_local $3)
                   (i32.const 0)
                 )
               )
@@ -19613,7 +18279,7 @@
     )
     (i32.store
       (i32.const 208)
-      (set_local $$dec
+      (set_local $0
         (i32.add
           (i32.load
             (i32.const 208)
@@ -19624,36 +18290,36 @@
     )
     (if
       (i32.eq
-        (get_local $$dec)
+        (get_local $0)
         (i32.const 0)
       )
-      (set_local $$sp$0$in$i
+      (set_local $0
         (i32.const 632)
       )
       (return)
     )
     (loop $while-out$20 $while-in$21
-      (set_local $$cmp$i
+      (set_local $0
         (i32.eq
-          (set_local $$sp$0$i
+          (set_local $5
             (i32.load
-              (get_local $$sp$0$in$i)
+              (get_local $0)
             )
           )
           (i32.const 0)
         )
       )
-      (set_local $$next4$i
+      (set_local $5
         (i32.add
-          (get_local $$sp$0$i)
+          (get_local $5)
           (i32.const 8)
         )
       )
       (if
-        (get_local $$cmp$i)
+        (get_local $0)
         (br $while-out$20)
-        (set_local $$sp$0$in$i
-          (get_local $$next4$i)
+        (set_local $0
+          (get_local $5)
         )
       )
       (br $while-in$21)
@@ -19666,97 +18332,96 @@
   (func $runPostSets
     (nop)
   )
-  (func $_i64Subtract (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
+  (func $_i64Subtract (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (i32.sub
-      (get_local $b)
-      (get_local $d)
+      (get_local $1)
+      (get_local $3)
     )
     (i32.store
       (i32.const 168)
       (i32.sub
         (i32.sub
-          (get_local $b)
-          (get_local $d)
+          (get_local $1)
+          (get_local $3)
         )
         (i32.gt_u
-          (get_local $c)
-          (get_local $a)
+          (get_local $2)
+          (get_local $0)
         )
       )
     )
     (i32.sub
-      (get_local $a)
-      (get_local $c)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $_i64Add (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
-    (local $l i32)
+  (func $_i64Add (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (i32.store
       (i32.const 168)
       (i32.add
         (i32.add
-          (get_local $b)
-          (get_local $d)
+          (get_local $1)
+          (get_local $3)
         )
         (i32.lt_u
-          (set_local $l
+          (set_local $1
             (i32.add
-              (get_local $a)
-              (get_local $c)
+              (get_local $0)
+              (get_local $2)
             )
           )
-          (get_local $a)
+          (get_local $0)
         )
       )
     )
-    (get_local $l)
+    (get_local $1)
   )
-  (func $_memset (param $ptr i32) (param $value i32) (param $num i32) (result i32)
-    (local $unaligned i32)
-    (local $stop i32)
-    (local $value4 i32)
-    (local $stop4 i32)
-    (set_local $stop
+  (func $_memset (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $4
       (i32.add
-        (get_local $ptr)
-        (get_local $num)
+        (get_local $0)
+        (get_local $2)
       )
     )
     (if
       (i32.ge_s
-        (get_local $num)
+        (get_local $2)
         (i32.const 20)
       )
       (block
-        (set_local $value4
+        (set_local $5
           (i32.or
             (i32.or
               (i32.or
-                (set_local $value
+                (set_local $1
                   (i32.and
-                    (get_local $value)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.shl
-                  (get_local $value)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (i32.shl
-                (get_local $value)
+                (get_local $1)
                 (i32.const 16)
               )
             )
             (i32.shl
-              (get_local $value)
+              (get_local $1)
               (i32.const 24)
             )
           )
         )
-        (set_local $stop4
+        (set_local $6
           (i32.and
-            (get_local $stop)
+            (get_local $4)
             (i32.xor
               (i32.const 3)
               (i32.const -1)
@@ -19764,36 +18429,36 @@
           )
         )
         (if
-          (set_local $unaligned
+          (set_local $3
             (i32.and
-              (get_local $ptr)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (block
-            (set_local $unaligned
+            (set_local $3
               (i32.sub
                 (i32.add
-                  (get_local $ptr)
+                  (get_local $0)
                   (i32.const 4)
                 )
-                (get_local $unaligned)
+                (get_local $3)
               )
             )
             (loop $while-out$0 $while-in$1
               (br_if $while-out$0
                 (i32.ge_s
-                  (get_local $ptr)
-                  (get_local $unaligned)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (i32.store8
-                (get_local $ptr)
-                (get_local $value)
+                (get_local $0)
+                (get_local $1)
               )
-              (set_local $ptr
+              (set_local $0
                 (i32.add
-                  (get_local $ptr)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
@@ -19804,17 +18469,17 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.ge_s
-              (get_local $ptr)
-              (get_local $stop4)
+              (get_local $0)
+              (get_local $6)
             )
           )
           (i32.store
-            (get_local $ptr)
-            (get_local $value4)
+            (get_local $0)
+            (get_local $5)
           )
-          (set_local $ptr
+          (set_local $0
             (i32.add
-              (get_local $ptr)
+              (get_local $0)
               (i32.const 4)
             )
           )
@@ -19825,61 +18490,61 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.ge_s
-          (get_local $ptr)
-          (get_local $stop)
+          (get_local $0)
+          (get_local $4)
         )
       )
       (i32.store8
-        (get_local $ptr)
-        (get_local $value)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $ptr
+      (set_local $0
         (i32.add
-          (get_local $ptr)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
     (i32.sub
-      (get_local $ptr)
-      (get_local $num)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $_bitshift64Lshr (param $low i32) (param $high i32) (param $bits i32) (result i32)
+  (func $_bitshift64Lshr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (if
       (i32.lt_s
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
       (block
         (i32.store
           (i32.const 168)
           (i32.shr_u
-            (get_local $high)
-            (get_local $bits)
+            (get_local $1)
+            (get_local $2)
           )
         )
         (return
           (i32.or
             (i32.shr_u
-              (get_local $low)
-              (get_local $bits)
+              (get_local $0)
+              (get_local $2)
             )
             (i32.shl
               (i32.and
-                (get_local $high)
+                (get_local $1)
                 (i32.sub
                   (i32.shl
                     (i32.const 1)
-                    (get_local $bits)
+                    (get_local $2)
                   )
                   (i32.const 1)
                 )
               )
               (i32.sub
                 (i32.const 32)
-                (get_local $bits)
+                (get_local $2)
               )
             )
           )
@@ -19891,17 +18556,17 @@
       (i32.const 0)
     )
     (i32.shr_u
-      (get_local $high)
+      (get_local $1)
       (i32.sub
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
     )
   )
-  (func $_bitshift64Shl (param $low i32) (param $high i32) (param $bits i32) (result i32)
+  (func $_bitshift64Shl (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (if
       (i32.lt_s
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
       (block
@@ -19909,37 +18574,37 @@
           (i32.const 168)
           (i32.or
             (i32.shl
-              (get_local $high)
-              (get_local $bits)
+              (get_local $1)
+              (get_local $2)
             )
             (i32.shr_u
               (i32.and
-                (get_local $low)
+                (get_local $0)
                 (i32.shl
                   (i32.sub
                     (i32.shl
                       (i32.const 1)
-                      (get_local $bits)
+                      (get_local $2)
                     )
                     (i32.const 1)
                   )
                   (i32.sub
                     (i32.const 32)
-                    (get_local $bits)
+                    (get_local $2)
                   )
                 )
               )
               (i32.sub
                 (i32.const 32)
-                (get_local $bits)
+                (get_local $2)
               )
             )
           )
         )
         (return
           (i32.shl
-            (get_local $low)
-            (get_local $bits)
+            (get_local $0)
+            (get_local $2)
           )
         )
       )
@@ -19947,41 +18612,41 @@
     (i32.store
       (i32.const 168)
       (i32.shl
-        (get_local $low)
+        (get_local $0)
         (i32.sub
-          (get_local $bits)
+          (get_local $2)
           (i32.const 32)
         )
       )
     )
     (i32.const 0)
   )
-  (func $_memcpy (param $dest i32) (param $src i32) (param $num i32) (result i32)
-    (local $ret i32)
+  (func $_memcpy (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
     (if
       (i32.ge_s
-        (get_local $num)
+        (get_local $2)
         (i32.const 4096)
       )
       (return
         (call_import $_emscripten_memcpy_big
-          (get_local $dest)
-          (get_local $src)
-          (get_local $num)
+          (get_local $0)
+          (get_local $1)
+          (get_local $2)
         )
       )
     )
-    (set_local $ret
-      (get_local $dest)
+    (set_local $3
+      (get_local $0)
     )
     (if
       (i32.eq
         (i32.and
-          (get_local $dest)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.and
-          (get_local $src)
+          (get_local $1)
           (i32.const 3)
         )
       )
@@ -19990,41 +18655,41 @@
           (br_if $while-out$0
             (i32.eqz
               (i32.and
-                (get_local $dest)
+                (get_local $0)
                 (i32.const 3)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $num)
+              (get_local $2)
               (i32.const 0)
             )
             (return
-              (get_local $ret)
+              (get_local $3)
             )
           )
           (i32.store8
-            (get_local $dest)
+            (get_local $0)
             (i32.load8_s
-              (get_local $src)
+              (get_local $1)
             )
           )
-          (set_local $dest
+          (set_local $0
             (i32.add
-              (get_local $dest)
+              (get_local $0)
               (i32.const 1)
             )
           )
-          (set_local $src
+          (set_local $1
             (i32.add
-              (get_local $src)
+              (get_local $1)
               (i32.const 1)
             )
           )
-          (set_local $num
+          (set_local $2
             (i32.sub
-              (get_local $num)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -20033,31 +18698,31 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.lt_s
-              (get_local $num)
+              (get_local $2)
               (i32.const 4)
             )
           )
           (i32.store
-            (get_local $dest)
+            (get_local $0)
             (i32.load
-              (get_local $src)
+              (get_local $1)
             )
           )
-          (set_local $dest
+          (set_local $0
             (i32.add
-              (get_local $dest)
+              (get_local $0)
               (i32.const 4)
             )
           )
-          (set_local $src
+          (set_local $1
             (i32.add
-              (get_local $src)
+              (get_local $1)
               (i32.const 4)
             )
           )
-          (set_local $num
+          (set_local $2
             (i32.sub
-              (get_local $num)
+              (get_local $2)
               (i32.const 4)
             )
           )
@@ -20068,72 +18733,72 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.le_s
-          (get_local $num)
+          (get_local $2)
           (i32.const 0)
         )
       )
       (i32.store8
-        (get_local $dest)
+        (get_local $0)
         (i32.load8_s
-          (get_local $src)
+          (get_local $1)
         )
       )
-      (set_local $dest
+      (set_local $0
         (i32.add
-          (get_local $dest)
+          (get_local $0)
           (i32.const 1)
         )
       )
-      (set_local $src
+      (set_local $1
         (i32.add
-          (get_local $src)
+          (get_local $1)
           (i32.const 1)
         )
       )
-      (set_local $num
+      (set_local $2
         (i32.sub
-          (get_local $num)
+          (get_local $2)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
-    (get_local $ret)
+    (get_local $3)
   )
-  (func $_bitshift64Ashr (param $low i32) (param $high i32) (param $bits i32) (result i32)
+  (func $_bitshift64Ashr (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (if
       (i32.lt_s
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
       (block
         (i32.store
           (i32.const 168)
           (i32.shr_s
-            (get_local $high)
-            (get_local $bits)
+            (get_local $1)
+            (get_local $2)
           )
         )
         (return
           (i32.or
             (i32.shr_u
-              (get_local $low)
-              (get_local $bits)
+              (get_local $0)
+              (get_local $2)
             )
             (i32.shl
               (i32.and
-                (get_local $high)
+                (get_local $1)
                 (i32.sub
                   (i32.shl
                     (i32.const 1)
-                    (get_local $bits)
+                    (get_local $2)
                   )
                   (i32.const 1)
                 )
               )
               (i32.sub
                 (i32.const 32)
-                (get_local $bits)
+                (get_local $2)
               )
             )
           )
@@ -20146,41 +18811,37 @@
         (i32.const -1)
         (i32.const 0)
         (i32.lt_s
-          (get_local $high)
+          (get_local $1)
           (i32.const 0)
         )
       )
     )
     (i32.shr_s
-      (get_local $high)
+      (get_local $1)
       (i32.sub
-        (get_local $bits)
+        (get_local $2)
         (i32.const 32)
       )
     )
   )
-  (func $___muldsi3 (param $$a i32) (param $$b i32) (result i32)
-    (local $$8 i32)
-    (local $$12 i32)
-    (local $$1 i32)
-    (local $$2 i32)
-    (local $$3 i32)
-    (local $$6 i32)
-    (local $$11 i32)
-    (set_local $$8
+  (func $___muldsi3 (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $2
       (i32.add
         (i32.shr_u
-          (set_local $$3
+          (set_local $4
             (i32.mul
-              (set_local $$2
+              (set_local $2
                 (i32.and
-                  (get_local $$b)
+                  (get_local $1)
                   (i32.const 65535)
                 )
               )
-              (set_local $$1
+              (set_local $3
                 (i32.and
-                  (get_local $$a)
+                  (get_local $0)
                   (i32.const 65535)
                 )
               )
@@ -20189,25 +18850,25 @@
           (i32.const 16)
         )
         (i32.mul
-          (get_local $$2)
-          (set_local $$6
+          (get_local $2)
+          (set_local $0
             (i32.shr_u
-              (get_local $$a)
+              (get_local $0)
               (i32.const 16)
             )
           )
         )
       )
     )
-    (set_local $$12
+    (set_local $3
       (i32.mul
-        (set_local $$11
+        (set_local $1
           (i32.shr_u
-            (get_local $$b)
+            (get_local $1)
             (i32.const 16)
           )
         )
-        (get_local $$1)
+        (get_local $3)
       )
     )
     (i32.store
@@ -20215,21 +18876,21 @@
       (i32.add
         (i32.add
           (i32.shr_u
-            (get_local $$8)
+            (get_local $2)
             (i32.const 16)
           )
           (i32.mul
-            (get_local $$11)
-            (get_local $$6)
+            (get_local $1)
+            (get_local $0)
           )
         )
         (i32.shr_u
           (i32.add
             (i32.and
-              (get_local $$8)
+              (get_local $2)
               (i32.const 65535)
             )
-            (get_local $$12)
+            (get_local $3)
           )
           (i32.const 16)
         )
@@ -20240,34 +18901,29 @@
       (i32.or
         (i32.shl
           (i32.add
-            (get_local $$8)
-            (get_local $$12)
+            (get_local $2)
+            (get_local $3)
           )
           (i32.const 16)
         )
         (i32.and
-          (get_local $$3)
+          (get_local $4)
           (i32.const 65535)
         )
       )
     )
   )
-  (func $___divdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$1$0 i32)
-    (local $$1$1 i32)
-    (local $$2$0 i32)
-    (local $$2$1 i32)
-    (local $$7$0 i32)
-    (local $$7$1 i32)
+  (func $___divdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
     (call $_i64Subtract
       (i32.xor
         (call $___udivmoddi4
           (call $_i64Subtract
             (i32.xor
-              (set_local $$1$0
+              (set_local $4
                 (i32.or
                   (i32.shr_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 31)
                   )
                   (i32.shl
@@ -20275,7 +18931,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20283,17 +18939,17 @@
                   )
                 )
               )
-              (get_local $$a$0)
+              (get_local $0)
             )
             (i32.xor
-              (set_local $$1$1
+              (set_local $0
                 (i32.or
                   (i32.shr_s
                     (select
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20304,7 +18960,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20312,20 +18968,20 @@
                   )
                 )
               )
-              (get_local $$a$1)
+              (get_local $1)
             )
-            (get_local $$1$0)
-            (get_local $$1$1)
+            (get_local $4)
+            (get_local $0)
           )
           (i32.load
             (i32.const 168)
           )
           (call $_i64Subtract
             (i32.xor
-              (set_local $$2$0
+              (set_local $1
                 (i32.or
                   (i32.shr_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 31)
                   )
                   (i32.shl
@@ -20333,7 +18989,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$b$1)
+                        (get_local $3)
                         (i32.const 0)
                       )
                     )
@@ -20341,17 +18997,17 @@
                   )
                 )
               )
-              (get_local $$b$0)
+              (get_local $2)
             )
             (i32.xor
-              (set_local $$2$1
+              (set_local $2
                 (i32.or
                   (i32.shr_s
                     (select
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$b$1)
+                        (get_local $3)
                         (i32.const 0)
                       )
                     )
@@ -20362,7 +19018,7 @@
                       (i32.const -1)
                       (i32.const 0)
                       (i32.lt_s
-                        (get_local $$b$1)
+                        (get_local $3)
                         (i32.const 0)
                       )
                     )
@@ -20370,20 +19026,20 @@
                   )
                 )
               )
-              (get_local $$b$1)
+              (get_local $3)
             )
-            (get_local $$2$0)
-            (get_local $$2$1)
+            (get_local $1)
+            (get_local $2)
           )
           (i32.load
             (i32.const 168)
           )
           (i32.const 0)
         )
-        (set_local $$7$0
+        (set_local $1
           (i32.xor
-            (get_local $$2$0)
-            (get_local $$1$0)
+            (get_local $1)
+            (get_local $4)
           )
         )
       )
@@ -20391,27 +19047,22 @@
         (i32.load
           (i32.const 168)
         )
-        (set_local $$7$1
+        (set_local $0
           (i32.xor
-            (get_local $$2$1)
-            (get_local $$1$1)
+            (get_local $2)
+            (get_local $0)
           )
         )
       )
-      (get_local $$7$0)
-      (get_local $$7$1)
+      (get_local $1)
+      (get_local $0)
     )
   )
-  (func $___remdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$1$0 i32)
-    (local $$1$1 i32)
-    (local $$rem i32)
-    (local $__stackBase__ i32)
-    (local $$2$0 i32)
-    (local $$2$1 i32)
-    (local $$10$0 i32)
-    (local $$10$1 i32)
-    (set_local $__stackBase__
+  (func $___remdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $6
       (i32.load
         (i32.const 8)
       )
@@ -20428,10 +19079,10 @@
     (call $___udivmoddi4
       (call $_i64Subtract
         (i32.xor
-          (set_local $$1$0
+          (set_local $4
             (i32.or
               (i32.shr_s
-                (get_local $$a$1)
+                (get_local $1)
                 (i32.const 31)
               )
               (i32.shl
@@ -20439,7 +19090,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -20447,17 +19098,17 @@
               )
             )
           )
-          (get_local $$a$0)
+          (get_local $0)
         )
         (i32.xor
-          (set_local $$1$1
+          (set_local $5
             (i32.or
               (i32.shr_s
                 (select
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -20468,7 +19119,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -20476,20 +19127,20 @@
               )
             )
           )
-          (get_local $$a$1)
+          (get_local $1)
         )
-        (get_local $$1$0)
-        (get_local $$1$1)
+        (get_local $4)
+        (get_local $5)
       )
       (i32.load
         (i32.const 168)
       )
       (call $_i64Subtract
         (i32.xor
-          (set_local $$2$0
+          (set_local $0
             (i32.or
               (i32.shr_s
-                (get_local $$b$1)
+                (get_local $3)
                 (i32.const 31)
               )
               (i32.shl
@@ -20497,7 +19148,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -20505,17 +19156,17 @@
               )
             )
           )
-          (get_local $$b$0)
+          (get_local $2)
         )
         (i32.xor
-          (set_local $$2$1
+          (set_local $1
             (i32.or
               (i32.shr_s
                 (select
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -20526,7 +19177,7 @@
                   (i32.const -1)
                   (i32.const 0)
                   (i32.lt_s
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -20534,64 +19185,57 @@
               )
             )
           )
-          (get_local $$b$1)
+          (get_local $3)
         )
-        (get_local $$2$0)
-        (get_local $$2$1)
+        (get_local $0)
+        (get_local $1)
       )
       (i32.load
         (i32.const 168)
       )
-      (set_local $$rem
-        (get_local $__stackBase__)
+      (set_local $0
+        (get_local $6)
       )
     )
-    (set_local $$10$0
+    (set_local $0
       (call $_i64Subtract
         (i32.xor
           (i32.load
-            (get_local $$rem)
+            (get_local $0)
           )
-          (get_local $$1$0)
+          (get_local $4)
         )
         (i32.xor
           (i32.load offset=4
-            (get_local $$rem)
+            (get_local $0)
           )
-          (get_local $$1$1)
+          (get_local $5)
         )
-        (get_local $$1$0)
-        (get_local $$1$1)
+        (get_local $4)
+        (get_local $5)
       )
     )
-    (set_local $$10$1
+    (set_local $1
       (i32.load
         (i32.const 168)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $__stackBase__)
+      (get_local $6)
     )
     (i32.store
       (i32.const 168)
-      (get_local $$10$1)
+      (get_local $1)
     )
-    (get_local $$10$0)
+    (get_local $0)
   )
-  (func $___muldi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$x_sroa_0_0_extract_trunc i32)
-    (local $$y_sroa_0_0_extract_trunc i32)
-    (local $$1$0 i32)
-    (local $$1$1 i32)
-    (set_local $$1$0
+  (func $___muldi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (set_local $4
       (call $___muldsi3
-        (set_local $$x_sroa_0_0_extract_trunc
-          (get_local $$a$0)
-        )
-        (set_local $$y_sroa_0_0_extract_trunc
-          (get_local $$b$0)
-        )
+        (get_local $0)
+        (get_local $2)
       )
     )
     (i32.store
@@ -20600,22 +19244,22 @@
         (i32.add
           (i32.add
             (i32.mul
-              (get_local $$b$1)
-              (get_local $$x_sroa_0_0_extract_trunc)
+              (get_local $3)
+              (get_local $0)
             )
             (i32.mul
-              (get_local $$a$1)
-              (get_local $$y_sroa_0_0_extract_trunc)
+              (get_local $1)
+              (get_local $2)
             )
           )
-          (set_local $$1$1
+          (set_local $0
             (i32.load
               (i32.const 168)
             )
           )
         )
         (i32.and
-          (get_local $$1$1)
+          (get_local $0)
           (i32.const 0)
         )
       )
@@ -20623,24 +19267,23 @@
     (i32.or
       (i32.const 0)
       (i32.and
-        (get_local $$1$0)
+        (get_local $4)
         (i32.const -1)
       )
     )
   )
-  (func $___udivdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
+  (func $___udivdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call $___udivmoddi4
-      (get_local $$a$0)
-      (get_local $$a$1)
-      (get_local $$b$0)
-      (get_local $$b$1)
+      (get_local $0)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
       (i32.const 0)
     )
   )
-  (func $___uremdi3 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (result i32)
-    (local $$rem i32)
-    (local $__stackBase__ i32)
-    (set_local $__stackBase__
+  (func $___uremdi3 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -20655,132 +19298,84 @@
       )
     )
     (call $___udivmoddi4
-      (get_local $$a$0)
-      (get_local $$a$1)
-      (get_local $$b$0)
-      (get_local $$b$1)
-      (set_local $$rem
-        (get_local $__stackBase__)
+      (get_local $0)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
+      (set_local $0
+        (get_local $4)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $__stackBase__)
+      (get_local $4)
     )
     (i32.store
       (i32.const 168)
       (i32.load offset=4
-        (get_local $$rem)
+        (get_local $0)
       )
     )
     (i32.load
-      (get_local $$rem)
+      (get_local $0)
     )
   )
-  (func $___udivmoddi4 (param $$a$0 i32) (param $$a$1 i32) (param $$b$0 i32) (param $$b$1 i32) (param $$rem i32) (result i32)
-    (local $$n_sroa_1_4_extract_trunc i32)
-    (local $$n_sroa_0_0_extract_trunc i32)
-    (local $$d_sroa_0_0_extract_trunc i32)
-    (local $$d_sroa_1_4_extract_trunc i32)
-    (local $$88 i32)
-    (local $$q_sroa_1_1_ph i32)
-    (local $$q_sroa_0_1_ph i32)
-    (local $$r_sroa_1_1_ph i32)
-    (local $$r_sroa_0_1_ph i32)
-    (local $$sr_1_ph i32)
-    (local $$n_sroa_1_4_extract_shift$0 i32)
-    (local $$91 i32)
-    (local $$119 i32)
-    (local $$r_sroa_0_1201 i32)
-    (local $$q_sroa_0_1199 i32)
-    (local $$q_sroa_1_1198 i32)
-    (local $$150$1 i32)
-    (local $$q_sroa_0_0_insert_ext75$0 i32)
-    (local $$4 i32)
-    (local $$17 i32)
-    (local $$51 i32)
-    (local $$57 i32)
-    (local $$78 i32)
-    (local $$89 i32)
-    (local $$92 i32)
-    (local $$95 i32)
-    (local $$105 i32)
-    (local $$125 i32)
-    (local $$carry_0203 i32)
-    (local $$sr_1202 i32)
-    (local $$r_sroa_1_1200 i32)
-    (local $$147 i32)
-    (local $$149 i32)
-    (local $$152 i32)
-    (local $$r_sroa_0_0_extract_trunc i32)
-    (local $$r_sroa_1_4_extract_trunc i32)
-    (local $$carry_0_lcssa$1 i32)
-    (local $$r_sroa_0_1_lcssa i32)
-    (local $$r_sroa_1_1_lcssa i32)
-    (local $$q_sroa_0_1_lcssa i32)
-    (local $$q_sroa_1_1_lcssa i32)
-    (local $$d_sroa_1_4_extract_shift$0 i32)
-    (local $$37 i32)
-    (local $$58 i32)
-    (local $$66 i32)
-    (local $$126 i32)
-    (local $$130 i32)
-    (local $$d_sroa_0_0_insert_insert99$0 i32)
-    (local $$d_sroa_0_0_insert_insert99$1 i32)
-    (local $$137$0 i32)
-    (local $$137$1 i32)
-    (local $$r_sroa_0_0_insert_insert42$0 i32)
-    (local $$r_sroa_0_0_insert_insert42$1 i32)
-    (local $$151$0 i32)
-    (local $$155 i32)
-    (local $$carry_0_lcssa$0 i32)
-    (local $$q_sroa_0_0_insert_ext75$1 i32)
-    (local $$q_sroa_0_0_insert_insert77$1 i32)
-    (set_local $$n_sroa_0_0_extract_trunc
-      (get_local $$a$0)
+  (func $___udivmoddi4 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (set_local $7
+      (get_local $0)
     )
-    (set_local $$d_sroa_0_0_extract_trunc
-      (get_local $$b$0)
+    (set_local $5
+      (get_local $2)
     )
-    (set_local $$d_sroa_1_4_extract_trunc
-      (set_local $$d_sroa_1_4_extract_shift$0
-        (get_local $$b$1)
+    (set_local $8
+      (set_local $11
+        (get_local $3)
       )
     )
     (if
       (i32.eq
-        (set_local $$n_sroa_1_4_extract_trunc
-          (set_local $$n_sroa_1_4_extract_shift$0
-            (get_local $$a$1)
+        (set_local $6
+          (set_local $9
+            (get_local $1)
           )
         )
         (i32.const 0)
       )
       (block
-        (set_local $$4
+        (set_local $2
           (i32.ne
-            (get_local $$rem)
+            (get_local $4)
             (i32.const 0)
           )
         )
         (if
           (i32.eq
-            (get_local $$d_sroa_1_4_extract_trunc)
+            (get_local $8)
             (i32.const 0)
           )
           (block
             (if
-              (get_local $$4)
+              (get_local $2)
               (block
                 (i32.store
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.rem_u
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$d_sroa_0_0_extract_trunc)
+                    (get_local $7)
+                    (get_local $5)
                   )
                 )
                 (i32.store offset=4
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
               )
@@ -20792,8 +19387,8 @@
                   (i32.const 0)
                 )
                 (i32.div_u
-                  (get_local $$n_sroa_0_0_extract_trunc)
-                  (get_local $$d_sroa_0_0_extract_trunc)
+                  (get_local $7)
+                  (get_local $5)
                 )
               )
             )
@@ -20801,7 +19396,7 @@
           (block
             (if
               (i32.eqz
-                (get_local $$4)
+                (get_local $2)
               )
               (return
                 (block
@@ -20814,16 +19409,16 @@
               )
             )
             (i32.store
-              (get_local $$rem)
+              (get_local $4)
               (i32.and
-                (get_local $$a$0)
+                (get_local $0)
                 (i32.const -1)
               )
             )
             (i32.store offset=4
-              (get_local $$rem)
+              (get_local $4)
               (i32.and
-                (get_local $$a$1)
+                (get_local $1)
                 (i32.const 0)
               )
             )
@@ -20840,37 +19435,37 @@
         )
       )
     )
-    (set_local $$17
+    (set_local $10
       (i32.eq
-        (get_local $$d_sroa_1_4_extract_trunc)
+        (get_local $8)
         (i32.const 0)
       )
     )
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $$d_sroa_0_0_extract_trunc)
+          (get_local $5)
           (i32.const 0)
         )
         (block
           (if
-            (get_local $$17)
+            (get_local $10)
             (block
               (if
                 (i32.ne
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (block
                   (i32.store
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.rem_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (get_local $$d_sroa_0_0_extract_trunc)
+                      (get_local $6)
+                      (get_local $5)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.const 0)
                   )
                 )
@@ -20882,8 +19477,8 @@
                     (i32.const 0)
                   )
                   (i32.div_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (get_local $$d_sroa_0_0_extract_trunc)
+                    (get_local $6)
+                    (get_local $5)
                   )
                 )
               )
@@ -20891,25 +19486,25 @@
           )
           (if
             (i32.eq
-              (get_local $$n_sroa_0_0_extract_trunc)
+              (get_local $7)
               (i32.const 0)
             )
             (block
               (if
                 (i32.ne
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (block
                   (i32.store
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.const 0)
                   )
                   (i32.store offset=4
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.rem_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (get_local $$d_sroa_1_4_extract_trunc)
+                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                 )
@@ -20921,8 +19516,8 @@
                     (i32.const 0)
                   )
                   (i32.div_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (get_local $$d_sroa_1_4_extract_trunc)
+                    (get_local $6)
+                    (get_local $8)
                   )
                 )
               )
@@ -20931,42 +19526,42 @@
           (if
             (i32.eq
               (i32.and
-                (set_local $$37
+                (set_local $5
                   (i32.sub
-                    (get_local $$d_sroa_1_4_extract_trunc)
+                    (get_local $8)
                     (i32.const 1)
                   )
                 )
-                (get_local $$d_sroa_1_4_extract_trunc)
+                (get_local $8)
               )
               (i32.const 0)
             )
             (block
               (if
                 (i32.ne
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (block
                   (i32.store
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.or
                       (i32.const 0)
                       (i32.and
-                        (get_local $$a$0)
+                        (get_local $0)
                         (i32.const -1)
                       )
                     )
                   )
                   (i32.store offset=4
-                    (get_local $$rem)
+                    (get_local $4)
                     (i32.or
                       (i32.and
-                        (get_local $$37)
-                        (get_local $$n_sroa_1_4_extract_trunc)
+                        (get_local $5)
+                        (get_local $6)
                       )
                       (i32.and
-                        (get_local $$a$1)
+                        (get_local $1)
                         (i32.const 0)
                       )
                     )
@@ -20980,9 +19575,9 @@
                     (i32.const 0)
                   )
                   (i32.shr_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
+                    (get_local $6)
                     (i32.ctz
-                      (get_local $$d_sroa_1_4_extract_trunc)
+                      (get_local $8)
                     )
                   )
                 )
@@ -20991,57 +19586,57 @@
           )
           (if
             (i32.le_u
-              (set_local $$51
+              (set_local $5
                 (i32.sub
                   (i32.clz
-                    (get_local $$d_sroa_1_4_extract_trunc)
+                    (get_local $8)
                   )
                   (i32.clz
-                    (get_local $$n_sroa_1_4_extract_trunc)
+                    (get_local $6)
                   )
                 )
               )
               (i32.const 30)
             )
             (block
-              (set_local $$sr_1_ph
-                (set_local $$57
+              (set_local $14
+                (set_local $0
                   (i32.add
-                    (get_local $$51)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
               )
-              (set_local $$r_sroa_0_1_ph
+              (set_local $13
                 (i32.or
                   (i32.shl
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (set_local $$58
+                    (get_local $6)
+                    (set_local $1
                       (i32.sub
                         (i32.const 31)
-                        (get_local $$51)
+                        (get_local $5)
                       )
                     )
                   )
                   (i32.shr_u
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$57)
+                    (get_local $7)
+                    (get_local $0)
                   )
                 )
               )
-              (set_local $$r_sroa_1_1_ph
+              (set_local $12
                 (i32.shr_u
-                  (get_local $$n_sroa_1_4_extract_trunc)
-                  (get_local $$57)
+                  (get_local $6)
+                  (get_local $0)
                 )
               )
-              (set_local $$q_sroa_0_1_ph
+              (set_local $10
                 (i32.const 0)
               )
-              (set_local $$q_sroa_1_1_ph
+              (set_local $0
                 (i32.shl
-                  (get_local $$n_sroa_0_0_extract_trunc)
-                  (get_local $$58)
+                  (get_local $7)
+                  (get_local $1)
                 )
               )
               (br $do-once$0)
@@ -21049,7 +19644,7 @@
           )
           (if
             (i32.eq
-              (get_local $$rem)
+              (get_local $4)
               (i32.const 0)
             )
             (return
@@ -21063,21 +19658,21 @@
             )
           )
           (i32.store
-            (get_local $$rem)
+            (get_local $4)
             (i32.or
               (i32.const 0)
               (i32.and
-                (get_local $$a$0)
+                (get_local $0)
                 (i32.const -1)
               )
             )
           )
           (i32.store offset=4
-            (get_local $$rem)
+            (get_local $4)
             (i32.or
-              (get_local $$n_sroa_1_4_extract_shift$0)
+              (get_local $9)
               (i32.and
-                (get_local $$a$1)
+                (get_local $1)
                 (i32.const 0)
               )
             )
@@ -21095,43 +19690,43 @@
         (block
           (if
             (i32.eqz
-              (get_local $$17)
+              (get_local $10)
             )
             (block
               (if
                 (i32.le_u
-                  (set_local $$119
+                  (set_local $5
                     (i32.sub
                       (i32.clz
-                        (get_local $$d_sroa_1_4_extract_trunc)
+                        (get_local $8)
                       )
                       (i32.clz
-                        (get_local $$n_sroa_1_4_extract_trunc)
+                        (get_local $6)
                       )
                     )
                   )
                   (i32.const 31)
                 )
                 (block
-                  (set_local $$sr_1_ph
-                    (set_local $$125
+                  (set_local $14
+                    (set_local $0
                       (i32.add
-                        (get_local $$119)
+                        (get_local $5)
                         (i32.const 1)
                       )
                     )
                   )
-                  (set_local $$r_sroa_0_1_ph
+                  (set_local $13
                     (i32.or
                       (i32.and
                         (i32.shr_u
-                          (get_local $$n_sroa_0_0_extract_trunc)
-                          (get_local $$125)
+                          (get_local $7)
+                          (get_local $0)
                         )
-                        (set_local $$130
+                        (set_local $9
                           (i32.shr_s
                             (i32.sub
-                              (get_local $$119)
+                              (get_local $5)
                               (i32.const 31)
                             )
                             (i32.const 31)
@@ -21139,32 +19734,32 @@
                         )
                       )
                       (i32.shl
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (set_local $$126
+                        (get_local $6)
+                        (set_local $1
                           (i32.sub
                             (i32.const 31)
-                            (get_local $$119)
+                            (get_local $5)
                           )
                         )
                       )
                     )
                   )
-                  (set_local $$r_sroa_1_1_ph
+                  (set_local $12
                     (i32.and
                       (i32.shr_u
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (get_local $$125)
+                        (get_local $6)
+                        (get_local $0)
                       )
-                      (get_local $$130)
+                      (get_local $9)
                     )
                   )
-                  (set_local $$q_sroa_0_1_ph
+                  (set_local $10
                     (i32.const 0)
                   )
-                  (set_local $$q_sroa_1_1_ph
+                  (set_local $0
                     (i32.shl
-                      (get_local $$n_sroa_0_0_extract_trunc)
-                      (get_local $$126)
+                      (get_local $7)
+                      (get_local $1)
                     )
                   )
                   (br $do-once$0)
@@ -21172,7 +19767,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $$rem)
+                  (get_local $4)
                   (i32.const 0)
                 )
                 (return
@@ -21186,21 +19781,21 @@
                 )
               )
               (i32.store
-                (get_local $$rem)
+                (get_local $4)
                 (i32.or
                   (i32.const 0)
                   (i32.and
-                    (get_local $$a$0)
+                    (get_local $0)
                     (i32.const -1)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $$rem)
+                (get_local $4)
                 (i32.or
-                  (get_local $$n_sroa_1_4_extract_shift$0)
+                  (get_local $9)
                   (i32.and
-                    (get_local $$a$1)
+                    (get_local $1)
                     (i32.const 0)
                   )
                 )
@@ -21219,131 +19814,131 @@
           (if
             (i32.ne
               (i32.and
-                (set_local $$66
+                (set_local $8
                   (i32.sub
-                    (get_local $$d_sroa_0_0_extract_trunc)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
-                (get_local $$d_sroa_0_0_extract_trunc)
+                (get_local $5)
               )
               (i32.const 0)
             )
             (block
-              (set_local $$89
+              (set_local $1
                 (i32.sub
                   (i32.const 64)
-                  (set_local $$88
+                  (set_local $0
                     (i32.sub
                       (i32.add
                         (i32.clz
-                          (get_local $$d_sroa_0_0_extract_trunc)
+                          (get_local $5)
                         )
                         (i32.const 33)
                       )
                       (i32.clz
-                        (get_local $$n_sroa_1_4_extract_trunc)
+                        (get_local $6)
                       )
                     )
                   )
                 )
               )
-              (set_local $$92
+              (set_local $5
                 (i32.shr_s
-                  (set_local $$91
+                  (set_local $9
                     (i32.sub
                       (i32.const 32)
-                      (get_local $$88)
+                      (get_local $0)
                     )
                   )
                   (i32.const 31)
                 )
               )
-              (set_local $$105
+              (set_local $10
                 (i32.shr_s
-                  (set_local $$95
+                  (set_local $8
                     (i32.sub
-                      (get_local $$88)
+                      (get_local $0)
                       (i32.const 32)
                     )
                   )
                   (i32.const 31)
                 )
               )
-              (set_local $$sr_1_ph
-                (get_local $$88)
+              (set_local $14
+                (get_local $0)
               )
-              (set_local $$r_sroa_0_1_ph
+              (set_local $13
                 (i32.or
                   (i32.and
                     (i32.shr_s
                       (i32.sub
-                        (get_local $$91)
+                        (get_local $9)
                         (i32.const 1)
                       )
                       (i32.const 31)
                     )
                     (i32.shr_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (get_local $$95)
+                      (get_local $6)
+                      (get_local $8)
                     )
                   )
                   (i32.and
                     (i32.or
                       (i32.shl
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (get_local $$91)
+                        (get_local $6)
+                        (get_local $9)
                       )
                       (i32.shr_u
-                        (get_local $$n_sroa_0_0_extract_trunc)
-                        (get_local $$88)
+                        (get_local $7)
+                        (get_local $0)
                       )
                     )
-                    (get_local $$105)
+                    (get_local $10)
                   )
                 )
               )
-              (set_local $$r_sroa_1_1_ph
+              (set_local $12
                 (i32.and
-                  (get_local $$105)
+                  (get_local $10)
                   (i32.shr_u
-                    (get_local $$n_sroa_1_4_extract_trunc)
-                    (get_local $$88)
+                    (get_local $6)
+                    (get_local $0)
                   )
                 )
               )
-              (set_local $$q_sroa_0_1_ph
+              (set_local $10
                 (i32.and
                   (i32.shl
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$89)
+                    (get_local $7)
+                    (get_local $1)
                   )
-                  (get_local $$92)
+                  (get_local $5)
                 )
               )
-              (set_local $$q_sroa_1_1_ph
+              (set_local $0
                 (i32.or
                   (i32.and
                     (i32.or
                       (i32.shl
-                        (get_local $$n_sroa_1_4_extract_trunc)
-                        (get_local $$89)
+                        (get_local $6)
+                        (get_local $1)
                       )
                       (i32.shr_u
-                        (get_local $$n_sroa_0_0_extract_trunc)
-                        (get_local $$95)
+                        (get_local $7)
+                        (get_local $8)
                       )
                     )
-                    (get_local $$92)
+                    (get_local $5)
                   )
                   (i32.and
                     (i32.shl
-                      (get_local $$n_sroa_0_0_extract_trunc)
-                      (get_local $$91)
+                      (get_local $7)
+                      (get_local $9)
                     )
                     (i32.shr_s
                       (i32.sub
-                        (get_local $$88)
+                        (get_local $0)
                         (i32.const 33)
                       )
                       (i32.const 31)
@@ -21356,26 +19951,26 @@
           )
           (if
             (i32.ne
-              (get_local $$rem)
+              (get_local $4)
               (i32.const 0)
             )
             (block
               (i32.store
-                (get_local $$rem)
+                (get_local $4)
                 (i32.and
-                  (get_local $$66)
-                  (get_local $$n_sroa_0_0_extract_trunc)
+                  (get_local $8)
+                  (get_local $7)
                 )
               )
               (i32.store offset=4
-                (get_local $$rem)
+                (get_local $4)
                 (i32.const 0)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $$d_sroa_0_0_extract_trunc)
+              (get_local $5)
               (i32.const 1)
             )
             (return
@@ -21383,9 +19978,9 @@
                 (i32.store
                   (i32.const 168)
                   (i32.or
-                    (get_local $$n_sroa_1_4_extract_shift$0)
+                    (get_local $9)
                     (i32.and
-                      (get_local $$a$1)
+                      (get_local $1)
                       (i32.const 0)
                     )
                   )
@@ -21393,7 +19988,7 @@
                 (i32.or
                   (i32.const 0)
                   (i32.and
-                    (get_local $$a$0)
+                    (get_local $0)
                     (i32.const -1)
                   )
                 )
@@ -21406,10 +20001,10 @@
                   (i32.or
                     (i32.const 0)
                     (i32.shr_u
-                      (get_local $$n_sroa_1_4_extract_trunc)
-                      (set_local $$78
+                      (get_local $6)
+                      (set_local $0
                         (i32.ctz
-                          (get_local $$d_sroa_0_0_extract_trunc)
+                          (get_local $5)
                         )
                       )
                     )
@@ -21417,15 +20012,15 @@
                 )
                 (i32.or
                   (i32.shl
-                    (get_local $$n_sroa_1_4_extract_trunc)
+                    (get_local $6)
                     (i32.sub
                       (i32.const 32)
-                      (get_local $$78)
+                      (get_local $0)
                     )
                   )
                   (i32.shr_u
-                    (get_local $$n_sroa_0_0_extract_trunc)
-                    (get_local $$78)
+                    (get_local $7)
+                    (get_local $0)
                   )
                 )
               )
@@ -21434,47 +20029,47 @@
         )
       )
     )
-    (set_local $$carry_0_lcssa$0
+    (set_local $0
       (if
         (i32.eq
-          (get_local $$sr_1_ph)
+          (get_local $14)
           (i32.const 0)
         )
         (block
-          (set_local $$q_sroa_1_1_lcssa
-            (get_local $$q_sroa_1_1_ph)
+          (set_local $9
+            (get_local $0)
           )
-          (set_local $$q_sroa_0_1_lcssa
-            (get_local $$q_sroa_0_1_ph)
+          (set_local $7
+            (get_local $10)
           )
-          (set_local $$r_sroa_1_1_lcssa
-            (get_local $$r_sroa_1_1_ph)
+          (set_local $3
+            (get_local $12)
           )
-          (set_local $$r_sroa_0_1_lcssa
-            (get_local $$r_sroa_0_1_ph)
+          (set_local $2
+            (get_local $13)
           )
-          (set_local $$carry_0_lcssa$1
+          (set_local $1
             (i32.const 0)
           )
           (i32.const 0)
         )
         (block
-          (set_local $$137$0
+          (set_local $3
             (call $_i64Add
-              (set_local $$d_sroa_0_0_insert_insert99$0
+              (set_local $1
                 (i32.or
                   (i32.const 0)
                   (i32.and
-                    (get_local $$b$0)
+                    (get_local $2)
                     (i32.const -1)
                   )
                 )
               )
-              (set_local $$d_sroa_0_0_insert_insert99$1
+              (set_local $2
                 (i32.or
-                  (get_local $$d_sroa_1_4_extract_shift$0)
+                  (get_local $11)
                   (i32.and
-                    (get_local $$b$1)
+                    (get_local $3)
                     (i32.const 0)
                   )
                 )
@@ -21483,88 +20078,88 @@
               (i32.const -1)
             )
           )
-          (set_local $$137$1
+          (set_local $7
             (i32.load
               (i32.const 168)
             )
           )
-          (set_local $$q_sroa_1_1198
-            (get_local $$q_sroa_1_1_ph)
+          (set_local $8
+            (get_local $0)
           )
-          (set_local $$q_sroa_0_1199
-            (get_local $$q_sroa_0_1_ph)
+          (set_local $11
+            (get_local $10)
           )
-          (set_local $$r_sroa_1_1200
-            (get_local $$r_sroa_1_1_ph)
+          (set_local $5
+            (get_local $12)
           )
-          (set_local $$r_sroa_0_1201
-            (get_local $$r_sroa_0_1_ph)
+          (set_local $6
+            (get_local $13)
           )
-          (set_local $$sr_1202
-            (get_local $$sr_1_ph)
+          (set_local $9
+            (get_local $14)
           )
-          (set_local $$carry_0203
+          (set_local $0
             (i32.const 0)
           )
           (loop $while-out$2 $while-in$3
-            (set_local $$147
+            (set_local $10
               (i32.or
                 (i32.shr_u
-                  (get_local $$q_sroa_0_1199)
+                  (get_local $11)
                   (i32.const 31)
                 )
                 (i32.shl
-                  (get_local $$q_sroa_1_1198)
+                  (get_local $8)
                   (i32.const 1)
                 )
               )
             )
-            (set_local $$149
+            (set_local $0
               (i32.or
-                (get_local $$carry_0203)
+                (get_local $0)
                 (i32.shl
-                  (get_local $$q_sroa_0_1199)
+                  (get_local $11)
                   (i32.const 1)
                 )
               )
             )
             (call $_i64Subtract
-              (get_local $$137$0)
-              (get_local $$137$1)
-              (set_local $$r_sroa_0_0_insert_insert42$0
+              (get_local $3)
+              (get_local $7)
+              (set_local $11
                 (i32.or
                   (i32.const 0)
                   (i32.or
                     (i32.shl
-                      (get_local $$r_sroa_0_1201)
+                      (get_local $6)
                       (i32.const 1)
                     )
                     (i32.shr_u
-                      (get_local $$q_sroa_1_1198)
+                      (get_local $8)
                       (i32.const 31)
                     )
                   )
                 )
               )
-              (set_local $$r_sroa_0_0_insert_insert42$1
+              (set_local $6
                 (i32.or
                   (i32.shr_u
-                    (get_local $$r_sroa_0_1201)
+                    (get_local $6)
                     (i32.const 31)
                   )
                   (i32.shl
-                    (get_local $$r_sroa_1_1200)
+                    (get_local $5)
                     (i32.const 1)
                   )
                 )
               )
             )
-            (set_local $$152
+            (set_local $12
               (i32.and
-                (set_local $$151$0
+                (set_local $8
                   (i32.or
                     (i32.shr_s
-                      (set_local $$150$1
+                      (set_local $5
                         (i32.load
                           (i32.const 168)
                         )
@@ -21576,7 +20171,7 @@
                         (i32.const -1)
                         (i32.const 0)
                         (i32.lt_s
-                          (get_local $$150$1)
+                          (get_local $5)
                           (i32.const 0)
                         )
                       )
@@ -21587,13 +20182,13 @@
                 (i32.const 1)
               )
             )
-            (set_local $$r_sroa_0_0_extract_trunc
+            (set_local $6
               (call $_i64Subtract
-                (get_local $$r_sroa_0_0_insert_insert42$0)
-                (get_local $$r_sroa_0_0_insert_insert42$1)
+                (get_local $11)
+                (get_local $6)
                 (i32.and
-                  (get_local $$151$0)
-                  (get_local $$d_sroa_0_0_insert_insert99$0)
+                  (get_local $8)
+                  (get_local $1)
                 )
                 (i32.and
                   (i32.or
@@ -21602,7 +20197,7 @@
                         (i32.const -1)
                         (i32.const 0)
                         (i32.lt_s
-                          (get_local $$150$1)
+                          (get_local $5)
                           (i32.const 0)
                         )
                       )
@@ -21613,27 +20208,27 @@
                         (i32.const -1)
                         (i32.const 0)
                         (i32.lt_s
-                          (get_local $$150$1)
+                          (get_local $5)
                           (i32.const 0)
                         )
                       )
                       (i32.const 1)
                     )
                   )
-                  (get_local $$d_sroa_0_0_insert_insert99$1)
+                  (get_local $2)
                 )
               )
             )
-            (set_local $$r_sroa_1_4_extract_trunc
+            (set_local $5
               (i32.load
                 (i32.const 168)
               )
             )
             (if
               (i32.eq
-                (set_local $$155
+                (set_local $9
                   (i32.sub
-                    (get_local $$sr_1202)
+                    (get_local $9)
                     (i32.const 1)
                   )
                 )
@@ -21641,74 +20236,66 @@
               )
               (br $while-out$2)
               (block
-                (set_local $$q_sroa_1_1198
-                  (get_local $$147)
+                (set_local $8
+                  (get_local $10)
                 )
-                (set_local $$q_sroa_0_1199
-                  (get_local $$149)
+                (set_local $11
+                  (get_local $0)
                 )
-                (set_local $$r_sroa_1_1200
-                  (get_local $$r_sroa_1_4_extract_trunc)
-                )
-                (set_local $$r_sroa_0_1201
-                  (get_local $$r_sroa_0_0_extract_trunc)
-                )
-                (set_local $$sr_1202
-                  (get_local $$155)
-                )
-                (set_local $$carry_0203
-                  (get_local $$152)
+                (get_local $5)
+                (get_local $6)
+                (get_local $9)
+                (set_local $0
+                  (get_local $12)
                 )
               )
             )
             (br $while-in$3)
           )
-          (set_local $$q_sroa_1_1_lcssa
-            (get_local $$147)
+          (set_local $9
+            (get_local $10)
           )
-          (set_local $$q_sroa_0_1_lcssa
-            (get_local $$149)
+          (set_local $7
+            (get_local $0)
           )
-          (set_local $$r_sroa_1_1_lcssa
-            (get_local $$r_sroa_1_4_extract_trunc)
+          (set_local $3
+            (get_local $5)
           )
-          (set_local $$r_sroa_0_1_lcssa
-            (get_local $$r_sroa_0_0_extract_trunc)
+          (set_local $2
+            (get_local $6)
           )
-          (set_local $$carry_0_lcssa$1
+          (set_local $1
             (i32.const 0)
           )
-          (get_local $$152)
+          (get_local $12)
         )
       )
     )
-    (set_local $$q_sroa_0_0_insert_ext75$0
-      (get_local $$q_sroa_0_1_lcssa)
-    )
-    (set_local $$q_sroa_0_0_insert_insert77$1
+    (get_local $7)
+    (set_local $6
       (i32.or
-        (get_local $$q_sroa_1_1_lcssa)
-        (set_local $$q_sroa_0_0_insert_ext75$1
+        (get_local $9)
+        (set_local $9
           (i32.const 0)
         )
       )
     )
     (if
       (i32.ne
-        (get_local $$rem)
+        (get_local $4)
         (i32.const 0)
       )
       (block
         (i32.store
-          (get_local $$rem)
+          (get_local $4)
           (i32.or
             (i32.const 0)
-            (get_local $$r_sroa_0_1_lcssa)
+            (get_local $2)
           )
         )
         (i32.store offset=4
-          (get_local $$rem)
-          (get_local $$r_sroa_1_1_lcssa)
+          (get_local $4)
+          (get_local $3)
         )
       )
     )
@@ -21720,37 +20307,37 @@
             (i32.shr_u
               (i32.or
                 (i32.const 0)
-                (get_local $$q_sroa_0_0_insert_ext75$0)
+                (get_local $7)
               )
               (i32.const 31)
             )
             (i32.shl
-              (get_local $$q_sroa_0_0_insert_insert77$1)
+              (get_local $6)
               (i32.const 1)
             )
           )
           (i32.and
             (i32.or
               (i32.shl
-                (get_local $$q_sroa_0_0_insert_ext75$1)
+                (get_local $9)
                 (i32.const 1)
               )
               (i32.shr_u
-                (get_local $$q_sroa_0_0_insert_ext75$0)
+                (get_local $7)
                 (i32.const 31)
               )
             )
             (i32.const 0)
           )
         )
-        (get_local $$carry_0_lcssa$1)
+        (get_local $1)
       )
     )
     (i32.or
       (i32.and
         (i32.or
           (i32.shl
-            (get_local $$q_sroa_0_0_insert_ext75$0)
+            (get_local $7)
             (i32.const 1)
           )
           (i32.shr_u
@@ -21760,60 +20347,60 @@
         )
         (i32.const -2)
       )
-      (get_local $$carry_0_lcssa$0)
+      (get_local $0)
     )
   )
-  (func $dynCall_ii (param $index i32) (param $a1 i32) (result i32)
+  (func $dynCall_ii (param $0 i32) (param $1 i32) (result i32)
     (call_indirect $FUNCSIG$ii
       (i32.add
         (i32.and
-          (get_local $index)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 0)
       )
-      (get_local $a1)
+      (get_local $1)
     )
   )
-  (func $dynCall_iiii (param $index i32) (param $a1 i32) (param $a2 i32) (param $a3 i32) (result i32)
+  (func $dynCall_iiii (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call_indirect $FUNCSIG$iiii
       (i32.add
         (i32.and
-          (get_local $index)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 2)
       )
-      (get_local $a1)
-      (get_local $a2)
-      (get_local $a3)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
     )
   )
-  (func $dynCall_vi (param $index i32) (param $a1 i32)
+  (func $dynCall_vi (param $0 i32) (param $1 i32)
     (call_indirect $FUNCSIG$vi
       (i32.add
         (i32.and
-          (get_local $index)
+          (get_local $0)
           (i32.const 7)
         )
         (i32.const 10)
       )
-      (get_local $a1)
+      (get_local $1)
     )
   )
-  (func $b0 (param $p0 i32) (result i32)
+  (func $b0 (param $0 i32) (result i32)
     (call_import $nullFunc_ii
       (i32.const 0)
     )
     (i32.const 0)
   )
-  (func $b1 (param $p0 i32) (param $p1 i32) (param $p2 i32) (result i32)
+  (func $b1 (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (call_import $nullFunc_iiii
       (i32.const 1)
     )
     (i32.const 0)
   )
-  (func $b2 (param $p0 i32)
+  (func $b2 (param $0 i32)
     (call_import $nullFunc_vi
       (i32.const 2)
     )

--- a/test/example/relooper-fuzz.txt
+++ b/test/example/relooper-fuzz.txt
@@ -158,33 +158,29 @@
     (if
       (i32.eq
         (i32.rem_u
-          (set_local $0
-            (call $check)
-          )
+          (call $check)
           (i32.const 2)
         )
         (i32.const 0)
       )
-      (set_local $1
+      (set_local $0
         (i32.const 6)
       )
       (block
         (call_import $print
           (i32.const 8)
         )
-        (set_local $0
-          (call $check)
-        )
+        (call $check)
       )
     )
     (loop $shape$3$break $shape$3$continue
       (if
         (i32.eq
-          (get_local $1)
+          (get_local $0)
           (i32.const 6)
         )
         (block
-          (set_local $1
+          (set_local $0
             (i32.const 0)
           )
           (call_import $print
@@ -193,16 +189,14 @@
           (if
             (i32.eq
               (i32.rem_u
-                (set_local $0
-                  (call $check)
-                )
+                (call $check)
                 (i32.const 2)
               )
               (i32.const 0)
             )
             (br $shape$3$continue)
             (block
-              (set_local $1
+              (set_local $0
                 (i32.const 6)
               )
               (br $shape$3$continue)
@@ -216,7 +210,7 @@
       (if
         (i32.eq
           (i32.rem_u
-            (set_local $0
+            (set_local $1
               (call $check)
             )
             (i32.const 3)
@@ -227,13 +221,13 @@
         (if
           (i32.eq
             (i32.rem_u
-              (get_local $0)
+              (get_local $1)
               (i32.const 3)
             )
             (i32.const 1)
           )
           (block
-            (set_local $1
+            (set_local $0
               (i32.const 6)
             )
             (br $shape$3$continue)
@@ -243,10 +237,8 @@
       (call_import $print
         (i32.const 2)
       )
+      (call $check)
       (set_local $0
-        (call $check)
-      )
-      (set_local $1
         (i32.const 6)
       )
       (br $shape$3$continue)

--- a/test/hello_world.fromasm
+++ b/test/hello_world.fromasm
@@ -2,10 +2,10 @@
   (memory 256 256)
   (export "memory" memory)
   (export "add" $add)
-  (func $add (param $x i32) (param $y i32) (result i32)
+  (func $add (param $0 i32) (param $1 i32) (result i32)
     (i32.add
-      (get_local $x)
-      (get_local $y)
+      (get_local $0)
+      (get_local $1)
     )
   )
 )

--- a/test/hello_world.fromasm.imprecise
+++ b/test/hello_world.fromasm.imprecise
@@ -2,10 +2,10 @@
   (memory 256 256)
   (export "memory" memory)
   (export "add" $add)
-  (func $add (param $x i32) (param $y i32) (result i32)
+  (func $add (param $0 i32) (param $1 i32) (result i32)
     (i32.add
-      (get_local $x)
-      (get_local $y)
+      (get_local $0)
+      (get_local $1)
     )
   )
 )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -40,99 +40,63 @@
   (export "dynCall_vi" $mb)
   (export "__growWasmMemory" $__growWasmMemory)
   (table $nb $Oa $ob $Va $Ua $Ra $pb $Sa)
-  (func $eb (param $a i32) (result i32)
-    (local $ka i32)
-    (local $e i32)
-    (local $s i32)
-    (local $ma i32)
-    (local $i i32)
-    (local $q i32)
-    (local $V i32)
-    (local $ja i32)
-    (local $aa i32)
-    (local $d i32)
-    (local $c i32)
-    (local $g i32)
-    (local $f i32)
-    (local $la i32)
-    (local $N i32)
-    (local $t i32)
-    (local $o i32)
-    (local $ca i32)
-    (local $U i32)
-    (local $ga i32)
-    (local $$ i32)
-    (local $ea i32)
-    (local $y i32)
-    (local $j i32)
-    (local $A i32)
-    (local $ha i32)
-    (local $u i32)
-    (local $da i32)
-    (local $ba i32)
-    (local $W i32)
-    (local $n i32)
-    (local $C i32)
-    (local $fa i32)
-    (local $ya i32)
-    (local $b i32)
-    (local $ia i32)
-    (local $l i32)
-    (local $Ea i32)
-    (local $P i32)
-    (local $m i32)
-    (local $z i32)
-    (local $D i32)
-    (local $X i32)
-    (local $za i32)
-    (local $O i32)
-    (local $wa i32)
-    (local $Pa i32)
-    (local $B i32)
-    (local $E i32)
-    (local $M i32)
-    (local $Q i32)
-    (local $Y i32)
-    (local $sa i32)
-    (local $Aa i32)
-    (local $Ha i32)
-    (local $Oa i32)
-    (local $v i32)
-    (local $x i32)
-    (local $I i32)
-    (local $J i32)
-    (local $K i32)
-    (local $L i32)
-    (local $R i32)
-    (local $S i32)
-    (local $Ga i32)
-    (local $Ia i32)
-    (local $Na i32)
-    (local $h i32)
-    (local $w i32)
-    (local $G i32)
-    (local $H i32)
-    (local $_ i32)
-    (local $va i32)
-    (local $xa i32)
-    (local $Ca i32)
-    (local $Fa i32)
-    (local $Ja i32)
-    (local $La i32)
-    (local $Ma i32)
-    (local $Ra i32)
-    (local $F i32)
-    (local $T i32)
-    (local $Z i32)
-    (local $na i32)
-    (local $oa i32)
-    (local $pa i32)
-    (local $ra i32)
-    (local $ua i32)
-    (local $Ba i32)
-    (local $Ka i32)
-    (local $Sa i32)
-    (set_local $b
+  (func $eb (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 i32)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
+    (local $47 i32)
+    (local $48 i32)
+    (local $49 i32)
+    (local $50 i32)
+    (local $51 i32)
+    (local $52 i32)
+    (local $53 i32)
+    (local $54 i32)
+    (local $55 i32)
+    (set_local $25
       (i32.load
         (i32.const 8)
       )
@@ -146,39 +110,39 @@
         (i32.const 16)
       )
     )
-    (set_local $c
-      (get_local $b)
+    (set_local $4
+      (get_local $25)
     )
     (block $do-once$0
       (if
         (i32.lt_u
-          (get_local $a)
+          (get_local $0)
           (i32.const 245)
         )
         (block
           (if
             (i32.and
-              (set_local $g
+              (set_local $6
                 (i32.shr_u
-                  (set_local $f
+                  (set_local $2
                     (i32.load
                       (i32.const 1208)
                     )
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.shr_u
-                      (set_local $d
+                      (set_local $0
                         (select
                           (i32.const 16)
                           (i32.and
                             (i32.add
-                              (get_local $a)
+                              (get_local $0)
                               (i32.const 11)
                             )
                             (i32.const -8)
                           )
                           (i32.lt_u
-                            (get_local $a)
+                            (get_local $0)
                             (i32.const 11)
                           )
                         )
@@ -191,29 +155,29 @@
               (i32.const 3)
             )
             (block
-              (set_local $n
+              (set_local $4
                 (i32.load
-                  (set_local $m
+                  (set_local $13
                     (i32.add
-                      (set_local $l
+                      (set_local $6
                         (i32.load
-                          (set_local $j
+                          (set_local $14
                             (i32.add
-                              (set_local $i
+                              (set_local $1
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $h
+                                      (set_local $0
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $g)
+                                              (get_local $6)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $e)
+                                          (get_local $3)
                                         )
                                       )
                                       (i32.const 1)
@@ -234,17 +198,17 @@
               )
               (if
                 (i32.eq
-                  (get_local $i)
-                  (get_local $n)
+                  (get_local $1)
+                  (get_local $4)
                 )
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $f)
+                    (get_local $2)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $h)
+                        (get_local $0)
                       )
                       (i32.const -1)
                     )
@@ -253,7 +217,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $n)
+                      (get_local $4)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -263,23 +227,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $o
+                        (set_local $8
                           (i32.add
-                            (get_local $n)
+                            (get_local $4)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $l)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
-                        (get_local $o)
-                        (get_local $i)
+                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.store
-                        (get_local $j)
-                        (get_local $n)
+                        (get_local $14)
+                        (get_local $4)
                       )
                     )
                     (call_import $qa)
@@ -287,11 +251,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $l)
+                (get_local $6)
                 (i32.or
-                  (set_local $n
+                  (set_local $4
                     (i32.shl
-                      (get_local $h)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -299,35 +263,35 @@
                 )
               )
               (i32.store
-                (set_local $j
+                (set_local $14
                   (i32.add
                     (i32.add
-                      (get_local $l)
-                      (get_local $n)
+                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $j)
+                    (get_local $14)
                   )
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.const 8)
-                (get_local $b)
+                (get_local $25)
               )
               (return
-                (get_local $m)
+                (get_local $13)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $d)
-              (set_local $j
+              (get_local $0)
+              (set_local $14
                 (i32.load
                   (i32.const 1216)
                 )
@@ -335,37 +299,37 @@
             )
             (block
               (if
-                (get_local $g)
+                (get_local $6)
                 (block
-                  (set_local $i
+                  (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (set_local $n
+                        (set_local $4
                           (i32.add
                             (i32.and
-                              (set_local $i
+                              (set_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $g)
-                                    (get_local $e)
+                                    (get_local $6)
+                                    (get_local $3)
                                   )
                                   (i32.or
-                                    (set_local $n
+                                    (set_local $4
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $e)
+                                        (get_local $3)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $n)
+                                      (get_local $4)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -376,32 +340,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $i
+                  (set_local $1
                     (i32.load
-                      (set_local $o
+                      (set_local $8
                         (i32.add
-                          (set_local $q
+                          (set_local $9
                             (i32.load
-                              (set_local $t
+                              (set_local $13
                                 (i32.add
-                                  (set_local $s
+                                  (set_local $7
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $u
+                                          (set_local $20
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $n
+                                                      (set_local $4
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $o
+                                                            (set_local $8
                                                               (i32.shr_u
-                                                                (get_local $n)
-                                                                (get_local $i)
+                                                                (get_local $4)
+                                                                (get_local $1)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -409,15 +373,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $i)
+                                                      (get_local $1)
                                                     )
-                                                    (set_local $o
+                                                    (set_local $8
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $q
+                                                          (set_local $9
                                                             (i32.shr_u
-                                                              (get_local $o)
-                                                              (get_local $n)
+                                                              (get_local $8)
+                                                              (get_local $4)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -426,13 +390,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $q
+                                                  (set_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $s
+                                                        (set_local $7
                                                           (i32.shr_u
-                                                            (get_local $q)
-                                                            (get_local $o)
+                                                            (get_local $9)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -441,13 +405,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $s
+                                                (set_local $7
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $t
+                                                      (set_local $13
                                                         (i32.shr_u
-                                                          (get_local $s)
-                                                          (get_local $q)
+                                                          (get_local $7)
+                                                          (get_local $9)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -457,8 +421,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $t)
-                                                (get_local $s)
+                                                (get_local $13)
+                                                (get_local $7)
                                               )
                                             )
                                           )
@@ -480,31 +444,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $s)
-                      (get_local $i)
+                      (get_local $7)
+                      (get_local $1)
                     )
                     (block
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $f)
+                          (get_local $2)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $u)
+                              (get_local $20)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $v
-                        (get_local $j)
+                      (set_local $33
+                        (get_local $14)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $i)
+                          (get_local $1)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -514,25 +478,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $n
+                            (set_local $4
                               (i32.add
-                                (get_local $i)
+                                (get_local $1)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $q)
+                          (get_local $9)
                         )
                         (block
                           (i32.store
-                            (get_local $n)
-                            (get_local $s)
+                            (get_local $4)
+                            (get_local $7)
                           )
                           (i32.store
-                            (get_local $t)
-                            (get_local $i)
+                            (get_local $13)
+                            (get_local $1)
                           )
-                          (set_local $v
+                          (set_local $33
                             (i32.load
                               (i32.const 1216)
                             )
@@ -543,27 +507,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $q)
+                    (get_local $9)
                     (i32.or
-                      (get_local $d)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $t
+                    (set_local $13
                       (i32.add
-                        (get_local $q)
-                        (get_local $d)
+                        (get_local $9)
+                        (get_local $0)
                       )
                     )
                     (i32.or
-                      (set_local $i
+                      (set_local $1
                         (i32.sub
                           (i32.shl
-                            (get_local $u)
+                            (get_local $20)
                             (i32.const 3)
                           )
-                          (get_local $d)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
@@ -571,27 +535,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $t)
-                      (get_local $i)
+                      (get_local $13)
+                      (get_local $1)
                     )
-                    (get_local $i)
+                    (get_local $1)
                   )
                   (if
-                    (get_local $v)
+                    (get_local $33)
                     (block
-                      (set_local $s
+                      (set_local $7
                         (i32.load
                           (i32.const 1228)
                         )
                       )
-                      (set_local $f
+                      (set_local $2
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (set_local $j
+                              (set_local $14
                                 (i32.shr_u
-                                  (get_local $v)
+                                  (get_local $33)
                                   (i32.const 3)
                                 )
                               )
@@ -603,25 +567,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $e
+                          (set_local $3
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $g
+                          (set_local $6
                             (i32.shl
                               (i32.const 1)
-                              (get_local $j)
+                              (get_local $14)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $e
+                            (set_local $3
                               (i32.load
-                                (set_local $g
+                                (set_local $6
                                   (i32.add
-                                    (get_local $f)
+                                    (get_local $2)
                                     (i32.const 8)
                                   )
                                 )
@@ -633,11 +597,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $w
-                              (get_local $g)
+                            (set_local $41
+                              (get_local $6)
                             )
-                            (set_local $x
-                              (get_local $e)
+                            (set_local $34
+                              (get_local $3)
                             )
                           )
                         )
@@ -645,73 +609,73 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $e)
-                              (get_local $g)
+                              (get_local $3)
+                              (get_local $6)
                             )
                           )
-                          (set_local $w
+                          (set_local $41
                             (i32.add
-                              (get_local $f)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
-                          (set_local $x
-                            (get_local $f)
+                          (set_local $34
+                            (get_local $2)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $w)
-                        (get_local $s)
+                        (get_local $41)
+                        (get_local $7)
                       )
                       (i32.store offset=12
-                        (get_local $x)
-                        (get_local $s)
+                        (get_local $34)
+                        (get_local $7)
                       )
                       (i32.store offset=8
-                        (get_local $s)
-                        (get_local $x)
+                        (get_local $7)
+                        (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $s)
-                        (get_local $f)
+                        (get_local $7)
+                        (get_local $2)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $i)
+                    (get_local $1)
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $t)
+                    (get_local $13)
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $b)
+                    (get_local $25)
                   )
                   (return
-                    (get_local $o)
+                    (get_local $8)
                   )
                 )
               )
               (if
-                (set_local $t
+                (set_local $13
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $t
+                  (set_local $13
                     (i32.and
                       (i32.shr_u
-                        (set_local $i
+                        (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $t)
+                              (get_local $13)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $t)
+                                (get_local $13)
                               )
                             )
                             (i32.const -1)
@@ -722,11 +686,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $j
+                          (set_local $14
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -735,13 +699,13 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (set_local $i
+                                            (set_local $1
                                               (i32.and
                                                 (i32.shr_u
-                                                  (set_local $f
+                                                  (set_local $2
                                                     (i32.shr_u
-                                                      (get_local $i)
-                                                      (get_local $t)
+                                                      (get_local $1)
+                                                      (get_local $13)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -749,15 +713,15 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $t)
+                                            (get_local $13)
                                           )
-                                          (set_local $f
+                                          (set_local $2
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $s
+                                                (set_local $7
                                                   (i32.shr_u
-                                                    (get_local $f)
-                                                    (get_local $i)
+                                                    (get_local $2)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -766,13 +730,13 @@
                                             )
                                           )
                                         )
-                                        (set_local $s
+                                        (set_local $7
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $e
+                                              (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $s)
-                                                  (get_local $f)
+                                                  (get_local $7)
+                                                  (get_local $2)
                                                 )
                                               )
                                               (i32.const 1)
@@ -781,13 +745,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $e
+                                      (set_local $3
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $g
+                                            (set_local $6
                                               (i32.shr_u
-                                                (get_local $e)
-                                                (get_local $s)
+                                                (get_local $3)
+                                                (get_local $7)
                                               )
                                             )
                                             (i32.const 1)
@@ -797,8 +761,8 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $g)
-                                      (get_local $e)
+                                      (get_local $6)
+                                      (get_local $3)
                                     )
                                   )
                                   (i32.const 2)
@@ -810,84 +774,84 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $d)
+                      (get_local $0)
                     )
                   )
-                  (set_local $g
-                    (get_local $j)
+                  (set_local $6
+                    (get_local $14)
                   )
-                  (set_local $s
-                    (get_local $j)
+                  (set_local $7
+                    (get_local $14)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $j
+                      (set_local $14
                         (i32.load offset=16
-                          (get_local $g)
+                          (get_local $6)
                         )
                       )
-                      (set_local $B
-                        (get_local $j)
+                      (set_local $4
+                        (get_local $14)
                       )
                       (if
-                        (set_local $f
+                        (set_local $2
                           (i32.load offset=20
-                            (get_local $g)
+                            (get_local $6)
                           )
                         )
-                        (set_local $B
-                          (get_local $f)
+                        (set_local $4
+                          (get_local $2)
                         )
                         (block
-                          (set_local $z
-                            (get_local $e)
+                          (set_local $4
+                            (get_local $3)
                           )
-                          (set_local $A
-                            (get_local $s)
+                          (set_local $1
+                            (get_local $7)
                           )
                           (br $while-out$6)
                         )
                       )
                     )
-                    (set_local $f
+                    (set_local $2
                       (i32.lt_u
-                        (set_local $j
+                        (set_local $14
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $B)
+                                (get_local $4)
                               )
                               (i32.const -8)
                             )
-                            (get_local $d)
+                            (get_local $0)
                           )
                         )
-                        (get_local $e)
+                        (get_local $3)
                       )
                     )
-                    (set_local $e
+                    (set_local $3
                       (select
-                        (get_local $j)
-                        (get_local $e)
-                        (get_local $f)
+                        (get_local $14)
+                        (get_local $3)
+                        (get_local $2)
                       )
                     )
-                    (set_local $g
-                      (get_local $B)
+                    (set_local $6
+                      (get_local $4)
                     )
-                    (set_local $s
+                    (set_local $7
                       (select
-                        (get_local $B)
-                        (get_local $s)
-                        (get_local $f)
+                        (get_local $4)
+                        (get_local $7)
+                        (get_local $2)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $A)
-                      (set_local $s
+                      (get_local $1)
+                      (set_local $7
                         (i32.load
                           (i32.const 1224)
                         )
@@ -897,72 +861,68 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $A)
-                      (set_local $g
+                      (get_local $1)
+                      (set_local $6
                         (i32.add
-                          (get_local $A)
-                          (get_local $d)
+                          (get_local $1)
+                          (get_local $0)
                         )
                       )
                     )
                     (call_import $qa)
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.load offset=24
-                      (get_local $A)
+                      (get_local $1)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $o
+                        (set_local $8
                           (i32.load offset=12
-                            (get_local $A)
+                            (get_local $1)
                           )
                         )
-                        (get_local $A)
+                        (get_local $1)
                       )
                       (block
                         (if
-                          (set_local $u
+                          (set_local $20
                             (i32.load
-                              (set_local $q
+                              (set_local $9
                                 (i32.add
-                                  (get_local $A)
+                                  (get_local $1)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $D
-                              (get_local $u)
+                            (set_local $14
+                              (get_local $20)
                             )
-                            (set_local $E
-                              (get_local $q)
+                            (set_local $2
+                              (get_local $9)
                             )
                           )
                           (if
-                            (set_local $j
+                            (set_local $14
                               (i32.load
-                                (set_local $f
+                                (set_local $2
                                   (i32.add
-                                    (get_local $A)
+                                    (get_local $1)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $D
-                                (get_local $j)
-                              )
-                              (set_local $E
-                                (get_local $f)
-                              )
+                              (get_local $14)
+                              (get_local $2)
                             )
                             (block
-                              (set_local $C
+                              (set_local $23
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -971,52 +931,48 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $u
+                            (set_local $20
                               (i32.load
-                                (set_local $q
+                                (set_local $9
                                   (i32.add
-                                    (get_local $D)
+                                    (get_local $14)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $D
-                                (get_local $u)
+                              (set_local $14
+                                (get_local $20)
                               )
-                              (set_local $E
-                                (get_local $q)
+                              (set_local $2
+                                (get_local $9)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
-                            (set_local $u
+                            (set_local $20
                               (i32.load
-                                (set_local $q
+                                (set_local $9
                                   (i32.add
-                                    (get_local $D)
+                                    (get_local $14)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $D
-                                (get_local $u)
+                              (set_local $14
+                                (get_local $20)
                               )
-                              (set_local $E
-                                (get_local $q)
+                              (set_local $2
+                                (get_local $9)
                               )
                             )
                             (block
-                              (set_local $F
-                                (get_local $D)
-                              )
-                              (set_local $G
-                                (get_local $E)
-                              )
+                              (get_local $14)
+                              (get_local $2)
                               (br $while-out$10)
                             )
                           )
@@ -1024,17 +980,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $G)
-                            (get_local $s)
+                            (get_local $2)
+                            (get_local $7)
                           )
                           (call_import $qa)
                           (block
                             (i32.store
-                              (get_local $G)
+                              (get_local $2)
                               (i32.const 0)
                             )
-                            (set_local $C
-                              (get_local $F)
+                            (set_local $23
+                              (get_local $14)
                             )
                           )
                         )
@@ -1042,52 +998,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $q
+                            (set_local $9
                               (i32.load offset=8
-                                (get_local $A)
+                                (get_local $1)
                               )
                             )
-                            (get_local $s)
+                            (get_local $7)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $u
+                              (set_local $20
                                 (i32.add
-                                  (get_local $q)
+                                  (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $A)
+                            (get_local $1)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $f
+                              (set_local $2
                                 (i32.add
-                                  (get_local $o)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $A)
+                            (get_local $1)
                           )
                           (block
                             (i32.store
-                              (get_local $u)
-                              (get_local $o)
+                              (get_local $20)
+                              (get_local $8)
                             )
                             (i32.store
-                              (get_local $f)
-                              (get_local $q)
+                              (get_local $2)
+                              (get_local $9)
                             )
-                            (set_local $C
-                              (get_local $o)
+                            (set_local $23
+                              (get_local $8)
                             )
                           )
                           (call_import $qa)
@@ -1097,19 +1053,19 @@
                   )
                   (block $do-once$12
                     (if
-                      (get_local $e)
+                      (get_local $3)
                       (block
                         (if
                           (i32.eq
-                            (get_local $A)
+                            (get_local $1)
                             (i32.load
-                              (set_local $s
+                              (set_local $7
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (set_local $o
+                                    (set_local $8
                                       (i32.load offset=28
-                                        (get_local $A)
+                                        (get_local $1)
                                       )
                                     )
                                     (i32.const 2)
@@ -1120,12 +1076,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $s)
-                              (get_local $C)
+                              (get_local $7)
+                              (get_local $23)
                             )
                             (if
                               (i32.eqz
-                                (get_local $C)
+                                (get_local $23)
                               )
                               (block
                                 (i32.store
@@ -1137,7 +1093,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $o)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1150,7 +1106,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $e)
+                                (get_local $3)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1160,35 +1116,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $o
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $e)
+                                      (get_local $3)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $A)
+                                (get_local $1)
                               )
                               (i32.store
-                                (get_local $o)
-                                (get_local $C)
+                                (get_local $8)
+                                (get_local $23)
                               )
                               (i32.store offset=20
-                                (get_local $e)
-                                (get_local $C)
+                                (get_local $3)
+                                (get_local $23)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eqz
-                                (get_local $C)
+                                (get_local $23)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $C)
-                            (set_local $o
+                            (get_local $23)
+                            (set_local $8
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1197,42 +1153,42 @@
                           (call_import $qa)
                         )
                         (i32.store offset=24
-                          (get_local $C)
-                          (get_local $e)
+                          (get_local $23)
+                          (get_local $3)
                         )
                         (if
-                          (set_local $s
+                          (set_local $7
                             (i32.load offset=16
-                              (get_local $A)
+                              (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $s)
-                              (get_local $o)
+                              (get_local $7)
+                              (get_local $8)
                             )
                             (call_import $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $C)
-                                (get_local $s)
+                                (get_local $23)
+                                (get_local $7)
                               )
                               (i32.store offset=24
-                                (get_local $s)
-                                (get_local $C)
+                                (get_local $7)
+                                (get_local $23)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $s
+                          (set_local $7
                             (i32.load offset=20
-                              (get_local $A)
+                              (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $s)
+                              (get_local $7)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1240,12 +1196,12 @@
                             (call_import $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $C)
-                                (get_local $s)
+                                (get_local $23)
+                                (get_local $7)
                               )
                               (i32.store offset=24
-                                (get_local $s)
-                                (get_local $C)
+                                (get_local $7)
+                                (get_local $23)
                               )
                             )
                           )
@@ -1255,35 +1211,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $z)
+                      (get_local $4)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $A)
+                        (get_local $1)
                         (i32.or
-                          (set_local $e
+                          (set_local $3
                             (i32.add
-                              (get_local $z)
-                              (get_local $d)
+                              (get_local $4)
+                              (get_local $0)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (set_local $s
+                        (set_local $7
                           (i32.add
                             (i32.add
-                              (get_local $A)
-                              (get_local $e)
+                              (get_local $1)
+                              (get_local $3)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $s)
+                            (get_local $7)
                           )
                           (i32.const 1)
                         )
@@ -1291,46 +1247,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $A)
+                        (get_local $1)
                         (i32.or
-                          (get_local $d)
+                          (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $g)
+                        (get_local $6)
                         (i32.or
-                          (get_local $z)
+                          (get_local $4)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $g)
-                          (get_local $z)
+                          (get_local $6)
+                          (get_local $4)
                         )
-                        (get_local $z)
+                        (get_local $4)
                       )
                       (if
-                        (set_local $s
+                        (set_local $7
                           (i32.load
                             (i32.const 1216)
                           )
                         )
                         (block
-                          (set_local $e
+                          (set_local $3
                             (i32.load
                               (i32.const 1228)
                             )
                           )
-                          (set_local $s
+                          (set_local $7
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $o
+                                  (set_local $8
                                     (i32.shr_u
-                                      (get_local $s)
+                                      (get_local $7)
                                       (i32.const 3)
                                     )
                                   )
@@ -1342,25 +1298,25 @@
                           )
                           (if
                             (i32.and
-                              (set_local $q
+                              (set_local $9
                                 (i32.load
                                   (i32.const 1208)
                                 )
                               )
-                              (set_local $f
+                              (set_local $2
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $o)
+                                  (get_local $8)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $q
+                                (set_local $9
                                   (i32.load
-                                    (set_local $f
+                                    (set_local $2
                                       (i32.add
-                                        (get_local $s)
+                                        (get_local $7)
                                         (i32.const 8)
                                       )
                                     )
@@ -1372,11 +1328,11 @@
                               )
                               (call_import $qa)
                               (block
-                                (set_local $H
-                                  (get_local $f)
+                                (set_local $42
+                                  (get_local $2)
                                 )
-                                (set_local $I
-                                  (get_local $q)
+                                (set_local $35
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -1384,84 +1340,80 @@
                               (i32.store
                                 (i32.const 1208)
                                 (i32.or
-                                  (get_local $q)
-                                  (get_local $f)
+                                  (get_local $9)
+                                  (get_local $2)
                                 )
                               )
-                              (set_local $H
+                              (set_local $42
                                 (i32.add
-                                  (get_local $s)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $I
-                                (get_local $s)
+                              (set_local $35
+                                (get_local $7)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $H)
-                            (get_local $e)
+                            (get_local $42)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $I)
-                            (get_local $e)
+                            (get_local $35)
+                            (get_local $3)
                           )
                           (i32.store offset=8
-                            (get_local $e)
-                            (get_local $I)
+                            (get_local $3)
+                            (get_local $35)
                           )
                           (i32.store offset=12
-                            (get_local $e)
-                            (get_local $s)
+                            (get_local $3)
+                            (get_local $7)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $z)
+                        (get_local $4)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $g)
+                        (get_local $6)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $b)
+                    (get_local $25)
                   )
                   (return
                     (i32.add
-                      (get_local $A)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
                 )
-                (set_local $y
-                  (get_local $d)
-                )
+                (get_local $0)
               )
             )
-            (set_local $y
-              (get_local $d)
-            )
+            (get_local $0)
           )
         )
         (if
           (i32.gt_u
-            (get_local $a)
+            (get_local $0)
             (i32.const -65)
           )
-          (set_local $y
+          (set_local $0
             (i32.const -1)
           )
           (block
-            (set_local $e
+            (set_local $3
               (i32.and
-                (set_local $s
+                (set_local $7
                   (i32.add
-                    (get_local $a)
+                    (get_local $0)
                     (i32.const 11)
                   )
                 )
@@ -1469,61 +1421,61 @@
               )
             )
             (if
-              (set_local $q
+              (set_local $9
                 (i32.load
                   (i32.const 1212)
                 )
               )
               (block
-                (set_local $f
+                (set_local $2
                   (i32.sub
                     (i32.const 0)
-                    (get_local $e)
+                    (get_local $3)
                   )
                 )
                 (block $label$break$a
                   (if
-                    (set_local $t
+                    (set_local $13
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (set_local $J
+                            (set_local $0
                               (if
-                                (set_local $o
+                                (set_local $8
                                   (i32.shr_u
-                                    (get_local $s)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
                                 (if
                                   (i32.gt_u
-                                    (get_local $e)
+                                    (get_local $3)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $e)
+                                        (get_local $3)
                                         (i32.add
-                                          (set_local $t
+                                          (set_local $13
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (set_local $o
+                                                    (set_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $u
+                                                            (set_local $20
                                                               (i32.shl
-                                                                (get_local $o)
-                                                                (set_local $s
+                                                                (get_local $8)
+                                                                (set_local $7
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $o)
+                                                                        (get_local $8)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1540,16 +1492,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $s)
+                                                    (get_local $7)
                                                   )
-                                                  (set_local $u
+                                                  (set_local $20
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $j
+                                                          (set_local $14
                                                             (i32.shl
-                                                              (get_local $u)
-                                                              (get_local $o)
+                                                              (get_local $20)
+                                                              (get_local $8)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1563,8 +1515,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $j)
-                                                  (get_local $u)
+                                                  (get_local $14)
+                                                  (get_local $20)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1576,7 +1528,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $t)
+                                      (get_local $13)
                                       (i32.const 1)
                                     )
                                   )
@@ -1591,118 +1543,116 @@
                       )
                     )
                     (block
-                      (set_local $u
-                        (get_local $f)
+                      (set_local $20
+                        (get_local $2)
                       )
-                      (set_local $j
+                      (set_local $14
                         (i32.const 0)
                       )
-                      (set_local $s
+                      (set_local $7
                         (i32.shl
-                          (get_local $e)
+                          (get_local $3)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $J)
+                                (get_local $0)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $J)
+                              (get_local $0)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $o
-                        (get_local $t)
+                      (set_local $8
+                        (get_local $13)
                       )
-                      (set_local $i
+                      (set_local $1
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $l
+                            (set_local $6
                               (i32.sub
-                                (set_local $m
+                                (set_local $13
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $o)
+                                      (get_local $8)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $e)
+                                (get_local $3)
                               )
                             )
-                            (get_local $u)
+                            (get_local $20)
                           )
                           (if
                             (i32.eq
-                              (get_local $m)
-                              (get_local $e)
+                              (get_local $13)
+                              (get_local $3)
                             )
                             (block
-                              (set_local $O
-                                (get_local $l)
+                              (set_local $28
+                                (get_local $6)
                               )
-                              (set_local $P
-                                (get_local $o)
+                              (set_local $27
+                                (get_local $8)
                               )
-                              (set_local $Q
-                                (get_local $o)
+                              (set_local $32
+                                (get_local $8)
                               )
-                              (set_local $N
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $R
-                                (get_local $l)
+                              (set_local $2
+                                (get_local $6)
                               )
-                              (set_local $S
-                                (get_local $o)
+                              (set_local $1
+                                (get_local $8)
                               )
                             )
                           )
                           (block
-                            (set_local $R
-                              (get_local $u)
+                            (set_local $2
+                              (get_local $20)
                             )
-                            (set_local $S
-                              (get_local $i)
-                            )
+                            (get_local $1)
                           )
                         )
-                        (set_local $m
+                        (set_local $13
                           (select
-                            (get_local $j)
-                            (set_local $l
+                            (get_local $14)
+                            (set_local $6
                               (i32.load offset=20
-                                (get_local $o)
+                                (get_local $8)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $l)
+                                (get_local $6)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $l)
-                                (set_local $o
+                                (get_local $6)
+                                (set_local $8
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $o)
+                                        (get_local $8)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $s)
+                                          (get_local $7)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1715,65 +1665,63 @@
                           )
                         )
                         (if
-                          (set_local $l
+                          (set_local $6
                             (i32.eq
-                              (get_local $o)
+                              (get_local $8)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $K
-                              (get_local $R)
+                            (set_local $36
+                              (get_local $2)
                             )
-                            (set_local $L
-                              (get_local $m)
+                            (set_local $37
+                              (get_local $13)
                             )
-                            (set_local $M
-                              (get_local $S)
+                            (set_local $31
+                              (get_local $1)
                             )
-                            (set_local $N
+                            (set_local $8
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $u
-                              (get_local $R)
+                            (set_local $20
+                              (get_local $2)
                             )
-                            (set_local $j
-                              (get_local $m)
+                            (set_local $14
+                              (get_local $13)
                             )
-                            (set_local $s
+                            (set_local $7
                               (i32.shl
-                                (get_local $s)
+                                (get_local $7)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $l)
+                                    (get_local $6)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
                                 )
                               )
                             )
-                            (set_local $i
-                              (get_local $S)
-                            )
+                            (get_local $1)
                           )
                         )
                         (br $while-in$18)
                       )
                     )
                     (block
-                      (set_local $K
-                        (get_local $f)
+                      (set_local $36
+                        (get_local $2)
                       )
-                      (set_local $L
+                      (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $M
+                      (set_local $31
                         (i32.const 0)
                       )
-                      (set_local $N
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1781,60 +1729,60 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $N)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
-                    (set_local $T
+                    (set_local $0
                       (if
                         (i32.and
                           (i32.eq
-                            (get_local $L)
+                            (get_local $37)
                             (i32.const 0)
                           )
                           (i32.eq
-                            (get_local $M)
+                            (get_local $31)
                             (i32.const 0)
                           )
                         )
                         (block
                           (if
                             (i32.eqz
-                              (set_local $f
+                              (set_local $2
                                 (i32.and
-                                  (get_local $q)
+                                  (get_local $9)
                                   (i32.or
-                                    (set_local $t
+                                    (set_local $13
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $J)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $t)
+                                      (get_local $13)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $y
-                                (get_local $e)
+                              (set_local $0
+                                (get_local $3)
                               )
                               (br $do-once$0)
                             )
                           )
-                          (set_local $f
+                          (set_local $2
                             (i32.and
                               (i32.shr_u
-                                (set_local $t
+                                (set_local $13
                                   (i32.add
                                     (i32.and
-                                      (get_local $f)
+                                      (get_local $2)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $f)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.const -1)
@@ -1853,13 +1801,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $t
+                                          (set_local $13
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $d
+                                                (set_local $0
                                                   (i32.shr_u
-                                                    (get_local $t)
-                                                    (get_local $f)
+                                                    (get_local $13)
+                                                    (get_local $2)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1867,15 +1815,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $f)
+                                          (get_local $2)
                                         )
-                                        (set_local $d
+                                        (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $g
+                                              (set_local $6
                                                 (i32.shr_u
-                                                  (get_local $d)
-                                                  (get_local $t)
+                                                  (get_local $0)
+                                                  (get_local $13)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1884,13 +1832,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $g
+                                      (set_local $6
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $i
+                                            (set_local $1
                                               (i32.shr_u
-                                                (get_local $g)
-                                                (get_local $d)
+                                                (get_local $6)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -1899,13 +1847,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $i
+                                    (set_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $s
+                                          (set_local $7
                                             (i32.shr_u
-                                              (get_local $i)
-                                              (get_local $g)
+                                              (get_local $1)
+                                              (get_local $6)
                                             )
                                           )
                                           (i32.const 1)
@@ -1915,8 +1863,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $s)
-                                    (get_local $i)
+                                    (get_local $7)
+                                    (get_local $1)
                                   )
                                 )
                                 (i32.const 2)
@@ -1925,117 +1873,113 @@
                             )
                           )
                         )
-                        (get_local $L)
+                        (get_local $37)
                       )
                     )
                     (block
-                      (set_local $O
-                        (get_local $K)
+                      (set_local $28
+                        (get_local $36)
                       )
-                      (set_local $P
-                        (get_local $T)
+                      (set_local $27
+                        (get_local $0)
                       )
-                      (set_local $Q
-                        (get_local $M)
+                      (set_local $32
+                        (get_local $31)
                       )
-                      (set_local $N
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $U
-                        (get_local $K)
+                      (set_local $16
+                        (get_local $36)
                       )
-                      (set_local $V
-                        (get_local $M)
+                      (set_local $10
+                        (get_local $31)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $N)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $N
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $s
+                    (set_local $7
                       (i32.lt_u
-                        (set_local $i
+                        (set_local $1
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $P)
+                                (get_local $27)
                               )
                               (i32.const -8)
                             )
-                            (get_local $e)
+                            (get_local $3)
                           )
                         )
-                        (get_local $O)
+                        (get_local $28)
                       )
                     )
-                    (set_local $g
+                    (set_local $6
                       (select
-                        (get_local $i)
-                        (get_local $O)
-                        (get_local $s)
+                        (get_local $1)
+                        (get_local $28)
+                        (get_local $7)
                       )
                     )
-                    (set_local $i
+                    (set_local $1
                       (select
-                        (get_local $P)
-                        (get_local $Q)
-                        (get_local $s)
+                        (get_local $27)
+                        (get_local $32)
+                        (get_local $7)
                       )
                     )
                     (if
-                      (set_local $s
+                      (set_local $7
                         (i32.load offset=16
-                          (get_local $P)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $O
-                          (get_local $g)
+                        (set_local $28
+                          (get_local $6)
                         )
-                        (set_local $P
-                          (get_local $s)
+                        (set_local $27
+                          (get_local $7)
                         )
-                        (set_local $Q
-                          (get_local $i)
+                        (set_local $32
+                          (get_local $1)
                         )
-                        (set_local $N
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                         (br $while-in$20)
                       )
                     )
                     (if
-                      (set_local $P
+                      (set_local $27
                         (i32.load offset=20
-                          (get_local $P)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $O
-                          (get_local $g)
+                        (set_local $28
+                          (get_local $6)
                         )
-                        (set_local $Q
-                          (get_local $i)
+                        (set_local $32
+                          (get_local $1)
                         )
-                        (set_local $N
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                       )
                       (block
-                        (set_local $U
-                          (get_local $g)
+                        (set_local $16
+                          (get_local $6)
                         )
-                        (set_local $V
-                          (get_local $i)
+                        (set_local $10
+                          (get_local $1)
                         )
                         (br $while-out$19)
                       )
@@ -2044,22 +1988,22 @@
                   )
                 )
                 (if
-                  (get_local $V)
+                  (get_local $10)
                   (if
                     (i32.lt_u
-                      (get_local $U)
+                      (get_local $16)
                       (i32.sub
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $e)
+                        (get_local $3)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $V)
-                          (set_local $q
+                          (get_local $10)
+                          (set_local $9
                             (i32.load
                               (i32.const 1224)
                             )
@@ -2069,72 +2013,72 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $V)
-                          (set_local $i
+                          (get_local $10)
+                          (set_local $1
                             (i32.add
-                              (get_local $V)
-                              (get_local $e)
+                              (get_local $10)
+                              (get_local $3)
                             )
                           )
                         )
                         (call_import $qa)
                       )
-                      (set_local $g
+                      (set_local $6
                         (i32.load offset=24
-                          (get_local $V)
+                          (get_local $10)
                         )
                       )
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $s
+                            (set_local $7
                               (i32.load offset=12
-                                (get_local $V)
+                                (get_local $10)
                               )
                             )
-                            (get_local $V)
+                            (get_local $10)
                           )
                           (block
                             (if
-                              (set_local $f
+                              (set_local $2
                                 (i32.load
-                                  (set_local $d
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $V)
+                                      (get_local $10)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $X
-                                  (get_local $f)
+                                (set_local $4
+                                  (get_local $2)
                                 )
-                                (set_local $Y
-                                  (get_local $d)
+                                (set_local $14
+                                  (get_local $0)
                                 )
                               )
                               (if
-                                (set_local $j
+                                (set_local $14
                                   (i32.load
-                                    (set_local $t
+                                    (set_local $13
                                       (i32.add
-                                        (get_local $V)
+                                        (get_local $10)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $X
-                                    (get_local $j)
+                                  (set_local $4
+                                    (get_local $14)
                                   )
-                                  (set_local $Y
-                                    (get_local $t)
+                                  (set_local $14
+                                    (get_local $13)
                                   )
                                 )
                                 (block
-                                  (set_local $W
+                                  (set_local $22
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
@@ -2143,51 +2087,51 @@
                             )
                             (loop $while-out$23 $while-in$24
                               (if
-                                (set_local $f
+                                (set_local $2
                                   (i32.load
-                                    (set_local $d
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $X)
+                                        (get_local $4)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $X
-                                    (get_local $f)
+                                  (set_local $4
+                                    (get_local $2)
                                   )
-                                  (set_local $Y
-                                    (get_local $d)
+                                  (set_local $14
+                                    (get_local $0)
                                   )
                                   (br $while-in$24)
                                 )
                               )
                               (if
-                                (set_local $f
+                                (set_local $2
                                   (i32.load
-                                    (set_local $d
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $X)
+                                        (get_local $4)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $X
-                                    (get_local $f)
+                                  (set_local $4
+                                    (get_local $2)
                                   )
-                                  (set_local $Y
-                                    (get_local $d)
+                                  (set_local $14
+                                    (get_local $0)
                                   )
                                 )
                                 (block
-                                  (set_local $Z
-                                    (get_local $X)
+                                  (set_local $0
+                                    (get_local $4)
                                   )
-                                  (set_local $_
-                                    (get_local $Y)
+                                  (set_local $4
+                                    (get_local $14)
                                   )
                                   (br $while-out$23)
                                 )
@@ -2196,17 +2140,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $_)
-                                (get_local $q)
+                                (get_local $4)
+                                (get_local $9)
                               )
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $_)
+                                  (get_local $4)
                                   (i32.const 0)
                                 )
-                                (set_local $W
-                                  (get_local $Z)
+                                (set_local $22
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -2214,52 +2158,52 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $d
+                                (set_local $0
                                   (i32.load offset=8
-                                    (get_local $V)
+                                    (get_local $10)
                                   )
                                 )
-                                (get_local $q)
+                                (get_local $9)
                               )
                               (call_import $qa)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (set_local $f
+                                  (set_local $2
                                     (i32.add
-                                      (get_local $d)
+                                      (get_local $0)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $V)
+                                (get_local $10)
                               )
                               (call_import $qa)
                             )
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $t
+                                  (set_local $13
                                     (i32.add
-                                      (get_local $s)
+                                      (get_local $7)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $V)
+                                (get_local $10)
                               )
                               (block
                                 (i32.store
-                                  (get_local $f)
-                                  (get_local $s)
+                                  (get_local $2)
+                                  (get_local $7)
                                 )
                                 (i32.store
-                                  (get_local $t)
-                                  (get_local $d)
+                                  (get_local $13)
+                                  (get_local $0)
                                 )
-                                (set_local $W
-                                  (get_local $s)
+                                (set_local $22
+                                  (get_local $7)
                                 )
                               )
                               (call_import $qa)
@@ -2269,19 +2213,19 @@
                       )
                       (block $do-once$25
                         (if
-                          (get_local $g)
+                          (get_local $6)
                           (block
                             (if
                               (i32.eq
-                                (get_local $V)
+                                (get_local $10)
                                 (i32.load
-                                  (set_local $q
+                                  (set_local $9
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (set_local $s
+                                        (set_local $7
                                           (i32.load offset=28
-                                            (get_local $V)
+                                            (get_local $10)
                                           )
                                         )
                                         (i32.const 2)
@@ -2292,12 +2236,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $q)
-                                  (get_local $W)
+                                  (get_local $9)
+                                  (get_local $22)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $W)
+                                    (get_local $22)
                                   )
                                   (block
                                     (i32.store
@@ -2309,7 +2253,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $s)
+                                            (get_local $7)
                                           )
                                           (i32.const -1)
                                         )
@@ -2322,7 +2266,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $g)
+                                    (get_local $6)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2332,35 +2276,35 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $s
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $g)
+                                          (get_local $6)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $V)
+                                    (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $s)
-                                    (get_local $W)
+                                    (get_local $7)
+                                    (get_local $22)
                                   )
                                   (i32.store offset=20
-                                    (get_local $g)
-                                    (get_local $W)
+                                    (get_local $6)
+                                    (get_local $22)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eqz
-                                    (get_local $W)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $W)
-                                (set_local $s
+                                (get_local $22)
+                                (set_local $7
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2369,42 +2313,42 @@
                               (call_import $qa)
                             )
                             (i32.store offset=24
-                              (get_local $W)
-                              (get_local $g)
+                              (get_local $22)
+                              (get_local $6)
                             )
                             (if
-                              (set_local $q
+                              (set_local $9
                                 (i32.load offset=16
-                                  (get_local $V)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $q)
-                                  (get_local $s)
+                                  (get_local $9)
+                                  (get_local $7)
                                 )
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $W)
-                                    (get_local $q)
+                                    (get_local $22)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $q)
-                                    (get_local $W)
+                                    (get_local $9)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                             (if
-                              (set_local $q
+                              (set_local $9
                                 (i32.load offset=20
-                                  (get_local $V)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $q)
+                                  (get_local $9)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2412,12 +2356,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $W)
-                                    (get_local $q)
+                                    (get_local $22)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $q)
-                                    (get_local $W)
+                                    (get_local $9)
+                                    (get_local $22)
                                   )
                                 )
                               )
@@ -2428,35 +2372,35 @@
                       (block $do-once$29
                         (if
                           (i32.lt_u
-                            (get_local $U)
+                            (get_local $16)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $V)
+                              (get_local $10)
                               (i32.or
-                                (set_local $g
+                                (set_local $6
                                   (i32.add
-                                    (get_local $U)
-                                    (get_local $e)
+                                    (get_local $16)
+                                    (get_local $3)
                                   )
                                 )
                                 (i32.const 3)
                               )
                             )
                             (i32.store
-                              (set_local $q
+                              (set_local $9
                                 (i32.add
                                   (i32.add
-                                    (get_local $V)
-                                    (get_local $g)
+                                    (get_local $10)
+                                    (get_local $6)
                                   )
                                   (i32.const 4)
                                 )
                               )
                               (i32.or
                                 (i32.load
-                                  (get_local $q)
+                                  (get_local $9)
                                 )
                                 (i32.const 1)
                               )
@@ -2464,44 +2408,44 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $V)
+                              (get_local $10)
                               (i32.or
-                                (get_local $e)
+                                (get_local $3)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $i)
+                              (get_local $1)
                               (i32.or
-                                (get_local $U)
+                                (get_local $16)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $i)
-                                (get_local $U)
+                                (get_local $1)
+                                (get_local $16)
                               )
-                              (get_local $U)
+                              (get_local $16)
                             )
-                            (set_local $q
+                            (set_local $9
                               (i32.shr_u
-                                (get_local $U)
+                                (get_local $16)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $U)
+                                (get_local $16)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $g
+                                (set_local $6
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $q)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -2510,25 +2454,25 @@
                                 )
                                 (if
                                   (i32.and
-                                    (set_local $s
+                                    (set_local $7
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $d
+                                    (set_local $0
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $q)
+                                        (get_local $9)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $s
+                                      (set_local $7
                                         (i32.load
-                                          (set_local $d
+                                          (set_local $0
                                             (i32.add
-                                              (get_local $g)
+                                              (get_local $6)
                                               (i32.const 8)
                                             )
                                           )
@@ -2540,11 +2484,11 @@
                                     )
                                     (call_import $qa)
                                     (block
-                                      (set_local $$
-                                        (get_local $d)
+                                      (set_local $17
+                                        (get_local $0)
                                       )
-                                      (set_local $aa
-                                        (get_local $s)
+                                      (set_local $12
+                                        (get_local $7)
                                       )
                                     )
                                   )
@@ -2552,81 +2496,81 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $s)
-                                        (get_local $d)
+                                        (get_local $7)
+                                        (get_local $0)
                                       )
                                     )
-                                    (set_local $$
+                                    (set_local $17
                                       (i32.add
-                                        (get_local $g)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $aa
-                                      (get_local $g)
+                                    (set_local $12
+                                      (get_local $6)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$)
-                                  (get_local $i)
+                                  (get_local $17)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=12
-                                  (get_local $aa)
-                                  (get_local $i)
+                                  (get_local $12)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i)
-                                  (get_local $aa)
+                                  (get_local $1)
+                                  (get_local $12)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i)
-                                  (get_local $g)
+                                  (get_local $1)
+                                  (get_local $6)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $t
+                            (set_local $13
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (set_local $ba
+                                  (set_local $2
                                     (if
-                                      (set_local $g
+                                      (set_local $6
                                         (i32.shr_u
-                                          (get_local $U)
+                                          (get_local $16)
                                           (i32.const 8)
                                         )
                                       )
                                       (if
                                         (i32.gt_u
-                                          (get_local $U)
+                                          (get_local $16)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $U)
+                                              (get_local $16)
                                               (i32.add
-                                                (set_local $t
+                                                (set_local $13
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $g
+                                                          (set_local $6
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $d
+                                                                  (set_local $0
                                                                     (i32.shl
-                                                                      (get_local $g)
-                                                                      (set_local $s
+                                                                      (get_local $6)
+                                                                      (set_local $7
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $g)
+                                                                              (get_local $6)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2643,16 +2587,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $s)
+                                                          (get_local $7)
                                                         )
-                                                        (set_local $d
+                                                        (set_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $q
+                                                                (set_local $9
                                                                   (i32.shl
-                                                                    (get_local $d)
-                                                                    (get_local $g)
+                                                                    (get_local $0)
+                                                                    (get_local $6)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2666,8 +2610,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $q)
-                                                        (get_local $d)
+                                                        (get_local $9)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2679,7 +2623,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $t)
+                                            (get_local $13)
                                             (i32.const 1)
                                           )
                                         )
@@ -2692,34 +2636,34 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $i)
-                              (get_local $ba)
+                              (get_local $1)
+                              (get_local $2)
                             )
                             (i32.store offset=4
-                              (set_local $d
+                              (set_local $0
                                 (i32.add
-                                  (get_local $i)
+                                  (get_local $1)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $d)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (set_local $d
+                                  (set_local $0
                                     (i32.load
                                       (i32.const 1212)
                                     )
                                   )
-                                  (set_local $q
+                                  (set_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $ba)
+                                      (get_local $2)
                                     )
                                   )
                                 )
@@ -2728,51 +2672,51 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $d)
-                                    (get_local $q)
+                                    (get_local $0)
+                                    (get_local $9)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $t)
-                                  (get_local $i)
+                                  (get_local $13)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i)
-                                  (get_local $t)
+                                  (get_local $1)
+                                  (get_local $13)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i)
-                                  (get_local $i)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i)
-                                  (get_local $i)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $q
+                            (set_local $9
                               (i32.shl
-                                (get_local $U)
+                                (get_local $16)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $ba)
+                                      (get_local $2)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $ba)
+                                    (get_local $2)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $d
+                            (set_local $0
                               (i32.load
-                                (get_local $t)
+                                (get_local $13)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -2780,34 +2724,34 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $d)
+                                      (get_local $0)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $U)
+                                  (get_local $16)
                                 )
                                 (block
-                                  (set_local $ca
-                                    (get_local $d)
+                                  (set_local $15
+                                    (get_local $0)
                                   )
-                                  (set_local $N
+                                  (set_local $8
                                     (i32.const 148)
                                   )
                                   (br $while-out$31)
                                 )
                               )
                               (if
-                                (set_local $s
+                                (set_local $7
                                   (i32.load
-                                    (set_local $t
+                                    (set_local $13
                                       (i32.add
                                         (i32.add
-                                          (get_local $d)
+                                          (get_local $0)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $q)
+                                            (get_local $9)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -2817,24 +2761,24 @@
                                   )
                                 )
                                 (block
-                                  (set_local $q
+                                  (set_local $9
                                     (i32.shl
-                                      (get_local $q)
+                                      (get_local $9)
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $d
-                                    (get_local $s)
+                                  (set_local $0
+                                    (get_local $7)
                                   )
                                 )
                                 (block
-                                  (set_local $da
-                                    (get_local $t)
+                                  (set_local $21
+                                    (get_local $13)
                                   )
-                                  (set_local $ea
-                                    (get_local $d)
+                                  (set_local $18
+                                    (get_local $0)
                                   )
-                                  (set_local $N
+                                  (set_local $8
                                     (i32.const 145)
                                   )
                                   (br $while-out$31)
@@ -2844,12 +2788,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $N)
+                                (get_local $8)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $da)
+                                  (get_local $21)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2857,71 +2801,71 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store
-                                    (get_local $da)
-                                    (get_local $i)
+                                    (get_local $21)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=24
-                                    (get_local $i)
-                                    (get_local $ea)
+                                    (get_local $1)
+                                    (get_local $18)
                                   )
                                   (i32.store offset=12
-                                    (get_local $i)
-                                    (get_local $i)
+                                    (get_local $1)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=8
-                                    (get_local $i)
-                                    (get_local $i)
+                                    (get_local $1)
+                                    (get_local $1)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $N)
+                                  (get_local $8)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (set_local $q
+                                      (set_local $9
                                         (i32.load
-                                          (set_local $d
+                                          (set_local $0
                                             (i32.add
-                                              (get_local $ca)
+                                              (get_local $15)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $s
+                                      (set_local $7
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $ca)
-                                      (get_local $s)
+                                      (get_local $15)
+                                      (get_local $7)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $q)
-                                      (get_local $i)
+                                      (get_local $9)
+                                      (get_local $1)
                                     )
                                     (i32.store
-                                      (get_local $d)
-                                      (get_local $i)
+                                      (get_local $0)
+                                      (get_local $1)
                                     )
                                     (i32.store offset=8
-                                      (get_local $i)
-                                      (get_local $q)
+                                      (get_local $1)
+                                      (get_local $9)
                                     )
                                     (i32.store offset=12
-                                      (get_local $i)
-                                      (get_local $ca)
+                                      (get_local $1)
+                                      (get_local $15)
                                     )
                                     (i32.store offset=24
-                                      (get_local $i)
+                                      (get_local $1)
                                       (i32.const 0)
                                     )
                                   )
@@ -2934,26 +2878,26 @@
                       )
                       (i32.store
                         (i32.const 8)
-                        (get_local $b)
+                        (get_local $25)
                       )
                       (return
                         (i32.add
-                          (get_local $V)
+                          (get_local $10)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $y
-                      (get_local $e)
+                    (set_local $0
+                      (get_local $3)
                     )
                   )
-                  (set_local $y
-                    (get_local $e)
+                  (set_local $0
+                    (get_local $3)
                   )
                 )
               )
-              (set_local $y
-                (get_local $e)
+              (set_local $0
+                (get_local $3)
               )
             )
           )
@@ -2962,25 +2906,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $V
+        (set_local $10
           (i32.load
             (i32.const 1216)
           )
         )
-        (get_local $y)
+        (get_local $0)
       )
       (block
-        (set_local $ea
+        (set_local $18
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (set_local $ca
+            (set_local $15
               (i32.sub
-                (get_local $V)
-                (get_local $y)
+                (get_local $10)
+                (get_local $0)
               )
             )
             (i32.const 15)
@@ -2988,35 +2932,35 @@
           (block
             (i32.store
               (i32.const 1228)
-              (set_local $da
+              (set_local $21
                 (i32.add
-                  (get_local $ea)
-                  (get_local $y)
+                  (get_local $18)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $ca)
+              (get_local $15)
             )
             (i32.store offset=4
-              (get_local $da)
+              (get_local $21)
               (i32.or
-                (get_local $ca)
+                (get_local $15)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $da)
-                (get_local $ca)
+                (get_local $21)
+                (get_local $15)
               )
-              (get_local $ca)
+              (get_local $15)
             )
             (i32.store offset=4
-              (get_local $ea)
+              (get_local $18)
               (i32.or
-                (get_local $y)
+                (get_local $0)
                 (i32.const 3)
               )
             )
@@ -3031,25 +2975,25 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $ea)
+              (get_local $18)
               (i32.or
-                (get_local $V)
+                (get_local $10)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $ca
+              (set_local $15
                 (i32.add
                   (i32.add
-                    (get_local $ea)
-                    (get_local $V)
+                    (get_local $18)
+                    (get_local $10)
                   )
                   (i32.const 4)
                 )
               )
               (i32.or
                 (i32.load
-                  (get_local $ca)
+                  (get_local $15)
                 )
                 (i32.const 1)
               )
@@ -3058,11 +3002,11 @@
         )
         (i32.store
           (i32.const 8)
-          (get_local $b)
+          (get_local $25)
         )
         (return
           (i32.add
-            (get_local $ea)
+            (get_local $18)
             (i32.const 8)
           )
         )
@@ -3070,57 +3014,57 @@
     )
     (if
       (i32.gt_u
-        (set_local $ea
+        (set_local $18
           (i32.load
             (i32.const 1220)
           )
         )
-        (get_local $y)
+        (get_local $0)
       )
       (block
         (i32.store
           (i32.const 1220)
-          (set_local $ca
+          (set_local $15
             (i32.sub
-              (get_local $ea)
-              (get_local $y)
+              (get_local $18)
+              (get_local $0)
             )
           )
         )
         (i32.store
           (i32.const 1232)
-          (set_local $V
+          (set_local $10
             (i32.add
-              (set_local $ea
+              (set_local $18
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $y)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=4
-          (get_local $V)
+          (get_local $10)
           (i32.or
-            (get_local $ca)
+            (get_local $15)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $ea)
+          (get_local $18)
           (i32.or
-            (get_local $y)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (i32.store
           (i32.const 8)
-          (get_local $b)
+          (get_local $25)
         )
         (return
           (i32.add
-            (get_local $ea)
+            (get_local $18)
             (i32.const 8)
           )
         )
@@ -3158,11 +3102,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $c)
-          (set_local $ea
+          (get_local $4)
+          (set_local $18
             (i32.xor
               (i32.and
-                (get_local $c)
+                (get_local $4)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3171,49 +3115,49 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $ea)
+          (get_local $18)
         )
       )
     )
-    (set_local $ea
+    (set_local $18
       (i32.add
-        (get_local $y)
+        (get_local $0)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $c
+        (set_local $4
           (i32.and
-            (set_local $V
+            (set_local $10
               (i32.add
-                (set_local $c
+                (set_local $4
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (set_local $ca
+                (set_local $15
                   (i32.add
-                    (get_local $y)
+                    (get_local $0)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $da
+            (set_local $21
               (i32.sub
                 (i32.const 0)
-                (get_local $c)
+                (get_local $4)
               )
             )
           )
         )
-        (get_local $y)
+        (get_local $0)
       )
       (block
         (i32.store
           (i32.const 8)
-          (get_local $b)
+          (get_local $25)
         )
         (return
           (i32.const 0)
@@ -3221,7 +3165,7 @@
       )
     )
     (if
-      (set_local $U
+      (set_local $16
         (i32.load
           (i32.const 1648)
         )
@@ -3229,27 +3173,27 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $aa
+            (set_local $12
               (i32.add
-                (set_local $ba
+                (set_local $2
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $c)
+                (get_local $4)
               )
             )
-            (get_local $ba)
+            (get_local $2)
           )
           (i32.gt_u
-            (get_local $aa)
-            (get_local $U)
+            (get_local $12)
+            (get_local $16)
           )
         )
         (block
           (i32.store
             (i32.const 8)
-            (get_local $b)
+            (get_local $25)
           )
           (return
             (i32.const 0)
@@ -3259,7 +3203,7 @@
     )
     (if
       (i32.eq
-        (set_local $N
+        (set_local $8
           (block $label$break$b
             (if
               (i32.and
@@ -3272,46 +3216,46 @@
               (block
                 (block $label$break$c
                   (if
-                    (set_local $U
+                    (set_local $16
                       (i32.load
                         (i32.const 1232)
                       )
                     )
                     (block
-                      (set_local $aa
+                      (set_local $12
                         (i32.const 1656)
                       )
                       (loop $while-out$35 $while-in$36
                         (if
                           (i32.le_u
-                            (set_local $ba
+                            (set_local $2
                               (i32.load
-                                (get_local $aa)
+                                (get_local $12)
                               )
                             )
-                            (get_local $U)
+                            (get_local $16)
                           )
                           (if
                             (i32.gt_u
                               (i32.add
-                                (get_local $ba)
+                                (get_local $2)
                                 (i32.load
-                                  (set_local $$
+                                  (set_local $17
                                     (i32.add
-                                      (get_local $aa)
+                                      (get_local $12)
                                       (i32.const 4)
                                     )
                                   )
                                 )
                               )
-                              (get_local $U)
+                              (get_local $16)
                             )
                             (block
-                              (set_local $fa
-                                (get_local $aa)
+                              (set_local $3
+                                (get_local $12)
                               )
-                              (set_local $ga
-                                (get_local $$)
+                              (set_local $6
+                                (get_local $17)
                               )
                               (br $while-out$35)
                             )
@@ -3319,14 +3263,14 @@
                         )
                         (if
                           (i32.eqz
-                            (set_local $aa
+                            (set_local $12
                               (i32.load offset=8
-                                (get_local $aa)
+                                (get_local $12)
                               )
                             )
                           )
                           (block
-                            (set_local $N
+                            (set_local $8
                               (i32.const 171)
                             )
                             (br $label$break$c)
@@ -3336,46 +3280,46 @@
                       )
                       (if
                         (i32.lt_u
-                          (set_local $aa
+                          (set_local $12
                             (i32.and
                               (i32.sub
-                                (get_local $V)
+                                (get_local $10)
                                 (i32.load
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $da)
+                              (get_local $21)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $$
+                            (set_local $17
                               (call_import $ta
-                                (get_local $aa)
+                                (get_local $12)
                               )
                             )
                             (i32.add
                               (i32.load
-                                (get_local $fa)
+                                (get_local $3)
                               )
                               (i32.load
-                                (get_local $ga)
+                                (get_local $6)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $$)
+                              (get_local $17)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $ha
-                                (get_local $$)
+                              (set_local $19
+                                (get_local $17)
                               )
-                              (set_local $ia
-                                (get_local $aa)
+                              (set_local $26
+                                (get_local $12)
                               )
                               (br $label$break$b
                                 (i32.const 191)
@@ -3383,20 +3327,20 @@
                             )
                           )
                           (block
-                            (set_local $ja
-                              (get_local $$)
+                            (set_local $11
+                              (get_local $17)
                             )
-                            (set_local $ka
-                              (get_local $aa)
+                            (set_local $5
+                              (get_local $12)
                             )
-                            (set_local $N
+                            (set_local $8
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $N
+                    (set_local $8
                       (i32.const 171)
                     )
                   )
@@ -3404,12 +3348,12 @@
                 (block $do-once$37
                   (if
                     (i32.eq
-                      (get_local $N)
+                      (get_local $8)
                       (i32.const 171)
                     )
                     (if
                       (i32.ne
-                        (set_local $U
+                        (set_local $16
                           (call_import $ta
                             (i32.const 0)
                           )
@@ -3417,12 +3361,12 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $la
+                        (set_local $2
                           (if
                             (i32.and
-                              (set_local $$
+                              (set_local $17
                                 (i32.add
-                                  (set_local $aa
+                                  (set_local $12
                                     (i32.load
                                       (i32.const 1684)
                                     )
@@ -3430,53 +3374,53 @@
                                   (i32.const -1)
                                 )
                               )
-                              (set_local $e
-                                (get_local $U)
+                              (set_local $3
+                                (get_local $16)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $c)
-                                (get_local $e)
+                                (get_local $4)
+                                (get_local $3)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $$)
-                                  (get_local $e)
+                                  (get_local $17)
+                                  (get_local $3)
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $aa)
+                                  (get_local $12)
                                 )
                               )
                             )
-                            (get_local $c)
+                            (get_local $4)
                           )
                         )
-                        (set_local $e
+                        (set_local $3
                           (i32.add
-                            (set_local $aa
+                            (set_local $12
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $la)
+                            (get_local $2)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $la)
-                              (get_local $y)
+                              (get_local $2)
+                              (get_local $0)
                             )
                             (i32.lt_u
-                              (get_local $la)
+                              (get_local $2)
                               (i32.const 2147483647)
                             )
                           )
                           (block
                             (if
-                              (set_local $$
+                              (set_local $17
                                 (i32.load
                                   (i32.const 1648)
                                 )
@@ -3484,44 +3428,44 @@
                               (br_if $do-once$37
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $e)
-                                    (get_local $aa)
+                                    (get_local $3)
+                                    (get_local $12)
                                   )
                                   (i32.gt_u
-                                    (get_local $e)
-                                    (get_local $$)
+                                    (get_local $3)
+                                    (get_local $17)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$
+                                (set_local $17
                                   (call_import $ta
-                                    (get_local $la)
+                                    (get_local $2)
                                   )
                                 )
-                                (get_local $U)
+                                (get_local $16)
                               )
                               (block
-                                (set_local $ha
-                                  (get_local $U)
+                                (set_local $19
+                                  (get_local $16)
                                 )
-                                (set_local $ia
-                                  (get_local $la)
+                                (set_local $26
+                                  (get_local $2)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
                                 )
                               )
                               (block
-                                (set_local $ja
-                                  (get_local $$)
+                                (set_local $11
+                                  (get_local $17)
                                 )
-                                (set_local $ka
-                                  (get_local $la)
+                                (set_local $5
+                                  (get_local $2)
                                 )
-                                (set_local $N
+                                (set_local $8
                                   (i32.const 181)
                                 )
                               )
@@ -3535,43 +3479,43 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $N)
+                      (get_local $8)
                       (i32.const 181)
                     )
                     (block
-                      (set_local $$
+                      (set_local $17
                         (i32.sub
                           (i32.const 0)
-                          (get_local $ka)
+                          (get_local $5)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $ea)
-                            (get_local $ka)
+                            (get_local $18)
+                            (get_local $5)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $ja)
+                              (get_local $11)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $e
+                            (set_local $3
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $ca)
-                                    (get_local $ka)
+                                    (get_local $15)
+                                    (get_local $5)
                                   )
-                                  (set_local $U
+                                  (set_local $16
                                     (i32.load
                                       (i32.const 1688)
                                     )
@@ -3579,7 +3523,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $U)
+                                  (get_local $16)
                                 )
                               )
                             )
@@ -3588,42 +3532,42 @@
                           (if
                             (i32.eq
                               (call_import $ta
-                                (get_local $e)
+                                (get_local $3)
                               )
                               (i32.const -1)
                             )
                             (block
                               (call_import $ta
-                                (get_local $$)
+                                (get_local $17)
                               )
                               (br $label$break$d)
                             )
-                            (set_local $ma
+                            (set_local $1
                               (i32.add
-                                (get_local $e)
-                                (get_local $ka)
+                                (get_local $3)
+                                (get_local $5)
                               )
                             )
                           )
-                          (set_local $ma
-                            (get_local $ka)
+                          (set_local $1
+                            (get_local $5)
                           )
                         )
-                        (set_local $ma
-                          (get_local $ka)
+                        (set_local $1
+                          (get_local $5)
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $ja)
+                          (get_local $11)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $ha
-                            (get_local $ja)
+                          (set_local $19
+                            (get_local $11)
                           )
-                          (set_local $ia
-                            (get_local $ma)
+                          (set_local $26
+                            (get_local $1)
                           )
                           (br $label$break$b
                             (i32.const 191)
@@ -3651,18 +3595,18 @@
       )
       (if
         (i32.lt_u
-          (get_local $c)
+          (get_local $4)
           (i32.const 2147483647)
         )
         (if
           (i32.and
             (i32.lt_u
-              (set_local $ma
+              (set_local $1
                 (call_import $ta
-                  (get_local $c)
+                  (get_local $4)
                 )
               )
-              (set_local $c
+              (set_local $4
                 (call_import $ta
                   (i32.const 0)
                 )
@@ -3670,36 +3614,36 @@
             )
             (i32.and
               (i32.ne
-                (get_local $ma)
+                (get_local $1)
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $c)
+                (get_local $4)
                 (i32.const -1)
               )
             )
           )
           (if
             (i32.gt_u
-              (set_local $ja
+              (set_local $11
                 (i32.sub
-                  (get_local $c)
-                  (get_local $ma)
+                  (get_local $4)
+                  (get_local $1)
                 )
               )
               (i32.add
-                (get_local $y)
+                (get_local $0)
                 (i32.const 40)
               )
             )
             (block
-              (set_local $ha
-                (get_local $ma)
+              (set_local $19
+                (get_local $1)
               )
-              (set_local $ia
-                (get_local $ja)
+              (set_local $26
+                (get_local $11)
               )
-              (set_local $N
+              (set_local $8
                 (i32.const 191)
               )
             )
@@ -3709,59 +3653,59 @@
     )
     (if
       (i32.eq
-        (get_local $N)
+        (get_local $8)
         (i32.const 191)
       )
       (block
         (i32.store
           (i32.const 1640)
-          (set_local $ja
+          (set_local $11
             (i32.add
               (i32.load
                 (i32.const 1640)
               )
-              (get_local $ia)
+              (get_local $26)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $ja)
+            (get_local $11)
             (i32.load
               (i32.const 1644)
             )
           )
           (i32.store
             (i32.const 1644)
-            (get_local $ja)
+            (get_local $11)
           )
         )
         (block $do-once$42
           (if
-            (set_local $ja
+            (set_local $11
               (i32.load
                 (i32.const 1232)
               )
             )
             (block
-              (set_local $ka
+              (set_local $5
                 (i32.const 1656)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $ha)
+                    (get_local $19)
                     (i32.add
-                      (set_local $ma
+                      (set_local $1
                         (i32.load
-                          (get_local $ka)
+                          (get_local $5)
                         )
                       )
-                      (set_local $ca
+                      (set_local $15
                         (i32.load
-                          (set_local $c
+                          (set_local $4
                             (i32.add
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 4)
                             )
                           )
@@ -3770,19 +3714,19 @@
                     )
                   )
                   (block
-                    (set_local $na
-                      (get_local $ma)
+                    (set_local $49
+                      (get_local $1)
                     )
-                    (set_local $oa
-                      (get_local $c)
+                    (set_local $50
+                      (get_local $4)
                     )
-                    (set_local $pa
-                      (get_local $ca)
+                    (set_local $51
+                      (get_local $15)
                     )
-                    (set_local $ra
-                      (get_local $ka)
+                    (set_local $52
+                      (get_local $5)
                     )
-                    (set_local $N
+                    (set_local $8
                       (i32.const 201)
                     )
                     (br $do-out$46)
@@ -3790,9 +3734,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $ka
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $ka)
+                        (get_local $5)
                       )
                     )
                     (i32.const 0)
@@ -3801,14 +3745,14 @@
               )
               (if
                 (i32.eq
-                  (get_local $N)
+                  (get_local $8)
                   (i32.const 201)
                 )
                 (if
                   (i32.eqz
                     (i32.and
                       (i32.load offset=12
-                        (get_local $ra)
+                        (get_local $52)
                       )
                       (i32.const 8)
                     )
@@ -3816,34 +3760,34 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $ja)
-                        (get_local $ha)
+                        (get_local $11)
+                        (get_local $19)
                       )
                       (i32.ge_u
-                        (get_local $ja)
-                        (get_local $na)
+                        (get_local $11)
+                        (get_local $49)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $oa)
+                        (get_local $50)
                         (i32.add
-                          (get_local $pa)
-                          (get_local $ia)
+                          (get_local $51)
+                          (get_local $26)
                         )
                       )
-                      (set_local $ka
+                      (set_local $5
                         (i32.add
-                          (get_local $ja)
-                          (set_local $ca
+                          (get_local $11)
+                          (set_local $15
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (set_local $ka
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $ja)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
@@ -3852,7 +3796,7 @@
                               )
                               (i32.eq
                                 (i32.and
-                                  (get_local $ka)
+                                  (get_local $5)
                                   (i32.const 7)
                                 )
                                 (i32.const 0)
@@ -3861,11 +3805,11 @@
                           )
                         )
                       )
-                      (set_local $c
+                      (set_local $4
                         (i32.add
                           (i32.sub
-                            (get_local $ia)
-                            (get_local $ca)
+                            (get_local $26)
+                            (get_local $15)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3874,23 +3818,23 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $ka)
+                        (get_local $5)
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $c)
+                        (get_local $4)
                       )
                       (i32.store offset=4
-                        (get_local $ka)
+                        (get_local $5)
                         (i32.or
-                          (get_local $c)
+                          (get_local $4)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $ka)
-                          (get_local $c)
+                          (get_local $5)
+                          (get_local $4)
                         )
                         (i32.const 40)
                       )
@@ -3905,11 +3849,11 @@
                   )
                 )
               )
-              (set_local $sa
+              (set_local $14
                 (if
                   (i32.lt_u
-                    (get_local $ha)
-                    (set_local $c
+                    (get_local $19)
+                    (set_local $4
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3918,38 +3862,38 @@
                   (block
                     (i32.store
                       (i32.const 1224)
-                      (get_local $ha)
+                      (get_local $19)
                     )
-                    (get_local $ha)
+                    (get_local $19)
                   )
-                  (get_local $c)
+                  (get_local $4)
                 )
               )
-              (set_local $c
+              (set_local $4
                 (i32.add
-                  (get_local $ha)
-                  (get_local $ia)
+                  (get_local $19)
+                  (get_local $26)
                 )
               )
-              (set_local $ka
+              (set_local $5
                 (i32.const 1656)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $ka)
+                      (get_local $5)
                     )
-                    (get_local $c)
+                    (get_local $4)
                   )
                   (block
-                    (set_local $ua
-                      (get_local $ka)
+                    (set_local $53
+                      (get_local $5)
                     )
-                    (set_local $va
-                      (get_local $ka)
+                    (set_local $43
+                      (get_local $5)
                     )
-                    (set_local $N
+                    (set_local $8
                       (i32.const 209)
                     )
                     (br $while-out$48)
@@ -3957,14 +3901,14 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $ka
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $ka)
+                        (get_local $5)
                       )
                     )
                   )
                   (block
-                    (set_local $wa
+                    (set_local $29
                       (i32.const 1656)
                     )
                     (br $while-out$48)
@@ -3974,49 +3918,49 @@
               )
               (if
                 (i32.eq
-                  (get_local $N)
+                  (get_local $8)
                   (i32.const 209)
                 )
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $va)
+                      (get_local $43)
                     )
                     (i32.const 8)
                   )
-                  (set_local $wa
+                  (set_local $29
                     (i32.const 1656)
                   )
                   (block
                     (i32.store
-                      (get_local $ua)
-                      (get_local $ha)
+                      (get_local $53)
+                      (get_local $19)
                     )
                     (i32.store
-                      (set_local $ka
+                      (set_local $5
                         (i32.add
-                          (get_local $va)
+                          (get_local $43)
                           (i32.const 4)
                         )
                       )
                       (i32.add
                         (i32.load
-                          (get_local $ka)
+                          (get_local $5)
                         )
-                        (get_local $ia)
+                        (get_local $26)
                       )
                     )
-                    (set_local $ca
+                    (set_local $15
                       (i32.add
-                        (get_local $ha)
+                        (get_local $19)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $ka
+                              (set_local $5
                                 (i32.add
-                                  (get_local $ha)
+                                  (get_local $19)
                                   (i32.const 8)
                                 )
                               )
@@ -4025,7 +3969,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -4033,17 +3977,17 @@
                         )
                       )
                     )
-                    (set_local $ma
+                    (set_local $1
                       (i32.add
-                        (get_local $c)
+                        (get_local $4)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $ka
+                              (set_local $5
                                 (i32.add
-                                  (get_local $c)
+                                  (get_local $4)
                                   (i32.const 8)
                                 )
                               )
@@ -4052,7 +3996,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -4060,54 +4004,54 @@
                         )
                       )
                     )
-                    (set_local $ka
+                    (set_local $5
                       (i32.add
-                        (get_local $ca)
-                        (get_local $y)
+                        (get_local $15)
+                        (get_local $0)
                       )
                     )
-                    (set_local $ea
+                    (set_local $18
                       (i32.sub
                         (i32.sub
-                          (get_local $ma)
-                          (get_local $ca)
+                          (get_local $1)
+                          (get_local $15)
                         )
-                        (get_local $y)
+                        (get_local $0)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $ca)
+                      (get_local $15)
                       (i32.or
-                        (get_local $y)
+                        (get_local $0)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$50
                       (if
                         (i32.eq
-                          (get_local $ma)
-                          (get_local $ja)
+                          (get_local $1)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (set_local $la
+                            (set_local $2
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $ea)
+                                (get_local $18)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $ka)
+                            (get_local $5)
                           )
                           (i32.store offset=4
-                            (get_local $ka)
+                            (get_local $5)
                             (i32.or
-                              (get_local $la)
+                              (get_local $2)
                               (i32.const 1)
                             )
                           )
@@ -4115,7 +4059,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $ma)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 1228)
                               )
@@ -4123,45 +4067,45 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (set_local $la
+                                (set_local $2
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $ea)
+                                    (get_local $18)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $ka)
+                                (get_local $5)
                               )
                               (i32.store offset=4
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.or
-                                  (get_local $la)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $ka)
-                                  (get_local $la)
+                                  (get_local $5)
+                                  (get_local $2)
                                 )
-                                (get_local $la)
+                                (get_local $2)
                               )
                               (br $do-once$50)
                             )
                           )
                           (i32.store
-                            (set_local $fa
+                            (set_local $3
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $la
+                                      (set_local $2
                                         (i32.load offset=4
-                                          (get_local $ma)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 3)
@@ -4169,44 +4113,44 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $ga
+                                    (set_local $6
                                       (i32.and
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $fa
+                                    (set_local $3
                                       (i32.shr_u
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $la)
+                                          (get_local $2)
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $V
+                                          (set_local $10
                                             (i32.load offset=12
-                                              (get_local $ma)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once$53
                                             (if
                                               (i32.ne
-                                                (set_local $da
+                                                (set_local $21
                                                   (i32.load offset=8
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                 )
-                                                (set_local $$
+                                                (set_local $17
                                                   (i32.add
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $fa)
+                                                        (get_local $3)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4217,17 +4161,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $da)
-                                                    (get_local $sa)
+                                                    (get_local $21)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (br_if $do-once$53
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $da)
+                                                      (get_local $21)
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (call_import $qa)
@@ -4236,8 +4180,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $V)
-                                              (get_local $da)
+                                              (get_local $10)
+                                              (get_local $21)
                                             )
                                             (block
                                               (i32.store
@@ -4249,7 +4193,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $fa)
+                                                      (get_local $3)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4261,38 +4205,38 @@
                                           (block $do-once$55
                                             (if
                                               (i32.eq
-                                                (get_local $V)
-                                                (get_local $$)
+                                                (get_local $10)
+                                                (get_local $17)
                                               )
-                                              (set_local $xa
+                                              (set_local $44
                                                 (i32.add
-                                                  (get_local $V)
+                                                  (get_local $10)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $V)
-                                                    (get_local $sa)
+                                                    (get_local $10)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $e
+                                                      (set_local $3
                                                         (i32.add
-                                                          (get_local $V)
+                                                          (get_local $10)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (block
-                                                    (set_local $xa
-                                                      (get_local $e)
+                                                    (set_local $44
+                                                      (get_local $3)
                                                     )
                                                     (br $do-once$55)
                                                   )
@@ -4302,39 +4246,39 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $da)
-                                            (get_local $V)
+                                            (get_local $21)
+                                            (get_local $10)
                                           )
                                           (i32.store
-                                            (get_local $xa)
-                                            (get_local $da)
+                                            (get_local $44)
+                                            (get_local $21)
                                           )
                                         )
                                         (block
-                                          (set_local $$
+                                          (set_local $17
                                             (i32.load offset=24
-                                              (get_local $ma)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once$57
                                             (if
                                               (i32.eq
-                                                (set_local $e
+                                                (set_local $3
                                                   (i32.load offset=12
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                 )
-                                                (get_local $ma)
+                                                (get_local $1)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $ba
+                                                  (set_local $2
                                                     (i32.load
-                                                      (set_local $aa
+                                                      (set_local $12
                                                         (i32.add
-                                                          (set_local $U
+                                                          (set_local $16
                                                             (i32.add
-                                                              (get_local $ma)
+                                                              (get_local $1)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4344,29 +4288,29 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $za
-                                                      (get_local $ba)
+                                                    (set_local $0
+                                                      (get_local $2)
                                                     )
-                                                    (set_local $Aa
-                                                      (get_local $aa)
+                                                    (set_local $4
+                                                      (get_local $12)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $W
+                                                    (set_local $22
                                                       (i32.load
-                                                        (get_local $U)
+                                                        (get_local $16)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $za
-                                                        (get_local $W)
+                                                      (set_local $0
+                                                        (get_local $22)
                                                       )
-                                                      (set_local $Aa
-                                                        (get_local $U)
+                                                      (set_local $4
+                                                        (get_local $16)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $ya
+                                                      (set_local $24
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once$57)
@@ -4375,52 +4319,48 @@
                                                 )
                                                 (loop $while-out$59 $while-in$60
                                                   (if
-                                                    (set_local $ba
+                                                    (set_local $2
                                                       (i32.load
-                                                        (set_local $aa
+                                                        (set_local $12
                                                           (i32.add
-                                                            (get_local $za)
+                                                            (get_local $0)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $za
-                                                        (get_local $ba)
+                                                      (set_local $0
+                                                        (get_local $2)
                                                       )
-                                                      (set_local $Aa
-                                                        (get_local $aa)
+                                                      (set_local $4
+                                                        (get_local $12)
                                                       )
                                                       (br $while-in$60)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $ba
+                                                    (set_local $2
                                                       (i32.load
-                                                        (set_local $aa
+                                                        (set_local $12
                                                           (i32.add
-                                                            (get_local $za)
+                                                            (get_local $0)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $za
-                                                        (get_local $ba)
+                                                      (set_local $0
+                                                        (get_local $2)
                                                       )
-                                                      (set_local $Aa
-                                                        (get_local $aa)
+                                                      (set_local $4
+                                                        (get_local $12)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $Ba
-                                                        (get_local $za)
-                                                      )
-                                                      (set_local $Ca
-                                                        (get_local $Aa)
-                                                      )
+                                                      (get_local $0)
+                                                      (get_local $4)
                                                       (br $while-out$59)
                                                     )
                                                   )
@@ -4428,17 +4368,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $Ca)
-                                                    (get_local $sa)
+                                                    (get_local $4)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $Ca)
+                                                      (get_local $4)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $ya
-                                                      (get_local $Ba)
+                                                    (set_local $24
+                                                      (get_local $0)
                                                     )
                                                   )
                                                 )
@@ -4446,52 +4386,52 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (set_local $aa
+                                                    (set_local $12
                                                       (i32.load offset=8
-                                                        (get_local $ma)
+                                                        (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $sa)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $ba
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $aa)
+                                                          (get_local $12)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $U
+                                                      (set_local $16
                                                         (i32.add
-                                                          (get_local $e)
+                                                          (get_local $3)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $ba)
-                                                      (get_local $e)
+                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (i32.store
-                                                      (get_local $U)
-                                                      (get_local $aa)
+                                                      (get_local $16)
+                                                      (get_local $12)
                                                     )
-                                                    (set_local $ya
-                                                      (get_local $e)
+                                                    (set_local $24
+                                                      (get_local $3)
                                                     )
                                                   )
                                                   (call_import $qa)
@@ -4501,21 +4441,21 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (get_local $$)
+                                              (get_local $17)
                                             )
                                           )
                                           (block $do-once$61
                                             (if
                                               (i32.eq
-                                                (get_local $ma)
+                                                (get_local $1)
                                                 (i32.load
-                                                  (set_local $da
+                                                  (set_local $21
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (set_local $e
+                                                        (set_local $3
                                                           (i32.load offset=28
-                                                            (get_local $ma)
+                                                            (get_local $1)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4526,11 +4466,11 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $da)
-                                                  (get_local $ya)
+                                                  (get_local $21)
+                                                  (get_local $24)
                                                 )
                                                 (br_if $do-once$61
-                                                  (get_local $ya)
+                                                  (get_local $24)
                                                 )
                                                 (i32.store
                                                   (i32.const 1212)
@@ -4541,7 +4481,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $e)
+                                                        (get_local $3)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4552,7 +4492,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $$)
+                                                    (get_local $17)
                                                     (i32.load
                                                       (i32.const 1224)
                                                     )
@@ -4562,27 +4502,27 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $V
+                                                      (set_local $10
                                                         (i32.add
-                                                          (get_local $$)
+                                                          (get_local $17)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (i32.store
-                                                    (get_local $V)
-                                                    (get_local $ya)
+                                                    (get_local $10)
+                                                    (get_local $24)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $$)
-                                                    (get_local $ya)
+                                                    (get_local $17)
+                                                    (get_local $24)
                                                   )
                                                 )
                                                 (br_if $label$break$e
                                                   (i32.eqz
-                                                    (get_local $ya)
+                                                    (get_local $24)
                                                   )
                                                 )
                                               )
@@ -4590,8 +4530,8 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $ya)
-                                              (set_local $e
+                                              (get_local $24)
+                                              (set_local $3
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4600,15 +4540,15 @@
                                             (call_import $qa)
                                           )
                                           (i32.store offset=24
-                                            (get_local $ya)
-                                            (get_local $$)
+                                            (get_local $24)
+                                            (get_local $17)
                                           )
                                           (if
-                                            (set_local $V
+                                            (set_local $10
                                               (i32.load
-                                                (set_local $da
+                                                (set_local $21
                                                   (i32.add
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4616,34 +4556,34 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $V)
-                                                (get_local $e)
+                                                (get_local $10)
+                                                (get_local $3)
                                               )
                                               (call_import $qa)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $ya)
-                                                  (get_local $V)
+                                                  (get_local $24)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $V)
-                                                  (get_local $ya)
+                                                  (get_local $10)
+                                                  (get_local $24)
                                                 )
                                               )
                                             )
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (set_local $V
+                                              (set_local $10
                                                 (i32.load offset=4
-                                                  (get_local $da)
+                                                  (get_local $21)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $V)
+                                              (get_local $10)
                                               (i32.load
                                                 (i32.const 1224)
                                               )
@@ -4651,34 +4591,34 @@
                                             (call_import $qa)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $ya)
-                                                (get_local $V)
+                                                (get_local $24)
+                                                (get_local $10)
                                               )
                                               (i32.store offset=24
-                                                (get_local $V)
-                                                (get_local $ya)
+                                                (get_local $10)
+                                                (get_local $24)
                                               )
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $Ea
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $ga)
-                                        (get_local $ea)
+                                        (get_local $6)
+                                        (get_local $18)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $ma)
-                                      (get_local $ga)
+                                      (get_local $1)
+                                      (get_local $6)
                                     )
                                   )
                                   (block
-                                    (set_local $Ea
-                                      (get_local $ea)
+                                    (set_local $0
+                                      (get_local $18)
                                     )
-                                    (get_local $ma)
+                                    (get_local $1)
                                   )
                                 )
                                 (i32.const 4)
@@ -4686,43 +4626,43 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $fa)
+                                (get_local $3)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $ka)
+                            (get_local $5)
                             (i32.or
-                              (get_local $Ea)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $ka)
-                              (get_local $Ea)
+                              (get_local $5)
+                              (get_local $0)
                             )
-                            (get_local $Ea)
+                            (get_local $0)
                           )
-                          (set_local $fa
+                          (set_local $3
                             (i32.shr_u
-                              (get_local $Ea)
+                              (get_local $0)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $Ea)
+                              (get_local $0)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $la
+                              (set_local $2
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $fa)
+                                      (get_local $3)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4732,26 +4672,26 @@
                               (block $do-once$65
                                 (if
                                   (i32.and
-                                    (set_local $V
+                                    (set_local $10
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $e
+                                    (set_local $3
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $fa)
+                                        (get_local $3)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $$
+                                        (set_local $17
                                           (i32.load
-                                            (set_local $fa
+                                            (set_local $3
                                               (i32.add
-                                                (get_local $la)
+                                                (get_local $2)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4762,11 +4702,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $Fa
-                                          (get_local $fa)
+                                        (set_local $45
+                                          (get_local $3)
                                         )
-                                        (set_local $Ga
-                                          (get_local $$)
+                                        (set_local $38
+                                          (get_local $17)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4777,58 +4717,58 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $V)
-                                        (get_local $e)
+                                        (get_local $10)
+                                        (get_local $3)
                                       )
                                     )
-                                    (set_local $Fa
+                                    (set_local $45
                                       (i32.add
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $Ga
-                                      (get_local $la)
+                                    (set_local $38
+                                      (get_local $2)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $Fa)
-                                (get_local $ka)
+                                (get_local $45)
+                                (get_local $5)
                               )
                               (i32.store offset=12
-                                (get_local $Ga)
-                                (get_local $ka)
+                                (get_local $38)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $ka)
-                                (get_local $Ga)
+                                (get_local $5)
+                                (get_local $38)
                               )
                               (i32.store offset=12
-                                (get_local $ka)
-                                (get_local $la)
+                                (get_local $5)
+                                (get_local $2)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $e
+                          (set_local $3
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
-                                (set_local $Ha
+                                (set_local $4
                                   (block $do-once$67
                                     (if
-                                      (set_local $e
+                                      (set_local $3
                                         (i32.shr_u
-                                          (get_local $Ea)
+                                          (get_local $0)
                                           (i32.const 8)
                                         )
                                       )
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $Ea)
+                                            (get_local $0)
                                             (i32.const 16777215)
                                           )
                                           (br $do-once$67
@@ -4838,26 +4778,26 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $Ea)
+                                              (get_local $0)
                                               (i32.add
-                                                (set_local $aa
+                                                (set_local $12
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $$
+                                                          (set_local $17
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $ga
+                                                                  (set_local $6
                                                                     (i32.shl
-                                                                      (get_local $e)
-                                                                      (set_local $V
+                                                                      (get_local $3)
+                                                                      (set_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $e)
+                                                                              (get_local $3)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4874,16 +4814,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $V)
+                                                          (get_local $10)
                                                         )
-                                                        (set_local $ga
+                                                        (set_local $6
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $fa
+                                                                (set_local $3
                                                                   (i32.shl
-                                                                    (get_local $ga)
-                                                                    (get_local $$)
+                                                                    (get_local $6)
+                                                                    (get_local $17)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4897,8 +4837,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $fa)
-                                                        (get_local $ga)
+                                                        (get_local $3)
+                                                        (get_local $6)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4910,7 +4850,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $aa)
+                                            (get_local $12)
                                             (i32.const 1)
                                           )
                                         )
@@ -4924,34 +4864,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $ka)
-                            (get_local $Ha)
+                            (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=4
-                            (set_local $la
+                            (set_local $2
                               (i32.add
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $la)
+                            (get_local $2)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $la
+                                (set_local $2
                                   (i32.load
                                     (i32.const 1212)
                                   )
                                 )
-                                (set_local $aa
+                                (set_local $12
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $Ha)
+                                    (get_local $4)
                                   )
                                 )
                               )
@@ -4960,51 +4900,51 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $la)
-                                  (get_local $aa)
+                                  (get_local $2)
+                                  (get_local $12)
                                 )
                               )
                               (i32.store
-                                (get_local $e)
-                                (get_local $ka)
+                                (get_local $3)
+                                (get_local $5)
                               )
                               (i32.store offset=24
-                                (get_local $ka)
-                                (get_local $e)
+                                (get_local $5)
+                                (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $ka)
-                                (get_local $ka)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $ka)
-                                (get_local $ka)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $aa
+                          (set_local $12
                             (i32.shl
-                              (get_local $Ea)
+                              (get_local $0)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $Ha)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $Ha)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $la
+                          (set_local $2
                             (i32.load
-                              (get_local $e)
+                              (get_local $3)
                             )
                           )
                           (loop $while-out$69 $while-in$70
@@ -5012,34 +4952,34 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $la)
+                                    (get_local $2)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $Ea)
+                                (get_local $0)
                               )
                               (block
-                                (set_local $Ia
-                                  (get_local $la)
+                                (set_local $39
+                                  (get_local $2)
                                 )
-                                (set_local $N
+                                (set_local $8
                                   (i32.const 279)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $ga
+                              (set_local $6
                                 (i32.load
-                                  (set_local $e
+                                  (set_local $3
                                     (i32.add
                                       (i32.add
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $aa)
+                                          (get_local $12)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -5049,24 +4989,24 @@
                                 )
                               )
                               (block
-                                (set_local $aa
+                                (set_local $12
                                   (i32.shl
-                                    (get_local $aa)
+                                    (get_local $12)
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $la
-                                  (get_local $ga)
+                                (set_local $2
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $Ja
-                                  (get_local $e)
+                                (set_local $46
+                                  (get_local $3)
                                 )
-                                (set_local $Ka
-                                  (get_local $la)
+                                (set_local $54
+                                  (get_local $2)
                                 )
-                                (set_local $N
+                                (set_local $8
                                   (i32.const 276)
                                 )
                                 (br $while-out$69)
@@ -5076,12 +5016,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $N)
+                              (get_local $8)
                               (i32.const 276)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $Ja)
+                                (get_local $46)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -5089,71 +5029,71 @@
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $Ja)
-                                  (get_local $ka)
+                                  (get_local $46)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $ka)
-                                  (get_local $Ka)
+                                  (get_local $5)
+                                  (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $ka)
-                                  (get_local $ka)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $ka)
-                                  (get_local $ka)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $N)
+                                (get_local $8)
                                 (i32.const 279)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $aa
+                                    (set_local $12
                                       (i32.load
-                                        (set_local $la
+                                        (set_local $2
                                           (i32.add
-                                            (get_local $Ia)
+                                            (get_local $39)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $ga
+                                    (set_local $6
                                       (i32.load
                                         (i32.const 1224)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $Ia)
-                                    (get_local $ga)
+                                    (get_local $39)
+                                    (get_local $6)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $aa)
-                                    (get_local $ka)
+                                    (get_local $12)
+                                    (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $la)
-                                    (get_local $ka)
+                                    (get_local $2)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $ka)
-                                    (get_local $aa)
+                                    (get_local $5)
+                                    (get_local $12)
                                   )
                                   (i32.store offset=12
-                                    (get_local $ka)
-                                    (get_local $Ia)
+                                    (get_local $5)
+                                    (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $ka)
+                                    (get_local $5)
                                     (i32.const 0)
                                   )
                                 )
@@ -5166,11 +5106,11 @@
                     )
                     (i32.store
                       (i32.const 8)
-                      (get_local $b)
+                      (get_local $25)
                     )
                     (return
                       (i32.add
-                        (get_local $ca)
+                        (get_local $15)
                         (i32.const 8)
                       )
                     )
@@ -5180,71 +5120,71 @@
               (loop $while-out$71 $while-in$72
                 (if
                   (i32.le_u
-                    (set_local $ka
+                    (set_local $5
                       (i32.load
-                        (get_local $wa)
+                        (get_local $29)
                       )
                     )
-                    (get_local $ja)
+                    (get_local $11)
                   )
                   (if
                     (i32.gt_u
-                      (set_local $ea
+                      (set_local $18
                         (i32.add
-                          (get_local $ka)
+                          (get_local $5)
                           (i32.load offset=4
-                            (get_local $wa)
+                            (get_local $29)
                           )
                         )
                       )
-                      (get_local $ja)
+                      (get_local $11)
                     )
                     (block
-                      (set_local $La
-                        (get_local $ea)
+                      (set_local $3
+                        (get_local $18)
                       )
                       (br $while-out$71)
                     )
                   )
                 )
-                (set_local $wa
+                (set_local $29
                   (i32.load offset=8
-                    (get_local $wa)
+                    (get_local $29)
                   )
                 )
                 (br $while-in$72)
               )
-              (set_local $ea
+              (set_local $18
                 (i32.add
-                  (set_local $ca
+                  (set_local $15
                     (i32.add
-                      (get_local $La)
+                      (get_local $3)
                       (i32.const -47)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $ka
+              (set_local $5
                 (i32.add
-                  (set_local $ca
+                  (set_local $15
                     (select
-                      (get_local $ja)
-                      (set_local $ka
+                      (get_local $11)
+                      (set_local $5
                         (i32.add
-                          (get_local $ca)
+                          (get_local $15)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $ea)
+                                (get_local $18)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $ea)
+                                (get_local $18)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5253,10 +5193,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $ka)
-                        (set_local $ea
+                        (get_local $5)
+                        (set_local $18
                           (i32.add
-                            (get_local $ja)
+                            (get_local $11)
                             (i32.const 16)
                           )
                         )
@@ -5268,18 +5208,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $ma
+                (set_local $1
                   (i32.add
-                    (get_local $ha)
-                    (set_local $c
+                    (get_local $19)
+                    (set_local $4
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $ma
+                            (set_local $1
                               (i32.add
-                                (get_local $ha)
+                                (get_local $19)
                                 (i32.const 8)
                               )
                             )
@@ -5288,7 +5228,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $ma)
+                            (get_local $1)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5300,27 +5240,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $aa
+                (set_local $12
                   (i32.sub
                     (i32.add
-                      (get_local $ia)
+                      (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $c)
+                    (get_local $4)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $ma)
+                (get_local $1)
                 (i32.or
-                  (get_local $aa)
+                  (get_local $12)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $ma)
-                  (get_local $aa)
+                  (get_local $1)
+                  (get_local $12)
                 )
                 (i32.const 40)
               )
@@ -5331,45 +5271,45 @@
                 )
               )
               (i32.store
-                (set_local $aa
+                (set_local $12
                   (i32.add
-                    (get_local $ca)
+                    (get_local $15)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1668)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $ha)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $ia)
+                (get_local $26)
               )
               (i32.store
                 (i32.const 1668)
@@ -5377,19 +5317,19 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $ka)
+                (get_local $5)
               )
-              (set_local $ka
+              (set_local $5
                 (i32.add
-                  (get_local $ca)
+                  (get_local $15)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $ka
+                  (set_local $5
                     (i32.add
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 4)
                     )
                   )
@@ -5398,62 +5338,62 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 4)
                     )
-                    (get_local $La)
+                    (get_local $3)
                   )
                 )
               )
               (if
                 (i32.ne
-                  (get_local $ca)
-                  (get_local $ja)
+                  (get_local $15)
+                  (get_local $11)
                 )
                 (block
                   (i32.store
-                    (get_local $aa)
+                    (get_local $12)
                     (i32.and
                       (i32.load
-                        (get_local $aa)
+                        (get_local $12)
                       )
                       (i32.const -2)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $ja)
+                    (get_local $11)
                     (i32.or
-                      (set_local $ka
+                      (set_local $5
                         (i32.sub
-                          (get_local $ca)
-                          (get_local $ja)
+                          (get_local $15)
+                          (get_local $11)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $ca)
-                    (get_local $ka)
+                    (get_local $15)
+                    (get_local $5)
                   )
-                  (set_local $ma
+                  (set_local $1
                     (i32.shr_u
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $c
+                      (set_local $4
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (get_local $ma)
+                              (get_local $1)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5462,25 +5402,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $la
+                          (set_local $2
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $ga
+                          (set_local $6
                             (i32.shl
                               (i32.const 1)
-                              (get_local $ma)
+                              (get_local $1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $la
+                            (set_local $2
                               (i32.load
-                                (set_local $ga
+                                (set_local $6
                                   (i32.add
-                                    (get_local $c)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -5492,11 +5432,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $Ma
-                              (get_local $ga)
+                            (set_local $47
+                              (get_local $6)
                             )
-                            (set_local $Na
-                              (get_local $la)
+                            (set_local $40
+                              (get_local $2)
                             )
                           )
                         )
@@ -5504,81 +5444,81 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $la)
-                              (get_local $ga)
+                              (get_local $2)
+                              (get_local $6)
                             )
                           )
-                          (set_local $Ma
+                          (set_local $47
                             (i32.add
-                              (get_local $c)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
-                          (set_local $Na
-                            (get_local $c)
+                          (set_local $40
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $Ma)
-                        (get_local $ja)
+                        (get_local $47)
+                        (get_local $11)
                       )
                       (i32.store offset=12
-                        (get_local $Na)
-                        (get_local $ja)
+                        (get_local $40)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $ja)
-                        (get_local $Na)
+                        (get_local $11)
+                        (get_local $40)
                       )
                       (i32.store offset=12
-                        (get_local $ja)
-                        (get_local $c)
+                        (get_local $11)
+                        (get_local $4)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (set_local $Oa
+                        (set_local $4
                           (if
-                            (set_local $c
+                            (set_local $4
                               (i32.shr_u
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $ka)
+                                    (get_local $5)
                                     (i32.add
-                                      (set_local $e
+                                      (set_local $3
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $c
+                                                (set_local $4
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $ga
+                                                        (set_local $6
                                                           (i32.shl
-                                                            (get_local $c)
-                                                            (set_local $la
+                                                            (get_local $4)
+                                                            (set_local $2
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $c)
+                                                                    (get_local $4)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5595,16 +5535,16 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $la)
+                                                (get_local $2)
                                               )
-                                              (set_local $ga
+                                              (set_local $6
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $ma
+                                                      (set_local $1
                                                         (i32.shl
-                                                          (get_local $ga)
-                                                          (get_local $c)
+                                                          (get_local $6)
+                                                          (get_local $4)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5618,8 +5558,8 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $ma)
-                                              (get_local $ga)
+                                              (get_local $1)
+                                              (get_local $6)
                                             )
                                             (i32.const 15)
                                           )
@@ -5631,7 +5571,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $e)
+                                  (get_local $3)
                                   (i32.const 1)
                                 )
                               )
@@ -5644,29 +5584,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $ja)
-                    (get_local $Oa)
+                    (get_local $11)
+                    (get_local $4)
                   )
                   (i32.store offset=20
-                    (get_local $ja)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $ea)
+                    (get_local $18)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $ga
+                        (set_local $6
                           (i32.load
                             (i32.const 1212)
                           )
                         )
-                        (set_local $ma
+                        (set_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $Oa)
+                            (get_local $4)
                           )
                         )
                       )
@@ -5675,51 +5615,51 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $ga)
-                          (get_local $ma)
+                          (get_local $6)
+                          (get_local $1)
                         )
                       )
                       (i32.store
-                        (get_local $e)
-                        (get_local $ja)
+                        (get_local $3)
+                        (get_local $11)
                       )
                       (i32.store offset=24
-                        (get_local $ja)
-                        (get_local $e)
+                        (get_local $11)
+                        (get_local $3)
                       )
                       (i32.store offset=12
-                        (get_local $ja)
-                        (get_local $ja)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $ja)
-                        (get_local $ja)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $ma
+                  (set_local $1
                     (i32.shl
-                      (get_local $ka)
+                      (get_local $5)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $Oa)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $Oa)
+                          (get_local $4)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $ga
+                  (set_local $6
                     (i32.load
-                      (get_local $e)
+                      (get_local $3)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5727,34 +5667,34 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $ga)
+                            (get_local $6)
                           )
                           (i32.const -8)
                         )
-                        (get_local $ka)
+                        (get_local $5)
                       )
                       (block
-                        (set_local $Pa
-                          (get_local $ga)
+                        (set_local $30
+                          (get_local $6)
                         )
-                        (set_local $N
+                        (set_local $8
                           (i32.const 305)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $la
+                      (set_local $2
                         (i32.load
-                          (set_local $e
+                          (set_local $3
                             (i32.add
                               (i32.add
-                                (get_local $ga)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                               (i32.shl
                                 (i32.shr_u
-                                  (get_local $ma)
+                                  (get_local $1)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5764,24 +5704,24 @@
                         )
                       )
                       (block
-                        (set_local $ma
+                        (set_local $1
                           (i32.shl
-                            (get_local $ma)
+                            (get_local $1)
                             (i32.const 1)
                           )
                         )
-                        (set_local $ga
-                          (get_local $la)
+                        (set_local $6
+                          (get_local $2)
                         )
                       )
                       (block
-                        (set_local $Ra
-                          (get_local $e)
+                        (set_local $48
+                          (get_local $3)
                         )
-                        (set_local $Sa
-                          (get_local $ga)
+                        (set_local $55
+                          (get_local $6)
                         )
-                        (set_local $N
+                        (set_local $8
                           (i32.const 302)
                         )
                         (br $while-out$75)
@@ -5791,12 +5731,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $N)
+                      (get_local $8)
                       (i32.const 302)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $Ra)
+                        (get_local $48)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -5804,71 +5744,71 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $Ra)
-                          (get_local $ja)
+                          (get_local $48)
+                          (get_local $11)
                         )
                         (i32.store offset=24
-                          (get_local $ja)
-                          (get_local $Sa)
+                          (get_local $11)
+                          (get_local $55)
                         )
                         (i32.store offset=12
-                          (get_local $ja)
-                          (get_local $ja)
+                          (get_local $11)
+                          (get_local $11)
                         )
                         (i32.store offset=8
-                          (get_local $ja)
-                          (get_local $ja)
+                          (get_local $11)
+                          (get_local $11)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $N)
+                        (get_local $8)
                         (i32.const 305)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $ma
+                            (set_local $1
                               (i32.load
-                                (set_local $ga
+                                (set_local $6
                                   (i32.add
-                                    (get_local $Pa)
+                                    (get_local $30)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $ka
+                            (set_local $5
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $Pa)
-                            (get_local $ka)
+                            (get_local $30)
+                            (get_local $5)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $ma)
-                            (get_local $ja)
+                            (get_local $1)
+                            (get_local $11)
                           )
                           (i32.store
-                            (get_local $ga)
-                            (get_local $ja)
+                            (get_local $6)
+                            (get_local $11)
                           )
                           (i32.store offset=8
-                            (get_local $ja)
-                            (get_local $ma)
+                            (get_local $11)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $ja)
-                            (get_local $Pa)
+                            (get_local $11)
+                            (get_local $30)
                           )
                           (i32.store offset=24
-                            (get_local $ja)
+                            (get_local $11)
                             (i32.const 0)
                           )
                         )
@@ -5883,7 +5823,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $ma
+                    (set_local $1
                       (i32.load
                         (i32.const 1224)
                       )
@@ -5891,22 +5831,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $ha)
-                    (get_local $ma)
+                    (get_local $19)
+                    (get_local $1)
                   )
                 )
                 (i32.store
                   (i32.const 1224)
-                  (get_local $ha)
+                  (get_local $19)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $ha)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $ia)
+                (get_local $26)
               )
               (i32.store
                 (i32.const 1668)
@@ -5922,34 +5862,34 @@
                 (i32.const 1240)
                 (i32.const -1)
               )
-              (set_local $ma
+              (set_local $1
                 (i32.const 0)
               )
               (loop $do-out$44 $do-in$45
                 (i32.store offset=12
-                  (set_local $c
+                  (set_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $ma)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $c)
+                  (get_local $4)
                 )
                 (i32.store offset=8
-                  (get_local $c)
-                  (get_local $c)
+                  (get_local $4)
+                  (get_local $4)
                 )
                 (br_if $do-in$45
                   (i32.ne
-                    (set_local $ma
+                    (set_local $1
                       (i32.add
-                        (get_local $ma)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
@@ -5959,18 +5899,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $ma
+                (set_local $1
                   (i32.add
-                    (get_local $ha)
-                    (set_local $c
+                    (get_local $19)
+                    (set_local $4
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $ma
+                            (set_local $1
                               (i32.add
-                                (get_local $ha)
+                                (get_local $19)
                                 (i32.const 8)
                               )
                             )
@@ -5979,7 +5919,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $ma)
+                            (get_local $1)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5991,27 +5931,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $ka
+                (set_local $5
                   (i32.sub
                     (i32.add
-                      (get_local $ia)
+                      (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $c)
+                    (get_local $4)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $ma)
+                (get_local $1)
                 (i32.or
-                  (get_local $ka)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $ma)
-                  (get_local $ka)
+                  (get_local $1)
+                  (get_local $5)
                 )
                 (i32.const 40)
               )
@@ -6026,57 +5966,57 @@
         )
         (if
           (i32.gt_u
-            (set_local $ja
+            (set_local $11
               (i32.load
                 (i32.const 1220)
               )
             )
-            (get_local $y)
+            (get_local $0)
           )
           (block
             (i32.store
               (i32.const 1220)
-              (set_local $Pa
+              (set_local $30
                 (i32.sub
-                  (get_local $ja)
-                  (get_local $y)
+                  (get_local $11)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (set_local $N
+              (set_local $8
                 (i32.add
-                  (set_local $ja
+                  (set_local $11
                     (i32.load
                       (i32.const 1232)
                     )
                   )
-                  (get_local $y)
+                  (get_local $0)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $N)
+              (get_local $8)
               (i32.or
-                (get_local $Pa)
+                (get_local $30)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $ja)
+              (get_local $11)
               (i32.or
-                (get_local $y)
+                (get_local $0)
                 (i32.const 3)
               )
             )
             (i32.store
               (i32.const 8)
-              (get_local $b)
+              (get_local $25)
             )
             (return
               (i32.add
-                (get_local $ja)
+                (get_local $11)
                 (i32.const 8)
               )
             )
@@ -6085,69 +6025,50 @@
       )
     )
     (i32.store
-      (set_local $ja
-        (call $Qa)
-      )
+      (call $Qa)
       (i32.const 12)
     )
     (i32.store
       (i32.const 8)
-      (get_local $b)
+      (get_local $25)
     )
     (i32.const 0)
   )
-  (func $fb (param $a i32)
-    (local $m i32)
-    (local $s i32)
-    (local $h i32)
-    (local $b i32)
-    (local $f i32)
-    (local $n i32)
-    (local $w i32)
-    (local $i i32)
-    (local $j i32)
-    (local $l i32)
-    (local $g i32)
-    (local $o i32)
-    (local $t i32)
-    (local $y i32)
-    (local $u i32)
-    (local $v i32)
-    (local $e i32)
-    (local $F i32)
-    (local $p i32)
-    (local $c i32)
-    (local $D i32)
-    (local $E i32)
-    (local $q i32)
-    (local $z i32)
-    (local $A i32)
-    (local $G i32)
-    (local $H i32)
-    (local $I i32)
-    (local $d i32)
-    (local $x i32)
-    (local $C i32)
-    (local $J i32)
-    (local $L i32)
-    (local $r i32)
-    (local $B i32)
-    (local $K i32)
+  (func $fb (param $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
     (if
       (i32.eqz
-        (get_local $a)
+        (get_local $0)
       )
       (return)
     )
     (if
       (i32.lt_u
-        (set_local $b
+        (set_local $1
           (i32.add
-            (get_local $a)
+            (get_local $0)
             (i32.const -8)
           )
         )
-        (set_local $c
+        (set_local $13
           (i32.load
             (i32.const 1224)
           )
@@ -6157,12 +6078,12 @@
     )
     (if
       (i32.eq
-        (set_local $a
+        (set_local $0
           (i32.and
-            (set_local $d
+            (set_local $9
               (i32.load
                 (i32.add
-                  (get_local $a)
+                  (get_local $0)
                   (i32.const -4)
                 )
               )
@@ -6174,12 +6095,12 @@
       )
       (call_import $qa)
     )
-    (set_local $f
+    (set_local $7
       (i32.add
-        (get_local $b)
-        (set_local $e
+        (get_local $1)
+        (set_local $4
           (i32.and
-            (get_local $d)
+            (get_local $9)
             (i32.const -8)
           )
         )
@@ -6188,53 +6109,53 @@
     (block $do-once$0
       (if
         (i32.and
-          (get_local $d)
+          (get_local $9)
           (i32.const 1)
         )
         (block
-          (set_local $m
-            (get_local $b)
+          (set_local $2
+            (get_local $1)
           )
-          (set_local $n
-            (get_local $e)
+          (set_local $8
+            (get_local $4)
           )
         )
         (block
-          (set_local $g
+          (set_local $9
             (i32.load
-              (get_local $b)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $a)
+              (get_local $0)
             )
             (return)
           )
-          (set_local $i
+          (set_local $4
             (i32.add
-              (get_local $g)
-              (get_local $e)
+              (get_local $9)
+              (get_local $4)
             )
           )
           (if
             (i32.lt_u
-              (set_local $h
+              (set_local $0
                 (i32.add
-                  (get_local $b)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $g)
+                    (get_local $9)
                   )
                 )
               )
-              (get_local $c)
+              (get_local $13)
             )
             (call_import $qa)
           )
           (if
             (i32.eq
-              (get_local $h)
+              (get_local $0)
               (i32.load
                 (i32.const 1228)
               )
@@ -6243,11 +6164,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $l
+                    (set_local $5
                       (i32.load
-                        (set_local $j
+                        (set_local $1
                           (i32.add
-                            (get_local $f)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
@@ -6258,73 +6179,73 @@
                   (i32.const 3)
                 )
                 (block
-                  (set_local $m
-                    (get_local $h)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $i)
+                  (set_local $8
+                    (get_local $4)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $i)
+                (get_local $4)
               )
               (i32.store
-                (get_local $j)
+                (get_local $1)
                 (i32.and
-                  (get_local $l)
+                  (get_local $5)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $h)
+                (get_local $0)
                 (i32.or
-                  (get_local $i)
+                  (get_local $4)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $h)
-                  (get_local $i)
+                  (get_local $0)
+                  (get_local $4)
                 )
-                (get_local $i)
+                (get_local $4)
               )
               (return)
             )
           )
-          (set_local $l
+          (set_local $5
             (i32.shr_u
-              (get_local $g)
+              (get_local $9)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $g)
+              (get_local $9)
               (i32.const 256)
             )
             (block
-              (set_local $j
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $h)
+                  (get_local $0)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $g
+                  (set_local $9
                     (i32.load offset=8
-                      (get_local $h)
+                      (get_local $0)
                     )
                   )
-                  (set_local $o
+                  (set_local $6
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $l)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6335,17 +6256,17 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $g)
-                      (get_local $c)
+                      (get_local $9)
+                      (get_local $13)
                     )
                     (call_import $qa)
                   )
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $g)
+                        (get_local $9)
                       )
-                      (get_local $h)
+                      (get_local $0)
                     )
                     (call_import $qa)
                   )
@@ -6353,8 +6274,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $j)
-                  (get_local $g)
+                  (get_local $1)
+                  (get_local $9)
                 )
                 (block
                   (i32.store
@@ -6366,100 +6287,100 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $l)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
-                  (set_local $m
-                    (get_local $h)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $i)
+                  (set_local $8
+                    (get_local $4)
                   )
                   (br $do-once$0)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $j)
-                  (get_local $o)
+                  (get_local $1)
+                  (get_local $6)
                 )
-                (set_local $p
+                (set_local $11
                   (i32.add
-                    (get_local $j)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $j)
-                      (get_local $c)
+                      (get_local $1)
+                      (get_local $13)
                     )
                     (call_import $qa)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $o
+                        (set_local $6
                           (i32.add
-                            (get_local $j)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $h)
+                      (get_local $0)
                     )
-                    (set_local $p
-                      (get_local $o)
+                    (set_local $11
+                      (get_local $6)
                     )
                     (call_import $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $g)
-                (get_local $j)
+                (get_local $9)
+                (get_local $1)
               )
               (i32.store
-                (get_local $p)
-                (get_local $g)
+                (get_local $11)
+                (get_local $9)
               )
-              (set_local $m
-                (get_local $h)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $n
-                (get_local $i)
+              (set_local $8
+                (get_local $4)
               )
               (br $do-once$0)
             )
           )
-          (set_local $g
+          (set_local $9
             (i32.load offset=24
-              (get_local $h)
+              (get_local $0)
             )
           )
           (block $do-once$2
             (if
               (i32.eq
-                (set_local $j
+                (set_local $1
                   (i32.load offset=12
-                    (get_local $h)
+                    (get_local $0)
                   )
                 )
-                (get_local $h)
+                (get_local $0)
               )
               (block
                 (if
-                  (set_local $q
+                  (set_local $11
                     (i32.load
-                      (set_local $l
+                      (set_local $5
                         (i32.add
-                          (set_local $o
+                          (set_local $6
                             (i32.add
-                              (get_local $h)
+                              (get_local $0)
                               (i32.const 16)
                             )
                           )
@@ -6469,29 +6390,25 @@
                     )
                   )
                   (block
-                    (set_local $t
-                      (get_local $q)
+                    (set_local $1
+                      (get_local $11)
                     )
-                    (set_local $u
-                      (get_local $l)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                   (if
-                    (set_local $r
+                    (set_local $1
                       (i32.load
-                        (get_local $o)
+                        (get_local $6)
                       )
                     )
                     (block
-                      (set_local $t
-                        (get_local $r)
-                      )
-                      (set_local $u
-                        (get_local $o)
-                      )
+                      (get_local $1)
+                      (get_local $6)
                     )
                     (block
-                      (set_local $s
+                      (set_local $3
                         (i32.const 0)
                       )
                       (br $do-once$2)
@@ -6500,51 +6417,51 @@
                 )
                 (loop $while-out$4 $while-in$5
                   (if
-                    (set_local $q
+                    (set_local $11
                       (i32.load
-                        (set_local $l
+                        (set_local $5
                           (i32.add
-                            (get_local $t)
+                            (get_local $1)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $t
-                        (get_local $q)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $u
-                        (get_local $l)
+                      (set_local $6
+                        (get_local $5)
                       )
                       (br $while-in$5)
                     )
                   )
                   (if
-                    (set_local $q
+                    (set_local $11
                       (i32.load
-                        (set_local $l
+                        (set_local $5
                           (i32.add
-                            (get_local $t)
+                            (get_local $1)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $t
-                        (get_local $q)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $u
-                        (get_local $l)
+                      (set_local $6
+                        (get_local $5)
                       )
                     )
                     (block
-                      (set_local $v
-                        (get_local $t)
+                      (set_local $5
+                        (get_local $1)
                       )
-                      (set_local $w
-                        (get_local $u)
+                      (set_local $10
+                        (get_local $6)
                       )
                       (br $while-out$4)
                     )
@@ -6553,17 +6470,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $w)
-                    (get_local $c)
+                    (get_local $10)
+                    (get_local $13)
                   )
                   (call_import $qa)
                   (block
                     (i32.store
-                      (get_local $w)
+                      (get_local $10)
                       (i32.const 0)
                     )
-                    (set_local $s
-                      (get_local $v)
+                    (set_local $3
+                      (get_local $5)
                     )
                   )
                 )
@@ -6571,52 +6488,52 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $l
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $h)
+                        (get_local $0)
                       )
                     )
-                    (get_local $c)
+                    (get_local $13)
                   )
                   (call_import $qa)
                 )
                 (if
                   (i32.ne
                     (i32.load
-                      (set_local $q
+                      (set_local $11
                         (i32.add
-                          (get_local $l)
+                          (get_local $5)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $h)
+                    (get_local $0)
                   )
                   (call_import $qa)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $o
+                      (set_local $6
                         (i32.add
-                          (get_local $j)
+                          (get_local $1)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $h)
+                    (get_local $0)
                   )
                   (block
                     (i32.store
-                      (get_local $q)
-                      (get_local $j)
+                      (get_local $11)
+                      (get_local $1)
                     )
                     (i32.store
-                      (get_local $o)
-                      (get_local $l)
+                      (get_local $6)
+                      (get_local $5)
                     )
-                    (set_local $s
-                      (get_local $j)
+                    (set_local $3
+                      (get_local $1)
                     )
                   )
                   (call_import $qa)
@@ -6625,19 +6542,19 @@
             )
           )
           (if
-            (get_local $g)
+            (get_local $9)
             (block
               (if
                 (i32.eq
-                  (get_local $h)
+                  (get_local $0)
                   (i32.load
-                    (set_local $l
+                    (set_local $5
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
-                          (set_local $j
+                          (set_local $1
                             (i32.load offset=28
-                              (get_local $h)
+                              (get_local $0)
                             )
                           )
                           (i32.const 2)
@@ -6648,12 +6565,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $l)
-                    (get_local $s)
+                    (get_local $5)
+                    (get_local $3)
                   )
                   (if
                     (i32.eqz
-                      (get_local $s)
+                      (get_local $3)
                     )
                     (block
                       (i32.store
@@ -6665,17 +6582,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $j)
+                              (get_local $1)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $m
-                        (get_local $h)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $n
-                        (get_local $i)
+                      (set_local $8
+                        (get_local $4)
                       )
                       (br $do-once$0)
                     )
@@ -6684,7 +6601,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $g)
+                      (get_local $9)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6694,34 +6611,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $j
+                        (set_local $1
                           (i32.add
-                            (get_local $g)
+                            (get_local $9)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $h)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $j)
-                      (get_local $s)
+                      (get_local $1)
+                      (get_local $3)
                     )
                     (i32.store offset=20
-                      (get_local $g)
-                      (get_local $s)
+                      (get_local $9)
+                      (get_local $3)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $s)
+                      (get_local $3)
                     )
                     (block
-                      (set_local $m
-                        (get_local $h)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $n
-                        (get_local $i)
+                      (set_local $8
+                        (get_local $4)
                       )
                       (br $do-once$0)
                     )
@@ -6730,8 +6647,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $s)
-                  (set_local $j
+                  (get_local $3)
+                  (set_local $1
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6740,15 +6657,15 @@
                 (call_import $qa)
               )
               (i32.store offset=24
-                (get_local $s)
-                (get_local $g)
+                (get_local $3)
+                (get_local $9)
               )
               (if
-                (set_local $o
+                (set_local $6
                   (i32.load
-                    (set_local $l
+                    (set_local $5
                       (i32.add
-                        (get_local $h)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
@@ -6756,31 +6673,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $o)
-                    (get_local $j)
+                    (get_local $6)
+                    (get_local $1)
                   )
                   (call_import $qa)
                   (block
                     (i32.store offset=16
-                      (get_local $s)
-                      (get_local $o)
+                      (get_local $3)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $o)
-                      (get_local $s)
+                      (get_local $6)
+                      (get_local $3)
                     )
                   )
                 )
               )
               (if
-                (set_local $o
+                (set_local $6
                   (i32.load offset=4
-                    (get_local $l)
+                    (get_local $5)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $o)
+                    (get_local $6)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6788,37 +6705,37 @@
                   (call_import $qa)
                   (block
                     (i32.store offset=20
-                      (get_local $s)
-                      (get_local $o)
+                      (get_local $3)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $o)
-                      (get_local $s)
+                      (get_local $6)
+                      (get_local $3)
                     )
-                    (set_local $m
-                      (get_local $h)
+                    (set_local $2
+                      (get_local $0)
                     )
-                    (set_local $n
-                      (get_local $i)
+                    (set_local $8
+                      (get_local $4)
                     )
                   )
                 )
                 (block
-                  (set_local $m
-                    (get_local $h)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $i)
+                  (set_local $8
+                    (get_local $4)
                   )
                 )
               )
             )
             (block
-              (set_local $m
-                (get_local $h)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $n
-                (get_local $i)
+              (set_local $8
+                (get_local $4)
               )
             )
           )
@@ -6827,19 +6744,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $m)
-        (get_local $f)
+        (get_local $2)
+        (get_local $7)
       )
       (call_import $qa)
     )
     (if
       (i32.eqz
         (i32.and
-          (set_local $b
+          (set_local $1
             (i32.load
-              (set_local $e
+              (set_local $4
                 (i32.add
-                  (get_local $f)
+                  (get_local $7)
                   (i32.const 4)
                 )
               )
@@ -6852,39 +6769,39 @@
     )
     (if
       (i32.and
-        (get_local $b)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $e)
+          (get_local $4)
           (i32.and
-            (get_local $b)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $m)
+          (get_local $2)
           (i32.or
-            (get_local $n)
+            (get_local $8)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $m)
-            (get_local $n)
+            (get_local $2)
+            (get_local $8)
           )
-          (get_local $n)
+          (get_local $8)
         )
-        (set_local $D
-          (get_local $n)
+        (set_local $0
+          (get_local $8)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $f)
+            (get_local $7)
             (i32.load
               (i32.const 1232)
             )
@@ -6892,29 +6809,29 @@
           (block
             (i32.store
               (i32.const 1220)
-              (set_local $s
+              (set_local $3
                 (i32.add
                   (i32.load
                     (i32.const 1220)
                   )
-                  (get_local $n)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (get_local $m)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $m)
+              (get_local $2)
               (i32.or
-                (get_local $s)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (if
               (i32.ne
-                (get_local $m)
+                (get_local $2)
                 (i32.load
                   (i32.const 1228)
                 )
@@ -6934,7 +6851,7 @@
         )
         (if
           (i32.eq
-            (get_local $f)
+            (get_local $7)
             (i32.load
               (i32.const 1228)
             )
@@ -6942,76 +6859,76 @@
           (block
             (i32.store
               (i32.const 1216)
-              (set_local $s
+              (set_local $3
                 (i32.add
                   (i32.load
                     (i32.const 1216)
                   )
-                  (get_local $n)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
               (i32.const 1228)
-              (get_local $m)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $m)
+              (get_local $2)
               (i32.or
-                (get_local $s)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $m)
-                (get_local $s)
+                (get_local $2)
+                (get_local $3)
               )
-              (get_local $s)
+              (get_local $3)
             )
             (return)
           )
         )
-        (set_local $s
+        (set_local $3
           (i32.add
             (i32.and
-              (get_local $b)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $n)
+            (get_local $8)
           )
         )
-        (set_local $c
+        (set_local $13
           (i32.shr_u
-            (get_local $b)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once$8
           (if
             (i32.lt_u
-              (get_local $b)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $w
+              (set_local $10
                 (i32.load offset=12
-                  (get_local $f)
+                  (get_local $7)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $v
+                  (set_local $5
                     (i32.load offset=8
-                      (get_local $f)
+                      (get_local $7)
                     )
                   )
-                  (set_local $u
+                  (set_local $6
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $c)
+                          (get_local $13)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -7022,7 +6939,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $v)
+                      (get_local $5)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -7032,9 +6949,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $v)
+                        (get_local $5)
                       )
-                      (get_local $f)
+                      (get_local $7)
                     )
                     (call_import $qa)
                   )
@@ -7042,8 +6959,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $w)
-                  (get_local $v)
+                  (get_local $10)
+                  (get_local $5)
                 )
                 (block
                   (i32.store
@@ -7055,7 +6972,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $c)
+                          (get_local $13)
                         )
                         (i32.const -1)
                       )
@@ -7066,19 +6983,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $w)
-                  (get_local $u)
+                  (get_local $10)
+                  (get_local $6)
                 )
-                (set_local $x
+                (set_local $17
                   (i32.add
-                    (get_local $w)
+                    (get_local $10)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $w)
+                      (get_local $10)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -7088,56 +7005,56 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $u
+                        (set_local $6
                           (i32.add
-                            (get_local $w)
+                            (get_local $10)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $f)
+                      (get_local $7)
                     )
-                    (set_local $x
-                      (get_local $u)
+                    (set_local $17
+                      (get_local $6)
                     )
                     (call_import $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $v)
-                (get_local $w)
+                (get_local $5)
+                (get_local $10)
               )
               (i32.store
-                (get_local $x)
-                (get_local $v)
+                (get_local $17)
+                (get_local $5)
               )
             )
             (block
-              (set_local $v
+              (set_local $5
                 (i32.load offset=24
-                  (get_local $f)
+                  (get_local $7)
                 )
               )
               (block $do-once$10
                 (if
                   (i32.eq
-                    (set_local $w
+                    (set_local $10
                       (i32.load offset=12
-                        (get_local $f)
+                        (get_local $7)
                       )
                     )
-                    (get_local $f)
+                    (get_local $7)
                   )
                   (block
                     (if
-                      (set_local $p
+                      (set_local $11
                         (i32.load
-                          (set_local $t
+                          (set_local $1
                             (i32.add
-                              (set_local $u
+                              (set_local $6
                                 (i32.add
-                                  (get_local $f)
+                                  (get_local $7)
                                   (i32.const 16)
                                 )
                               )
@@ -7147,29 +7064,27 @@
                         )
                       )
                       (block
-                        (set_local $z
-                          (get_local $p)
+                        (set_local $0
+                          (get_local $11)
                         )
-                        (set_local $A
-                          (get_local $t)
+                        (set_local $13
+                          (get_local $1)
                         )
                       )
                       (if
-                        (set_local $a
+                        (set_local $0
                           (i32.load
-                            (get_local $u)
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $z
-                            (get_local $a)
-                          )
-                          (set_local $A
-                            (get_local $u)
+                          (get_local $0)
+                          (set_local $13
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $y
+                          (set_local $12
                             (i32.const 0)
                           )
                           (br $do-once$10)
@@ -7178,51 +7093,49 @@
                     )
                     (loop $while-out$12 $while-in$13
                       (if
-                        (set_local $p
+                        (set_local $11
                           (i32.load
-                            (set_local $t
+                            (set_local $1
                               (i32.add
-                                (get_local $z)
+                                (get_local $0)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $z
-                            (get_local $p)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $A
-                            (get_local $t)
+                          (set_local $13
+                            (get_local $1)
                           )
                           (br $while-in$13)
                         )
                       )
                       (if
-                        (set_local $p
+                        (set_local $11
                           (i32.load
-                            (set_local $t
+                            (set_local $1
                               (i32.add
-                                (get_local $z)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $z
-                            (get_local $p)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $A
-                            (get_local $t)
+                          (set_local $13
+                            (get_local $1)
                           )
                         )
                         (block
-                          (set_local $B
-                            (get_local $z)
-                          )
-                          (set_local $C
-                            (get_local $A)
+                          (get_local $0)
+                          (set_local $1
+                            (get_local $13)
                           )
                           (br $while-out$12)
                         )
@@ -7231,7 +7144,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $C)
+                        (get_local $1)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7239,11 +7152,11 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $C)
+                          (get_local $1)
                           (i32.const 0)
                         )
-                        (set_local $y
-                          (get_local $B)
+                        (set_local $12
+                          (get_local $0)
                         )
                       )
                     )
@@ -7251,9 +7164,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (set_local $t
+                        (set_local $1
                           (i32.load offset=8
-                            (get_local $f)
+                            (get_local $7)
                           )
                         )
                         (i32.load
@@ -7265,40 +7178,40 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $p
+                          (set_local $11
                             (i32.add
-                              (get_local $t)
+                              (get_local $1)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $f)
+                        (get_local $7)
                       )
                       (call_import $qa)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $u
+                          (set_local $6
                             (i32.add
-                              (get_local $w)
+                              (get_local $10)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $f)
+                        (get_local $7)
                       )
                       (block
                         (i32.store
-                          (get_local $p)
-                          (get_local $w)
+                          (get_local $11)
+                          (get_local $10)
                         )
                         (i32.store
-                          (get_local $u)
-                          (get_local $t)
+                          (get_local $6)
+                          (get_local $1)
                         )
-                        (set_local $y
-                          (get_local $w)
+                        (set_local $12
+                          (get_local $10)
                         )
                       )
                       (call_import $qa)
@@ -7307,19 +7220,19 @@
                 )
               )
               (if
-                (get_local $v)
+                (get_local $5)
                 (block
                   (if
                     (i32.eq
-                      (get_local $f)
+                      (get_local $7)
                       (i32.load
-                        (set_local $i
+                        (set_local $4
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (set_local $w
+                              (set_local $10
                                 (i32.load offset=28
-                                  (get_local $f)
+                                  (get_local $7)
                                 )
                               )
                               (i32.const 2)
@@ -7330,12 +7243,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $i)
-                        (get_local $y)
+                        (get_local $4)
+                        (get_local $12)
                       )
                       (if
                         (i32.eqz
-                          (get_local $y)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
@@ -7347,7 +7260,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $w)
+                                  (get_local $10)
                                 )
                                 (i32.const -1)
                               )
@@ -7360,7 +7273,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $v)
+                          (get_local $5)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7370,35 +7283,35 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $w
+                            (set_local $10
                               (i32.add
-                                (get_local $v)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $f)
+                          (get_local $7)
                         )
                         (i32.store
-                          (get_local $w)
-                          (get_local $y)
+                          (get_local $10)
+                          (get_local $12)
                         )
                         (i32.store offset=20
-                          (get_local $v)
-                          (get_local $y)
+                          (get_local $5)
+                          (get_local $12)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eqz
-                          (get_local $y)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $y)
-                      (set_local $w
+                      (get_local $12)
+                      (set_local $10
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7407,15 +7320,15 @@
                     (call_import $qa)
                   )
                   (i32.store offset=24
-                    (get_local $y)
-                    (get_local $v)
+                    (get_local $12)
+                    (get_local $5)
                   )
                   (if
-                    (set_local $h
+                    (set_local $0
                       (i32.load
-                        (set_local $i
+                        (set_local $4
                           (i32.add
-                            (get_local $f)
+                            (get_local $7)
                             (i32.const 16)
                           )
                         )
@@ -7423,31 +7336,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $h)
-                        (get_local $w)
+                        (get_local $0)
+                        (get_local $10)
                       )
                       (call_import $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $y)
-                          (get_local $h)
+                          (get_local $12)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $h)
-                          (get_local $y)
+                          (get_local $0)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (set_local $h
+                    (set_local $0
                       (i32.load offset=4
-                        (get_local $i)
+                        (get_local $4)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $h)
+                        (get_local $0)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7455,12 +7368,12 @@
                       (call_import $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $y)
-                          (get_local $h)
+                          (get_local $12)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $h)
-                          (get_local $y)
+                          (get_local $0)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7471,22 +7384,22 @@
           )
         )
         (i32.store offset=4
-          (get_local $m)
+          (get_local $2)
           (i32.or
-            (get_local $s)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $m)
-            (get_local $s)
+            (get_local $2)
+            (get_local $3)
           )
-          (get_local $s)
+          (get_local $3)
         )
         (if
           (i32.eq
-            (get_local $m)
+            (get_local $2)
             (i32.load
               (i32.const 1228)
             )
@@ -7494,34 +7407,34 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $s)
+              (get_local $3)
             )
             (return)
           )
-          (set_local $D
-            (get_local $s)
+          (set_local $0
+            (get_local $3)
           )
         )
       )
     )
-    (set_local $n
+    (set_local $8
       (i32.shr_u
-        (get_local $D)
+        (get_local $0)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $D)
+        (get_local $0)
         (i32.const 256)
       )
       (block
-        (set_local $b
+        (set_local $1
           (i32.add
             (i32.const 1248)
             (i32.shl
               (i32.shl
-                (get_local $n)
+                (get_local $8)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7530,25 +7443,25 @@
         )
         (if
           (i32.and
-            (set_local $e
+            (set_local $4
               (i32.load
                 (i32.const 1208)
               )
             )
-            (set_local $s
+            (set_local $3
               (i32.shl
                 (i32.const 1)
-                (get_local $n)
+                (get_local $8)
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $e
+              (set_local $4
                 (i32.load
-                  (set_local $s
+                  (set_local $3
                     (i32.add
-                      (get_local $b)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -7560,11 +7473,11 @@
             )
             (call_import $qa)
             (block
-              (set_local $E
-                (get_local $s)
+              (set_local $15
+                (get_local $3)
               )
-              (set_local $F
-                (get_local $e)
+              (set_local $14
+                (get_local $4)
               )
             )
           )
@@ -7572,81 +7485,81 @@
             (i32.store
               (i32.const 1208)
               (i32.or
-                (get_local $e)
-                (get_local $s)
+                (get_local $4)
+                (get_local $3)
               )
             )
-            (set_local $E
+            (set_local $15
               (i32.add
-                (get_local $b)
+                (get_local $1)
                 (i32.const 8)
               )
             )
-            (set_local $F
-              (get_local $b)
+            (set_local $14
+              (get_local $1)
             )
           )
         )
         (i32.store
-          (get_local $E)
-          (get_local $m)
+          (get_local $15)
+          (get_local $2)
         )
         (i32.store offset=12
-          (get_local $F)
-          (get_local $m)
+          (get_local $14)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $m)
-          (get_local $F)
+          (get_local $2)
+          (get_local $14)
         )
         (i32.store offset=12
-          (get_local $m)
-          (get_local $b)
+          (get_local $2)
+          (get_local $1)
         )
         (return)
       )
     )
-    (set_local $s
+    (set_local $3
       (i32.add
         (i32.const 1512)
         (i32.shl
-          (set_local $G
+          (set_local $1
             (if
-              (set_local $b
+              (set_local $1
                 (i32.shr_u
-                  (get_local $D)
+                  (get_local $0)
                   (i32.const 8)
                 )
               )
               (if
                 (i32.gt_u
-                  (get_local $D)
+                  (get_local $0)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $D)
+                      (get_local $0)
                       (i32.add
-                        (set_local $s
+                        (set_local $3
                           (i32.add
                             (i32.sub
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (set_local $b
+                                  (set_local $1
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (set_local $E
+                                          (set_local $15
                                             (i32.shl
-                                              (get_local $b)
-                                              (set_local $F
+                                              (get_local $1)
+                                              (set_local $14
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (get_local $b)
+                                                      (get_local $1)
                                                       (i32.const 1048320)
                                                     )
                                                     (i32.const 16)
@@ -7663,16 +7576,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $F)
+                                  (get_local $14)
                                 )
-                                (set_local $E
+                                (set_local $15
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $e
+                                        (set_local $4
                                           (i32.shl
-                                            (get_local $E)
-                                            (get_local $b)
+                                            (get_local $15)
+                                            (get_local $1)
                                           )
                                         )
                                         (i32.const 245760)
@@ -7686,8 +7599,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $e)
-                                (get_local $E)
+                                (get_local $4)
+                                (get_local $15)
                               )
                               (i32.const 15)
                             )
@@ -7699,7 +7612,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $s)
+                    (get_local $3)
                     (i32.const 1)
                   )
                 )
@@ -7712,54 +7625,54 @@
       )
     )
     (i32.store offset=28
-      (get_local $m)
-      (get_local $G)
+      (get_local $2)
+      (get_local $1)
     )
     (i32.store offset=20
-      (get_local $m)
+      (get_local $2)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $m)
+      (get_local $2)
       (i32.const 0)
     )
     (if
       (i32.and
-        (set_local $E
+        (set_local $15
           (i32.load
             (i32.const 1212)
           )
         )
-        (set_local $e
+        (set_local $4
           (i32.shl
             (i32.const 1)
-            (get_local $G)
+            (get_local $1)
           )
         )
       )
       (block
-        (set_local $F
+        (set_local $14
           (i32.shl
-            (get_local $D)
+            (get_local $0)
             (select
               (i32.const 0)
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $G)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $G)
+                (get_local $1)
                 (i32.const 31)
               )
             )
           )
         )
-        (set_local $b
+        (set_local $1
           (i32.load
-            (get_local $s)
+            (get_local $3)
           )
         )
         (loop $while-out$18 $while-in$19
@@ -7767,34 +7680,34 @@
             (i32.eq
               (i32.and
                 (i32.load offset=4
-                  (get_local $b)
+                  (get_local $1)
                 )
                 (i32.const -8)
               )
-              (get_local $D)
+              (get_local $0)
             )
             (block
-              (set_local $H
-                (get_local $b)
+              (set_local $16
+                (get_local $1)
               )
-              (set_local $I
+              (set_local $0
                 (i32.const 130)
               )
               (br $while-out$18)
             )
           )
           (if
-            (set_local $y
+            (set_local $12
               (i32.load
-                (set_local $n
+                (set_local $8
                   (i32.add
                     (i32.add
-                      (get_local $b)
+                      (get_local $1)
                       (i32.const 16)
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $F)
+                        (get_local $14)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7804,24 +7717,24 @@
               )
             )
             (block
-              (set_local $F
+              (set_local $14
                 (i32.shl
-                  (get_local $F)
+                  (get_local $14)
                   (i32.const 1)
                 )
               )
-              (set_local $b
-                (get_local $y)
+              (set_local $1
+                (get_local $12)
               )
             )
             (block
-              (set_local $J
-                (get_local $n)
+              (set_local $18
+                (get_local $8)
               )
-              (set_local $K
-                (get_local $b)
+              (set_local $19
+                (get_local $1)
               )
-              (set_local $I
+              (set_local $0
                 (i32.const 127)
               )
               (br $while-out$18)
@@ -7831,12 +7744,12 @@
         )
         (if
           (i32.eq
-            (get_local $I)
+            (get_local $0)
             (i32.const 127)
           )
           (if
             (i32.lt_u
-              (get_local $J)
+              (get_local $18)
               (i32.load
                 (i32.const 1224)
               )
@@ -7844,71 +7757,71 @@
             (call_import $qa)
             (block
               (i32.store
-                (get_local $J)
-                (get_local $m)
+                (get_local $18)
+                (get_local $2)
               )
               (i32.store offset=24
-                (get_local $m)
-                (get_local $K)
+                (get_local $2)
+                (get_local $19)
               )
               (i32.store offset=12
-                (get_local $m)
-                (get_local $m)
+                (get_local $2)
+                (get_local $2)
               )
               (i32.store offset=8
-                (get_local $m)
-                (get_local $m)
+                (get_local $2)
+                (get_local $2)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $I)
+              (get_local $0)
               (i32.const 130)
             )
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $F
+                  (set_local $14
                     (i32.load
-                      (set_local $b
+                      (set_local $1
                         (i32.add
-                          (get_local $H)
+                          (get_local $16)
                           (i32.const 8)
                         )
                       )
                     )
                   )
-                  (set_local $i
+                  (set_local $4
                     (i32.load
                       (i32.const 1224)
                     )
                   )
                 )
                 (i32.ge_u
-                  (get_local $H)
-                  (get_local $i)
+                  (get_local $16)
+                  (get_local $4)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $F)
-                  (get_local $m)
+                  (get_local $14)
+                  (get_local $2)
                 )
                 (i32.store
-                  (get_local $b)
-                  (get_local $m)
+                  (get_local $1)
+                  (get_local $2)
                 )
                 (i32.store offset=8
-                  (get_local $m)
-                  (get_local $F)
+                  (get_local $2)
+                  (get_local $14)
                 )
                 (i32.store offset=12
-                  (get_local $m)
-                  (get_local $H)
+                  (get_local $2)
+                  (get_local $16)
                 )
                 (i32.store offset=24
-                  (get_local $m)
+                  (get_local $2)
                   (i32.const 0)
                 )
               )
@@ -7921,31 +7834,31 @@
         (i32.store
           (i32.const 1212)
           (i32.or
-            (get_local $E)
-            (get_local $e)
+            (get_local $15)
+            (get_local $4)
           )
         )
         (i32.store
-          (get_local $s)
-          (get_local $m)
+          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=24
-          (get_local $m)
-          (get_local $s)
+          (get_local $2)
+          (get_local $3)
         )
         (i32.store offset=12
-          (get_local $m)
-          (get_local $m)
+          (get_local $2)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $m)
-          (get_local $m)
+          (get_local $2)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 1240)
-      (set_local $m
+      (set_local $2
         (i32.add
           (i32.load
             (i32.const 1240)
@@ -7955,22 +7868,22 @@
       )
     )
     (if
-      (get_local $m)
+      (get_local $2)
       (return)
-      (set_local $L
+      (set_local $0
         (i32.const 1664)
       )
     )
     (loop $while-out$20 $while-in$21
       (if
-        (set_local $m
+        (set_local $2
           (i32.load
-            (get_local $L)
+            (get_local $0)
           )
         )
-        (set_local $L
+        (set_local $0
           (i32.add
-            (get_local $m)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -7983,29 +7896,24 @@
       (i32.const -1)
     )
   )
-  (func $Ra (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $g i32)
-    (local $m i32)
-    (local $o i32)
-    (local $i i32)
-    (local $x i32)
-    (local $h i32)
-    (local $l i32)
-    (local $n i32)
-    (local $d i32)
-    (local $e i32)
-    (local $f i32)
-    (local $w i32)
-    (local $j i32)
-    (local $p i32)
-    (local $t i32)
-    (local $y i32)
-    (local $z i32)
-    (local $q i32)
-    (local $s i32)
-    (local $u i32)
-    (local $v i32)
-    (set_local $d
+  (func $Ra (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (set_local $11
       (i32.load
         (i32.const 8)
       )
@@ -8019,27 +7927,27 @@
         (i32.const 48)
       )
     )
-    (set_local $e
+    (set_local $12
       (i32.add
-        (get_local $d)
+        (get_local $11)
         (i32.const 16)
       )
     )
-    (set_local $f
-      (get_local $d)
+    (set_local $13
+      (get_local $11)
     )
     (i32.store
-      (set_local $g
+      (set_local $3
         (i32.add
-          (get_local $d)
+          (get_local $11)
           (i32.const 32)
         )
       )
-      (set_local $i
+      (set_local $8
         (i32.load
-          (set_local $h
+          (set_local $9
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -8047,55 +7955,55 @@
       )
     )
     (i32.store offset=4
-      (get_local $g)
-      (set_local $l
+      (get_local $3)
+      (set_local $10
         (i32.sub
           (i32.load
-            (set_local $j
+            (set_local $14
               (i32.add
-                (get_local $a)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $i)
+          (get_local $8)
         )
       )
     )
     (i32.store offset=8
-      (get_local $g)
-      (get_local $b)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $g)
-      (get_local $c)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $b
+    (set_local $1
       (i32.add
-        (get_local $a)
+        (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $i
+    (set_local $8
       (i32.add
-        (get_local $a)
+        (get_local $0)
         (i32.const 44)
       )
     )
-    (set_local $m
-      (get_local $g)
+    (set_local $5
+      (get_local $3)
     )
-    (set_local $g
+    (set_local $3
       (i32.const 2)
     )
-    (set_local $n
+    (set_local $6
       (i32.add
-        (get_local $l)
-        (get_local $c)
+        (get_local $10)
+        (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $o
+      (set_local $4
         (if
           (i32.load
             (i32.const 1160)
@@ -8103,54 +8011,54 @@
           (block
             (call_import $ra
               (i32.const 1)
-              (get_local $a)
+              (get_local $0)
             )
             (i32.store
-              (get_local $f)
+              (get_local $13)
               (i32.load
-                (get_local $b)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $f)
-              (get_local $m)
+              (get_local $13)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $f)
-              (get_local $g)
+              (get_local $13)
+              (get_local $3)
             )
-            (set_local $l
+            (set_local $10
               (call $Pa
                 (call_import $ya
                   (i32.const 146)
-                  (get_local $f)
+                  (get_local $13)
                 )
               )
             )
             (call_import $oa
               (i32.const 0)
             )
-            (get_local $l)
+            (get_local $10)
           )
           (block
             (i32.store
-              (get_local $e)
+              (get_local $12)
               (i32.load
-                (get_local $b)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $e)
-              (get_local $m)
+              (get_local $12)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $e)
-              (get_local $g)
+              (get_local $12)
+              (get_local $3)
             )
             (call $Pa
               (call_import $ya
                 (i32.const 146)
-                (get_local $e)
+                (get_local $12)
               )
             )
           )
@@ -8158,11 +8066,11 @@
       )
       (if
         (i32.eq
-          (get_local $n)
-          (get_local $o)
+          (get_local $6)
+          (get_local $4)
         )
         (block
-          (set_local $p
+          (set_local $1
             (i32.const 6)
           )
           (br $while-out$0)
@@ -8170,212 +8078,208 @@
       )
       (if
         (i32.lt_s
-          (get_local $o)
+          (get_local $4)
           (i32.const 0)
         )
         (block
-          (set_local $q
-            (get_local $m)
+          (set_local $17
+            (get_local $5)
           )
-          (set_local $s
-            (get_local $g)
+          (set_local $18
+            (get_local $3)
           )
-          (set_local $p
+          (set_local $1
             (i32.const 8)
           )
           (br $while-out$0)
         )
       )
-      (set_local $l
+      (set_local $10
         (i32.sub
-          (get_local $n)
-          (get_local $o)
+          (get_local $6)
+          (get_local $4)
         )
       )
-      (set_local $v
+      (set_local $3
         (if
           (i32.gt_u
-            (get_local $o)
-            (set_local $t
+            (get_local $4)
+            (set_local $6
               (i32.load offset=4
-                (get_local $m)
+                (get_local $5)
               )
             )
           )
           (block
             (i32.store
-              (get_local $h)
-              (set_local $u
+              (get_local $9)
+              (set_local $7
                 (i32.load
-                  (get_local $i)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
-              (get_local $j)
-              (get_local $u)
+              (get_local $14)
+              (get_local $7)
             )
-            (set_local $w
+            (set_local $4
               (i32.sub
-                (get_local $o)
-                (get_local $t)
+                (get_local $4)
+                (get_local $6)
               )
             )
-            (set_local $x
+            (set_local $7
               (i32.add
-                (get_local $m)
+                (get_local $5)
                 (i32.const 8)
               )
             )
-            (set_local $y
+            (set_local $15
               (i32.add
-                (get_local $g)
+                (get_local $3)
                 (i32.const -1)
               )
             )
             (i32.load offset=12
-              (get_local $m)
+              (get_local $5)
             )
           )
           (if
             (i32.eq
-              (get_local $g)
+              (get_local $3)
               (i32.const 2)
             )
             (block
               (i32.store
-                (get_local $h)
+                (get_local $9)
                 (i32.add
                   (i32.load
-                    (get_local $h)
+                    (get_local $9)
                   )
-                  (get_local $o)
+                  (get_local $4)
                 )
               )
-              (set_local $w
-                (get_local $o)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $x
-                (get_local $m)
-              )
-              (set_local $y
+              (set_local $15
                 (i32.const 2)
               )
-              (get_local $t)
+              (get_local $6)
             )
             (block
-              (set_local $w
-                (get_local $o)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $x
-                (get_local $m)
+              (set_local $15
+                (get_local $3)
               )
-              (set_local $y
-                (get_local $g)
-              )
-              (get_local $t)
+              (get_local $6)
             )
           )
         )
       )
       (i32.store
-        (get_local $x)
+        (get_local $7)
         (i32.add
           (i32.load
-            (get_local $x)
+            (get_local $7)
           )
-          (get_local $w)
+          (get_local $4)
         )
       )
       (i32.store offset=4
-        (get_local $x)
+        (get_local $7)
         (i32.sub
-          (get_local $v)
-          (get_local $w)
+          (get_local $3)
+          (get_local $4)
         )
       )
-      (set_local $m
-        (get_local $x)
+      (set_local $5
+        (get_local $7)
       )
-      (set_local $g
-        (get_local $y)
+      (set_local $3
+        (get_local $15)
       )
-      (set_local $n
-        (get_local $l)
+      (set_local $6
+        (get_local $10)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $p)
+        (get_local $1)
         (i32.const 6)
       )
       (block
         (i32.store offset=16
-          (get_local $a)
+          (get_local $0)
           (i32.add
-            (set_local $n
+            (set_local $6
               (i32.load
-                (get_local $i)
+                (get_local $8)
               )
             )
             (i32.load offset=48
-              (get_local $a)
+              (get_local $0)
             )
           )
         )
         (i32.store
-          (get_local $h)
-          (set_local $i
-            (get_local $n)
+          (get_local $9)
+          (set_local $8
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $j)
-          (get_local $i)
+          (get_local $14)
+          (get_local $8)
         )
-        (set_local $z
-          (get_local $c)
+        (set_local $16
+          (get_local $2)
         )
       )
       (if
         (i32.eq
-          (get_local $p)
+          (get_local $1)
           (i32.const 8)
         )
         (block
           (i32.store offset=16
-            (get_local $a)
+            (get_local $0)
             (i32.const 0)
           )
           (i32.store
-            (get_local $h)
+            (get_local $9)
             (i32.const 0)
           )
           (i32.store
-            (get_local $j)
+            (get_local $14)
             (i32.const 0)
           )
           (i32.store
-            (get_local $a)
+            (get_local $0)
             (i32.or
               (i32.load
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const 32)
             )
           )
-          (set_local $z
+          (set_local $16
             (if
               (i32.eq
-                (get_local $s)
+                (get_local $18)
                 (i32.const 2)
               )
               (i32.const 0)
               (i32.sub
-                (get_local $c)
+                (get_local $2)
                 (i32.load offset=4
-                  (get_local $q)
+                  (get_local $17)
                 )
               )
             )
@@ -8385,56 +8289,49 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $d)
+      (get_local $11)
     )
-    (get_local $z)
+    (get_local $16)
   )
-  (func $Wa (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $d i32)
-    (local $q i32)
-    (local $e i32)
-    (local $h i32)
-    (local $l i32)
-    (local $m i32)
-    (local $n i32)
-    (local $o i32)
-    (local $f i32)
-    (local $g i32)
-    (local $j i32)
-    (local $p i32)
+  (func $Wa (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
     (if
-      (set_local $e
+      (set_local $6
         (i32.load
-          (set_local $d
+          (set_local $3
             (i32.add
-              (get_local $c)
+              (get_local $2)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $f
-          (get_local $e)
+        (set_local $5
+          (get_local $6)
         )
-        (set_local $g
+        (set_local $4
           (i32.const 5)
         )
       )
       (if
         (call $Xa
-          (get_local $c)
+          (get_local $2)
         )
-        (set_local $h
+        (set_local $7
           (i32.const 0)
         )
         (block
-          (set_local $f
+          (set_local $5
             (i32.load
-              (get_local $d)
+              (get_local $3)
             )
           )
-          (set_local $g
+          (set_local $4
             (i32.const 5)
           )
         )
@@ -8443,16 +8340,16 @@
     (block $label$break$a
       (if
         (i32.eq
-          (get_local $g)
+          (get_local $4)
           (i32.const 5)
         )
         (block
-          (set_local $j
-            (set_local $d
+          (set_local $4
+            (set_local $3
               (i32.load
-                (set_local $e
+                (set_local $6
                   (i32.add
-                    (get_local $c)
+                    (get_local $2)
                     (i32.const 20)
                   )
                 )
@@ -8462,61 +8359,61 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $f)
-                (get_local $d)
+                (get_local $5)
+                (get_local $3)
               )
-              (get_local $b)
+              (get_local $1)
             )
             (block
-              (set_local $h
+              (set_local $7
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $c)
+                        (get_local $2)
                       )
                       (i32.const 3)
                     )
                     (i32.const 2)
                   )
-                  (get_local $c)
-                  (get_local $a)
-                  (get_local $b)
+                  (get_local $2)
+                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br $label$break$a)
             )
           )
-          (set_local $l
+          (set_local $0
             (block $label$break$b
               (if
                 (i32.gt_s
                   (i32.load8_s offset=75
-                    (get_local $c)
+                    (get_local $2)
                   )
                   (i32.const -1)
                 )
                 (block
-                  (set_local $d
-                    (get_local $b)
+                  (set_local $3
+                    (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eqz
-                        (get_local $d)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $m
-                          (get_local $a)
+                        (set_local $2
+                          (get_local $0)
                         )
-                        (set_local $n
-                          (get_local $j)
+                        (set_local $3
+                          (get_local $4)
                         )
-                        (set_local $o
+                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$b
-                          (get_local $b)
+                          (get_local $1)
                         )
                       )
                     )
@@ -8524,10 +8421,10 @@
                       (i32.eq
                         (i32.load8_s
                           (i32.add
-                            (get_local $a)
-                            (set_local $p
+                            (get_local $0)
+                            (set_local $5
                               (i32.add
-                                (get_local $d)
+                                (get_local $3)
                                 (i32.const -1)
                               )
                             )
@@ -8536,13 +8433,13 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $q
-                          (get_local $d)
+                        (set_local $4
+                          (get_local $3)
                         )
                         (br $while-out$2)
                       )
-                      (set_local $d
-                        (get_local $p)
+                      (set_local $3
+                        (get_local $5)
                       )
                     )
                     (br $while-in$3)
@@ -8553,144 +8450,135 @@
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $c)
+                              (get_local $2)
                             )
                             (i32.const 3)
                           )
                           (i32.const 2)
                         )
-                        (get_local $c)
-                        (get_local $a)
-                        (get_local $q)
+                        (get_local $2)
+                        (get_local $0)
+                        (get_local $4)
                       )
-                      (get_local $q)
+                      (get_local $4)
                     )
                     (block
-                      (set_local $h
-                        (get_local $q)
+                      (set_local $7
+                        (get_local $4)
                       )
                       (br $label$break$a)
                     )
                   )
-                  (set_local $m
+                  (set_local $2
                     (i32.add
-                      (get_local $a)
-                      (get_local $q)
+                      (get_local $0)
+                      (get_local $4)
                     )
                   )
-                  (set_local $n
+                  (set_local $3
                     (i32.load
-                      (get_local $e)
+                      (get_local $6)
                     )
                   )
-                  (set_local $o
-                    (get_local $q)
+                  (set_local $5
+                    (get_local $4)
                   )
                   (i32.sub
-                    (get_local $b)
-                    (get_local $q)
+                    (get_local $1)
+                    (get_local $4)
                   )
                 )
                 (block
-                  (set_local $m
-                    (get_local $a)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $j)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $o
+                  (set_local $5
                     (i32.const 0)
                   )
-                  (get_local $b)
+                  (get_local $1)
                 )
               )
             )
           )
           (call $jb
-            (get_local $n)
-            (get_local $m)
-            (get_local $l)
+            (get_local $3)
+            (get_local $2)
+            (get_local $0)
           )
           (i32.store
-            (get_local $e)
+            (get_local $6)
             (i32.add
               (i32.load
-                (get_local $e)
+                (get_local $6)
               )
-              (get_local $l)
+              (get_local $0)
             )
           )
-          (set_local $h
+          (set_local $7
             (i32.add
-              (get_local $o)
-              (get_local $l)
+              (get_local $5)
+              (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $h)
+    (get_local $7)
   )
-  (func $Za (param $a i32) (result i32)
-    (local $d i32)
-    (local $c i32)
-    (local $l i32)
-    (local $j i32)
-    (local $e i32)
-    (local $b i32)
-    (local $f i32)
-    (local $g i32)
-    (local $h i32)
-    (local $m i32)
+  (func $Za (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
     (block $label$break$a
       (if
         (i32.and
-          (set_local $b
-            (get_local $a)
+          (set_local $3
+            (get_local $0)
           )
           (i32.const 3)
         )
         (block
-          (set_local $e
-            (get_local $a)
-          )
-          (set_local $f
-            (get_local $b)
+          (get_local $0)
+          (set_local $4
+            (get_local $3)
           )
           (loop $while-out$1 $while-in$2
             (if
               (i32.eqz
                 (i32.load8_s
-                  (get_local $e)
+                  (get_local $0)
                 )
               )
               (block
-                (set_local $g
-                  (get_local $f)
+                (set_local $5
+                  (get_local $4)
                 )
                 (br $label$break$a)
               )
             )
             (if
               (i32.and
-                (set_local $f
-                  (set_local $h
+                (set_local $4
+                  (set_local $0
                     (i32.add
-                      (get_local $e)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
                 (i32.const 3)
               )
-              (set_local $e
-                (get_local $h)
-              )
+              (get_local $0)
               (block
-                (set_local $c
-                  (get_local $h)
+                (set_local $1
+                  (get_local $0)
                 )
-                (set_local $d
+                (set_local $2
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8700,10 +8588,10 @@
           )
         )
         (block
-          (set_local $c
-            (get_local $a)
+          (set_local $1
+            (get_local $0)
           )
-          (set_local $d
+          (set_local $2
             (i32.const 4)
           )
         )
@@ -8711,21 +8599,21 @@
     )
     (if
       (i32.eq
-        (get_local $d)
+        (get_local $2)
         (i32.const 4)
       )
       (block
-        (set_local $d
-          (get_local $c)
+        (set_local $2
+          (get_local $1)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $c
+                  (set_local $1
                     (i32.load
-                      (get_local $d)
+                      (get_local $2)
                     )
                   )
                   (i32.const -2139062144)
@@ -8733,22 +8621,22 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $c)
+                (get_local $1)
                 (i32.const -16843009)
               )
             )
             (block
-              (set_local $j
-                (get_local $c)
+              (set_local $0
+                (get_local $1)
               )
-              (set_local $l
-                (get_local $d)
+              (set_local $1
+                (get_local $2)
               )
               (br $while-out$3)
             )
-            (set_local $d
+            (set_local $2
               (i32.add
-                (get_local $d)
+                (get_local $2)
                 (i32.const 4)
               )
             )
@@ -8759,7 +8647,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $j)
+                (get_local $0)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8767,25 +8655,25 @@
             (i32.const 24)
           )
           (block
-            (set_local $j
-              (get_local $l)
+            (set_local $0
+              (get_local $1)
             )
             (loop $while-out$5 $while-in$6
               (if
                 (i32.load8_s
-                  (set_local $l
+                  (set_local $1
                     (i32.add
-                      (get_local $j)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $j
-                  (get_local $l)
+                (set_local $0
+                  (get_local $1)
                 )
                 (block
-                  (set_local $m
-                    (get_local $l)
+                  (set_local $0
+                    (get_local $1)
                   )
                   (br $while-out$5)
                 )
@@ -8793,70 +8681,66 @@
               (br $while-in$6)
             )
           )
-          (set_local $m
-            (get_local $l)
+          (set_local $0
+            (get_local $1)
           )
         )
-        (set_local $g
-          (get_local $m)
+        (set_local $5
+          (get_local $0)
         )
       )
     )
     (i32.sub
-      (get_local $g)
-      (get_local $b)
+      (get_local $5)
+      (get_local $3)
     )
   )
-  (func $_a (param $a i32) (result i32)
-    (local $e i32)
-    (local $c i32)
-    (local $b i32)
-    (local $d i32)
-    (local $g i32)
-    (local $f i32)
+  (func $_a (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (block $do-once$0
       (if
-        (get_local $a)
+        (get_local $0)
         (block
           (if
             (i32.le_s
               (i32.load offset=76
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const -1)
             )
             (br $do-once$0
               (call $$a
-                (get_local $a)
+                (get_local $0)
               )
             )
           )
-          (set_local $c
+          (set_local $2
             (i32.eq
               (call $Ya
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $e
+          (set_local $1
             (call $$a
-              (get_local $a)
+              (get_local $0)
             )
           )
           (if
-            (get_local $c)
-            (get_local $e)
+            (get_local $2)
+            (get_local $1)
             (block
               (call $Ta
-                (get_local $a)
+                (get_local $0)
               )
-              (get_local $e)
+              (get_local $1)
             )
           )
         )
         (block
-          (set_local $b
+          (set_local $0
             (if
               (i32.load
                 (i32.const 1140)
@@ -8873,70 +8757,68 @@
             (i32.const 1188)
           )
           (if
-            (set_local $c
+            (set_local $2
               (i32.load
                 (i32.const 1184)
               )
             )
             (block
-              (set_local $e
-                (get_local $c)
+              (set_local $1
+                (get_local $2)
               )
-              (set_local $c
-                (get_local $b)
+              (set_local $2
+                (get_local $0)
               )
               (loop $while-out$2 $while-in$3
-                (set_local $f
+                (set_local $0
                   (if
                     (i32.gt_s
                       (i32.load offset=76
-                        (get_local $e)
+                        (get_local $1)
                       )
                       (i32.const -1)
                     )
                     (call $Ya
-                      (get_local $e)
+                      (get_local $1)
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $g
+                (set_local $2
                   (if
                     (i32.gt_u
                       (i32.load offset=20
-                        (get_local $e)
+                        (get_local $1)
                       )
                       (i32.load offset=28
-                        (get_local $e)
+                        (get_local $1)
                       )
                     )
                     (i32.or
                       (call $$a
-                        (get_local $e)
+                        (get_local $1)
                       )
-                      (get_local $c)
+                      (get_local $2)
                     )
-                    (get_local $c)
+                    (get_local $2)
                   )
                 )
                 (if
-                  (get_local $f)
+                  (get_local $0)
                   (call $Ta
-                    (get_local $e)
+                    (get_local $1)
                   )
                 )
                 (if
-                  (set_local $e
+                  (set_local $1
                     (i32.load offset=56
-                      (get_local $e)
+                      (get_local $1)
                     )
                   )
-                  (set_local $c
-                    (get_local $g)
-                  )
+                  (get_local $2)
                   (block
-                    (set_local $d
-                      (get_local $g)
+                    (set_local $0
+                      (get_local $2)
                     )
                     (br $while-out$2)
                   )
@@ -8944,29 +8826,26 @@
                 (br $while-in$3)
               )
             )
-            (set_local $d
-              (get_local $b)
-            )
+            (get_local $0)
           )
           (call_import $xa
             (i32.const 1188)
           )
-          (get_local $d)
+          (get_local $0)
         )
       )
     )
   )
-  (func $ab (param $a i32) (param $b i32) (result i32)
-    (local $f i32)
-    (local $g i32)
-    (local $m i32)
-    (local $c i32)
-    (local $d i32)
-    (local $h i32)
-    (local $j i32)
-    (local $e i32)
-    (local $n i32)
-    (set_local $c
+  (func $ab (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (set_local $5
       (i32.load
         (i32.const 8)
       )
@@ -8981,49 +8860,49 @@
       )
     )
     (i32.store8
-      (set_local $d
-        (get_local $c)
+      (set_local $6
+        (get_local $5)
       )
-      (set_local $e
+      (set_local $9
         (i32.and
-          (get_local $b)
+          (get_local $1)
           (i32.const 255)
         )
       )
     )
     (if
-      (set_local $g
+      (set_local $3
         (i32.load
-          (set_local $f
+          (set_local $2
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $h
-          (get_local $g)
+        (set_local $7
+          (get_local $3)
         )
-        (set_local $j
+        (set_local $8
           (i32.const 4)
         )
       )
       (if
         (call $Xa
-          (get_local $a)
+          (get_local $0)
         )
-        (set_local $m
+        (set_local $4
           (i32.const -1)
         )
         (block
-          (set_local $h
+          (set_local $7
             (i32.load
-              (get_local $f)
+              (get_local $2)
             )
           )
-          (set_local $j
+          (set_local $8
             (i32.const 4)
           )
         )
@@ -9032,76 +8911,76 @@
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $j)
+          (get_local $8)
           (i32.const 4)
         )
         (block
           (if
             (i32.lt_u
-              (set_local $f
+              (set_local $2
                 (i32.load
-                  (set_local $g
+                  (set_local $3
                     (i32.add
-                      (get_local $a)
+                      (get_local $0)
                       (i32.const 20)
                     )
                   )
                 )
               )
-              (get_local $h)
+              (get_local $7)
             )
             (if
               (i32.ne
-                (set_local $n
+                (set_local $1
                   (i32.and
-                    (get_local $b)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.load8_s offset=75
-                  (get_local $a)
+                  (get_local $0)
                 )
               )
               (block
                 (i32.store
-                  (get_local $g)
+                  (get_local $3)
                   (i32.add
-                    (get_local $f)
+                    (get_local $2)
                     (i32.const 1)
                   )
                 )
                 (i32.store8
-                  (get_local $f)
-                  (get_local $e)
+                  (get_local $2)
+                  (get_local $9)
                 )
-                (set_local $m
-                  (get_local $n)
+                (set_local $4
+                  (get_local $1)
                 )
                 (br $do-once$0)
               )
             )
           )
-          (set_local $m
+          (set_local $4
             (if
               (i32.eq
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $a)
+                        (get_local $0)
                       )
                       (i32.const 3)
                     )
                     (i32.const 2)
                   )
-                  (get_local $a)
-                  (get_local $d)
+                  (get_local $0)
+                  (get_local $6)
                   (i32.const 1)
                 )
                 (i32.const 1)
               )
               (i32.load8_u
-                (get_local $d)
+                (get_local $6)
               )
               (i32.const -1)
             )
@@ -9111,32 +8990,31 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $c)
+      (get_local $5)
     )
-    (get_local $m)
+    (get_local $4)
   )
-  (func $$a (param $a i32) (result i32)
-    (local $e i32)
-    (local $b i32)
-    (local $d i32)
-    (local $c i32)
-    (local $f i32)
-    (local $g i32)
-    (local $h i32)
+  (func $$a (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
     (if
       (i32.gt_u
         (i32.load
-          (set_local $b
+          (set_local $3
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 20)
             )
           )
         )
         (i32.load
-          (set_local $c
+          (set_local $4
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -9147,55 +9025,55 @@
           (i32.add
             (i32.and
               (i32.load offset=36
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const 3)
             )
             (i32.const 2)
           )
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
           (i32.const 0)
         )
         (if
           (i32.load
-            (get_local $b)
+            (get_local $3)
           )
-          (set_local $e
+          (set_local $2
             (i32.const 3)
           )
-          (set_local $d
+          (set_local $1
             (i32.const -1)
           )
         )
       )
-      (set_local $e
+      (set_local $2
         (i32.const 3)
       )
     )
     (if
       (i32.eq
-        (get_local $e)
+        (get_local $2)
         (i32.const 3)
       )
       (block
         (if
           (i32.lt_u
-            (set_local $f
+            (set_local $1
               (i32.load
-                (set_local $e
+                (set_local $2
                   (i32.add
-                    (get_local $a)
+                    (get_local $0)
                     (i32.const 4)
                   )
                 )
               )
             )
-            (set_local $h
+            (set_local $6
               (i32.load
-                (set_local $g
+                (set_local $5
                   (i32.add
-                    (get_local $a)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
@@ -9206,73 +9084,73 @@
             (i32.add
               (i32.and
                 (i32.load offset=40
-                  (get_local $a)
+                  (get_local $0)
                 )
                 (i32.const 3)
               )
               (i32.const 2)
             )
-            (get_local $a)
+            (get_local $0)
             (i32.sub
-              (get_local $f)
-              (get_local $h)
+              (get_local $1)
+              (get_local $6)
             )
             (i32.const 1)
           )
         )
         (i32.store offset=16
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store
-          (get_local $c)
+          (get_local $4)
           (i32.const 0)
         )
         (i32.store
-          (get_local $b)
+          (get_local $3)
           (i32.const 0)
         )
         (i32.store
-          (get_local $g)
+          (get_local $5)
           (i32.const 0)
         )
         (i32.store
-          (get_local $e)
+          (get_local $2)
           (i32.const 0)
         )
-        (set_local $d
+        (set_local $1
           (i32.const 0)
         )
       )
     )
-    (get_local $d)
+    (get_local $1)
   )
-  (func $jb (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $d i32)
+  (func $jb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
     (if
       (i32.ge_s
-        (get_local $c)
+        (get_local $2)
         (i32.const 4096)
       )
       (return
         (call_import $va
-          (get_local $a)
-          (get_local $b)
-          (get_local $c)
+          (get_local $0)
+          (get_local $1)
+          (get_local $2)
         )
       )
     )
-    (set_local $d
-      (get_local $a)
+    (set_local $3
+      (get_local $0)
     )
     (if
       (i32.eq
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.and
-          (get_local $b)
+          (get_local $1)
           (i32.const 3)
         )
       )
@@ -9281,40 +9159,40 @@
           (br_if $while-out$0
             (i32.eqz
               (i32.and
-                (get_local $a)
+                (get_local $0)
                 (i32.const 3)
               )
             )
           )
           (if
             (i32.eqz
-              (get_local $c)
+              (get_local $2)
             )
             (return
-              (get_local $d)
+              (get_local $3)
             )
           )
           (i32.store8
-            (get_local $a)
+            (get_local $0)
             (i32.load8_s
-              (get_local $b)
+              (get_local $1)
             )
           )
-          (set_local $a
+          (set_local $0
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 1)
             )
           )
-          (set_local $b
+          (set_local $1
             (i32.add
-              (get_local $b)
+              (get_local $1)
               (i32.const 1)
             )
           )
-          (set_local $c
+          (set_local $2
             (i32.sub
-              (get_local $c)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -9323,31 +9201,31 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.lt_s
-              (get_local $c)
+              (get_local $2)
               (i32.const 4)
             )
           )
           (i32.store
-            (get_local $a)
+            (get_local $0)
             (i32.load
-              (get_local $b)
+              (get_local $1)
             )
           )
-          (set_local $a
+          (set_local $0
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 4)
             )
           )
-          (set_local $b
+          (set_local $1
             (i32.add
-              (get_local $b)
+              (get_local $1)
               (i32.const 4)
             )
           )
-          (set_local $c
+          (set_local $2
             (i32.sub
-              (get_local $c)
+              (get_local $2)
               (i32.const 4)
             )
           )
@@ -9358,87 +9236,87 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.le_s
-          (get_local $c)
+          (get_local $2)
           (i32.const 0)
         )
       )
       (i32.store8
-        (get_local $a)
+        (get_local $0)
         (i32.load8_s
-          (get_local $b)
+          (get_local $1)
         )
       )
-      (set_local $a
+      (set_local $0
         (i32.add
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
       )
-      (set_local $b
+      (set_local $1
         (i32.add
-          (get_local $b)
+          (get_local $1)
           (i32.const 1)
         )
       )
-      (set_local $c
+      (set_local $2
         (i32.sub
-          (get_local $c)
+          (get_local $2)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
-    (get_local $d)
+    (get_local $3)
   )
   (func $gb
     (nop)
   )
-  (func $hb (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $e i32)
-    (local $d i32)
-    (local $f i32)
-    (local $g i32)
-    (set_local $d
+  (func $hb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $4
       (i32.add
-        (get_local $a)
-        (get_local $c)
+        (get_local $0)
+        (get_local $2)
       )
     )
     (if
       (i32.ge_s
-        (get_local $c)
+        (get_local $2)
         (i32.const 20)
       )
       (block
-        (set_local $f
+        (set_local $5
           (i32.or
             (i32.or
               (i32.or
-                (set_local $b
+                (set_local $1
                   (i32.and
-                    (get_local $b)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.shl
-                  (get_local $b)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (i32.shl
-                (get_local $b)
+                (get_local $1)
                 (i32.const 16)
               )
             )
             (i32.shl
-              (get_local $b)
+              (get_local $1)
               (i32.const 24)
             )
           )
         )
-        (set_local $g
+        (set_local $6
           (i32.and
-            (get_local $d)
+            (get_local $4)
             (i32.xor
               (i32.const 3)
               (i32.const -1)
@@ -9446,36 +9324,36 @@
           )
         )
         (if
-          (set_local $e
+          (set_local $3
             (i32.and
-              (get_local $a)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (block
-            (set_local $e
+            (set_local $3
               (i32.sub
                 (i32.add
-                  (get_local $a)
+                  (get_local $0)
                   (i32.const 4)
                 )
-                (get_local $e)
+                (get_local $3)
               )
             )
             (loop $while-out$0 $while-in$1
               (br_if $while-out$0
                 (i32.ge_s
-                  (get_local $a)
-                  (get_local $e)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (i32.store8
-                (get_local $a)
-                (get_local $b)
+                (get_local $0)
+                (get_local $1)
               )
-              (set_local $a
+              (set_local $0
                 (i32.add
-                  (get_local $a)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
@@ -9486,17 +9364,17 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.ge_s
-              (get_local $a)
-              (get_local $g)
+              (get_local $0)
+              (get_local $6)
             )
           )
           (i32.store
-            (get_local $a)
-            (get_local $f)
+            (get_local $0)
+            (get_local $5)
           )
-          (set_local $a
+          (set_local $0
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 4)
             )
           )
@@ -9507,38 +9385,36 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.ge_s
-          (get_local $a)
-          (get_local $d)
+          (get_local $0)
+          (get_local $4)
         )
       )
       (i32.store8
-        (get_local $a)
-        (get_local $b)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $a
+      (set_local $0
         (i32.add
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
     (i32.sub
-      (get_local $a)
-      (get_local $c)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $db (param $a i32) (result i32)
-    (local $b i32)
-    (local $f i32)
-    (local $c i32)
-    (local $d i32)
-    (local $e i32)
-    (set_local $c
+  (func $db (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (set_local $3
       (if
         (i32.gt_s
           (i32.load offset=76
-            (set_local $b
+            (set_local $1
               (i32.load
                 (i32.const 1024)
               )
@@ -9547,18 +9423,18 @@
           (i32.const -1)
         )
         (call $Ya
-          (get_local $b)
+          (get_local $1)
         )
         (i32.const 0)
       )
     )
-    (set_local $d
+    (set_local $0
       (block $do-once$0
         (if
           (i32.lt_s
             (call $cb
-              (get_local $a)
-              (get_local $b)
+              (get_local $0)
+              (get_local $1)
             )
             (i32.const 0)
           )
@@ -9567,36 +9443,36 @@
             (if
               (i32.ne
                 (i32.load8_s offset=75
-                  (get_local $b)
+                  (get_local $1)
                 )
                 (i32.const 10)
               )
               (if
                 (i32.lt_u
-                  (set_local $f
+                  (set_local $2
                     (i32.load
-                      (set_local $e
+                      (set_local $0
                         (i32.add
-                          (get_local $b)
+                          (get_local $1)
                           (i32.const 20)
                         )
                       )
                     )
                   )
                   (i32.load offset=16
-                    (get_local $b)
+                    (get_local $1)
                   )
                 )
                 (block
                   (i32.store
-                    (get_local $e)
+                    (get_local $0)
                     (i32.add
-                      (get_local $f)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
                   (i32.store8
-                    (get_local $f)
+                    (get_local $2)
                     (i32.const 10)
                   )
                   (br $do-once$0
@@ -9607,7 +9483,7 @@
             )
             (i32.lt_s
               (call $ab
-                (get_local $b)
+                (get_local $1)
                 (i32.const 10)
               )
               (i32.const 0)
@@ -9617,56 +9493,56 @@
       )
     )
     (if
-      (get_local $c)
+      (get_local $3)
       (call $Ta
-        (get_local $b)
+        (get_local $1)
       )
     )
     (i32.shr_s
       (i32.shl
-        (get_local $d)
+        (get_local $0)
         (i32.const 31)
       )
       (i32.const 31)
     )
   )
-  (func $Xa (param $a i32) (result i32)
-    (local $b i32)
-    (local $c i32)
-    (set_local $c
+  (func $Xa (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $2
       (i32.load8_s
-        (set_local $b
+        (set_local $1
           (i32.add
-            (get_local $a)
+            (get_local $0)
             (i32.const 74)
           )
         )
       )
     )
     (i32.store8
-      (get_local $b)
+      (get_local $1)
       (i32.or
         (i32.add
-          (get_local $c)
+          (get_local $2)
           (i32.const 255)
         )
-        (get_local $c)
+        (get_local $2)
       )
     )
     (if
       (i32.and
-        (set_local $c
+        (set_local $2
           (i32.load
-            (get_local $a)
+            (get_local $0)
           )
         )
         (i32.const 8)
       )
       (block
         (i32.store
-          (get_local $a)
+          (get_local $0)
           (i32.or
-            (get_local $c)
+            (get_local $2)
             (i32.const 32)
           )
         )
@@ -9674,31 +9550,31 @@
       )
       (block
         (i32.store offset=8
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=4
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=28
-          (get_local $a)
-          (set_local $b
+          (get_local $0)
+          (set_local $1
             (i32.load offset=44
-              (get_local $a)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=20
-          (get_local $a)
-          (get_local $b)
+          (get_local $0)
+          (get_local $1)
         )
         (i32.store offset=16
-          (get_local $a)
+          (get_local $0)
           (i32.add
-            (get_local $b)
+            (get_local $1)
             (i32.load offset=48
-              (get_local $a)
+              (get_local $0)
             )
           )
         )
@@ -9706,76 +9582,72 @@
       )
     )
   )
-  (func $bb (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
-    (local $e i32)
-    (local $g i32)
-    (local $f i32)
-    (local $h i32)
-    (set_local $e
+  (func $bb (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (local $5 i32)
+    (set_local $4
       (i32.mul
-        (get_local $c)
-        (get_local $b)
+        (get_local $2)
+        (get_local $1)
       )
     )
     (if
       (i32.eq
-        (set_local $h
+        (set_local $0
           (if
             (i32.gt_s
               (i32.load offset=76
-                (get_local $d)
+                (get_local $3)
               )
               (i32.const -1)
             )
             (block
-              (set_local $f
+              (set_local $5
                 (i32.eq
                   (call $Ya
-                    (get_local $d)
+                    (get_local $3)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $g
+              (set_local $0
                 (call $Wa
-                  (get_local $a)
-                  (get_local $e)
-                  (get_local $d)
+                  (get_local $0)
+                  (get_local $4)
+                  (get_local $3)
                 )
               )
               (if
-                (get_local $f)
-                (get_local $g)
+                (get_local $5)
+                (get_local $0)
                 (block
                   (call $Ta
-                    (get_local $d)
+                    (get_local $3)
                   )
-                  (get_local $g)
+                  (get_local $0)
                 )
               )
             )
             (call $Wa
-              (get_local $a)
-              (get_local $e)
-              (get_local $d)
+              (get_local $0)
+              (get_local $4)
+              (get_local $3)
             )
           )
         )
-        (get_local $e)
+        (get_local $4)
       )
-      (get_local $c)
+      (get_local $2)
       (i32.div_u
-        (get_local $h)
-        (get_local $b)
+        (get_local $0)
+        (get_local $1)
       )
     )
   )
-  (func $Ua (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $e i32)
-    (local $d i32)
-    (local $f i32)
-    (local $g i32)
-    (set_local $d
+  (func $Ua (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9790,67 +9662,67 @@
       )
     )
     (i32.store
-      (set_local $e
-        (get_local $d)
+      (set_local $3
+        (get_local $4)
       )
       (i32.load offset=60
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store offset=4
-      (get_local $e)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=8
-      (get_local $e)
-      (get_local $b)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $e)
-      (set_local $f
+      (get_local $3)
+      (set_local $0
         (i32.add
-          (get_local $d)
+          (get_local $4)
           (i32.const 20)
         )
       )
     )
     (i32.store offset=16
-      (get_local $e)
-      (get_local $c)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $g
+    (set_local $0
       (if
         (i32.lt_s
           (call $Pa
             (call_import $ua
               (i32.const 140)
-              (get_local $e)
+              (get_local $3)
             )
           )
           (i32.const 0)
         )
         (block
           (i32.store
-            (get_local $f)
+            (get_local $0)
             (i32.const -1)
           )
           (i32.const -1)
         )
         (i32.load
-          (get_local $f)
+          (get_local $0)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $d)
+      (get_local $4)
     )
-    (get_local $g)
+    (get_local $0)
   )
-  (func $Va (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $e i32)
-    (local $d i32)
-    (set_local $d
+  (func $Va (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9864,72 +9736,72 @@
         (i32.const 80)
       )
     )
-    (set_local $e
-      (get_local $d)
+    (set_local $3
+      (get_local $4)
     )
     (i32.store offset=36
-      (get_local $a)
+      (get_local $0)
       (i32.const 3)
     )
     (if
       (i32.eqz
         (i32.and
           (i32.load
-            (get_local $a)
+            (get_local $0)
           )
           (i32.const 64)
         )
       )
       (block
         (i32.store
-          (get_local $e)
+          (get_local $3)
           (i32.load offset=60
-            (get_local $a)
+            (get_local $0)
           )
         )
         (i32.store offset=4
-          (get_local $e)
+          (get_local $3)
           (i32.const 21505)
         )
         (i32.store offset=8
-          (get_local $e)
+          (get_local $3)
           (i32.add
-            (get_local $d)
+            (get_local $4)
             (i32.const 12)
           )
         )
         (if
           (call_import $wa
             (i32.const 54)
-            (get_local $e)
+            (get_local $3)
           )
           (i32.store8 offset=75
-            (get_local $a)
+            (get_local $0)
             (i32.const -1)
           )
         )
       )
     )
-    (set_local $e
+    (set_local $3
       (call $Ra
-        (get_local $a)
-        (get_local $b)
-        (get_local $c)
+        (get_local $0)
+        (get_local $1)
+        (get_local $2)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $d)
+      (get_local $4)
     )
-    (get_local $e)
+    (get_local $3)
   )
-  (func $Ka (param $a i32)
+  (func $Ka (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -9937,7 +9809,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -9945,7 +9817,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -9953,7 +9825,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=4
@@ -9961,7 +9833,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=4
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=5
@@ -9969,7 +9841,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=5
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=6
@@ -9977,7 +9849,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=6
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=7
@@ -9985,14 +9857,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=7
-        (get_local $a)
+        (get_local $0)
       )
     )
   )
-  (func $Oa (param $a i32) (result i32)
-    (local $b i32)
-    (local $c i32)
-    (set_local $b
+  (func $Oa (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -10007,31 +9879,31 @@
       )
     )
     (i32.store
-      (set_local $c
-        (get_local $b)
+      (set_local $2
+        (get_local $1)
       )
       (i32.load offset=60
-        (get_local $a)
+        (get_local $0)
       )
     )
-    (set_local $a
+    (set_local $0
       (call $Pa
         (call_import $sa
           (i32.const 6)
-          (get_local $c)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $b)
+      (get_local $1)
     )
-    (get_local $a)
+    (get_local $0)
   )
-  (func $Pa (param $a i32) (result i32)
+  (func $Pa (param $0 i32) (result i32)
     (if
       (i32.gt_u
-        (get_local $a)
+        (get_local $0)
         (i32.const -4096)
       )
       (block
@@ -10039,21 +9911,21 @@
           (call $Qa)
           (i32.sub
             (i32.const 0)
-            (get_local $a)
+            (get_local $0)
           )
         )
         (i32.const -1)
       )
-      (get_local $a)
+      (get_local $0)
     )
   )
-  (func $Ja (param $a i32)
+  (func $Ja (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -10061,7 +9933,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -10069,7 +9941,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -10077,7 +9949,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $a)
+        (get_local $0)
       )
     )
   )
@@ -10092,23 +9964,23 @@
       (i32.const 1204)
     )
   )
-  (func $lb (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
+  (func $lb (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call_indirect $FUNCSIG$iiii
       (i32.add
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.const 2)
       )
-      (get_local $b)
-      (get_local $c)
-      (get_local $d)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
     )
   )
-  (func $Ea (param $a i32) (result i32)
-    (local $b i32)
-    (set_local $b
+  (func $Ea (param $0 i32) (result i32)
+    (local $1 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -10119,7 +9991,7 @@
         (i32.load
           (i32.const 8)
         )
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store
@@ -10134,28 +10006,28 @@
         (i32.const -16)
       )
     )
-    (get_local $b)
+    (get_local $1)
   )
-  (func $cb (param $a i32) (param $b i32) (result i32)
+  (func $cb (param $0 i32) (param $1 i32) (result i32)
     (i32.add
       (call $bb
-        (get_local $a)
+        (get_local $0)
         (call $Za
-          (get_local $a)
+          (get_local $0)
         )
         (i32.const 1)
-        (get_local $b)
+        (get_local $1)
       )
       (i32.const -1)
     )
   )
-  (func $ob (param $a i32) (param $b i32) (param $c i32) (result i32)
+  (func $ob (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (call_import $ja
       (i32.const 1)
     )
     (i32.const 0)
   )
-  (func $Ia (param $a i32) (param $b i32)
+  (func $Ia (param $0 i32) (param $1 i32)
     (if
       (i32.eqz
         (i32.load
@@ -10165,62 +10037,62 @@
       (block
         (i32.store
           (i32.const 40)
-          (get_local $a)
+          (get_local $0)
         )
         (i32.store
           (i32.const 48)
-          (get_local $b)
+          (get_local $1)
         )
       )
     )
   )
-  (func $kb (param $a i32) (param $b i32) (result i32)
+  (func $kb (param $0 i32) (param $1 i32) (result i32)
     (call_indirect $FUNCSIG$ii
       (i32.add
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 0)
       )
-      (get_local $b)
+      (get_local $1)
     )
   )
-  (func $Sa (param $a i32)
+  (func $Sa (param $0 i32)
     (if
       (i32.eqz
         (i32.load offset=68
-          (get_local $a)
+          (get_local $0)
         )
       )
       (call $Ta
-        (get_local $a)
+        (get_local $0)
       )
     )
   )
-  (func $mb (param $a i32) (param $b i32)
+  (func $mb (param $0 i32) (param $1 i32)
     (call_indirect $FUNCSIG$vi
       (i32.add
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 6)
       )
-      (get_local $b)
+      (get_local $1)
     )
   )
-  (func $Ha (param $a i32) (param $b i32)
+  (func $Ha (param $0 i32) (param $1 i32)
     (i32.store
       (i32.const 8)
-      (get_local $a)
+      (get_local $0)
     )
     (i32.store
       (i32.const 16)
-      (get_local $b)
+      (get_local $1)
     )
   )
-  (func $nb (param $a i32) (result i32)
+  (func $nb (param $0 i32) (result i32)
     (call_import $ja
       (i32.const 0)
     )
@@ -10232,27 +10104,27 @@
     )
     (i32.const 0)
   )
-  (func $Ya (param $a i32) (result i32)
+  (func $Ya (param $0 i32) (result i32)
     (i32.const 0)
   )
-  (func $Ta (param $a i32)
+  (func $Ta (param $0 i32)
     (nop)
   )
-  (func $pb (param $a i32)
+  (func $pb (param $0 i32)
     (call_import $ja
       (i32.const 2)
     )
   )
-  (func $La (param $a i32)
+  (func $La (param $0 i32)
     (i32.store
       (i32.const 160)
-      (get_local $a)
+      (get_local $0)
     )
   )
-  (func $Ga (param $a i32)
+  (func $Ga (param $0 i32)
     (i32.store
       (i32.const 8)
-      (get_local $a)
+      (get_local $0)
     )
   )
   (func $Ma (result i32)
@@ -10268,9 +10140,9 @@
   (func $ib (result i32)
     (i32.const 0)
   )
-  (func $__growWasmMemory (param $newSize i32)
+  (func $__growWasmMemory (param $0 i32)
     (grow_memory
-      (get_local $newSize)
+      (get_local $0)
     )
   )
 )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -40,99 +40,63 @@
   (export "dynCall_vi" $mb)
   (export "__growWasmMemory" $__growWasmMemory)
   (table $nb $Oa $ob $Va $Ua $Ra $pb $Sa)
-  (func $eb (param $a i32) (result i32)
-    (local $ka i32)
-    (local $e i32)
-    (local $s i32)
-    (local $ma i32)
-    (local $i i32)
-    (local $q i32)
-    (local $V i32)
-    (local $ja i32)
-    (local $aa i32)
-    (local $d i32)
-    (local $c i32)
-    (local $g i32)
-    (local $f i32)
-    (local $la i32)
-    (local $N i32)
-    (local $t i32)
-    (local $o i32)
-    (local $ca i32)
-    (local $U i32)
-    (local $ga i32)
-    (local $$ i32)
-    (local $ea i32)
-    (local $y i32)
-    (local $j i32)
-    (local $A i32)
-    (local $ha i32)
-    (local $u i32)
-    (local $da i32)
-    (local $ba i32)
-    (local $W i32)
-    (local $n i32)
-    (local $C i32)
-    (local $fa i32)
-    (local $ya i32)
-    (local $b i32)
-    (local $ia i32)
-    (local $l i32)
-    (local $Ea i32)
-    (local $P i32)
-    (local $m i32)
-    (local $z i32)
-    (local $D i32)
-    (local $X i32)
-    (local $za i32)
-    (local $O i32)
-    (local $wa i32)
-    (local $Pa i32)
-    (local $B i32)
-    (local $E i32)
-    (local $M i32)
-    (local $Q i32)
-    (local $Y i32)
-    (local $sa i32)
-    (local $Aa i32)
-    (local $Ha i32)
-    (local $Oa i32)
-    (local $v i32)
-    (local $x i32)
-    (local $I i32)
-    (local $J i32)
-    (local $K i32)
-    (local $L i32)
-    (local $R i32)
-    (local $S i32)
-    (local $Ga i32)
-    (local $Ia i32)
-    (local $Na i32)
-    (local $h i32)
-    (local $w i32)
-    (local $G i32)
-    (local $H i32)
-    (local $_ i32)
-    (local $va i32)
-    (local $xa i32)
-    (local $Ca i32)
-    (local $Fa i32)
-    (local $Ja i32)
-    (local $La i32)
-    (local $Ma i32)
-    (local $Ra i32)
-    (local $F i32)
-    (local $T i32)
-    (local $Z i32)
-    (local $na i32)
-    (local $oa i32)
-    (local $pa i32)
-    (local $ra i32)
-    (local $ua i32)
-    (local $Ba i32)
-    (local $Ka i32)
-    (local $Sa i32)
-    (set_local $b
+  (func $eb (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
+    (local $20 i32)
+    (local $21 i32)
+    (local $22 i32)
+    (local $23 i32)
+    (local $24 i32)
+    (local $25 i32)
+    (local $26 i32)
+    (local $27 i32)
+    (local $28 i32)
+    (local $29 i32)
+    (local $30 i32)
+    (local $31 i32)
+    (local $32 i32)
+    (local $33 i32)
+    (local $34 i32)
+    (local $35 i32)
+    (local $36 i32)
+    (local $37 i32)
+    (local $38 i32)
+    (local $39 i32)
+    (local $40 i32)
+    (local $41 i32)
+    (local $42 i32)
+    (local $43 i32)
+    (local $44 i32)
+    (local $45 i32)
+    (local $46 i32)
+    (local $47 i32)
+    (local $48 i32)
+    (local $49 i32)
+    (local $50 i32)
+    (local $51 i32)
+    (local $52 i32)
+    (local $53 i32)
+    (local $54 i32)
+    (local $55 i32)
+    (set_local $25
       (i32.load
         (i32.const 8)
       )
@@ -146,39 +110,39 @@
         (i32.const 16)
       )
     )
-    (set_local $c
-      (get_local $b)
+    (set_local $4
+      (get_local $25)
     )
     (block $do-once$0
       (if
         (i32.lt_u
-          (get_local $a)
+          (get_local $0)
           (i32.const 245)
         )
         (block
           (if
             (i32.and
-              (set_local $g
+              (set_local $6
                 (i32.shr_u
-                  (set_local $f
+                  (set_local $2
                     (i32.load
                       (i32.const 1208)
                     )
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.shr_u
-                      (set_local $d
+                      (set_local $0
                         (select
                           (i32.const 16)
                           (i32.and
                             (i32.add
-                              (get_local $a)
+                              (get_local $0)
                               (i32.const 11)
                             )
                             (i32.const -8)
                           )
                           (i32.lt_u
-                            (get_local $a)
+                            (get_local $0)
                             (i32.const 11)
                           )
                         )
@@ -191,29 +155,29 @@
               (i32.const 3)
             )
             (block
-              (set_local $n
+              (set_local $4
                 (i32.load
-                  (set_local $m
+                  (set_local $13
                     (i32.add
-                      (set_local $l
+                      (set_local $6
                         (i32.load
-                          (set_local $j
+                          (set_local $14
                             (i32.add
-                              (set_local $i
+                              (set_local $1
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $h
+                                      (set_local $0
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $g)
+                                              (get_local $6)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $e)
+                                          (get_local $3)
                                         )
                                       )
                                       (i32.const 1)
@@ -234,17 +198,17 @@
               )
               (if
                 (i32.eq
-                  (get_local $i)
-                  (get_local $n)
+                  (get_local $1)
+                  (get_local $4)
                 )
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $f)
+                    (get_local $2)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $h)
+                        (get_local $0)
                       )
                       (i32.const -1)
                     )
@@ -253,7 +217,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $n)
+                      (get_local $4)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -263,23 +227,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $o
+                        (set_local $8
                           (i32.add
-                            (get_local $n)
+                            (get_local $4)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $l)
+                      (get_local $6)
                     )
                     (block
                       (i32.store
-                        (get_local $o)
-                        (get_local $i)
+                        (get_local $8)
+                        (get_local $1)
                       )
                       (i32.store
-                        (get_local $j)
-                        (get_local $n)
+                        (get_local $14)
+                        (get_local $4)
                       )
                     )
                     (call_import $qa)
@@ -287,11 +251,11 @@
                 )
               )
               (i32.store offset=4
-                (get_local $l)
+                (get_local $6)
                 (i32.or
-                  (set_local $n
+                  (set_local $4
                     (i32.shl
-                      (get_local $h)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
@@ -299,35 +263,35 @@
                 )
               )
               (i32.store
-                (set_local $j
+                (set_local $14
                   (i32.add
                     (i32.add
-                      (get_local $l)
-                      (get_local $n)
+                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $j)
+                    (get_local $14)
                   )
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.const 8)
-                (get_local $b)
+                (get_local $25)
               )
               (return
-                (get_local $m)
+                (get_local $13)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $d)
-              (set_local $j
+              (get_local $0)
+              (set_local $14
                 (i32.load
                   (i32.const 1216)
                 )
@@ -335,37 +299,37 @@
             )
             (block
               (if
-                (get_local $g)
+                (get_local $6)
                 (block
-                  (set_local $i
+                  (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (set_local $n
+                        (set_local $4
                           (i32.add
                             (i32.and
-                              (set_local $i
+                              (set_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $g)
-                                    (get_local $e)
+                                    (get_local $6)
+                                    (get_local $3)
                                   )
                                   (i32.or
-                                    (set_local $n
+                                    (set_local $4
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $e)
+                                        (get_local $3)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $n)
+                                      (get_local $4)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $i)
+                                (get_local $1)
                               )
                             )
                             (i32.const -1)
@@ -376,32 +340,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $i
+                  (set_local $1
                     (i32.load
-                      (set_local $o
+                      (set_local $8
                         (i32.add
-                          (set_local $q
+                          (set_local $9
                             (i32.load
-                              (set_local $t
+                              (set_local $13
                                 (i32.add
-                                  (set_local $s
+                                  (set_local $7
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $u
+                                          (set_local $20
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $n
+                                                      (set_local $4
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $o
+                                                            (set_local $8
                                                               (i32.shr_u
-                                                                (get_local $n)
-                                                                (get_local $i)
+                                                                (get_local $4)
+                                                                (get_local $1)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -409,15 +373,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $i)
+                                                      (get_local $1)
                                                     )
-                                                    (set_local $o
+                                                    (set_local $8
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $q
+                                                          (set_local $9
                                                             (i32.shr_u
-                                                              (get_local $o)
-                                                              (get_local $n)
+                                                              (get_local $8)
+                                                              (get_local $4)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -426,13 +390,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $q
+                                                  (set_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $s
+                                                        (set_local $7
                                                           (i32.shr_u
-                                                            (get_local $q)
-                                                            (get_local $o)
+                                                            (get_local $9)
+                                                            (get_local $8)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -441,13 +405,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $s
+                                                (set_local $7
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $t
+                                                      (set_local $13
                                                         (i32.shr_u
-                                                          (get_local $s)
-                                                          (get_local $q)
+                                                          (get_local $7)
+                                                          (get_local $9)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -457,8 +421,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $t)
-                                                (get_local $s)
+                                                (get_local $13)
+                                                (get_local $7)
                                               )
                                             )
                                           )
@@ -480,31 +444,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $s)
-                      (get_local $i)
+                      (get_local $7)
+                      (get_local $1)
                     )
                     (block
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $f)
+                          (get_local $2)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $u)
+                              (get_local $20)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $v
-                        (get_local $j)
+                      (set_local $33
+                        (get_local $14)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $i)
+                          (get_local $1)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -514,25 +478,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $n
+                            (set_local $4
                               (i32.add
-                                (get_local $i)
+                                (get_local $1)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $q)
+                          (get_local $9)
                         )
                         (block
                           (i32.store
-                            (get_local $n)
-                            (get_local $s)
+                            (get_local $4)
+                            (get_local $7)
                           )
                           (i32.store
-                            (get_local $t)
-                            (get_local $i)
+                            (get_local $13)
+                            (get_local $1)
                           )
-                          (set_local $v
+                          (set_local $33
                             (i32.load
                               (i32.const 1216)
                             )
@@ -543,27 +507,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $q)
+                    (get_local $9)
                     (i32.or
-                      (get_local $d)
+                      (get_local $0)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $t
+                    (set_local $13
                       (i32.add
-                        (get_local $q)
-                        (get_local $d)
+                        (get_local $9)
+                        (get_local $0)
                       )
                     )
                     (i32.or
-                      (set_local $i
+                      (set_local $1
                         (i32.sub
                           (i32.shl
-                            (get_local $u)
+                            (get_local $20)
                             (i32.const 3)
                           )
-                          (get_local $d)
+                          (get_local $0)
                         )
                       )
                       (i32.const 1)
@@ -571,27 +535,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $t)
-                      (get_local $i)
+                      (get_local $13)
+                      (get_local $1)
                     )
-                    (get_local $i)
+                    (get_local $1)
                   )
                   (if
-                    (get_local $v)
+                    (get_local $33)
                     (block
-                      (set_local $s
+                      (set_local $7
                         (i32.load
                           (i32.const 1228)
                         )
                       )
-                      (set_local $f
+                      (set_local $2
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (set_local $j
+                              (set_local $14
                                 (i32.shr_u
-                                  (get_local $v)
+                                  (get_local $33)
                                   (i32.const 3)
                                 )
                               )
@@ -603,25 +567,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $e
+                          (set_local $3
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $g
+                          (set_local $6
                             (i32.shl
                               (i32.const 1)
-                              (get_local $j)
+                              (get_local $14)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $e
+                            (set_local $3
                               (i32.load
-                                (set_local $g
+                                (set_local $6
                                   (i32.add
-                                    (get_local $f)
+                                    (get_local $2)
                                     (i32.const 8)
                                   )
                                 )
@@ -633,11 +597,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $w
-                              (get_local $g)
+                            (set_local $41
+                              (get_local $6)
                             )
-                            (set_local $x
-                              (get_local $e)
+                            (set_local $34
+                              (get_local $3)
                             )
                           )
                         )
@@ -645,73 +609,73 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $e)
-                              (get_local $g)
+                              (get_local $3)
+                              (get_local $6)
                             )
                           )
-                          (set_local $w
+                          (set_local $41
                             (i32.add
-                              (get_local $f)
+                              (get_local $2)
                               (i32.const 8)
                             )
                           )
-                          (set_local $x
-                            (get_local $f)
+                          (set_local $34
+                            (get_local $2)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $w)
-                        (get_local $s)
+                        (get_local $41)
+                        (get_local $7)
                       )
                       (i32.store offset=12
-                        (get_local $x)
-                        (get_local $s)
+                        (get_local $34)
+                        (get_local $7)
                       )
                       (i32.store offset=8
-                        (get_local $s)
-                        (get_local $x)
+                        (get_local $7)
+                        (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $s)
-                        (get_local $f)
+                        (get_local $7)
+                        (get_local $2)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $i)
+                    (get_local $1)
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $t)
+                    (get_local $13)
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $b)
+                    (get_local $25)
                   )
                   (return
-                    (get_local $o)
+                    (get_local $8)
                   )
                 )
               )
               (if
-                (set_local $t
+                (set_local $13
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $t
+                  (set_local $13
                     (i32.and
                       (i32.shr_u
-                        (set_local $i
+                        (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $t)
+                              (get_local $13)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $t)
+                                (get_local $13)
                               )
                             )
                             (i32.const -1)
@@ -722,11 +686,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $j
+                          (set_local $14
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -735,13 +699,13 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (set_local $i
+                                            (set_local $1
                                               (i32.and
                                                 (i32.shr_u
-                                                  (set_local $f
+                                                  (set_local $2
                                                     (i32.shr_u
-                                                      (get_local $i)
-                                                      (get_local $t)
+                                                      (get_local $1)
+                                                      (get_local $13)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -749,15 +713,15 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $t)
+                                            (get_local $13)
                                           )
-                                          (set_local $f
+                                          (set_local $2
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $s
+                                                (set_local $7
                                                   (i32.shr_u
-                                                    (get_local $f)
-                                                    (get_local $i)
+                                                    (get_local $2)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -766,13 +730,13 @@
                                             )
                                           )
                                         )
-                                        (set_local $s
+                                        (set_local $7
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $e
+                                              (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $s)
-                                                  (get_local $f)
+                                                  (get_local $7)
+                                                  (get_local $2)
                                                 )
                                               )
                                               (i32.const 1)
@@ -781,13 +745,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $e
+                                      (set_local $3
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $g
+                                            (set_local $6
                                               (i32.shr_u
-                                                (get_local $e)
-                                                (get_local $s)
+                                                (get_local $3)
+                                                (get_local $7)
                                               )
                                             )
                                             (i32.const 1)
@@ -797,8 +761,8 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $g)
-                                      (get_local $e)
+                                      (get_local $6)
+                                      (get_local $3)
                                     )
                                   )
                                   (i32.const 2)
@@ -810,84 +774,84 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $d)
+                      (get_local $0)
                     )
                   )
-                  (set_local $g
-                    (get_local $j)
+                  (set_local $6
+                    (get_local $14)
                   )
-                  (set_local $s
-                    (get_local $j)
+                  (set_local $7
+                    (get_local $14)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $j
+                      (set_local $14
                         (i32.load offset=16
-                          (get_local $g)
+                          (get_local $6)
                         )
                       )
-                      (set_local $B
-                        (get_local $j)
+                      (set_local $4
+                        (get_local $14)
                       )
                       (if
-                        (set_local $f
+                        (set_local $2
                           (i32.load offset=20
-                            (get_local $g)
+                            (get_local $6)
                           )
                         )
-                        (set_local $B
-                          (get_local $f)
+                        (set_local $4
+                          (get_local $2)
                         )
                         (block
-                          (set_local $z
-                            (get_local $e)
+                          (set_local $4
+                            (get_local $3)
                           )
-                          (set_local $A
-                            (get_local $s)
+                          (set_local $1
+                            (get_local $7)
                           )
                           (br $while-out$6)
                         )
                       )
                     )
-                    (set_local $f
+                    (set_local $2
                       (i32.lt_u
-                        (set_local $j
+                        (set_local $14
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $B)
+                                (get_local $4)
                               )
                               (i32.const -8)
                             )
-                            (get_local $d)
+                            (get_local $0)
                           )
                         )
-                        (get_local $e)
+                        (get_local $3)
                       )
                     )
-                    (set_local $e
+                    (set_local $3
                       (select
-                        (get_local $j)
-                        (get_local $e)
-                        (get_local $f)
+                        (get_local $14)
+                        (get_local $3)
+                        (get_local $2)
                       )
                     )
-                    (set_local $g
-                      (get_local $B)
+                    (set_local $6
+                      (get_local $4)
                     )
-                    (set_local $s
+                    (set_local $7
                       (select
-                        (get_local $B)
-                        (get_local $s)
-                        (get_local $f)
+                        (get_local $4)
+                        (get_local $7)
+                        (get_local $2)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $A)
-                      (set_local $s
+                      (get_local $1)
+                      (set_local $7
                         (i32.load
                           (i32.const 1224)
                         )
@@ -897,72 +861,68 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $A)
-                      (set_local $g
+                      (get_local $1)
+                      (set_local $6
                         (i32.add
-                          (get_local $A)
-                          (get_local $d)
+                          (get_local $1)
+                          (get_local $0)
                         )
                       )
                     )
                     (call_import $qa)
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.load offset=24
-                      (get_local $A)
+                      (get_local $1)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $o
+                        (set_local $8
                           (i32.load offset=12
-                            (get_local $A)
+                            (get_local $1)
                           )
                         )
-                        (get_local $A)
+                        (get_local $1)
                       )
                       (block
                         (if
-                          (set_local $u
+                          (set_local $20
                             (i32.load
-                              (set_local $q
+                              (set_local $9
                                 (i32.add
-                                  (get_local $A)
+                                  (get_local $1)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $D
-                              (get_local $u)
+                            (set_local $14
+                              (get_local $20)
                             )
-                            (set_local $E
-                              (get_local $q)
+                            (set_local $2
+                              (get_local $9)
                             )
                           )
                           (if
-                            (set_local $j
+                            (set_local $14
                               (i32.load
-                                (set_local $f
+                                (set_local $2
                                   (i32.add
-                                    (get_local $A)
+                                    (get_local $1)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $D
-                                (get_local $j)
-                              )
-                              (set_local $E
-                                (get_local $f)
-                              )
+                              (get_local $14)
+                              (get_local $2)
                             )
                             (block
-                              (set_local $C
+                              (set_local $23
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -971,52 +931,48 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $u
+                            (set_local $20
                               (i32.load
-                                (set_local $q
+                                (set_local $9
                                   (i32.add
-                                    (get_local $D)
+                                    (get_local $14)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $D
-                                (get_local $u)
+                              (set_local $14
+                                (get_local $20)
                               )
-                              (set_local $E
-                                (get_local $q)
+                              (set_local $2
+                                (get_local $9)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
-                            (set_local $u
+                            (set_local $20
                               (i32.load
-                                (set_local $q
+                                (set_local $9
                                   (i32.add
-                                    (get_local $D)
+                                    (get_local $14)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $D
-                                (get_local $u)
+                              (set_local $14
+                                (get_local $20)
                               )
-                              (set_local $E
-                                (get_local $q)
+                              (set_local $2
+                                (get_local $9)
                               )
                             )
                             (block
-                              (set_local $F
-                                (get_local $D)
-                              )
-                              (set_local $G
-                                (get_local $E)
-                              )
+                              (get_local $14)
+                              (get_local $2)
                               (br $while-out$10)
                             )
                           )
@@ -1024,17 +980,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $G)
-                            (get_local $s)
+                            (get_local $2)
+                            (get_local $7)
                           )
                           (call_import $qa)
                           (block
                             (i32.store
-                              (get_local $G)
+                              (get_local $2)
                               (i32.const 0)
                             )
-                            (set_local $C
-                              (get_local $F)
+                            (set_local $23
+                              (get_local $14)
                             )
                           )
                         )
@@ -1042,52 +998,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $q
+                            (set_local $9
                               (i32.load offset=8
-                                (get_local $A)
+                                (get_local $1)
                               )
                             )
-                            (get_local $s)
+                            (get_local $7)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $u
+                              (set_local $20
                                 (i32.add
-                                  (get_local $q)
+                                  (get_local $9)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $A)
+                            (get_local $1)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $f
+                              (set_local $2
                                 (i32.add
-                                  (get_local $o)
+                                  (get_local $8)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $A)
+                            (get_local $1)
                           )
                           (block
                             (i32.store
-                              (get_local $u)
-                              (get_local $o)
+                              (get_local $20)
+                              (get_local $8)
                             )
                             (i32.store
-                              (get_local $f)
-                              (get_local $q)
+                              (get_local $2)
+                              (get_local $9)
                             )
-                            (set_local $C
-                              (get_local $o)
+                            (set_local $23
+                              (get_local $8)
                             )
                           )
                           (call_import $qa)
@@ -1097,19 +1053,19 @@
                   )
                   (block $do-once$12
                     (if
-                      (get_local $e)
+                      (get_local $3)
                       (block
                         (if
                           (i32.eq
-                            (get_local $A)
+                            (get_local $1)
                             (i32.load
-                              (set_local $s
+                              (set_local $7
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (set_local $o
+                                    (set_local $8
                                       (i32.load offset=28
-                                        (get_local $A)
+                                        (get_local $1)
                                       )
                                     )
                                     (i32.const 2)
@@ -1120,12 +1076,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $s)
-                              (get_local $C)
+                              (get_local $7)
+                              (get_local $23)
                             )
                             (if
                               (i32.eqz
-                                (get_local $C)
+                                (get_local $23)
                               )
                               (block
                                 (i32.store
@@ -1137,7 +1093,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $o)
+                                        (get_local $8)
                                       )
                                       (i32.const -1)
                                     )
@@ -1150,7 +1106,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $e)
+                                (get_local $3)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1160,35 +1116,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $o
+                                  (set_local $8
                                     (i32.add
-                                      (get_local $e)
+                                      (get_local $3)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $A)
+                                (get_local $1)
                               )
                               (i32.store
-                                (get_local $o)
-                                (get_local $C)
+                                (get_local $8)
+                                (get_local $23)
                               )
                               (i32.store offset=20
-                                (get_local $e)
-                                (get_local $C)
+                                (get_local $3)
+                                (get_local $23)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eqz
-                                (get_local $C)
+                                (get_local $23)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $C)
-                            (set_local $o
+                            (get_local $23)
+                            (set_local $8
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1197,42 +1153,42 @@
                           (call_import $qa)
                         )
                         (i32.store offset=24
-                          (get_local $C)
-                          (get_local $e)
+                          (get_local $23)
+                          (get_local $3)
                         )
                         (if
-                          (set_local $s
+                          (set_local $7
                             (i32.load offset=16
-                              (get_local $A)
+                              (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $s)
-                              (get_local $o)
+                              (get_local $7)
+                              (get_local $8)
                             )
                             (call_import $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $C)
-                                (get_local $s)
+                                (get_local $23)
+                                (get_local $7)
                               )
                               (i32.store offset=24
-                                (get_local $s)
-                                (get_local $C)
+                                (get_local $7)
+                                (get_local $23)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $s
+                          (set_local $7
                             (i32.load offset=20
-                              (get_local $A)
+                              (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $s)
+                              (get_local $7)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1240,12 +1196,12 @@
                             (call_import $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $C)
-                                (get_local $s)
+                                (get_local $23)
+                                (get_local $7)
                               )
                               (i32.store offset=24
-                                (get_local $s)
-                                (get_local $C)
+                                (get_local $7)
+                                (get_local $23)
                               )
                             )
                           )
@@ -1255,35 +1211,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $z)
+                      (get_local $4)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $A)
+                        (get_local $1)
                         (i32.or
-                          (set_local $e
+                          (set_local $3
                             (i32.add
-                              (get_local $z)
-                              (get_local $d)
+                              (get_local $4)
+                              (get_local $0)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (set_local $s
+                        (set_local $7
                           (i32.add
                             (i32.add
-                              (get_local $A)
-                              (get_local $e)
+                              (get_local $1)
+                              (get_local $3)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $s)
+                            (get_local $7)
                           )
                           (i32.const 1)
                         )
@@ -1291,46 +1247,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $A)
+                        (get_local $1)
                         (i32.or
-                          (get_local $d)
+                          (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $g)
+                        (get_local $6)
                         (i32.or
-                          (get_local $z)
+                          (get_local $4)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $g)
-                          (get_local $z)
+                          (get_local $6)
+                          (get_local $4)
                         )
-                        (get_local $z)
+                        (get_local $4)
                       )
                       (if
-                        (set_local $s
+                        (set_local $7
                           (i32.load
                             (i32.const 1216)
                           )
                         )
                         (block
-                          (set_local $e
+                          (set_local $3
                             (i32.load
                               (i32.const 1228)
                             )
                           )
-                          (set_local $s
+                          (set_local $7
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $o
+                                  (set_local $8
                                     (i32.shr_u
-                                      (get_local $s)
+                                      (get_local $7)
                                       (i32.const 3)
                                     )
                                   )
@@ -1342,25 +1298,25 @@
                           )
                           (if
                             (i32.and
-                              (set_local $q
+                              (set_local $9
                                 (i32.load
                                   (i32.const 1208)
                                 )
                               )
-                              (set_local $f
+                              (set_local $2
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $o)
+                                  (get_local $8)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $q
+                                (set_local $9
                                   (i32.load
-                                    (set_local $f
+                                    (set_local $2
                                       (i32.add
-                                        (get_local $s)
+                                        (get_local $7)
                                         (i32.const 8)
                                       )
                                     )
@@ -1372,11 +1328,11 @@
                               )
                               (call_import $qa)
                               (block
-                                (set_local $H
-                                  (get_local $f)
+                                (set_local $42
+                                  (get_local $2)
                                 )
-                                (set_local $I
-                                  (get_local $q)
+                                (set_local $35
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -1384,84 +1340,80 @@
                               (i32.store
                                 (i32.const 1208)
                                 (i32.or
-                                  (get_local $q)
-                                  (get_local $f)
+                                  (get_local $9)
+                                  (get_local $2)
                                 )
                               )
-                              (set_local $H
+                              (set_local $42
                                 (i32.add
-                                  (get_local $s)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $I
-                                (get_local $s)
+                              (set_local $35
+                                (get_local $7)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $H)
-                            (get_local $e)
+                            (get_local $42)
+                            (get_local $3)
                           )
                           (i32.store offset=12
-                            (get_local $I)
-                            (get_local $e)
+                            (get_local $35)
+                            (get_local $3)
                           )
                           (i32.store offset=8
-                            (get_local $e)
-                            (get_local $I)
+                            (get_local $3)
+                            (get_local $35)
                           )
                           (i32.store offset=12
-                            (get_local $e)
-                            (get_local $s)
+                            (get_local $3)
+                            (get_local $7)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $z)
+                        (get_local $4)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $g)
+                        (get_local $6)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $b)
+                    (get_local $25)
                   )
                   (return
                     (i32.add
-                      (get_local $A)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
                 )
-                (set_local $y
-                  (get_local $d)
-                )
+                (get_local $0)
               )
             )
-            (set_local $y
-              (get_local $d)
-            )
+            (get_local $0)
           )
         )
         (if
           (i32.gt_u
-            (get_local $a)
+            (get_local $0)
             (i32.const -65)
           )
-          (set_local $y
+          (set_local $0
             (i32.const -1)
           )
           (block
-            (set_local $e
+            (set_local $3
               (i32.and
-                (set_local $s
+                (set_local $7
                   (i32.add
-                    (get_local $a)
+                    (get_local $0)
                     (i32.const 11)
                   )
                 )
@@ -1469,61 +1421,61 @@
               )
             )
             (if
-              (set_local $q
+              (set_local $9
                 (i32.load
                   (i32.const 1212)
                 )
               )
               (block
-                (set_local $f
+                (set_local $2
                   (i32.sub
                     (i32.const 0)
-                    (get_local $e)
+                    (get_local $3)
                   )
                 )
                 (block $label$break$a
                   (if
-                    (set_local $t
+                    (set_local $13
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (set_local $J
+                            (set_local $0
                               (if
-                                (set_local $o
+                                (set_local $8
                                   (i32.shr_u
-                                    (get_local $s)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
                                 (if
                                   (i32.gt_u
-                                    (get_local $e)
+                                    (get_local $3)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $e)
+                                        (get_local $3)
                                         (i32.add
-                                          (set_local $t
+                                          (set_local $13
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (set_local $o
+                                                    (set_local $8
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $u
+                                                            (set_local $20
                                                               (i32.shl
-                                                                (get_local $o)
-                                                                (set_local $s
+                                                                (get_local $8)
+                                                                (set_local $7
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $o)
+                                                                        (get_local $8)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1540,16 +1492,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $s)
+                                                    (get_local $7)
                                                   )
-                                                  (set_local $u
+                                                  (set_local $20
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $j
+                                                          (set_local $14
                                                             (i32.shl
-                                                              (get_local $u)
-                                                              (get_local $o)
+                                                              (get_local $20)
+                                                              (get_local $8)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1563,8 +1515,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $j)
-                                                  (get_local $u)
+                                                  (get_local $14)
+                                                  (get_local $20)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1576,7 +1528,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $t)
+                                      (get_local $13)
                                       (i32.const 1)
                                     )
                                   )
@@ -1591,118 +1543,116 @@
                       )
                     )
                     (block
-                      (set_local $u
-                        (get_local $f)
+                      (set_local $20
+                        (get_local $2)
                       )
-                      (set_local $j
+                      (set_local $14
                         (i32.const 0)
                       )
-                      (set_local $s
+                      (set_local $7
                         (i32.shl
-                          (get_local $e)
+                          (get_local $3)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $J)
+                                (get_local $0)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $J)
+                              (get_local $0)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $o
-                        (get_local $t)
+                      (set_local $8
+                        (get_local $13)
                       )
-                      (set_local $i
+                      (set_local $1
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $l
+                            (set_local $6
                               (i32.sub
-                                (set_local $m
+                                (set_local $13
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $o)
+                                      (get_local $8)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $e)
+                                (get_local $3)
                               )
                             )
-                            (get_local $u)
+                            (get_local $20)
                           )
                           (if
                             (i32.eq
-                              (get_local $m)
-                              (get_local $e)
+                              (get_local $13)
+                              (get_local $3)
                             )
                             (block
-                              (set_local $O
-                                (get_local $l)
+                              (set_local $28
+                                (get_local $6)
                               )
-                              (set_local $P
-                                (get_local $o)
+                              (set_local $27
+                                (get_local $8)
                               )
-                              (set_local $Q
-                                (get_local $o)
+                              (set_local $32
+                                (get_local $8)
                               )
-                              (set_local $N
+                              (set_local $8
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $R
-                                (get_local $l)
+                              (set_local $2
+                                (get_local $6)
                               )
-                              (set_local $S
-                                (get_local $o)
+                              (set_local $1
+                                (get_local $8)
                               )
                             )
                           )
                           (block
-                            (set_local $R
-                              (get_local $u)
+                            (set_local $2
+                              (get_local $20)
                             )
-                            (set_local $S
-                              (get_local $i)
-                            )
+                            (get_local $1)
                           )
                         )
-                        (set_local $m
+                        (set_local $13
                           (select
-                            (get_local $j)
-                            (set_local $l
+                            (get_local $14)
+                            (set_local $6
                               (i32.load offset=20
-                                (get_local $o)
+                                (get_local $8)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $l)
+                                (get_local $6)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $l)
-                                (set_local $o
+                                (get_local $6)
+                                (set_local $8
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $o)
+                                        (get_local $8)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $s)
+                                          (get_local $7)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1715,65 +1665,63 @@
                           )
                         )
                         (if
-                          (set_local $l
+                          (set_local $6
                             (i32.eq
-                              (get_local $o)
+                              (get_local $8)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $K
-                              (get_local $R)
+                            (set_local $36
+                              (get_local $2)
                             )
-                            (set_local $L
-                              (get_local $m)
+                            (set_local $37
+                              (get_local $13)
                             )
-                            (set_local $M
-                              (get_local $S)
+                            (set_local $31
+                              (get_local $1)
                             )
-                            (set_local $N
+                            (set_local $8
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $u
-                              (get_local $R)
+                            (set_local $20
+                              (get_local $2)
                             )
-                            (set_local $j
-                              (get_local $m)
+                            (set_local $14
+                              (get_local $13)
                             )
-                            (set_local $s
+                            (set_local $7
                               (i32.shl
-                                (get_local $s)
+                                (get_local $7)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $l)
+                                    (get_local $6)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
                                 )
                               )
                             )
-                            (set_local $i
-                              (get_local $S)
-                            )
+                            (get_local $1)
                           )
                         )
                         (br $while-in$18)
                       )
                     )
                     (block
-                      (set_local $K
-                        (get_local $f)
+                      (set_local $36
+                        (get_local $2)
                       )
-                      (set_local $L
+                      (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $M
+                      (set_local $31
                         (i32.const 0)
                       )
-                      (set_local $N
+                      (set_local $8
                         (i32.const 86)
                       )
                     )
@@ -1781,60 +1729,60 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $N)
+                    (get_local $8)
                     (i32.const 86)
                   )
                   (if
-                    (set_local $T
+                    (set_local $0
                       (if
                         (i32.and
                           (i32.eq
-                            (get_local $L)
+                            (get_local $37)
                             (i32.const 0)
                           )
                           (i32.eq
-                            (get_local $M)
+                            (get_local $31)
                             (i32.const 0)
                           )
                         )
                         (block
                           (if
                             (i32.eqz
-                              (set_local $f
+                              (set_local $2
                                 (i32.and
-                                  (get_local $q)
+                                  (get_local $9)
                                   (i32.or
-                                    (set_local $t
+                                    (set_local $13
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $J)
+                                        (get_local $0)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $t)
+                                      (get_local $13)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $y
-                                (get_local $e)
+                              (set_local $0
+                                (get_local $3)
                               )
                               (br $do-once$0)
                             )
                           )
-                          (set_local $f
+                          (set_local $2
                             (i32.and
                               (i32.shr_u
-                                (set_local $t
+                                (set_local $13
                                   (i32.add
                                     (i32.and
-                                      (get_local $f)
+                                      (get_local $2)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $f)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.const -1)
@@ -1853,13 +1801,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $t
+                                          (set_local $13
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $d
+                                                (set_local $0
                                                   (i32.shr_u
-                                                    (get_local $t)
-                                                    (get_local $f)
+                                                    (get_local $13)
+                                                    (get_local $2)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1867,15 +1815,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $f)
+                                          (get_local $2)
                                         )
-                                        (set_local $d
+                                        (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $g
+                                              (set_local $6
                                                 (i32.shr_u
-                                                  (get_local $d)
-                                                  (get_local $t)
+                                                  (get_local $0)
+                                                  (get_local $13)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1884,13 +1832,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $g
+                                      (set_local $6
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $i
+                                            (set_local $1
                                               (i32.shr_u
-                                                (get_local $g)
-                                                (get_local $d)
+                                                (get_local $6)
+                                                (get_local $0)
                                               )
                                             )
                                             (i32.const 1)
@@ -1899,13 +1847,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $i
+                                    (set_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $s
+                                          (set_local $7
                                             (i32.shr_u
-                                              (get_local $i)
-                                              (get_local $g)
+                                              (get_local $1)
+                                              (get_local $6)
                                             )
                                           )
                                           (i32.const 1)
@@ -1915,8 +1863,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $s)
-                                    (get_local $i)
+                                    (get_local $7)
+                                    (get_local $1)
                                   )
                                 )
                                 (i32.const 2)
@@ -1925,117 +1873,113 @@
                             )
                           )
                         )
-                        (get_local $L)
+                        (get_local $37)
                       )
                     )
                     (block
-                      (set_local $O
-                        (get_local $K)
+                      (set_local $28
+                        (get_local $36)
                       )
-                      (set_local $P
-                        (get_local $T)
+                      (set_local $27
+                        (get_local $0)
                       )
-                      (set_local $Q
-                        (get_local $M)
+                      (set_local $32
+                        (get_local $31)
                       )
-                      (set_local $N
+                      (set_local $8
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $U
-                        (get_local $K)
+                      (set_local $16
+                        (get_local $36)
                       )
-                      (set_local $V
-                        (get_local $M)
+                      (set_local $10
+                        (get_local $31)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $N)
+                    (get_local $8)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $N
+                    (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $s
+                    (set_local $7
                       (i32.lt_u
-                        (set_local $i
+                        (set_local $1
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $P)
+                                (get_local $27)
                               )
                               (i32.const -8)
                             )
-                            (get_local $e)
+                            (get_local $3)
                           )
                         )
-                        (get_local $O)
+                        (get_local $28)
                       )
                     )
-                    (set_local $g
+                    (set_local $6
                       (select
-                        (get_local $i)
-                        (get_local $O)
-                        (get_local $s)
+                        (get_local $1)
+                        (get_local $28)
+                        (get_local $7)
                       )
                     )
-                    (set_local $i
+                    (set_local $1
                       (select
-                        (get_local $P)
-                        (get_local $Q)
-                        (get_local $s)
+                        (get_local $27)
+                        (get_local $32)
+                        (get_local $7)
                       )
                     )
                     (if
-                      (set_local $s
+                      (set_local $7
                         (i32.load offset=16
-                          (get_local $P)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $O
-                          (get_local $g)
+                        (set_local $28
+                          (get_local $6)
                         )
-                        (set_local $P
-                          (get_local $s)
+                        (set_local $27
+                          (get_local $7)
                         )
-                        (set_local $Q
-                          (get_local $i)
+                        (set_local $32
+                          (get_local $1)
                         )
-                        (set_local $N
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                         (br $while-in$20)
                       )
                     )
                     (if
-                      (set_local $P
+                      (set_local $27
                         (i32.load offset=20
-                          (get_local $P)
+                          (get_local $27)
                         )
                       )
                       (block
-                        (set_local $O
-                          (get_local $g)
+                        (set_local $28
+                          (get_local $6)
                         )
-                        (set_local $Q
-                          (get_local $i)
+                        (set_local $32
+                          (get_local $1)
                         )
-                        (set_local $N
-                          (i32.const 90)
-                        )
+                        (i32.const 90)
                       )
                       (block
-                        (set_local $U
-                          (get_local $g)
+                        (set_local $16
+                          (get_local $6)
                         )
-                        (set_local $V
-                          (get_local $i)
+                        (set_local $10
+                          (get_local $1)
                         )
                         (br $while-out$19)
                       )
@@ -2044,22 +1988,22 @@
                   )
                 )
                 (if
-                  (get_local $V)
+                  (get_local $10)
                   (if
                     (i32.lt_u
-                      (get_local $U)
+                      (get_local $16)
                       (i32.sub
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $e)
+                        (get_local $3)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $V)
-                          (set_local $q
+                          (get_local $10)
+                          (set_local $9
                             (i32.load
                               (i32.const 1224)
                             )
@@ -2069,72 +2013,72 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $V)
-                          (set_local $i
+                          (get_local $10)
+                          (set_local $1
                             (i32.add
-                              (get_local $V)
-                              (get_local $e)
+                              (get_local $10)
+                              (get_local $3)
                             )
                           )
                         )
                         (call_import $qa)
                       )
-                      (set_local $g
+                      (set_local $6
                         (i32.load offset=24
-                          (get_local $V)
+                          (get_local $10)
                         )
                       )
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $s
+                            (set_local $7
                               (i32.load offset=12
-                                (get_local $V)
+                                (get_local $10)
                               )
                             )
-                            (get_local $V)
+                            (get_local $10)
                           )
                           (block
                             (if
-                              (set_local $f
+                              (set_local $2
                                 (i32.load
-                                  (set_local $d
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $V)
+                                      (get_local $10)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $X
-                                  (get_local $f)
+                                (set_local $4
+                                  (get_local $2)
                                 )
-                                (set_local $Y
-                                  (get_local $d)
+                                (set_local $14
+                                  (get_local $0)
                                 )
                               )
                               (if
-                                (set_local $j
+                                (set_local $14
                                   (i32.load
-                                    (set_local $t
+                                    (set_local $13
                                       (i32.add
-                                        (get_local $V)
+                                        (get_local $10)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $X
-                                    (get_local $j)
+                                  (set_local $4
+                                    (get_local $14)
                                   )
-                                  (set_local $Y
-                                    (get_local $t)
+                                  (set_local $14
+                                    (get_local $13)
                                   )
                                 )
                                 (block
-                                  (set_local $W
+                                  (set_local $22
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
@@ -2143,51 +2087,51 @@
                             )
                             (loop $while-out$23 $while-in$24
                               (if
-                                (set_local $f
+                                (set_local $2
                                   (i32.load
-                                    (set_local $d
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $X)
+                                        (get_local $4)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $X
-                                    (get_local $f)
+                                  (set_local $4
+                                    (get_local $2)
                                   )
-                                  (set_local $Y
-                                    (get_local $d)
+                                  (set_local $14
+                                    (get_local $0)
                                   )
                                   (br $while-in$24)
                                 )
                               )
                               (if
-                                (set_local $f
+                                (set_local $2
                                   (i32.load
-                                    (set_local $d
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $X)
+                                        (get_local $4)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $X
-                                    (get_local $f)
+                                  (set_local $4
+                                    (get_local $2)
                                   )
-                                  (set_local $Y
-                                    (get_local $d)
+                                  (set_local $14
+                                    (get_local $0)
                                   )
                                 )
                                 (block
-                                  (set_local $Z
-                                    (get_local $X)
+                                  (set_local $0
+                                    (get_local $4)
                                   )
-                                  (set_local $_
-                                    (get_local $Y)
+                                  (set_local $4
+                                    (get_local $14)
                                   )
                                   (br $while-out$23)
                                 )
@@ -2196,17 +2140,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $_)
-                                (get_local $q)
+                                (get_local $4)
+                                (get_local $9)
                               )
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $_)
+                                  (get_local $4)
                                   (i32.const 0)
                                 )
-                                (set_local $W
-                                  (get_local $Z)
+                                (set_local $22
+                                  (get_local $0)
                                 )
                               )
                             )
@@ -2214,52 +2158,52 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $d
+                                (set_local $0
                                   (i32.load offset=8
-                                    (get_local $V)
+                                    (get_local $10)
                                   )
                                 )
-                                (get_local $q)
+                                (get_local $9)
                               )
                               (call_import $qa)
                             )
                             (if
                               (i32.ne
                                 (i32.load
-                                  (set_local $f
+                                  (set_local $2
                                     (i32.add
-                                      (get_local $d)
+                                      (get_local $0)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $V)
+                                (get_local $10)
                               )
                               (call_import $qa)
                             )
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $t
+                                  (set_local $13
                                     (i32.add
-                                      (get_local $s)
+                                      (get_local $7)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $V)
+                                (get_local $10)
                               )
                               (block
                                 (i32.store
-                                  (get_local $f)
-                                  (get_local $s)
+                                  (get_local $2)
+                                  (get_local $7)
                                 )
                                 (i32.store
-                                  (get_local $t)
-                                  (get_local $d)
+                                  (get_local $13)
+                                  (get_local $0)
                                 )
-                                (set_local $W
-                                  (get_local $s)
+                                (set_local $22
+                                  (get_local $7)
                                 )
                               )
                               (call_import $qa)
@@ -2269,19 +2213,19 @@
                       )
                       (block $do-once$25
                         (if
-                          (get_local $g)
+                          (get_local $6)
                           (block
                             (if
                               (i32.eq
-                                (get_local $V)
+                                (get_local $10)
                                 (i32.load
-                                  (set_local $q
+                                  (set_local $9
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (set_local $s
+                                        (set_local $7
                                           (i32.load offset=28
-                                            (get_local $V)
+                                            (get_local $10)
                                           )
                                         )
                                         (i32.const 2)
@@ -2292,12 +2236,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $q)
-                                  (get_local $W)
+                                  (get_local $9)
+                                  (get_local $22)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $W)
+                                    (get_local $22)
                                   )
                                   (block
                                     (i32.store
@@ -2309,7 +2253,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $s)
+                                            (get_local $7)
                                           )
                                           (i32.const -1)
                                         )
@@ -2322,7 +2266,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $g)
+                                    (get_local $6)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2332,35 +2276,35 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $s
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $g)
+                                          (get_local $6)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $V)
+                                    (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $s)
-                                    (get_local $W)
+                                    (get_local $7)
+                                    (get_local $22)
                                   )
                                   (i32.store offset=20
-                                    (get_local $g)
-                                    (get_local $W)
+                                    (get_local $6)
+                                    (get_local $22)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eqz
-                                    (get_local $W)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $W)
-                                (set_local $s
+                                (get_local $22)
+                                (set_local $7
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2369,42 +2313,42 @@
                               (call_import $qa)
                             )
                             (i32.store offset=24
-                              (get_local $W)
-                              (get_local $g)
+                              (get_local $22)
+                              (get_local $6)
                             )
                             (if
-                              (set_local $q
+                              (set_local $9
                                 (i32.load offset=16
-                                  (get_local $V)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $q)
-                                  (get_local $s)
+                                  (get_local $9)
+                                  (get_local $7)
                                 )
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $W)
-                                    (get_local $q)
+                                    (get_local $22)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $q)
-                                    (get_local $W)
+                                    (get_local $9)
+                                    (get_local $22)
                                   )
                                 )
                               )
                             )
                             (if
-                              (set_local $q
+                              (set_local $9
                                 (i32.load offset=20
-                                  (get_local $V)
+                                  (get_local $10)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $q)
+                                  (get_local $9)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2412,12 +2356,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $W)
-                                    (get_local $q)
+                                    (get_local $22)
+                                    (get_local $9)
                                   )
                                   (i32.store offset=24
-                                    (get_local $q)
-                                    (get_local $W)
+                                    (get_local $9)
+                                    (get_local $22)
                                   )
                                 )
                               )
@@ -2428,35 +2372,35 @@
                       (block $do-once$29
                         (if
                           (i32.lt_u
-                            (get_local $U)
+                            (get_local $16)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $V)
+                              (get_local $10)
                               (i32.or
-                                (set_local $g
+                                (set_local $6
                                   (i32.add
-                                    (get_local $U)
-                                    (get_local $e)
+                                    (get_local $16)
+                                    (get_local $3)
                                   )
                                 )
                                 (i32.const 3)
                               )
                             )
                             (i32.store
-                              (set_local $q
+                              (set_local $9
                                 (i32.add
                                   (i32.add
-                                    (get_local $V)
-                                    (get_local $g)
+                                    (get_local $10)
+                                    (get_local $6)
                                   )
                                   (i32.const 4)
                                 )
                               )
                               (i32.or
                                 (i32.load
-                                  (get_local $q)
+                                  (get_local $9)
                                 )
                                 (i32.const 1)
                               )
@@ -2464,44 +2408,44 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $V)
+                              (get_local $10)
                               (i32.or
-                                (get_local $e)
+                                (get_local $3)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $i)
+                              (get_local $1)
                               (i32.or
-                                (get_local $U)
+                                (get_local $16)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $i)
-                                (get_local $U)
+                                (get_local $1)
+                                (get_local $16)
                               )
-                              (get_local $U)
+                              (get_local $16)
                             )
-                            (set_local $q
+                            (set_local $9
                               (i32.shr_u
-                                (get_local $U)
+                                (get_local $16)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $U)
+                                (get_local $16)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $g
+                                (set_local $6
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $q)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -2510,25 +2454,25 @@
                                 )
                                 (if
                                   (i32.and
-                                    (set_local $s
+                                    (set_local $7
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $d
+                                    (set_local $0
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $q)
+                                        (get_local $9)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $s
+                                      (set_local $7
                                         (i32.load
-                                          (set_local $d
+                                          (set_local $0
                                             (i32.add
-                                              (get_local $g)
+                                              (get_local $6)
                                               (i32.const 8)
                                             )
                                           )
@@ -2540,11 +2484,11 @@
                                     )
                                     (call_import $qa)
                                     (block
-                                      (set_local $$
-                                        (get_local $d)
+                                      (set_local $17
+                                        (get_local $0)
                                       )
-                                      (set_local $aa
-                                        (get_local $s)
+                                      (set_local $12
+                                        (get_local $7)
                                       )
                                     )
                                   )
@@ -2552,81 +2496,81 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $s)
-                                        (get_local $d)
+                                        (get_local $7)
+                                        (get_local $0)
                                       )
                                     )
-                                    (set_local $$
+                                    (set_local $17
                                       (i32.add
-                                        (get_local $g)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $aa
-                                      (get_local $g)
+                                    (set_local $12
+                                      (get_local $6)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $$)
-                                  (get_local $i)
+                                  (get_local $17)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=12
-                                  (get_local $aa)
-                                  (get_local $i)
+                                  (get_local $12)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i)
-                                  (get_local $aa)
+                                  (get_local $1)
+                                  (get_local $12)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i)
-                                  (get_local $g)
+                                  (get_local $1)
+                                  (get_local $6)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $t
+                            (set_local $13
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (set_local $ba
+                                  (set_local $2
                                     (if
-                                      (set_local $g
+                                      (set_local $6
                                         (i32.shr_u
-                                          (get_local $U)
+                                          (get_local $16)
                                           (i32.const 8)
                                         )
                                       )
                                       (if
                                         (i32.gt_u
-                                          (get_local $U)
+                                          (get_local $16)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $U)
+                                              (get_local $16)
                                               (i32.add
-                                                (set_local $t
+                                                (set_local $13
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $g
+                                                          (set_local $6
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $d
+                                                                  (set_local $0
                                                                     (i32.shl
-                                                                      (get_local $g)
-                                                                      (set_local $s
+                                                                      (get_local $6)
+                                                                      (set_local $7
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $g)
+                                                                              (get_local $6)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2643,16 +2587,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $s)
+                                                          (get_local $7)
                                                         )
-                                                        (set_local $d
+                                                        (set_local $0
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $q
+                                                                (set_local $9
                                                                   (i32.shl
-                                                                    (get_local $d)
-                                                                    (get_local $g)
+                                                                    (get_local $0)
+                                                                    (get_local $6)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2666,8 +2610,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $q)
-                                                        (get_local $d)
+                                                        (get_local $9)
+                                                        (get_local $0)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2679,7 +2623,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $t)
+                                            (get_local $13)
                                             (i32.const 1)
                                           )
                                         )
@@ -2692,34 +2636,34 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $i)
-                              (get_local $ba)
+                              (get_local $1)
+                              (get_local $2)
                             )
                             (i32.store offset=4
-                              (set_local $d
+                              (set_local $0
                                 (i32.add
-                                  (get_local $i)
+                                  (get_local $1)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $d)
+                              (get_local $0)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (set_local $d
+                                  (set_local $0
                                     (i32.load
                                       (i32.const 1212)
                                     )
                                   )
-                                  (set_local $q
+                                  (set_local $9
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $ba)
+                                      (get_local $2)
                                     )
                                   )
                                 )
@@ -2728,51 +2672,51 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $d)
-                                    (get_local $q)
+                                    (get_local $0)
+                                    (get_local $9)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $t)
-                                  (get_local $i)
+                                  (get_local $13)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=24
-                                  (get_local $i)
-                                  (get_local $t)
+                                  (get_local $1)
+                                  (get_local $13)
                                 )
                                 (i32.store offset=12
-                                  (get_local $i)
-                                  (get_local $i)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=8
-                                  (get_local $i)
-                                  (get_local $i)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $q
+                            (set_local $9
                               (i32.shl
-                                (get_local $U)
+                                (get_local $16)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $ba)
+                                      (get_local $2)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $ba)
+                                    (get_local $2)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $d
+                            (set_local $0
                               (i32.load
-                                (get_local $t)
+                                (get_local $13)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -2780,34 +2724,34 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $d)
+                                      (get_local $0)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $U)
+                                  (get_local $16)
                                 )
                                 (block
-                                  (set_local $ca
-                                    (get_local $d)
+                                  (set_local $15
+                                    (get_local $0)
                                   )
-                                  (set_local $N
+                                  (set_local $8
                                     (i32.const 148)
                                   )
                                   (br $while-out$31)
                                 )
                               )
                               (if
-                                (set_local $s
+                                (set_local $7
                                   (i32.load
-                                    (set_local $t
+                                    (set_local $13
                                       (i32.add
                                         (i32.add
-                                          (get_local $d)
+                                          (get_local $0)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $q)
+                                            (get_local $9)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -2817,24 +2761,24 @@
                                   )
                                 )
                                 (block
-                                  (set_local $q
+                                  (set_local $9
                                     (i32.shl
-                                      (get_local $q)
+                                      (get_local $9)
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $d
-                                    (get_local $s)
+                                  (set_local $0
+                                    (get_local $7)
                                   )
                                 )
                                 (block
-                                  (set_local $da
-                                    (get_local $t)
+                                  (set_local $21
+                                    (get_local $13)
                                   )
-                                  (set_local $ea
-                                    (get_local $d)
+                                  (set_local $18
+                                    (get_local $0)
                                   )
-                                  (set_local $N
+                                  (set_local $8
                                     (i32.const 145)
                                   )
                                   (br $while-out$31)
@@ -2844,12 +2788,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $N)
+                                (get_local $8)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $da)
+                                  (get_local $21)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2857,71 +2801,71 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store
-                                    (get_local $da)
-                                    (get_local $i)
+                                    (get_local $21)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=24
-                                    (get_local $i)
-                                    (get_local $ea)
+                                    (get_local $1)
+                                    (get_local $18)
                                   )
                                   (i32.store offset=12
-                                    (get_local $i)
-                                    (get_local $i)
+                                    (get_local $1)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=8
-                                    (get_local $i)
-                                    (get_local $i)
+                                    (get_local $1)
+                                    (get_local $1)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $N)
+                                  (get_local $8)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (set_local $q
+                                      (set_local $9
                                         (i32.load
-                                          (set_local $d
+                                          (set_local $0
                                             (i32.add
-                                              (get_local $ca)
+                                              (get_local $15)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $s
+                                      (set_local $7
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $ca)
-                                      (get_local $s)
+                                      (get_local $15)
+                                      (get_local $7)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $q)
-                                      (get_local $i)
+                                      (get_local $9)
+                                      (get_local $1)
                                     )
                                     (i32.store
-                                      (get_local $d)
-                                      (get_local $i)
+                                      (get_local $0)
+                                      (get_local $1)
                                     )
                                     (i32.store offset=8
-                                      (get_local $i)
-                                      (get_local $q)
+                                      (get_local $1)
+                                      (get_local $9)
                                     )
                                     (i32.store offset=12
-                                      (get_local $i)
-                                      (get_local $ca)
+                                      (get_local $1)
+                                      (get_local $15)
                                     )
                                     (i32.store offset=24
-                                      (get_local $i)
+                                      (get_local $1)
                                       (i32.const 0)
                                     )
                                   )
@@ -2934,26 +2878,26 @@
                       )
                       (i32.store
                         (i32.const 8)
-                        (get_local $b)
+                        (get_local $25)
                       )
                       (return
                         (i32.add
-                          (get_local $V)
+                          (get_local $10)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $y
-                      (get_local $e)
+                    (set_local $0
+                      (get_local $3)
                     )
                   )
-                  (set_local $y
-                    (get_local $e)
+                  (set_local $0
+                    (get_local $3)
                   )
                 )
               )
-              (set_local $y
-                (get_local $e)
+              (set_local $0
+                (get_local $3)
               )
             )
           )
@@ -2962,25 +2906,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $V
+        (set_local $10
           (i32.load
             (i32.const 1216)
           )
         )
-        (get_local $y)
+        (get_local $0)
       )
       (block
-        (set_local $ea
+        (set_local $18
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (set_local $ca
+            (set_local $15
               (i32.sub
-                (get_local $V)
-                (get_local $y)
+                (get_local $10)
+                (get_local $0)
               )
             )
             (i32.const 15)
@@ -2988,35 +2932,35 @@
           (block
             (i32.store
               (i32.const 1228)
-              (set_local $da
+              (set_local $21
                 (i32.add
-                  (get_local $ea)
-                  (get_local $y)
+                  (get_local $18)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $ca)
+              (get_local $15)
             )
             (i32.store offset=4
-              (get_local $da)
+              (get_local $21)
               (i32.or
-                (get_local $ca)
+                (get_local $15)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $da)
-                (get_local $ca)
+                (get_local $21)
+                (get_local $15)
               )
-              (get_local $ca)
+              (get_local $15)
             )
             (i32.store offset=4
-              (get_local $ea)
+              (get_local $18)
               (i32.or
-                (get_local $y)
+                (get_local $0)
                 (i32.const 3)
               )
             )
@@ -3031,25 +2975,25 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $ea)
+              (get_local $18)
               (i32.or
-                (get_local $V)
+                (get_local $10)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $ca
+              (set_local $15
                 (i32.add
                   (i32.add
-                    (get_local $ea)
-                    (get_local $V)
+                    (get_local $18)
+                    (get_local $10)
                   )
                   (i32.const 4)
                 )
               )
               (i32.or
                 (i32.load
-                  (get_local $ca)
+                  (get_local $15)
                 )
                 (i32.const 1)
               )
@@ -3058,11 +3002,11 @@
         )
         (i32.store
           (i32.const 8)
-          (get_local $b)
+          (get_local $25)
         )
         (return
           (i32.add
-            (get_local $ea)
+            (get_local $18)
             (i32.const 8)
           )
         )
@@ -3070,57 +3014,57 @@
     )
     (if
       (i32.gt_u
-        (set_local $ea
+        (set_local $18
           (i32.load
             (i32.const 1220)
           )
         )
-        (get_local $y)
+        (get_local $0)
       )
       (block
         (i32.store
           (i32.const 1220)
-          (set_local $ca
+          (set_local $15
             (i32.sub
-              (get_local $ea)
-              (get_local $y)
+              (get_local $18)
+              (get_local $0)
             )
           )
         )
         (i32.store
           (i32.const 1232)
-          (set_local $V
+          (set_local $10
             (i32.add
-              (set_local $ea
+              (set_local $18
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $y)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=4
-          (get_local $V)
+          (get_local $10)
           (i32.or
-            (get_local $ca)
+            (get_local $15)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $ea)
+          (get_local $18)
           (i32.or
-            (get_local $y)
+            (get_local $0)
             (i32.const 3)
           )
         )
         (i32.store
           (i32.const 8)
-          (get_local $b)
+          (get_local $25)
         )
         (return
           (i32.add
-            (get_local $ea)
+            (get_local $18)
             (i32.const 8)
           )
         )
@@ -3158,11 +3102,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $c)
-          (set_local $ea
+          (get_local $4)
+          (set_local $18
             (i32.xor
               (i32.and
-                (get_local $c)
+                (get_local $4)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3171,49 +3115,49 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $ea)
+          (get_local $18)
         )
       )
     )
-    (set_local $ea
+    (set_local $18
       (i32.add
-        (get_local $y)
+        (get_local $0)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $c
+        (set_local $4
           (i32.and
-            (set_local $V
+            (set_local $10
               (i32.add
-                (set_local $c
+                (set_local $4
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (set_local $ca
+                (set_local $15
                   (i32.add
-                    (get_local $y)
+                    (get_local $0)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $da
+            (set_local $21
               (i32.sub
                 (i32.const 0)
-                (get_local $c)
+                (get_local $4)
               )
             )
           )
         )
-        (get_local $y)
+        (get_local $0)
       )
       (block
         (i32.store
           (i32.const 8)
-          (get_local $b)
+          (get_local $25)
         )
         (return
           (i32.const 0)
@@ -3221,7 +3165,7 @@
       )
     )
     (if
-      (set_local $U
+      (set_local $16
         (i32.load
           (i32.const 1648)
         )
@@ -3229,27 +3173,27 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $aa
+            (set_local $12
               (i32.add
-                (set_local $ba
+                (set_local $2
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $c)
+                (get_local $4)
               )
             )
-            (get_local $ba)
+            (get_local $2)
           )
           (i32.gt_u
-            (get_local $aa)
-            (get_local $U)
+            (get_local $12)
+            (get_local $16)
           )
         )
         (block
           (i32.store
             (i32.const 8)
-            (get_local $b)
+            (get_local $25)
           )
           (return
             (i32.const 0)
@@ -3259,7 +3203,7 @@
     )
     (if
       (i32.eq
-        (set_local $N
+        (set_local $8
           (block $label$break$b
             (if
               (i32.and
@@ -3272,46 +3216,46 @@
               (block
                 (block $label$break$c
                   (if
-                    (set_local $U
+                    (set_local $16
                       (i32.load
                         (i32.const 1232)
                       )
                     )
                     (block
-                      (set_local $aa
+                      (set_local $12
                         (i32.const 1656)
                       )
                       (loop $while-out$35 $while-in$36
                         (if
                           (i32.le_u
-                            (set_local $ba
+                            (set_local $2
                               (i32.load
-                                (get_local $aa)
+                                (get_local $12)
                               )
                             )
-                            (get_local $U)
+                            (get_local $16)
                           )
                           (if
                             (i32.gt_u
                               (i32.add
-                                (get_local $ba)
+                                (get_local $2)
                                 (i32.load
-                                  (set_local $$
+                                  (set_local $17
                                     (i32.add
-                                      (get_local $aa)
+                                      (get_local $12)
                                       (i32.const 4)
                                     )
                                   )
                                 )
                               )
-                              (get_local $U)
+                              (get_local $16)
                             )
                             (block
-                              (set_local $fa
-                                (get_local $aa)
+                              (set_local $3
+                                (get_local $12)
                               )
-                              (set_local $ga
-                                (get_local $$)
+                              (set_local $6
+                                (get_local $17)
                               )
                               (br $while-out$35)
                             )
@@ -3319,14 +3263,14 @@
                         )
                         (if
                           (i32.eqz
-                            (set_local $aa
+                            (set_local $12
                               (i32.load offset=8
-                                (get_local $aa)
+                                (get_local $12)
                               )
                             )
                           )
                           (block
-                            (set_local $N
+                            (set_local $8
                               (i32.const 171)
                             )
                             (br $label$break$c)
@@ -3336,46 +3280,46 @@
                       )
                       (if
                         (i32.lt_u
-                          (set_local $aa
+                          (set_local $12
                             (i32.and
                               (i32.sub
-                                (get_local $V)
+                                (get_local $10)
                                 (i32.load
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $da)
+                              (get_local $21)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $$
+                            (set_local $17
                               (call_import $ta
-                                (get_local $aa)
+                                (get_local $12)
                               )
                             )
                             (i32.add
                               (i32.load
-                                (get_local $fa)
+                                (get_local $3)
                               )
                               (i32.load
-                                (get_local $ga)
+                                (get_local $6)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $$)
+                              (get_local $17)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $ha
-                                (get_local $$)
+                              (set_local $19
+                                (get_local $17)
                               )
-                              (set_local $ia
-                                (get_local $aa)
+                              (set_local $26
+                                (get_local $12)
                               )
                               (br $label$break$b
                                 (i32.const 191)
@@ -3383,20 +3327,20 @@
                             )
                           )
                           (block
-                            (set_local $ja
-                              (get_local $$)
+                            (set_local $11
+                              (get_local $17)
                             )
-                            (set_local $ka
-                              (get_local $aa)
+                            (set_local $5
+                              (get_local $12)
                             )
-                            (set_local $N
+                            (set_local $8
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $N
+                    (set_local $8
                       (i32.const 171)
                     )
                   )
@@ -3404,12 +3348,12 @@
                 (block $do-once$37
                   (if
                     (i32.eq
-                      (get_local $N)
+                      (get_local $8)
                       (i32.const 171)
                     )
                     (if
                       (i32.ne
-                        (set_local $U
+                        (set_local $16
                           (call_import $ta
                             (i32.const 0)
                           )
@@ -3417,12 +3361,12 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $la
+                        (set_local $2
                           (if
                             (i32.and
-                              (set_local $$
+                              (set_local $17
                                 (i32.add
-                                  (set_local $aa
+                                  (set_local $12
                                     (i32.load
                                       (i32.const 1684)
                                     )
@@ -3430,53 +3374,53 @@
                                   (i32.const -1)
                                 )
                               )
-                              (set_local $e
-                                (get_local $U)
+                              (set_local $3
+                                (get_local $16)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $c)
-                                (get_local $e)
+                                (get_local $4)
+                                (get_local $3)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $$)
-                                  (get_local $e)
+                                  (get_local $17)
+                                  (get_local $3)
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $aa)
+                                  (get_local $12)
                                 )
                               )
                             )
-                            (get_local $c)
+                            (get_local $4)
                           )
                         )
-                        (set_local $e
+                        (set_local $3
                           (i32.add
-                            (set_local $aa
+                            (set_local $12
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $la)
+                            (get_local $2)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $la)
-                              (get_local $y)
+                              (get_local $2)
+                              (get_local $0)
                             )
                             (i32.lt_u
-                              (get_local $la)
+                              (get_local $2)
                               (i32.const 2147483647)
                             )
                           )
                           (block
                             (if
-                              (set_local $$
+                              (set_local $17
                                 (i32.load
                                   (i32.const 1648)
                                 )
@@ -3484,44 +3428,44 @@
                               (br_if $do-once$37
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $e)
-                                    (get_local $aa)
+                                    (get_local $3)
+                                    (get_local $12)
                                   )
                                   (i32.gt_u
-                                    (get_local $e)
-                                    (get_local $$)
+                                    (get_local $3)
+                                    (get_local $17)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $$
+                                (set_local $17
                                   (call_import $ta
-                                    (get_local $la)
+                                    (get_local $2)
                                   )
                                 )
-                                (get_local $U)
+                                (get_local $16)
                               )
                               (block
-                                (set_local $ha
-                                  (get_local $U)
+                                (set_local $19
+                                  (get_local $16)
                                 )
-                                (set_local $ia
-                                  (get_local $la)
+                                (set_local $26
+                                  (get_local $2)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
                                 )
                               )
                               (block
-                                (set_local $ja
-                                  (get_local $$)
+                                (set_local $11
+                                  (get_local $17)
                                 )
-                                (set_local $ka
-                                  (get_local $la)
+                                (set_local $5
+                                  (get_local $2)
                                 )
-                                (set_local $N
+                                (set_local $8
                                   (i32.const 181)
                                 )
                               )
@@ -3535,43 +3479,43 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $N)
+                      (get_local $8)
                       (i32.const 181)
                     )
                     (block
-                      (set_local $$
+                      (set_local $17
                         (i32.sub
                           (i32.const 0)
-                          (get_local $ka)
+                          (get_local $5)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $ea)
-                            (get_local $ka)
+                            (get_local $18)
+                            (get_local $5)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $ja)
+                              (get_local $11)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $e
+                            (set_local $3
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $ca)
-                                    (get_local $ka)
+                                    (get_local $15)
+                                    (get_local $5)
                                   )
-                                  (set_local $U
+                                  (set_local $16
                                     (i32.load
                                       (i32.const 1688)
                                     )
@@ -3579,7 +3523,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $U)
+                                  (get_local $16)
                                 )
                               )
                             )
@@ -3588,42 +3532,42 @@
                           (if
                             (i32.eq
                               (call_import $ta
-                                (get_local $e)
+                                (get_local $3)
                               )
                               (i32.const -1)
                             )
                             (block
                               (call_import $ta
-                                (get_local $$)
+                                (get_local $17)
                               )
                               (br $label$break$d)
                             )
-                            (set_local $ma
+                            (set_local $1
                               (i32.add
-                                (get_local $e)
-                                (get_local $ka)
+                                (get_local $3)
+                                (get_local $5)
                               )
                             )
                           )
-                          (set_local $ma
-                            (get_local $ka)
+                          (set_local $1
+                            (get_local $5)
                           )
                         )
-                        (set_local $ma
-                          (get_local $ka)
+                        (set_local $1
+                          (get_local $5)
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $ja)
+                          (get_local $11)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $ha
-                            (get_local $ja)
+                          (set_local $19
+                            (get_local $11)
                           )
-                          (set_local $ia
-                            (get_local $ma)
+                          (set_local $26
+                            (get_local $1)
                           )
                           (br $label$break$b
                             (i32.const 191)
@@ -3651,18 +3595,18 @@
       )
       (if
         (i32.lt_u
-          (get_local $c)
+          (get_local $4)
           (i32.const 2147483647)
         )
         (if
           (i32.and
             (i32.lt_u
-              (set_local $ma
+              (set_local $1
                 (call_import $ta
-                  (get_local $c)
+                  (get_local $4)
                 )
               )
-              (set_local $c
+              (set_local $4
                 (call_import $ta
                   (i32.const 0)
                 )
@@ -3670,36 +3614,36 @@
             )
             (i32.and
               (i32.ne
-                (get_local $ma)
+                (get_local $1)
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $c)
+                (get_local $4)
                 (i32.const -1)
               )
             )
           )
           (if
             (i32.gt_u
-              (set_local $ja
+              (set_local $11
                 (i32.sub
-                  (get_local $c)
-                  (get_local $ma)
+                  (get_local $4)
+                  (get_local $1)
                 )
               )
               (i32.add
-                (get_local $y)
+                (get_local $0)
                 (i32.const 40)
               )
             )
             (block
-              (set_local $ha
-                (get_local $ma)
+              (set_local $19
+                (get_local $1)
               )
-              (set_local $ia
-                (get_local $ja)
+              (set_local $26
+                (get_local $11)
               )
-              (set_local $N
+              (set_local $8
                 (i32.const 191)
               )
             )
@@ -3709,59 +3653,59 @@
     )
     (if
       (i32.eq
-        (get_local $N)
+        (get_local $8)
         (i32.const 191)
       )
       (block
         (i32.store
           (i32.const 1640)
-          (set_local $ja
+          (set_local $11
             (i32.add
               (i32.load
                 (i32.const 1640)
               )
-              (get_local $ia)
+              (get_local $26)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $ja)
+            (get_local $11)
             (i32.load
               (i32.const 1644)
             )
           )
           (i32.store
             (i32.const 1644)
-            (get_local $ja)
+            (get_local $11)
           )
         )
         (block $do-once$42
           (if
-            (set_local $ja
+            (set_local $11
               (i32.load
                 (i32.const 1232)
               )
             )
             (block
-              (set_local $ka
+              (set_local $5
                 (i32.const 1656)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $ha)
+                    (get_local $19)
                     (i32.add
-                      (set_local $ma
+                      (set_local $1
                         (i32.load
-                          (get_local $ka)
+                          (get_local $5)
                         )
                       )
-                      (set_local $ca
+                      (set_local $15
                         (i32.load
-                          (set_local $c
+                          (set_local $4
                             (i32.add
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 4)
                             )
                           )
@@ -3770,19 +3714,19 @@
                     )
                   )
                   (block
-                    (set_local $na
-                      (get_local $ma)
+                    (set_local $49
+                      (get_local $1)
                     )
-                    (set_local $oa
-                      (get_local $c)
+                    (set_local $50
+                      (get_local $4)
                     )
-                    (set_local $pa
-                      (get_local $ca)
+                    (set_local $51
+                      (get_local $15)
                     )
-                    (set_local $ra
-                      (get_local $ka)
+                    (set_local $52
+                      (get_local $5)
                     )
-                    (set_local $N
+                    (set_local $8
                       (i32.const 201)
                     )
                     (br $do-out$46)
@@ -3790,9 +3734,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $ka
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $ka)
+                        (get_local $5)
                       )
                     )
                     (i32.const 0)
@@ -3801,14 +3745,14 @@
               )
               (if
                 (i32.eq
-                  (get_local $N)
+                  (get_local $8)
                   (i32.const 201)
                 )
                 (if
                   (i32.eqz
                     (i32.and
                       (i32.load offset=12
-                        (get_local $ra)
+                        (get_local $52)
                       )
                       (i32.const 8)
                     )
@@ -3816,34 +3760,34 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $ja)
-                        (get_local $ha)
+                        (get_local $11)
+                        (get_local $19)
                       )
                       (i32.ge_u
-                        (get_local $ja)
-                        (get_local $na)
+                        (get_local $11)
+                        (get_local $49)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $oa)
+                        (get_local $50)
                         (i32.add
-                          (get_local $pa)
-                          (get_local $ia)
+                          (get_local $51)
+                          (get_local $26)
                         )
                       )
-                      (set_local $ka
+                      (set_local $5
                         (i32.add
-                          (get_local $ja)
-                          (set_local $ca
+                          (get_local $11)
+                          (set_local $15
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (set_local $ka
+                                  (set_local $5
                                     (i32.add
-                                      (get_local $ja)
+                                      (get_local $11)
                                       (i32.const 8)
                                     )
                                   )
@@ -3852,7 +3796,7 @@
                               )
                               (i32.eq
                                 (i32.and
-                                  (get_local $ka)
+                                  (get_local $5)
                                   (i32.const 7)
                                 )
                                 (i32.const 0)
@@ -3861,11 +3805,11 @@
                           )
                         )
                       )
-                      (set_local $c
+                      (set_local $4
                         (i32.add
                           (i32.sub
-                            (get_local $ia)
-                            (get_local $ca)
+                            (get_local $26)
+                            (get_local $15)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3874,23 +3818,23 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $ka)
+                        (get_local $5)
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $c)
+                        (get_local $4)
                       )
                       (i32.store offset=4
-                        (get_local $ka)
+                        (get_local $5)
                         (i32.or
-                          (get_local $c)
+                          (get_local $4)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $ka)
-                          (get_local $c)
+                          (get_local $5)
+                          (get_local $4)
                         )
                         (i32.const 40)
                       )
@@ -3905,11 +3849,11 @@
                   )
                 )
               )
-              (set_local $sa
+              (set_local $14
                 (if
                   (i32.lt_u
-                    (get_local $ha)
-                    (set_local $c
+                    (get_local $19)
+                    (set_local $4
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3918,38 +3862,38 @@
                   (block
                     (i32.store
                       (i32.const 1224)
-                      (get_local $ha)
+                      (get_local $19)
                     )
-                    (get_local $ha)
+                    (get_local $19)
                   )
-                  (get_local $c)
+                  (get_local $4)
                 )
               )
-              (set_local $c
+              (set_local $4
                 (i32.add
-                  (get_local $ha)
-                  (get_local $ia)
+                  (get_local $19)
+                  (get_local $26)
                 )
               )
-              (set_local $ka
+              (set_local $5
                 (i32.const 1656)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $ka)
+                      (get_local $5)
                     )
-                    (get_local $c)
+                    (get_local $4)
                   )
                   (block
-                    (set_local $ua
-                      (get_local $ka)
+                    (set_local $53
+                      (get_local $5)
                     )
-                    (set_local $va
-                      (get_local $ka)
+                    (set_local $43
+                      (get_local $5)
                     )
-                    (set_local $N
+                    (set_local $8
                       (i32.const 209)
                     )
                     (br $while-out$48)
@@ -3957,14 +3901,14 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $ka
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $ka)
+                        (get_local $5)
                       )
                     )
                   )
                   (block
-                    (set_local $wa
+                    (set_local $29
                       (i32.const 1656)
                     )
                     (br $while-out$48)
@@ -3974,49 +3918,49 @@
               )
               (if
                 (i32.eq
-                  (get_local $N)
+                  (get_local $8)
                   (i32.const 209)
                 )
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $va)
+                      (get_local $43)
                     )
                     (i32.const 8)
                   )
-                  (set_local $wa
+                  (set_local $29
                     (i32.const 1656)
                   )
                   (block
                     (i32.store
-                      (get_local $ua)
-                      (get_local $ha)
+                      (get_local $53)
+                      (get_local $19)
                     )
                     (i32.store
-                      (set_local $ka
+                      (set_local $5
                         (i32.add
-                          (get_local $va)
+                          (get_local $43)
                           (i32.const 4)
                         )
                       )
                       (i32.add
                         (i32.load
-                          (get_local $ka)
+                          (get_local $5)
                         )
-                        (get_local $ia)
+                        (get_local $26)
                       )
                     )
-                    (set_local $ca
+                    (set_local $15
                       (i32.add
-                        (get_local $ha)
+                        (get_local $19)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $ka
+                              (set_local $5
                                 (i32.add
-                                  (get_local $ha)
+                                  (get_local $19)
                                   (i32.const 8)
                                 )
                               )
@@ -4025,7 +3969,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -4033,17 +3977,17 @@
                         )
                       )
                     )
-                    (set_local $ma
+                    (set_local $1
                       (i32.add
-                        (get_local $c)
+                        (get_local $4)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $ka
+                              (set_local $5
                                 (i32.add
-                                  (get_local $c)
+                                  (get_local $4)
                                   (i32.const 8)
                                 )
                               )
@@ -4052,7 +3996,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $ka)
+                              (get_local $5)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -4060,54 +4004,54 @@
                         )
                       )
                     )
-                    (set_local $ka
+                    (set_local $5
                       (i32.add
-                        (get_local $ca)
-                        (get_local $y)
+                        (get_local $15)
+                        (get_local $0)
                       )
                     )
-                    (set_local $ea
+                    (set_local $18
                       (i32.sub
                         (i32.sub
-                          (get_local $ma)
-                          (get_local $ca)
+                          (get_local $1)
+                          (get_local $15)
                         )
-                        (get_local $y)
+                        (get_local $0)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $ca)
+                      (get_local $15)
                       (i32.or
-                        (get_local $y)
+                        (get_local $0)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$50
                       (if
                         (i32.eq
-                          (get_local $ma)
-                          (get_local $ja)
+                          (get_local $1)
+                          (get_local $11)
                         )
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (set_local $la
+                            (set_local $2
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $ea)
+                                (get_local $18)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $ka)
+                            (get_local $5)
                           )
                           (i32.store offset=4
-                            (get_local $ka)
+                            (get_local $5)
                             (i32.or
-                              (get_local $la)
+                              (get_local $2)
                               (i32.const 1)
                             )
                           )
@@ -4115,7 +4059,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $ma)
+                              (get_local $1)
                               (i32.load
                                 (i32.const 1228)
                               )
@@ -4123,45 +4067,45 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (set_local $la
+                                (set_local $2
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $ea)
+                                    (get_local $18)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $ka)
+                                (get_local $5)
                               )
                               (i32.store offset=4
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.or
-                                  (get_local $la)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $ka)
-                                  (get_local $la)
+                                  (get_local $5)
+                                  (get_local $2)
                                 )
-                                (get_local $la)
+                                (get_local $2)
                               )
                               (br $do-once$50)
                             )
                           )
                           (i32.store
-                            (set_local $fa
+                            (set_local $3
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $la
+                                      (set_local $2
                                         (i32.load offset=4
-                                          (get_local $ma)
+                                          (get_local $1)
                                         )
                                       )
                                       (i32.const 3)
@@ -4169,44 +4113,44 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $ga
+                                    (set_local $6
                                       (i32.and
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $fa
+                                    (set_local $3
                                       (i32.shr_u
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $la)
+                                          (get_local $2)
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $V
+                                          (set_local $10
                                             (i32.load offset=12
-                                              (get_local $ma)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once$53
                                             (if
                                               (i32.ne
-                                                (set_local $da
+                                                (set_local $21
                                                   (i32.load offset=8
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                 )
-                                                (set_local $$
+                                                (set_local $17
                                                   (i32.add
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $fa)
+                                                        (get_local $3)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4217,17 +4161,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $da)
-                                                    (get_local $sa)
+                                                    (get_local $21)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (br_if $do-once$53
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $da)
+                                                      (get_local $21)
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                 )
                                                 (call_import $qa)
@@ -4236,8 +4180,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $V)
-                                              (get_local $da)
+                                              (get_local $10)
+                                              (get_local $21)
                                             )
                                             (block
                                               (i32.store
@@ -4249,7 +4193,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $fa)
+                                                      (get_local $3)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4261,38 +4205,38 @@
                                           (block $do-once$55
                                             (if
                                               (i32.eq
-                                                (get_local $V)
-                                                (get_local $$)
+                                                (get_local $10)
+                                                (get_local $17)
                                               )
-                                              (set_local $xa
+                                              (set_local $44
                                                 (i32.add
-                                                  (get_local $V)
+                                                  (get_local $10)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $V)
-                                                    (get_local $sa)
+                                                    (get_local $10)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $e
+                                                      (set_local $3
                                                         (i32.add
-                                                          (get_local $V)
+                                                          (get_local $10)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (block
-                                                    (set_local $xa
-                                                      (get_local $e)
+                                                    (set_local $44
+                                                      (get_local $3)
                                                     )
                                                     (br $do-once$55)
                                                   )
@@ -4302,39 +4246,39 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $da)
-                                            (get_local $V)
+                                            (get_local $21)
+                                            (get_local $10)
                                           )
                                           (i32.store
-                                            (get_local $xa)
-                                            (get_local $da)
+                                            (get_local $44)
+                                            (get_local $21)
                                           )
                                         )
                                         (block
-                                          (set_local $$
+                                          (set_local $17
                                             (i32.load offset=24
-                                              (get_local $ma)
+                                              (get_local $1)
                                             )
                                           )
                                           (block $do-once$57
                                             (if
                                               (i32.eq
-                                                (set_local $e
+                                                (set_local $3
                                                   (i32.load offset=12
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                 )
-                                                (get_local $ma)
+                                                (get_local $1)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $ba
+                                                  (set_local $2
                                                     (i32.load
-                                                      (set_local $aa
+                                                      (set_local $12
                                                         (i32.add
-                                                          (set_local $U
+                                                          (set_local $16
                                                             (i32.add
-                                                              (get_local $ma)
+                                                              (get_local $1)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4344,29 +4288,29 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $za
-                                                      (get_local $ba)
+                                                    (set_local $0
+                                                      (get_local $2)
                                                     )
-                                                    (set_local $Aa
-                                                      (get_local $aa)
+                                                    (set_local $4
+                                                      (get_local $12)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $W
+                                                    (set_local $22
                                                       (i32.load
-                                                        (get_local $U)
+                                                        (get_local $16)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $za
-                                                        (get_local $W)
+                                                      (set_local $0
+                                                        (get_local $22)
                                                       )
-                                                      (set_local $Aa
-                                                        (get_local $U)
+                                                      (set_local $4
+                                                        (get_local $16)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $ya
+                                                      (set_local $24
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once$57)
@@ -4375,52 +4319,48 @@
                                                 )
                                                 (loop $while-out$59 $while-in$60
                                                   (if
-                                                    (set_local $ba
+                                                    (set_local $2
                                                       (i32.load
-                                                        (set_local $aa
+                                                        (set_local $12
                                                           (i32.add
-                                                            (get_local $za)
+                                                            (get_local $0)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $za
-                                                        (get_local $ba)
+                                                      (set_local $0
+                                                        (get_local $2)
                                                       )
-                                                      (set_local $Aa
-                                                        (get_local $aa)
+                                                      (set_local $4
+                                                        (get_local $12)
                                                       )
                                                       (br $while-in$60)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $ba
+                                                    (set_local $2
                                                       (i32.load
-                                                        (set_local $aa
+                                                        (set_local $12
                                                           (i32.add
-                                                            (get_local $za)
+                                                            (get_local $0)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $za
-                                                        (get_local $ba)
+                                                      (set_local $0
+                                                        (get_local $2)
                                                       )
-                                                      (set_local $Aa
-                                                        (get_local $aa)
+                                                      (set_local $4
+                                                        (get_local $12)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $Ba
-                                                        (get_local $za)
-                                                      )
-                                                      (set_local $Ca
-                                                        (get_local $Aa)
-                                                      )
+                                                      (get_local $0)
+                                                      (get_local $4)
                                                       (br $while-out$59)
                                                     )
                                                   )
@@ -4428,17 +4368,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $Ca)
-                                                    (get_local $sa)
+                                                    (get_local $4)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $Ca)
+                                                      (get_local $4)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $ya
-                                                      (get_local $Ba)
+                                                    (set_local $24
+                                                      (get_local $0)
                                                     )
                                                   )
                                                 )
@@ -4446,52 +4386,52 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (set_local $aa
+                                                    (set_local $12
                                                       (i32.load offset=8
-                                                        (get_local $ma)
+                                                        (get_local $1)
                                                       )
                                                     )
-                                                    (get_local $sa)
+                                                    (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $ba
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $aa)
+                                                          (get_local $12)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $U
+                                                      (set_local $16
                                                         (i32.add
-                                                          (get_local $e)
+                                                          (get_local $3)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $ba)
-                                                      (get_local $e)
+                                                      (get_local $2)
+                                                      (get_local $3)
                                                     )
                                                     (i32.store
-                                                      (get_local $U)
-                                                      (get_local $aa)
+                                                      (get_local $16)
+                                                      (get_local $12)
                                                     )
-                                                    (set_local $ya
-                                                      (get_local $e)
+                                                    (set_local $24
+                                                      (get_local $3)
                                                     )
                                                   )
                                                   (call_import $qa)
@@ -4501,21 +4441,21 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (get_local $$)
+                                              (get_local $17)
                                             )
                                           )
                                           (block $do-once$61
                                             (if
                                               (i32.eq
-                                                (get_local $ma)
+                                                (get_local $1)
                                                 (i32.load
-                                                  (set_local $da
+                                                  (set_local $21
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (set_local $e
+                                                        (set_local $3
                                                           (i32.load offset=28
-                                                            (get_local $ma)
+                                                            (get_local $1)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4526,11 +4466,11 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $da)
-                                                  (get_local $ya)
+                                                  (get_local $21)
+                                                  (get_local $24)
                                                 )
                                                 (br_if $do-once$61
-                                                  (get_local $ya)
+                                                  (get_local $24)
                                                 )
                                                 (i32.store
                                                   (i32.const 1212)
@@ -4541,7 +4481,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $e)
+                                                        (get_local $3)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4552,7 +4492,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $$)
+                                                    (get_local $17)
                                                     (i32.load
                                                       (i32.const 1224)
                                                     )
@@ -4562,27 +4502,27 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $V
+                                                      (set_local $10
                                                         (i32.add
-                                                          (get_local $$)
+                                                          (get_local $17)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                   )
                                                   (i32.store
-                                                    (get_local $V)
-                                                    (get_local $ya)
+                                                    (get_local $10)
+                                                    (get_local $24)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $$)
-                                                    (get_local $ya)
+                                                    (get_local $17)
+                                                    (get_local $24)
                                                   )
                                                 )
                                                 (br_if $label$break$e
                                                   (i32.eqz
-                                                    (get_local $ya)
+                                                    (get_local $24)
                                                   )
                                                 )
                                               )
@@ -4590,8 +4530,8 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $ya)
-                                              (set_local $e
+                                              (get_local $24)
+                                              (set_local $3
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4600,15 +4540,15 @@
                                             (call_import $qa)
                                           )
                                           (i32.store offset=24
-                                            (get_local $ya)
-                                            (get_local $$)
+                                            (get_local $24)
+                                            (get_local $17)
                                           )
                                           (if
-                                            (set_local $V
+                                            (set_local $10
                                               (i32.load
-                                                (set_local $da
+                                                (set_local $21
                                                   (i32.add
-                                                    (get_local $ma)
+                                                    (get_local $1)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4616,34 +4556,34 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $V)
-                                                (get_local $e)
+                                                (get_local $10)
+                                                (get_local $3)
                                               )
                                               (call_import $qa)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $ya)
-                                                  (get_local $V)
+                                                  (get_local $24)
+                                                  (get_local $10)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $V)
-                                                  (get_local $ya)
+                                                  (get_local $10)
+                                                  (get_local $24)
                                                 )
                                               )
                                             )
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (set_local $V
+                                              (set_local $10
                                                 (i32.load offset=4
-                                                  (get_local $da)
+                                                  (get_local $21)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $V)
+                                              (get_local $10)
                                               (i32.load
                                                 (i32.const 1224)
                                               )
@@ -4651,34 +4591,34 @@
                                             (call_import $qa)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $ya)
-                                                (get_local $V)
+                                                (get_local $24)
+                                                (get_local $10)
                                               )
                                               (i32.store offset=24
-                                                (get_local $V)
-                                                (get_local $ya)
+                                                (get_local $10)
+                                                (get_local $24)
                                               )
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $Ea
+                                    (set_local $0
                                       (i32.add
-                                        (get_local $ga)
-                                        (get_local $ea)
+                                        (get_local $6)
+                                        (get_local $18)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $ma)
-                                      (get_local $ga)
+                                      (get_local $1)
+                                      (get_local $6)
                                     )
                                   )
                                   (block
-                                    (set_local $Ea
-                                      (get_local $ea)
+                                    (set_local $0
+                                      (get_local $18)
                                     )
-                                    (get_local $ma)
+                                    (get_local $1)
                                   )
                                 )
                                 (i32.const 4)
@@ -4686,43 +4626,43 @@
                             )
                             (i32.and
                               (i32.load
-                                (get_local $fa)
+                                (get_local $3)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $ka)
+                            (get_local $5)
                             (i32.or
-                              (get_local $Ea)
+                              (get_local $0)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $ka)
-                              (get_local $Ea)
+                              (get_local $5)
+                              (get_local $0)
                             )
-                            (get_local $Ea)
+                            (get_local $0)
                           )
-                          (set_local $fa
+                          (set_local $3
                             (i32.shr_u
-                              (get_local $Ea)
+                              (get_local $0)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $Ea)
+                              (get_local $0)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $la
+                              (set_local $2
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $fa)
+                                      (get_local $3)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4732,26 +4672,26 @@
                               (block $do-once$65
                                 (if
                                   (i32.and
-                                    (set_local $V
+                                    (set_local $10
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $e
+                                    (set_local $3
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $fa)
+                                        (get_local $3)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $$
+                                        (set_local $17
                                           (i32.load
-                                            (set_local $fa
+                                            (set_local $3
                                               (i32.add
-                                                (get_local $la)
+                                                (get_local $2)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4762,11 +4702,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $Fa
-                                          (get_local $fa)
+                                        (set_local $45
+                                          (get_local $3)
                                         )
-                                        (set_local $Ga
-                                          (get_local $$)
+                                        (set_local $38
+                                          (get_local $17)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4777,58 +4717,58 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $V)
-                                        (get_local $e)
+                                        (get_local $10)
+                                        (get_local $3)
                                       )
                                     )
-                                    (set_local $Fa
+                                    (set_local $45
                                       (i32.add
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $Ga
-                                      (get_local $la)
+                                    (set_local $38
+                                      (get_local $2)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $Fa)
-                                (get_local $ka)
+                                (get_local $45)
+                                (get_local $5)
                               )
                               (i32.store offset=12
-                                (get_local $Ga)
-                                (get_local $ka)
+                                (get_local $38)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $ka)
-                                (get_local $Ga)
+                                (get_local $5)
+                                (get_local $38)
                               )
                               (i32.store offset=12
-                                (get_local $ka)
-                                (get_local $la)
+                                (get_local $5)
+                                (get_local $2)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $e
+                          (set_local $3
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
-                                (set_local $Ha
+                                (set_local $4
                                   (block $do-once$67
                                     (if
-                                      (set_local $e
+                                      (set_local $3
                                         (i32.shr_u
-                                          (get_local $Ea)
+                                          (get_local $0)
                                           (i32.const 8)
                                         )
                                       )
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $Ea)
+                                            (get_local $0)
                                             (i32.const 16777215)
                                           )
                                           (br $do-once$67
@@ -4838,26 +4778,26 @@
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $Ea)
+                                              (get_local $0)
                                               (i32.add
-                                                (set_local $aa
+                                                (set_local $12
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $$
+                                                          (set_local $17
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $ga
+                                                                  (set_local $6
                                                                     (i32.shl
-                                                                      (get_local $e)
-                                                                      (set_local $V
+                                                                      (get_local $3)
+                                                                      (set_local $10
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $e)
+                                                                              (get_local $3)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4874,16 +4814,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $V)
+                                                          (get_local $10)
                                                         )
-                                                        (set_local $ga
+                                                        (set_local $6
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $fa
+                                                                (set_local $3
                                                                   (i32.shl
-                                                                    (get_local $ga)
-                                                                    (get_local $$)
+                                                                    (get_local $6)
+                                                                    (get_local $17)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4897,8 +4837,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $fa)
-                                                        (get_local $ga)
+                                                        (get_local $3)
+                                                        (get_local $6)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4910,7 +4850,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $aa)
+                                            (get_local $12)
                                             (i32.const 1)
                                           )
                                         )
@@ -4924,34 +4864,34 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $ka)
-                            (get_local $Ha)
+                            (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=4
-                            (set_local $la
+                            (set_local $2
                               (i32.add
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $la)
+                            (get_local $2)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $la
+                                (set_local $2
                                   (i32.load
                                     (i32.const 1212)
                                   )
                                 )
-                                (set_local $aa
+                                (set_local $12
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $Ha)
+                                    (get_local $4)
                                   )
                                 )
                               )
@@ -4960,51 +4900,51 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $la)
-                                  (get_local $aa)
+                                  (get_local $2)
+                                  (get_local $12)
                                 )
                               )
                               (i32.store
-                                (get_local $e)
-                                (get_local $ka)
+                                (get_local $3)
+                                (get_local $5)
                               )
                               (i32.store offset=24
-                                (get_local $ka)
-                                (get_local $e)
+                                (get_local $5)
+                                (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $ka)
-                                (get_local $ka)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (i32.store offset=8
-                                (get_local $ka)
-                                (get_local $ka)
+                                (get_local $5)
+                                (get_local $5)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $aa
+                          (set_local $12
                             (i32.shl
-                              (get_local $Ea)
+                              (get_local $0)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $Ha)
+                                    (get_local $4)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $Ha)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                               )
                             )
                           )
-                          (set_local $la
+                          (set_local $2
                             (i32.load
-                              (get_local $e)
+                              (get_local $3)
                             )
                           )
                           (loop $while-out$69 $while-in$70
@@ -5012,34 +4952,34 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $la)
+                                    (get_local $2)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $Ea)
+                                (get_local $0)
                               )
                               (block
-                                (set_local $Ia
-                                  (get_local $la)
+                                (set_local $39
+                                  (get_local $2)
                                 )
-                                (set_local $N
+                                (set_local $8
                                   (i32.const 279)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $ga
+                              (set_local $6
                                 (i32.load
-                                  (set_local $e
+                                  (set_local $3
                                     (i32.add
                                       (i32.add
-                                        (get_local $la)
+                                        (get_local $2)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $aa)
+                                          (get_local $12)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -5049,24 +4989,24 @@
                                 )
                               )
                               (block
-                                (set_local $aa
+                                (set_local $12
                                   (i32.shl
-                                    (get_local $aa)
+                                    (get_local $12)
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $la
-                                  (get_local $ga)
+                                (set_local $2
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $Ja
-                                  (get_local $e)
+                                (set_local $46
+                                  (get_local $3)
                                 )
-                                (set_local $Ka
-                                  (get_local $la)
+                                (set_local $54
+                                  (get_local $2)
                                 )
-                                (set_local $N
+                                (set_local $8
                                   (i32.const 276)
                                 )
                                 (br $while-out$69)
@@ -5076,12 +5016,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $N)
+                              (get_local $8)
                               (i32.const 276)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $Ja)
+                                (get_local $46)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -5089,71 +5029,71 @@
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $Ja)
-                                  (get_local $ka)
+                                  (get_local $46)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $ka)
-                                  (get_local $Ka)
+                                  (get_local $5)
+                                  (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $ka)
-                                  (get_local $ka)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $ka)
-                                  (get_local $ka)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $N)
+                                (get_local $8)
                                 (i32.const 279)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $aa
+                                    (set_local $12
                                       (i32.load
-                                        (set_local $la
+                                        (set_local $2
                                           (i32.add
-                                            (get_local $Ia)
+                                            (get_local $39)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $ga
+                                    (set_local $6
                                       (i32.load
                                         (i32.const 1224)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $Ia)
-                                    (get_local $ga)
+                                    (get_local $39)
+                                    (get_local $6)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $aa)
-                                    (get_local $ka)
+                                    (get_local $12)
+                                    (get_local $5)
                                   )
                                   (i32.store
-                                    (get_local $la)
-                                    (get_local $ka)
+                                    (get_local $2)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $ka)
-                                    (get_local $aa)
+                                    (get_local $5)
+                                    (get_local $12)
                                   )
                                   (i32.store offset=12
-                                    (get_local $ka)
-                                    (get_local $Ia)
+                                    (get_local $5)
+                                    (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $ka)
+                                    (get_local $5)
                                     (i32.const 0)
                                   )
                                 )
@@ -5166,11 +5106,11 @@
                     )
                     (i32.store
                       (i32.const 8)
-                      (get_local $b)
+                      (get_local $25)
                     )
                     (return
                       (i32.add
-                        (get_local $ca)
+                        (get_local $15)
                         (i32.const 8)
                       )
                     )
@@ -5180,71 +5120,71 @@
               (loop $while-out$71 $while-in$72
                 (if
                   (i32.le_u
-                    (set_local $ka
+                    (set_local $5
                       (i32.load
-                        (get_local $wa)
+                        (get_local $29)
                       )
                     )
-                    (get_local $ja)
+                    (get_local $11)
                   )
                   (if
                     (i32.gt_u
-                      (set_local $ea
+                      (set_local $18
                         (i32.add
-                          (get_local $ka)
+                          (get_local $5)
                           (i32.load offset=4
-                            (get_local $wa)
+                            (get_local $29)
                           )
                         )
                       )
-                      (get_local $ja)
+                      (get_local $11)
                     )
                     (block
-                      (set_local $La
-                        (get_local $ea)
+                      (set_local $3
+                        (get_local $18)
                       )
                       (br $while-out$71)
                     )
                   )
                 )
-                (set_local $wa
+                (set_local $29
                   (i32.load offset=8
-                    (get_local $wa)
+                    (get_local $29)
                   )
                 )
                 (br $while-in$72)
               )
-              (set_local $ea
+              (set_local $18
                 (i32.add
-                  (set_local $ca
+                  (set_local $15
                     (i32.add
-                      (get_local $La)
+                      (get_local $3)
                       (i32.const -47)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $ka
+              (set_local $5
                 (i32.add
-                  (set_local $ca
+                  (set_local $15
                     (select
-                      (get_local $ja)
-                      (set_local $ka
+                      (get_local $11)
+                      (set_local $5
                         (i32.add
-                          (get_local $ca)
+                          (get_local $15)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $ea)
+                                (get_local $18)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $ea)
+                                (get_local $18)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5253,10 +5193,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $ka)
-                        (set_local $ea
+                        (get_local $5)
+                        (set_local $18
                           (i32.add
-                            (get_local $ja)
+                            (get_local $11)
                             (i32.const 16)
                           )
                         )
@@ -5268,18 +5208,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $ma
+                (set_local $1
                   (i32.add
-                    (get_local $ha)
-                    (set_local $c
+                    (get_local $19)
+                    (set_local $4
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $ma
+                            (set_local $1
                               (i32.add
-                                (get_local $ha)
+                                (get_local $19)
                                 (i32.const 8)
                               )
                             )
@@ -5288,7 +5228,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $ma)
+                            (get_local $1)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5300,27 +5240,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $aa
+                (set_local $12
                   (i32.sub
                     (i32.add
-                      (get_local $ia)
+                      (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $c)
+                    (get_local $4)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $ma)
+                (get_local $1)
                 (i32.or
-                  (get_local $aa)
+                  (get_local $12)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $ma)
-                  (get_local $aa)
+                  (get_local $1)
+                  (get_local $12)
                 )
                 (i32.const 40)
               )
@@ -5331,45 +5271,45 @@
                 )
               )
               (i32.store
-                (set_local $aa
+                (set_local $12
                   (i32.add
-                    (get_local $ca)
+                    (get_local $15)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $ka)
+                (get_local $5)
                 (i32.load
                   (i32.const 1668)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $ha)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $ia)
+                (get_local $26)
               )
               (i32.store
                 (i32.const 1668)
@@ -5377,19 +5317,19 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $ka)
+                (get_local $5)
               )
-              (set_local $ka
+              (set_local $5
                 (i32.add
-                  (get_local $ca)
+                  (get_local $15)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $ka
+                  (set_local $5
                     (i32.add
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 4)
                     )
                   )
@@ -5398,62 +5338,62 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 4)
                     )
-                    (get_local $La)
+                    (get_local $3)
                   )
                 )
               )
               (if
                 (i32.ne
-                  (get_local $ca)
-                  (get_local $ja)
+                  (get_local $15)
+                  (get_local $11)
                 )
                 (block
                   (i32.store
-                    (get_local $aa)
+                    (get_local $12)
                     (i32.and
                       (i32.load
-                        (get_local $aa)
+                        (get_local $12)
                       )
                       (i32.const -2)
                     )
                   )
                   (i32.store offset=4
-                    (get_local $ja)
+                    (get_local $11)
                     (i32.or
-                      (set_local $ka
+                      (set_local $5
                         (i32.sub
-                          (get_local $ca)
-                          (get_local $ja)
+                          (get_local $15)
+                          (get_local $11)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $ca)
-                    (get_local $ka)
+                    (get_local $15)
+                    (get_local $5)
                   )
-                  (set_local $ma
+                  (set_local $1
                     (i32.shr_u
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $ka)
+                      (get_local $5)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $c
+                      (set_local $4
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (get_local $ma)
+                              (get_local $1)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5462,25 +5402,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $la
+                          (set_local $2
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $ga
+                          (set_local $6
                             (i32.shl
                               (i32.const 1)
-                              (get_local $ma)
+                              (get_local $1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $la
+                            (set_local $2
                               (i32.load
-                                (set_local $ga
+                                (set_local $6
                                   (i32.add
-                                    (get_local $c)
+                                    (get_local $4)
                                     (i32.const 8)
                                   )
                                 )
@@ -5492,11 +5432,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $Ma
-                              (get_local $ga)
+                            (set_local $47
+                              (get_local $6)
                             )
-                            (set_local $Na
-                              (get_local $la)
+                            (set_local $40
+                              (get_local $2)
                             )
                           )
                         )
@@ -5504,81 +5444,81 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $la)
-                              (get_local $ga)
+                              (get_local $2)
+                              (get_local $6)
                             )
                           )
-                          (set_local $Ma
+                          (set_local $47
                             (i32.add
-                              (get_local $c)
+                              (get_local $4)
                               (i32.const 8)
                             )
                           )
-                          (set_local $Na
-                            (get_local $c)
+                          (set_local $40
+                            (get_local $4)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $Ma)
-                        (get_local $ja)
+                        (get_local $47)
+                        (get_local $11)
                       )
                       (i32.store offset=12
-                        (get_local $Na)
-                        (get_local $ja)
+                        (get_local $40)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $ja)
-                        (get_local $Na)
+                        (get_local $11)
+                        (get_local $40)
                       )
                       (i32.store offset=12
-                        (get_local $ja)
-                        (get_local $c)
+                        (get_local $11)
+                        (get_local $4)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $e
+                  (set_local $3
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (set_local $Oa
+                        (set_local $4
                           (if
-                            (set_local $c
+                            (set_local $4
                               (i32.shr_u
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $ka)
+                                (get_local $5)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $ka)
+                                    (get_local $5)
                                     (i32.add
-                                      (set_local $e
+                                      (set_local $3
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $c
+                                                (set_local $4
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $ga
+                                                        (set_local $6
                                                           (i32.shl
-                                                            (get_local $c)
-                                                            (set_local $la
+                                                            (get_local $4)
+                                                            (set_local $2
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $c)
+                                                                    (get_local $4)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5595,16 +5535,16 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $la)
+                                                (get_local $2)
                                               )
-                                              (set_local $ga
+                                              (set_local $6
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $ma
+                                                      (set_local $1
                                                         (i32.shl
-                                                          (get_local $ga)
-                                                          (get_local $c)
+                                                          (get_local $6)
+                                                          (get_local $4)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5618,8 +5558,8 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $ma)
-                                              (get_local $ga)
+                                              (get_local $1)
+                                              (get_local $6)
                                             )
                                             (i32.const 15)
                                           )
@@ -5631,7 +5571,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $e)
+                                  (get_local $3)
                                   (i32.const 1)
                                 )
                               )
@@ -5644,29 +5584,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $ja)
-                    (get_local $Oa)
+                    (get_local $11)
+                    (get_local $4)
                   )
                   (i32.store offset=20
-                    (get_local $ja)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $ea)
+                    (get_local $18)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $ga
+                        (set_local $6
                           (i32.load
                             (i32.const 1212)
                           )
                         )
-                        (set_local $ma
+                        (set_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $Oa)
+                            (get_local $4)
                           )
                         )
                       )
@@ -5675,51 +5615,51 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $ga)
-                          (get_local $ma)
+                          (get_local $6)
+                          (get_local $1)
                         )
                       )
                       (i32.store
-                        (get_local $e)
-                        (get_local $ja)
+                        (get_local $3)
+                        (get_local $11)
                       )
                       (i32.store offset=24
-                        (get_local $ja)
-                        (get_local $e)
+                        (get_local $11)
+                        (get_local $3)
                       )
                       (i32.store offset=12
-                        (get_local $ja)
-                        (get_local $ja)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (i32.store offset=8
-                        (get_local $ja)
-                        (get_local $ja)
+                        (get_local $11)
+                        (get_local $11)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $ma
+                  (set_local $1
                     (i32.shl
-                      (get_local $ka)
+                      (get_local $5)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $Oa)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $Oa)
+                          (get_local $4)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $ga
+                  (set_local $6
                     (i32.load
-                      (get_local $e)
+                      (get_local $3)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5727,34 +5667,34 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $ga)
+                            (get_local $6)
                           )
                           (i32.const -8)
                         )
-                        (get_local $ka)
+                        (get_local $5)
                       )
                       (block
-                        (set_local $Pa
-                          (get_local $ga)
+                        (set_local $30
+                          (get_local $6)
                         )
-                        (set_local $N
+                        (set_local $8
                           (i32.const 305)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $la
+                      (set_local $2
                         (i32.load
-                          (set_local $e
+                          (set_local $3
                             (i32.add
                               (i32.add
-                                (get_local $ga)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                               (i32.shl
                                 (i32.shr_u
-                                  (get_local $ma)
+                                  (get_local $1)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5764,24 +5704,24 @@
                         )
                       )
                       (block
-                        (set_local $ma
+                        (set_local $1
                           (i32.shl
-                            (get_local $ma)
+                            (get_local $1)
                             (i32.const 1)
                           )
                         )
-                        (set_local $ga
-                          (get_local $la)
+                        (set_local $6
+                          (get_local $2)
                         )
                       )
                       (block
-                        (set_local $Ra
-                          (get_local $e)
+                        (set_local $48
+                          (get_local $3)
                         )
-                        (set_local $Sa
-                          (get_local $ga)
+                        (set_local $55
+                          (get_local $6)
                         )
-                        (set_local $N
+                        (set_local $8
                           (i32.const 302)
                         )
                         (br $while-out$75)
@@ -5791,12 +5731,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $N)
+                      (get_local $8)
                       (i32.const 302)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $Ra)
+                        (get_local $48)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -5804,71 +5744,71 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $Ra)
-                          (get_local $ja)
+                          (get_local $48)
+                          (get_local $11)
                         )
                         (i32.store offset=24
-                          (get_local $ja)
-                          (get_local $Sa)
+                          (get_local $11)
+                          (get_local $55)
                         )
                         (i32.store offset=12
-                          (get_local $ja)
-                          (get_local $ja)
+                          (get_local $11)
+                          (get_local $11)
                         )
                         (i32.store offset=8
-                          (get_local $ja)
-                          (get_local $ja)
+                          (get_local $11)
+                          (get_local $11)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $N)
+                        (get_local $8)
                         (i32.const 305)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $ma
+                            (set_local $1
                               (i32.load
-                                (set_local $ga
+                                (set_local $6
                                   (i32.add
-                                    (get_local $Pa)
+                                    (get_local $30)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $ka
+                            (set_local $5
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $Pa)
-                            (get_local $ka)
+                            (get_local $30)
+                            (get_local $5)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $ma)
-                            (get_local $ja)
+                            (get_local $1)
+                            (get_local $11)
                           )
                           (i32.store
-                            (get_local $ga)
-                            (get_local $ja)
+                            (get_local $6)
+                            (get_local $11)
                           )
                           (i32.store offset=8
-                            (get_local $ja)
-                            (get_local $ma)
+                            (get_local $11)
+                            (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $ja)
-                            (get_local $Pa)
+                            (get_local $11)
+                            (get_local $30)
                           )
                           (i32.store offset=24
-                            (get_local $ja)
+                            (get_local $11)
                             (i32.const 0)
                           )
                         )
@@ -5883,7 +5823,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $ma
+                    (set_local $1
                       (i32.load
                         (i32.const 1224)
                       )
@@ -5891,22 +5831,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $ha)
-                    (get_local $ma)
+                    (get_local $19)
+                    (get_local $1)
                   )
                 )
                 (i32.store
                   (i32.const 1224)
-                  (get_local $ha)
+                  (get_local $19)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $ha)
+                (get_local $19)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $ia)
+                (get_local $26)
               )
               (i32.store
                 (i32.const 1668)
@@ -5922,34 +5862,34 @@
                 (i32.const 1240)
                 (i32.const -1)
               )
-              (set_local $ma
+              (set_local $1
                 (i32.const 0)
               )
               (loop $do-out$44 $do-in$45
                 (i32.store offset=12
-                  (set_local $c
+                  (set_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $ma)
+                          (get_local $1)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $c)
+                  (get_local $4)
                 )
                 (i32.store offset=8
-                  (get_local $c)
-                  (get_local $c)
+                  (get_local $4)
+                  (get_local $4)
                 )
                 (br_if $do-in$45
                   (i32.ne
-                    (set_local $ma
+                    (set_local $1
                       (i32.add
-                        (get_local $ma)
+                        (get_local $1)
                         (i32.const 1)
                       )
                     )
@@ -5959,18 +5899,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $ma
+                (set_local $1
                   (i32.add
-                    (get_local $ha)
-                    (set_local $c
+                    (get_local $19)
+                    (set_local $4
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $ma
+                            (set_local $1
                               (i32.add
-                                (get_local $ha)
+                                (get_local $19)
                                 (i32.const 8)
                               )
                             )
@@ -5979,7 +5919,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $ma)
+                            (get_local $1)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5991,27 +5931,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $ka
+                (set_local $5
                   (i32.sub
                     (i32.add
-                      (get_local $ia)
+                      (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $c)
+                    (get_local $4)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $ma)
+                (get_local $1)
                 (i32.or
-                  (get_local $ka)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $ma)
-                  (get_local $ka)
+                  (get_local $1)
+                  (get_local $5)
                 )
                 (i32.const 40)
               )
@@ -6026,57 +5966,57 @@
         )
         (if
           (i32.gt_u
-            (set_local $ja
+            (set_local $11
               (i32.load
                 (i32.const 1220)
               )
             )
-            (get_local $y)
+            (get_local $0)
           )
           (block
             (i32.store
               (i32.const 1220)
-              (set_local $Pa
+              (set_local $30
                 (i32.sub
-                  (get_local $ja)
-                  (get_local $y)
+                  (get_local $11)
+                  (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (set_local $N
+              (set_local $8
                 (i32.add
-                  (set_local $ja
+                  (set_local $11
                     (i32.load
                       (i32.const 1232)
                     )
                   )
-                  (get_local $y)
+                  (get_local $0)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $N)
+              (get_local $8)
               (i32.or
-                (get_local $Pa)
+                (get_local $30)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $ja)
+              (get_local $11)
               (i32.or
-                (get_local $y)
+                (get_local $0)
                 (i32.const 3)
               )
             )
             (i32.store
               (i32.const 8)
-              (get_local $b)
+              (get_local $25)
             )
             (return
               (i32.add
-                (get_local $ja)
+                (get_local $11)
                 (i32.const 8)
               )
             )
@@ -6085,69 +6025,50 @@
       )
     )
     (i32.store
-      (set_local $ja
-        (call $Qa)
-      )
+      (call $Qa)
       (i32.const 12)
     )
     (i32.store
       (i32.const 8)
-      (get_local $b)
+      (get_local $25)
     )
     (i32.const 0)
   )
-  (func $fb (param $a i32)
-    (local $m i32)
-    (local $s i32)
-    (local $h i32)
-    (local $b i32)
-    (local $f i32)
-    (local $n i32)
-    (local $w i32)
-    (local $i i32)
-    (local $j i32)
-    (local $l i32)
-    (local $g i32)
-    (local $o i32)
-    (local $t i32)
-    (local $y i32)
-    (local $u i32)
-    (local $v i32)
-    (local $e i32)
-    (local $F i32)
-    (local $p i32)
-    (local $c i32)
-    (local $D i32)
-    (local $E i32)
-    (local $q i32)
-    (local $z i32)
-    (local $A i32)
-    (local $G i32)
-    (local $H i32)
-    (local $I i32)
-    (local $d i32)
-    (local $x i32)
-    (local $C i32)
-    (local $J i32)
-    (local $L i32)
-    (local $r i32)
-    (local $B i32)
-    (local $K i32)
+  (func $fb (param $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (local $19 i32)
     (if
       (i32.eqz
-        (get_local $a)
+        (get_local $0)
       )
       (return)
     )
     (if
       (i32.lt_u
-        (set_local $b
+        (set_local $1
           (i32.add
-            (get_local $a)
+            (get_local $0)
             (i32.const -8)
           )
         )
-        (set_local $c
+        (set_local $13
           (i32.load
             (i32.const 1224)
           )
@@ -6157,12 +6078,12 @@
     )
     (if
       (i32.eq
-        (set_local $a
+        (set_local $0
           (i32.and
-            (set_local $d
+            (set_local $9
               (i32.load
                 (i32.add
-                  (get_local $a)
+                  (get_local $0)
                   (i32.const -4)
                 )
               )
@@ -6174,12 +6095,12 @@
       )
       (call_import $qa)
     )
-    (set_local $f
+    (set_local $7
       (i32.add
-        (get_local $b)
-        (set_local $e
+        (get_local $1)
+        (set_local $4
           (i32.and
-            (get_local $d)
+            (get_local $9)
             (i32.const -8)
           )
         )
@@ -6188,53 +6109,53 @@
     (block $do-once$0
       (if
         (i32.and
-          (get_local $d)
+          (get_local $9)
           (i32.const 1)
         )
         (block
-          (set_local $m
-            (get_local $b)
+          (set_local $2
+            (get_local $1)
           )
-          (set_local $n
-            (get_local $e)
+          (set_local $8
+            (get_local $4)
           )
         )
         (block
-          (set_local $g
+          (set_local $9
             (i32.load
-              (get_local $b)
+              (get_local $1)
             )
           )
           (if
             (i32.eqz
-              (get_local $a)
+              (get_local $0)
             )
             (return)
           )
-          (set_local $i
+          (set_local $4
             (i32.add
-              (get_local $g)
-              (get_local $e)
+              (get_local $9)
+              (get_local $4)
             )
           )
           (if
             (i32.lt_u
-              (set_local $h
+              (set_local $0
                 (i32.add
-                  (get_local $b)
+                  (get_local $1)
                   (i32.sub
                     (i32.const 0)
-                    (get_local $g)
+                    (get_local $9)
                   )
                 )
               )
-              (get_local $c)
+              (get_local $13)
             )
             (call_import $qa)
           )
           (if
             (i32.eq
-              (get_local $h)
+              (get_local $0)
               (i32.load
                 (i32.const 1228)
               )
@@ -6243,11 +6164,11 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $l
+                    (set_local $5
                       (i32.load
-                        (set_local $j
+                        (set_local $1
                           (i32.add
-                            (get_local $f)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
@@ -6258,73 +6179,73 @@
                   (i32.const 3)
                 )
                 (block
-                  (set_local $m
-                    (get_local $h)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $i)
+                  (set_local $8
+                    (get_local $4)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $i)
+                (get_local $4)
               )
               (i32.store
-                (get_local $j)
+                (get_local $1)
                 (i32.and
-                  (get_local $l)
+                  (get_local $5)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
-                (get_local $h)
+                (get_local $0)
                 (i32.or
-                  (get_local $i)
+                  (get_local $4)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
-                  (get_local $h)
-                  (get_local $i)
+                  (get_local $0)
+                  (get_local $4)
                 )
-                (get_local $i)
+                (get_local $4)
               )
               (return)
             )
           )
-          (set_local $l
+          (set_local $5
             (i32.shr_u
-              (get_local $g)
+              (get_local $9)
               (i32.const 3)
             )
           )
           (if
             (i32.lt_u
-              (get_local $g)
+              (get_local $9)
               (i32.const 256)
             )
             (block
-              (set_local $j
+              (set_local $1
                 (i32.load offset=12
-                  (get_local $h)
+                  (get_local $0)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $g
+                  (set_local $9
                     (i32.load offset=8
-                      (get_local $h)
+                      (get_local $0)
                     )
                   )
-                  (set_local $o
+                  (set_local $6
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $l)
+                          (get_local $5)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6335,17 +6256,17 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $g)
-                      (get_local $c)
+                      (get_local $9)
+                      (get_local $13)
                     )
                     (call_import $qa)
                   )
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $g)
+                        (get_local $9)
                       )
-                      (get_local $h)
+                      (get_local $0)
                     )
                     (call_import $qa)
                   )
@@ -6353,8 +6274,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $j)
-                  (get_local $g)
+                  (get_local $1)
+                  (get_local $9)
                 )
                 (block
                   (i32.store
@@ -6366,100 +6287,100 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $l)
+                          (get_local $5)
                         )
                         (i32.const -1)
                       )
                     )
                   )
-                  (set_local $m
-                    (get_local $h)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $i)
+                  (set_local $8
+                    (get_local $4)
                   )
                   (br $do-once$0)
                 )
               )
               (if
                 (i32.eq
-                  (get_local $j)
-                  (get_local $o)
+                  (get_local $1)
+                  (get_local $6)
                 )
-                (set_local $p
+                (set_local $11
                   (i32.add
-                    (get_local $j)
+                    (get_local $1)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $j)
-                      (get_local $c)
+                      (get_local $1)
+                      (get_local $13)
                     )
                     (call_import $qa)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $o
+                        (set_local $6
                           (i32.add
-                            (get_local $j)
+                            (get_local $1)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $h)
+                      (get_local $0)
                     )
-                    (set_local $p
-                      (get_local $o)
+                    (set_local $11
+                      (get_local $6)
                     )
                     (call_import $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $g)
-                (get_local $j)
+                (get_local $9)
+                (get_local $1)
               )
               (i32.store
-                (get_local $p)
-                (get_local $g)
+                (get_local $11)
+                (get_local $9)
               )
-              (set_local $m
-                (get_local $h)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $n
-                (get_local $i)
+              (set_local $8
+                (get_local $4)
               )
               (br $do-once$0)
             )
           )
-          (set_local $g
+          (set_local $9
             (i32.load offset=24
-              (get_local $h)
+              (get_local $0)
             )
           )
           (block $do-once$2
             (if
               (i32.eq
-                (set_local $j
+                (set_local $1
                   (i32.load offset=12
-                    (get_local $h)
+                    (get_local $0)
                   )
                 )
-                (get_local $h)
+                (get_local $0)
               )
               (block
                 (if
-                  (set_local $q
+                  (set_local $11
                     (i32.load
-                      (set_local $l
+                      (set_local $5
                         (i32.add
-                          (set_local $o
+                          (set_local $6
                             (i32.add
-                              (get_local $h)
+                              (get_local $0)
                               (i32.const 16)
                             )
                           )
@@ -6469,29 +6390,25 @@
                     )
                   )
                   (block
-                    (set_local $t
-                      (get_local $q)
+                    (set_local $1
+                      (get_local $11)
                     )
-                    (set_local $u
-                      (get_local $l)
+                    (set_local $6
+                      (get_local $5)
                     )
                   )
                   (if
-                    (set_local $r
+                    (set_local $1
                       (i32.load
-                        (get_local $o)
+                        (get_local $6)
                       )
                     )
                     (block
-                      (set_local $t
-                        (get_local $r)
-                      )
-                      (set_local $u
-                        (get_local $o)
-                      )
+                      (get_local $1)
+                      (get_local $6)
                     )
                     (block
-                      (set_local $s
+                      (set_local $3
                         (i32.const 0)
                       )
                       (br $do-once$2)
@@ -6500,51 +6417,51 @@
                 )
                 (loop $while-out$4 $while-in$5
                   (if
-                    (set_local $q
+                    (set_local $11
                       (i32.load
-                        (set_local $l
+                        (set_local $5
                           (i32.add
-                            (get_local $t)
+                            (get_local $1)
                             (i32.const 20)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $t
-                        (get_local $q)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $u
-                        (get_local $l)
+                      (set_local $6
+                        (get_local $5)
                       )
                       (br $while-in$5)
                     )
                   )
                   (if
-                    (set_local $q
+                    (set_local $11
                       (i32.load
-                        (set_local $l
+                        (set_local $5
                           (i32.add
-                            (get_local $t)
+                            (get_local $1)
                             (i32.const 16)
                           )
                         )
                       )
                     )
                     (block
-                      (set_local $t
-                        (get_local $q)
+                      (set_local $1
+                        (get_local $11)
                       )
-                      (set_local $u
-                        (get_local $l)
+                      (set_local $6
+                        (get_local $5)
                       )
                     )
                     (block
-                      (set_local $v
-                        (get_local $t)
+                      (set_local $5
+                        (get_local $1)
                       )
-                      (set_local $w
-                        (get_local $u)
+                      (set_local $10
+                        (get_local $6)
                       )
                       (br $while-out$4)
                     )
@@ -6553,17 +6470,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $w)
-                    (get_local $c)
+                    (get_local $10)
+                    (get_local $13)
                   )
                   (call_import $qa)
                   (block
                     (i32.store
-                      (get_local $w)
+                      (get_local $10)
                       (i32.const 0)
                     )
-                    (set_local $s
-                      (get_local $v)
+                    (set_local $3
+                      (get_local $5)
                     )
                   )
                 )
@@ -6571,52 +6488,52 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $l
+                    (set_local $5
                       (i32.load offset=8
-                        (get_local $h)
+                        (get_local $0)
                       )
                     )
-                    (get_local $c)
+                    (get_local $13)
                   )
                   (call_import $qa)
                 )
                 (if
                   (i32.ne
                     (i32.load
-                      (set_local $q
+                      (set_local $11
                         (i32.add
-                          (get_local $l)
+                          (get_local $5)
                           (i32.const 12)
                         )
                       )
                     )
-                    (get_local $h)
+                    (get_local $0)
                   )
                   (call_import $qa)
                 )
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $o
+                      (set_local $6
                         (i32.add
-                          (get_local $j)
+                          (get_local $1)
                           (i32.const 8)
                         )
                       )
                     )
-                    (get_local $h)
+                    (get_local $0)
                   )
                   (block
                     (i32.store
-                      (get_local $q)
-                      (get_local $j)
+                      (get_local $11)
+                      (get_local $1)
                     )
                     (i32.store
-                      (get_local $o)
-                      (get_local $l)
+                      (get_local $6)
+                      (get_local $5)
                     )
-                    (set_local $s
-                      (get_local $j)
+                    (set_local $3
+                      (get_local $1)
                     )
                   )
                   (call_import $qa)
@@ -6625,19 +6542,19 @@
             )
           )
           (if
-            (get_local $g)
+            (get_local $9)
             (block
               (if
                 (i32.eq
-                  (get_local $h)
+                  (get_local $0)
                   (i32.load
-                    (set_local $l
+                    (set_local $5
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
-                          (set_local $j
+                          (set_local $1
                             (i32.load offset=28
-                              (get_local $h)
+                              (get_local $0)
                             )
                           )
                           (i32.const 2)
@@ -6648,12 +6565,12 @@
                 )
                 (block
                   (i32.store
-                    (get_local $l)
-                    (get_local $s)
+                    (get_local $5)
+                    (get_local $3)
                   )
                   (if
                     (i32.eqz
-                      (get_local $s)
+                      (get_local $3)
                     )
                     (block
                       (i32.store
@@ -6665,17 +6582,17 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $j)
+                              (get_local $1)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $m
-                        (get_local $h)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $n
-                        (get_local $i)
+                      (set_local $8
+                        (get_local $4)
                       )
                       (br $do-once$0)
                     )
@@ -6684,7 +6601,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $g)
+                      (get_local $9)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6694,34 +6611,34 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $j
+                        (set_local $1
                           (i32.add
-                            (get_local $g)
+                            (get_local $9)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $h)
+                      (get_local $0)
                     )
                     (i32.store
-                      (get_local $j)
-                      (get_local $s)
+                      (get_local $1)
+                      (get_local $3)
                     )
                     (i32.store offset=20
-                      (get_local $g)
-                      (get_local $s)
+                      (get_local $9)
+                      (get_local $3)
                     )
                   )
                   (if
                     (i32.eqz
-                      (get_local $s)
+                      (get_local $3)
                     )
                     (block
-                      (set_local $m
-                        (get_local $h)
+                      (set_local $2
+                        (get_local $0)
                       )
-                      (set_local $n
-                        (get_local $i)
+                      (set_local $8
+                        (get_local $4)
                       )
                       (br $do-once$0)
                     )
@@ -6730,8 +6647,8 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $s)
-                  (set_local $j
+                  (get_local $3)
+                  (set_local $1
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6740,15 +6657,15 @@
                 (call_import $qa)
               )
               (i32.store offset=24
-                (get_local $s)
-                (get_local $g)
+                (get_local $3)
+                (get_local $9)
               )
               (if
-                (set_local $o
+                (set_local $6
                   (i32.load
-                    (set_local $l
+                    (set_local $5
                       (i32.add
-                        (get_local $h)
+                        (get_local $0)
                         (i32.const 16)
                       )
                     )
@@ -6756,31 +6673,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $o)
-                    (get_local $j)
+                    (get_local $6)
+                    (get_local $1)
                   )
                   (call_import $qa)
                   (block
                     (i32.store offset=16
-                      (get_local $s)
-                      (get_local $o)
+                      (get_local $3)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $o)
-                      (get_local $s)
+                      (get_local $6)
+                      (get_local $3)
                     )
                   )
                 )
               )
               (if
-                (set_local $o
+                (set_local $6
                   (i32.load offset=4
-                    (get_local $l)
+                    (get_local $5)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $o)
+                    (get_local $6)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6788,37 +6705,37 @@
                   (call_import $qa)
                   (block
                     (i32.store offset=20
-                      (get_local $s)
-                      (get_local $o)
+                      (get_local $3)
+                      (get_local $6)
                     )
                     (i32.store offset=24
-                      (get_local $o)
-                      (get_local $s)
+                      (get_local $6)
+                      (get_local $3)
                     )
-                    (set_local $m
-                      (get_local $h)
+                    (set_local $2
+                      (get_local $0)
                     )
-                    (set_local $n
-                      (get_local $i)
+                    (set_local $8
+                      (get_local $4)
                     )
                   )
                 )
                 (block
-                  (set_local $m
-                    (get_local $h)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $i)
+                  (set_local $8
+                    (get_local $4)
                   )
                 )
               )
             )
             (block
-              (set_local $m
-                (get_local $h)
+              (set_local $2
+                (get_local $0)
               )
-              (set_local $n
-                (get_local $i)
+              (set_local $8
+                (get_local $4)
               )
             )
           )
@@ -6827,19 +6744,19 @@
     )
     (if
       (i32.ge_u
-        (get_local $m)
-        (get_local $f)
+        (get_local $2)
+        (get_local $7)
       )
       (call_import $qa)
     )
     (if
       (i32.eqz
         (i32.and
-          (set_local $b
+          (set_local $1
             (i32.load
-              (set_local $e
+              (set_local $4
                 (i32.add
-                  (get_local $f)
+                  (get_local $7)
                   (i32.const 4)
                 )
               )
@@ -6852,39 +6769,39 @@
     )
     (if
       (i32.and
-        (get_local $b)
+        (get_local $1)
         (i32.const 2)
       )
       (block
         (i32.store
-          (get_local $e)
+          (get_local $4)
           (i32.and
-            (get_local $b)
+            (get_local $1)
             (i32.const -2)
           )
         )
         (i32.store offset=4
-          (get_local $m)
+          (get_local $2)
           (i32.or
-            (get_local $n)
+            (get_local $8)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $m)
-            (get_local $n)
+            (get_local $2)
+            (get_local $8)
           )
-          (get_local $n)
+          (get_local $8)
         )
-        (set_local $D
-          (get_local $n)
+        (set_local $0
+          (get_local $8)
         )
       )
       (block
         (if
           (i32.eq
-            (get_local $f)
+            (get_local $7)
             (i32.load
               (i32.const 1232)
             )
@@ -6892,29 +6809,29 @@
           (block
             (i32.store
               (i32.const 1220)
-              (set_local $s
+              (set_local $3
                 (i32.add
                   (i32.load
                     (i32.const 1220)
                   )
-                  (get_local $n)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (get_local $m)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $m)
+              (get_local $2)
               (i32.or
-                (get_local $s)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (if
               (i32.ne
-                (get_local $m)
+                (get_local $2)
                 (i32.load
                   (i32.const 1228)
                 )
@@ -6934,7 +6851,7 @@
         )
         (if
           (i32.eq
-            (get_local $f)
+            (get_local $7)
             (i32.load
               (i32.const 1228)
             )
@@ -6942,76 +6859,76 @@
           (block
             (i32.store
               (i32.const 1216)
-              (set_local $s
+              (set_local $3
                 (i32.add
                   (i32.load
                     (i32.const 1216)
                   )
-                  (get_local $n)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
               (i32.const 1228)
-              (get_local $m)
+              (get_local $2)
             )
             (i32.store offset=4
-              (get_local $m)
+              (get_local $2)
               (i32.or
-                (get_local $s)
+                (get_local $3)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $m)
-                (get_local $s)
+                (get_local $2)
+                (get_local $3)
               )
-              (get_local $s)
+              (get_local $3)
             )
             (return)
           )
         )
-        (set_local $s
+        (set_local $3
           (i32.add
             (i32.and
-              (get_local $b)
+              (get_local $1)
               (i32.const -8)
             )
-            (get_local $n)
+            (get_local $8)
           )
         )
-        (set_local $c
+        (set_local $13
           (i32.shr_u
-            (get_local $b)
+            (get_local $1)
             (i32.const 3)
           )
         )
         (block $do-once$8
           (if
             (i32.lt_u
-              (get_local $b)
+              (get_local $1)
               (i32.const 256)
             )
             (block
-              (set_local $w
+              (set_local $10
                 (i32.load offset=12
-                  (get_local $f)
+                  (get_local $7)
                 )
               )
               (if
                 (i32.ne
-                  (set_local $v
+                  (set_local $5
                     (i32.load offset=8
-                      (get_local $f)
+                      (get_local $7)
                     )
                   )
-                  (set_local $u
+                  (set_local $6
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $c)
+                          (get_local $13)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -7022,7 +6939,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $v)
+                      (get_local $5)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -7032,9 +6949,9 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $v)
+                        (get_local $5)
                       )
-                      (get_local $f)
+                      (get_local $7)
                     )
                     (call_import $qa)
                   )
@@ -7042,8 +6959,8 @@
               )
               (if
                 (i32.eq
-                  (get_local $w)
-                  (get_local $v)
+                  (get_local $10)
+                  (get_local $5)
                 )
                 (block
                   (i32.store
@@ -7055,7 +6972,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $c)
+                          (get_local $13)
                         )
                         (i32.const -1)
                       )
@@ -7066,19 +6983,19 @@
               )
               (if
                 (i32.eq
-                  (get_local $w)
-                  (get_local $u)
+                  (get_local $10)
+                  (get_local $6)
                 )
-                (set_local $x
+                (set_local $17
                   (i32.add
-                    (get_local $w)
+                    (get_local $10)
                     (i32.const 8)
                   )
                 )
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $w)
+                      (get_local $10)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -7088,56 +7005,56 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $u
+                        (set_local $6
                           (i32.add
-                            (get_local $w)
+                            (get_local $10)
                             (i32.const 8)
                           )
                         )
                       )
-                      (get_local $f)
+                      (get_local $7)
                     )
-                    (set_local $x
-                      (get_local $u)
+                    (set_local $17
+                      (get_local $6)
                     )
                     (call_import $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $v)
-                (get_local $w)
+                (get_local $5)
+                (get_local $10)
               )
               (i32.store
-                (get_local $x)
-                (get_local $v)
+                (get_local $17)
+                (get_local $5)
               )
             )
             (block
-              (set_local $v
+              (set_local $5
                 (i32.load offset=24
-                  (get_local $f)
+                  (get_local $7)
                 )
               )
               (block $do-once$10
                 (if
                   (i32.eq
-                    (set_local $w
+                    (set_local $10
                       (i32.load offset=12
-                        (get_local $f)
+                        (get_local $7)
                       )
                     )
-                    (get_local $f)
+                    (get_local $7)
                   )
                   (block
                     (if
-                      (set_local $p
+                      (set_local $11
                         (i32.load
-                          (set_local $t
+                          (set_local $1
                             (i32.add
-                              (set_local $u
+                              (set_local $6
                                 (i32.add
-                                  (get_local $f)
+                                  (get_local $7)
                                   (i32.const 16)
                                 )
                               )
@@ -7147,29 +7064,27 @@
                         )
                       )
                       (block
-                        (set_local $z
-                          (get_local $p)
+                        (set_local $0
+                          (get_local $11)
                         )
-                        (set_local $A
-                          (get_local $t)
+                        (set_local $13
+                          (get_local $1)
                         )
                       )
                       (if
-                        (set_local $a
+                        (set_local $0
                           (i32.load
-                            (get_local $u)
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $z
-                            (get_local $a)
-                          )
-                          (set_local $A
-                            (get_local $u)
+                          (get_local $0)
+                          (set_local $13
+                            (get_local $6)
                           )
                         )
                         (block
-                          (set_local $y
+                          (set_local $12
                             (i32.const 0)
                           )
                           (br $do-once$10)
@@ -7178,51 +7093,49 @@
                     )
                     (loop $while-out$12 $while-in$13
                       (if
-                        (set_local $p
+                        (set_local $11
                           (i32.load
-                            (set_local $t
+                            (set_local $1
                               (i32.add
-                                (get_local $z)
+                                (get_local $0)
                                 (i32.const 20)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $z
-                            (get_local $p)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $A
-                            (get_local $t)
+                          (set_local $13
+                            (get_local $1)
                           )
                           (br $while-in$13)
                         )
                       )
                       (if
-                        (set_local $p
+                        (set_local $11
                           (i32.load
-                            (set_local $t
+                            (set_local $1
                               (i32.add
-                                (get_local $z)
+                                (get_local $0)
                                 (i32.const 16)
                               )
                             )
                           )
                         )
                         (block
-                          (set_local $z
-                            (get_local $p)
+                          (set_local $0
+                            (get_local $11)
                           )
-                          (set_local $A
-                            (get_local $t)
+                          (set_local $13
+                            (get_local $1)
                           )
                         )
                         (block
-                          (set_local $B
-                            (get_local $z)
-                          )
-                          (set_local $C
-                            (get_local $A)
+                          (get_local $0)
+                          (set_local $1
+                            (get_local $13)
                           )
                           (br $while-out$12)
                         )
@@ -7231,7 +7144,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $C)
+                        (get_local $1)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7239,11 +7152,11 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $C)
+                          (get_local $1)
                           (i32.const 0)
                         )
-                        (set_local $y
-                          (get_local $B)
+                        (set_local $12
+                          (get_local $0)
                         )
                       )
                     )
@@ -7251,9 +7164,9 @@
                   (block
                     (if
                       (i32.lt_u
-                        (set_local $t
+                        (set_local $1
                           (i32.load offset=8
-                            (get_local $f)
+                            (get_local $7)
                           )
                         )
                         (i32.load
@@ -7265,40 +7178,40 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $p
+                          (set_local $11
                             (i32.add
-                              (get_local $t)
+                              (get_local $1)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $f)
+                        (get_local $7)
                       )
                       (call_import $qa)
                     )
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $u
+                          (set_local $6
                             (i32.add
-                              (get_local $w)
+                              (get_local $10)
                               (i32.const 8)
                             )
                           )
                         )
-                        (get_local $f)
+                        (get_local $7)
                       )
                       (block
                         (i32.store
-                          (get_local $p)
-                          (get_local $w)
+                          (get_local $11)
+                          (get_local $10)
                         )
                         (i32.store
-                          (get_local $u)
-                          (get_local $t)
+                          (get_local $6)
+                          (get_local $1)
                         )
-                        (set_local $y
-                          (get_local $w)
+                        (set_local $12
+                          (get_local $10)
                         )
                       )
                       (call_import $qa)
@@ -7307,19 +7220,19 @@
                 )
               )
               (if
-                (get_local $v)
+                (get_local $5)
                 (block
                   (if
                     (i32.eq
-                      (get_local $f)
+                      (get_local $7)
                       (i32.load
-                        (set_local $i
+                        (set_local $4
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
-                              (set_local $w
+                              (set_local $10
                                 (i32.load offset=28
-                                  (get_local $f)
+                                  (get_local $7)
                                 )
                               )
                               (i32.const 2)
@@ -7330,12 +7243,12 @@
                     )
                     (block
                       (i32.store
-                        (get_local $i)
-                        (get_local $y)
+                        (get_local $4)
+                        (get_local $12)
                       )
                       (if
                         (i32.eqz
-                          (get_local $y)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
@@ -7347,7 +7260,7 @@
                               (i32.xor
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $w)
+                                  (get_local $10)
                                 )
                                 (i32.const -1)
                               )
@@ -7360,7 +7273,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $v)
+                          (get_local $5)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7370,35 +7283,35 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $w
+                            (set_local $10
                               (i32.add
-                                (get_local $v)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                             )
                           )
-                          (get_local $f)
+                          (get_local $7)
                         )
                         (i32.store
-                          (get_local $w)
-                          (get_local $y)
+                          (get_local $10)
+                          (get_local $12)
                         )
                         (i32.store offset=20
-                          (get_local $v)
-                          (get_local $y)
+                          (get_local $5)
+                          (get_local $12)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eqz
-                          (get_local $y)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $y)
-                      (set_local $w
+                      (get_local $12)
+                      (set_local $10
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7407,15 +7320,15 @@
                     (call_import $qa)
                   )
                   (i32.store offset=24
-                    (get_local $y)
-                    (get_local $v)
+                    (get_local $12)
+                    (get_local $5)
                   )
                   (if
-                    (set_local $h
+                    (set_local $0
                       (i32.load
-                        (set_local $i
+                        (set_local $4
                           (i32.add
-                            (get_local $f)
+                            (get_local $7)
                             (i32.const 16)
                           )
                         )
@@ -7423,31 +7336,31 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $h)
-                        (get_local $w)
+                        (get_local $0)
+                        (get_local $10)
                       )
                       (call_import $qa)
                       (block
                         (i32.store offset=16
-                          (get_local $y)
-                          (get_local $h)
+                          (get_local $12)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $h)
-                          (get_local $y)
+                          (get_local $0)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
-                    (set_local $h
+                    (set_local $0
                       (i32.load offset=4
-                        (get_local $i)
+                        (get_local $4)
                       )
                     )
                     (if
                       (i32.lt_u
-                        (get_local $h)
+                        (get_local $0)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7455,12 +7368,12 @@
                       (call_import $qa)
                       (block
                         (i32.store offset=20
-                          (get_local $y)
-                          (get_local $h)
+                          (get_local $12)
+                          (get_local $0)
                         )
                         (i32.store offset=24
-                          (get_local $h)
-                          (get_local $y)
+                          (get_local $0)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7471,22 +7384,22 @@
           )
         )
         (i32.store offset=4
-          (get_local $m)
+          (get_local $2)
           (i32.or
-            (get_local $s)
+            (get_local $3)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
-            (get_local $m)
-            (get_local $s)
+            (get_local $2)
+            (get_local $3)
           )
-          (get_local $s)
+          (get_local $3)
         )
         (if
           (i32.eq
-            (get_local $m)
+            (get_local $2)
             (i32.load
               (i32.const 1228)
             )
@@ -7494,34 +7407,34 @@
           (block
             (i32.store
               (i32.const 1216)
-              (get_local $s)
+              (get_local $3)
             )
             (return)
           )
-          (set_local $D
-            (get_local $s)
+          (set_local $0
+            (get_local $3)
           )
         )
       )
     )
-    (set_local $n
+    (set_local $8
       (i32.shr_u
-        (get_local $D)
+        (get_local $0)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $D)
+        (get_local $0)
         (i32.const 256)
       )
       (block
-        (set_local $b
+        (set_local $1
           (i32.add
             (i32.const 1248)
             (i32.shl
               (i32.shl
-                (get_local $n)
+                (get_local $8)
                 (i32.const 1)
               )
               (i32.const 2)
@@ -7530,25 +7443,25 @@
         )
         (if
           (i32.and
-            (set_local $e
+            (set_local $4
               (i32.load
                 (i32.const 1208)
               )
             )
-            (set_local $s
+            (set_local $3
               (i32.shl
                 (i32.const 1)
-                (get_local $n)
+                (get_local $8)
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $e
+              (set_local $4
                 (i32.load
-                  (set_local $s
+                  (set_local $3
                     (i32.add
-                      (get_local $b)
+                      (get_local $1)
                       (i32.const 8)
                     )
                   )
@@ -7560,11 +7473,11 @@
             )
             (call_import $qa)
             (block
-              (set_local $E
-                (get_local $s)
+              (set_local $15
+                (get_local $3)
               )
-              (set_local $F
-                (get_local $e)
+              (set_local $14
+                (get_local $4)
               )
             )
           )
@@ -7572,81 +7485,81 @@
             (i32.store
               (i32.const 1208)
               (i32.or
-                (get_local $e)
-                (get_local $s)
+                (get_local $4)
+                (get_local $3)
               )
             )
-            (set_local $E
+            (set_local $15
               (i32.add
-                (get_local $b)
+                (get_local $1)
                 (i32.const 8)
               )
             )
-            (set_local $F
-              (get_local $b)
+            (set_local $14
+              (get_local $1)
             )
           )
         )
         (i32.store
-          (get_local $E)
-          (get_local $m)
+          (get_local $15)
+          (get_local $2)
         )
         (i32.store offset=12
-          (get_local $F)
-          (get_local $m)
+          (get_local $14)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $m)
-          (get_local $F)
+          (get_local $2)
+          (get_local $14)
         )
         (i32.store offset=12
-          (get_local $m)
-          (get_local $b)
+          (get_local $2)
+          (get_local $1)
         )
         (return)
       )
     )
-    (set_local $s
+    (set_local $3
       (i32.add
         (i32.const 1512)
         (i32.shl
-          (set_local $G
+          (set_local $1
             (if
-              (set_local $b
+              (set_local $1
                 (i32.shr_u
-                  (get_local $D)
+                  (get_local $0)
                   (i32.const 8)
                 )
               )
               (if
                 (i32.gt_u
-                  (get_local $D)
+                  (get_local $0)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
                 (i32.or
                   (i32.and
                     (i32.shr_u
-                      (get_local $D)
+                      (get_local $0)
                       (i32.add
-                        (set_local $s
+                        (set_local $3
                           (i32.add
                             (i32.sub
                               (i32.const 14)
                               (i32.or
                                 (i32.or
-                                  (set_local $b
+                                  (set_local $1
                                     (i32.and
                                       (i32.shr_u
                                         (i32.add
-                                          (set_local $E
+                                          (set_local $15
                                             (i32.shl
-                                              (get_local $b)
-                                              (set_local $F
+                                              (get_local $1)
+                                              (set_local $14
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (get_local $b)
+                                                      (get_local $1)
                                                       (i32.const 1048320)
                                                     )
                                                     (i32.const 16)
@@ -7663,16 +7576,16 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $F)
+                                  (get_local $14)
                                 )
-                                (set_local $E
+                                (set_local $15
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $e
+                                        (set_local $4
                                           (i32.shl
-                                            (get_local $E)
-                                            (get_local $b)
+                                            (get_local $15)
+                                            (get_local $1)
                                           )
                                         )
                                         (i32.const 245760)
@@ -7686,8 +7599,8 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $e)
-                                (get_local $E)
+                                (get_local $4)
+                                (get_local $15)
                               )
                               (i32.const 15)
                             )
@@ -7699,7 +7612,7 @@
                     (i32.const 1)
                   )
                   (i32.shl
-                    (get_local $s)
+                    (get_local $3)
                     (i32.const 1)
                   )
                 )
@@ -7712,54 +7625,54 @@
       )
     )
     (i32.store offset=28
-      (get_local $m)
-      (get_local $G)
+      (get_local $2)
+      (get_local $1)
     )
     (i32.store offset=20
-      (get_local $m)
+      (get_local $2)
       (i32.const 0)
     )
     (i32.store offset=16
-      (get_local $m)
+      (get_local $2)
       (i32.const 0)
     )
     (if
       (i32.and
-        (set_local $E
+        (set_local $15
           (i32.load
             (i32.const 1212)
           )
         )
-        (set_local $e
+        (set_local $4
           (i32.shl
             (i32.const 1)
-            (get_local $G)
+            (get_local $1)
           )
         )
       )
       (block
-        (set_local $F
+        (set_local $14
           (i32.shl
-            (get_local $D)
+            (get_local $0)
             (select
               (i32.const 0)
               (i32.sub
                 (i32.const 25)
                 (i32.shr_u
-                  (get_local $G)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.eq
-                (get_local $G)
+                (get_local $1)
                 (i32.const 31)
               )
             )
           )
         )
-        (set_local $b
+        (set_local $1
           (i32.load
-            (get_local $s)
+            (get_local $3)
           )
         )
         (loop $while-out$18 $while-in$19
@@ -7767,34 +7680,34 @@
             (i32.eq
               (i32.and
                 (i32.load offset=4
-                  (get_local $b)
+                  (get_local $1)
                 )
                 (i32.const -8)
               )
-              (get_local $D)
+              (get_local $0)
             )
             (block
-              (set_local $H
-                (get_local $b)
+              (set_local $16
+                (get_local $1)
               )
-              (set_local $I
+              (set_local $0
                 (i32.const 130)
               )
               (br $while-out$18)
             )
           )
           (if
-            (set_local $y
+            (set_local $12
               (i32.load
-                (set_local $n
+                (set_local $8
                   (i32.add
                     (i32.add
-                      (get_local $b)
+                      (get_local $1)
                       (i32.const 16)
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $F)
+                        (get_local $14)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7804,24 +7717,24 @@
               )
             )
             (block
-              (set_local $F
+              (set_local $14
                 (i32.shl
-                  (get_local $F)
+                  (get_local $14)
                   (i32.const 1)
                 )
               )
-              (set_local $b
-                (get_local $y)
+              (set_local $1
+                (get_local $12)
               )
             )
             (block
-              (set_local $J
-                (get_local $n)
+              (set_local $18
+                (get_local $8)
               )
-              (set_local $K
-                (get_local $b)
+              (set_local $19
+                (get_local $1)
               )
-              (set_local $I
+              (set_local $0
                 (i32.const 127)
               )
               (br $while-out$18)
@@ -7831,12 +7744,12 @@
         )
         (if
           (i32.eq
-            (get_local $I)
+            (get_local $0)
             (i32.const 127)
           )
           (if
             (i32.lt_u
-              (get_local $J)
+              (get_local $18)
               (i32.load
                 (i32.const 1224)
               )
@@ -7844,71 +7757,71 @@
             (call_import $qa)
             (block
               (i32.store
-                (get_local $J)
-                (get_local $m)
+                (get_local $18)
+                (get_local $2)
               )
               (i32.store offset=24
-                (get_local $m)
-                (get_local $K)
+                (get_local $2)
+                (get_local $19)
               )
               (i32.store offset=12
-                (get_local $m)
-                (get_local $m)
+                (get_local $2)
+                (get_local $2)
               )
               (i32.store offset=8
-                (get_local $m)
-                (get_local $m)
+                (get_local $2)
+                (get_local $2)
               )
             )
           )
           (if
             (i32.eq
-              (get_local $I)
+              (get_local $0)
               (i32.const 130)
             )
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $F
+                  (set_local $14
                     (i32.load
-                      (set_local $b
+                      (set_local $1
                         (i32.add
-                          (get_local $H)
+                          (get_local $16)
                           (i32.const 8)
                         )
                       )
                     )
                   )
-                  (set_local $i
+                  (set_local $4
                     (i32.load
                       (i32.const 1224)
                     )
                   )
                 )
                 (i32.ge_u
-                  (get_local $H)
-                  (get_local $i)
+                  (get_local $16)
+                  (get_local $4)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $F)
-                  (get_local $m)
+                  (get_local $14)
+                  (get_local $2)
                 )
                 (i32.store
-                  (get_local $b)
-                  (get_local $m)
+                  (get_local $1)
+                  (get_local $2)
                 )
                 (i32.store offset=8
-                  (get_local $m)
-                  (get_local $F)
+                  (get_local $2)
+                  (get_local $14)
                 )
                 (i32.store offset=12
-                  (get_local $m)
-                  (get_local $H)
+                  (get_local $2)
+                  (get_local $16)
                 )
                 (i32.store offset=24
-                  (get_local $m)
+                  (get_local $2)
                   (i32.const 0)
                 )
               )
@@ -7921,31 +7834,31 @@
         (i32.store
           (i32.const 1212)
           (i32.or
-            (get_local $E)
-            (get_local $e)
+            (get_local $15)
+            (get_local $4)
           )
         )
         (i32.store
-          (get_local $s)
-          (get_local $m)
+          (get_local $3)
+          (get_local $2)
         )
         (i32.store offset=24
-          (get_local $m)
-          (get_local $s)
+          (get_local $2)
+          (get_local $3)
         )
         (i32.store offset=12
-          (get_local $m)
-          (get_local $m)
+          (get_local $2)
+          (get_local $2)
         )
         (i32.store offset=8
-          (get_local $m)
-          (get_local $m)
+          (get_local $2)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 1240)
-      (set_local $m
+      (set_local $2
         (i32.add
           (i32.load
             (i32.const 1240)
@@ -7955,22 +7868,22 @@
       )
     )
     (if
-      (get_local $m)
+      (get_local $2)
       (return)
-      (set_local $L
+      (set_local $0
         (i32.const 1664)
       )
     )
     (loop $while-out$20 $while-in$21
       (if
-        (set_local $m
+        (set_local $2
           (i32.load
-            (get_local $L)
+            (get_local $0)
           )
         )
-        (set_local $L
+        (set_local $0
           (i32.add
-            (get_local $m)
+            (get_local $2)
             (i32.const 8)
           )
         )
@@ -7983,29 +7896,24 @@
       (i32.const -1)
     )
   )
-  (func $Ra (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $g i32)
-    (local $m i32)
-    (local $o i32)
-    (local $i i32)
-    (local $x i32)
-    (local $h i32)
-    (local $l i32)
-    (local $n i32)
-    (local $d i32)
-    (local $e i32)
-    (local $f i32)
-    (local $w i32)
-    (local $j i32)
-    (local $p i32)
-    (local $t i32)
-    (local $y i32)
-    (local $z i32)
-    (local $q i32)
-    (local $s i32)
-    (local $u i32)
-    (local $v i32)
-    (set_local $d
+  (func $Ra (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (local $10 i32)
+    (local $11 i32)
+    (local $12 i32)
+    (local $13 i32)
+    (local $14 i32)
+    (local $15 i32)
+    (local $16 i32)
+    (local $17 i32)
+    (local $18 i32)
+    (set_local $11
       (i32.load
         (i32.const 8)
       )
@@ -8019,27 +7927,27 @@
         (i32.const 48)
       )
     )
-    (set_local $e
+    (set_local $12
       (i32.add
-        (get_local $d)
+        (get_local $11)
         (i32.const 16)
       )
     )
-    (set_local $f
-      (get_local $d)
+    (set_local $13
+      (get_local $11)
     )
     (i32.store
-      (set_local $g
+      (set_local $3
         (i32.add
-          (get_local $d)
+          (get_local $11)
           (i32.const 32)
         )
       )
-      (set_local $i
+      (set_local $8
         (i32.load
-          (set_local $h
+          (set_local $9
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -8047,55 +7955,55 @@
       )
     )
     (i32.store offset=4
-      (get_local $g)
-      (set_local $l
+      (get_local $3)
+      (set_local $10
         (i32.sub
           (i32.load
-            (set_local $j
+            (set_local $14
               (i32.add
-                (get_local $a)
+                (get_local $0)
                 (i32.const 20)
               )
             )
           )
-          (get_local $i)
+          (get_local $8)
         )
       )
     )
     (i32.store offset=8
-      (get_local $g)
-      (get_local $b)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $g)
-      (get_local $c)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $b
+    (set_local $1
       (i32.add
-        (get_local $a)
+        (get_local $0)
         (i32.const 60)
       )
     )
-    (set_local $i
+    (set_local $8
       (i32.add
-        (get_local $a)
+        (get_local $0)
         (i32.const 44)
       )
     )
-    (set_local $m
-      (get_local $g)
+    (set_local $5
+      (get_local $3)
     )
-    (set_local $g
+    (set_local $3
       (i32.const 2)
     )
-    (set_local $n
+    (set_local $6
       (i32.add
-        (get_local $l)
-        (get_local $c)
+        (get_local $10)
+        (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $o
+      (set_local $4
         (if
           (i32.load
             (i32.const 1160)
@@ -8103,54 +8011,54 @@
           (block
             (call_import $ra
               (i32.const 1)
-              (get_local $a)
+              (get_local $0)
             )
             (i32.store
-              (get_local $f)
+              (get_local $13)
               (i32.load
-                (get_local $b)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $f)
-              (get_local $m)
+              (get_local $13)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $f)
-              (get_local $g)
+              (get_local $13)
+              (get_local $3)
             )
-            (set_local $l
+            (set_local $10
               (call $Pa
                 (call_import $ya
                   (i32.const 146)
-                  (get_local $f)
+                  (get_local $13)
                 )
               )
             )
             (call_import $oa
               (i32.const 0)
             )
-            (get_local $l)
+            (get_local $10)
           )
           (block
             (i32.store
-              (get_local $e)
+              (get_local $12)
               (i32.load
-                (get_local $b)
+                (get_local $1)
               )
             )
             (i32.store offset=4
-              (get_local $e)
-              (get_local $m)
+              (get_local $12)
+              (get_local $5)
             )
             (i32.store offset=8
-              (get_local $e)
-              (get_local $g)
+              (get_local $12)
+              (get_local $3)
             )
             (call $Pa
               (call_import $ya
                 (i32.const 146)
-                (get_local $e)
+                (get_local $12)
               )
             )
           )
@@ -8158,11 +8066,11 @@
       )
       (if
         (i32.eq
-          (get_local $n)
-          (get_local $o)
+          (get_local $6)
+          (get_local $4)
         )
         (block
-          (set_local $p
+          (set_local $1
             (i32.const 6)
           )
           (br $while-out$0)
@@ -8170,212 +8078,208 @@
       )
       (if
         (i32.lt_s
-          (get_local $o)
+          (get_local $4)
           (i32.const 0)
         )
         (block
-          (set_local $q
-            (get_local $m)
+          (set_local $17
+            (get_local $5)
           )
-          (set_local $s
-            (get_local $g)
+          (set_local $18
+            (get_local $3)
           )
-          (set_local $p
+          (set_local $1
             (i32.const 8)
           )
           (br $while-out$0)
         )
       )
-      (set_local $l
+      (set_local $10
         (i32.sub
-          (get_local $n)
-          (get_local $o)
+          (get_local $6)
+          (get_local $4)
         )
       )
-      (set_local $v
+      (set_local $3
         (if
           (i32.gt_u
-            (get_local $o)
-            (set_local $t
+            (get_local $4)
+            (set_local $6
               (i32.load offset=4
-                (get_local $m)
+                (get_local $5)
               )
             )
           )
           (block
             (i32.store
-              (get_local $h)
-              (set_local $u
+              (get_local $9)
+              (set_local $7
                 (i32.load
-                  (get_local $i)
+                  (get_local $8)
                 )
               )
             )
             (i32.store
-              (get_local $j)
-              (get_local $u)
+              (get_local $14)
+              (get_local $7)
             )
-            (set_local $w
+            (set_local $4
               (i32.sub
-                (get_local $o)
-                (get_local $t)
+                (get_local $4)
+                (get_local $6)
               )
             )
-            (set_local $x
+            (set_local $7
               (i32.add
-                (get_local $m)
+                (get_local $5)
                 (i32.const 8)
               )
             )
-            (set_local $y
+            (set_local $15
               (i32.add
-                (get_local $g)
+                (get_local $3)
                 (i32.const -1)
               )
             )
             (i32.load offset=12
-              (get_local $m)
+              (get_local $5)
             )
           )
           (if
             (i32.eq
-              (get_local $g)
+              (get_local $3)
               (i32.const 2)
             )
             (block
               (i32.store
-                (get_local $h)
+                (get_local $9)
                 (i32.add
                   (i32.load
-                    (get_local $h)
+                    (get_local $9)
                   )
-                  (get_local $o)
+                  (get_local $4)
                 )
               )
-              (set_local $w
-                (get_local $o)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $x
-                (get_local $m)
-              )
-              (set_local $y
+              (set_local $15
                 (i32.const 2)
               )
-              (get_local $t)
+              (get_local $6)
             )
             (block
-              (set_local $w
-                (get_local $o)
+              (get_local $4)
+              (set_local $7
+                (get_local $5)
               )
-              (set_local $x
-                (get_local $m)
+              (set_local $15
+                (get_local $3)
               )
-              (set_local $y
-                (get_local $g)
-              )
-              (get_local $t)
+              (get_local $6)
             )
           )
         )
       )
       (i32.store
-        (get_local $x)
+        (get_local $7)
         (i32.add
           (i32.load
-            (get_local $x)
+            (get_local $7)
           )
-          (get_local $w)
+          (get_local $4)
         )
       )
       (i32.store offset=4
-        (get_local $x)
+        (get_local $7)
         (i32.sub
-          (get_local $v)
-          (get_local $w)
+          (get_local $3)
+          (get_local $4)
         )
       )
-      (set_local $m
-        (get_local $x)
+      (set_local $5
+        (get_local $7)
       )
-      (set_local $g
-        (get_local $y)
+      (set_local $3
+        (get_local $15)
       )
-      (set_local $n
-        (get_local $l)
+      (set_local $6
+        (get_local $10)
       )
       (br $while-in$1)
     )
     (if
       (i32.eq
-        (get_local $p)
+        (get_local $1)
         (i32.const 6)
       )
       (block
         (i32.store offset=16
-          (get_local $a)
+          (get_local $0)
           (i32.add
-            (set_local $n
+            (set_local $6
               (i32.load
-                (get_local $i)
+                (get_local $8)
               )
             )
             (i32.load offset=48
-              (get_local $a)
+              (get_local $0)
             )
           )
         )
         (i32.store
-          (get_local $h)
-          (set_local $i
-            (get_local $n)
+          (get_local $9)
+          (set_local $8
+            (get_local $6)
           )
         )
         (i32.store
-          (get_local $j)
-          (get_local $i)
+          (get_local $14)
+          (get_local $8)
         )
-        (set_local $z
-          (get_local $c)
+        (set_local $16
+          (get_local $2)
         )
       )
       (if
         (i32.eq
-          (get_local $p)
+          (get_local $1)
           (i32.const 8)
         )
         (block
           (i32.store offset=16
-            (get_local $a)
+            (get_local $0)
             (i32.const 0)
           )
           (i32.store
-            (get_local $h)
+            (get_local $9)
             (i32.const 0)
           )
           (i32.store
-            (get_local $j)
+            (get_local $14)
             (i32.const 0)
           )
           (i32.store
-            (get_local $a)
+            (get_local $0)
             (i32.or
               (i32.load
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const 32)
             )
           )
-          (set_local $z
+          (set_local $16
             (if
               (i32.eq
-                (get_local $s)
+                (get_local $18)
                 (i32.const 2)
               )
               (i32.const 0)
               (i32.sub
-                (get_local $c)
+                (get_local $2)
                 (i32.load offset=4
-                  (get_local $q)
+                  (get_local $17)
                 )
               )
             )
@@ -8385,56 +8289,49 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $d)
+      (get_local $11)
     )
-    (get_local $z)
+    (get_local $16)
   )
-  (func $Wa (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $d i32)
-    (local $q i32)
-    (local $e i32)
-    (local $h i32)
-    (local $l i32)
-    (local $m i32)
-    (local $n i32)
-    (local $o i32)
-    (local $f i32)
-    (local $g i32)
-    (local $j i32)
-    (local $p i32)
+  (func $Wa (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
     (if
-      (set_local $e
+      (set_local $6
         (i32.load
-          (set_local $d
+          (set_local $3
             (i32.add
-              (get_local $c)
+              (get_local $2)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $f
-          (get_local $e)
+        (set_local $5
+          (get_local $6)
         )
-        (set_local $g
+        (set_local $4
           (i32.const 5)
         )
       )
       (if
         (call $Xa
-          (get_local $c)
+          (get_local $2)
         )
-        (set_local $h
+        (set_local $7
           (i32.const 0)
         )
         (block
-          (set_local $f
+          (set_local $5
             (i32.load
-              (get_local $d)
+              (get_local $3)
             )
           )
-          (set_local $g
+          (set_local $4
             (i32.const 5)
           )
         )
@@ -8443,16 +8340,16 @@
     (block $label$break$a
       (if
         (i32.eq
-          (get_local $g)
+          (get_local $4)
           (i32.const 5)
         )
         (block
-          (set_local $j
-            (set_local $d
+          (set_local $4
+            (set_local $3
               (i32.load
-                (set_local $e
+                (set_local $6
                   (i32.add
-                    (get_local $c)
+                    (get_local $2)
                     (i32.const 20)
                   )
                 )
@@ -8462,61 +8359,61 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $f)
-                (get_local $d)
+                (get_local $5)
+                (get_local $3)
               )
-              (get_local $b)
+              (get_local $1)
             )
             (block
-              (set_local $h
+              (set_local $7
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $c)
+                        (get_local $2)
                       )
                       (i32.const 3)
                     )
                     (i32.const 2)
                   )
-                  (get_local $c)
-                  (get_local $a)
-                  (get_local $b)
+                  (get_local $2)
+                  (get_local $0)
+                  (get_local $1)
                 )
               )
               (br $label$break$a)
             )
           )
-          (set_local $l
+          (set_local $0
             (block $label$break$b
               (if
                 (i32.gt_s
                   (i32.load8_s offset=75
-                    (get_local $c)
+                    (get_local $2)
                   )
                   (i32.const -1)
                 )
                 (block
-                  (set_local $d
-                    (get_local $b)
+                  (set_local $3
+                    (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eqz
-                        (get_local $d)
+                        (get_local $3)
                       )
                       (block
-                        (set_local $m
-                          (get_local $a)
+                        (set_local $2
+                          (get_local $0)
                         )
-                        (set_local $n
-                          (get_local $j)
+                        (set_local $3
+                          (get_local $4)
                         )
-                        (set_local $o
+                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$b
-                          (get_local $b)
+                          (get_local $1)
                         )
                       )
                     )
@@ -8524,10 +8421,10 @@
                       (i32.eq
                         (i32.load8_s
                           (i32.add
-                            (get_local $a)
-                            (set_local $p
+                            (get_local $0)
+                            (set_local $5
                               (i32.add
-                                (get_local $d)
+                                (get_local $3)
                                 (i32.const -1)
                               )
                             )
@@ -8536,13 +8433,13 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $q
-                          (get_local $d)
+                        (set_local $4
+                          (get_local $3)
                         )
                         (br $while-out$2)
                       )
-                      (set_local $d
-                        (get_local $p)
+                      (set_local $3
+                        (get_local $5)
                       )
                     )
                     (br $while-in$3)
@@ -8553,144 +8450,135 @@
                         (i32.add
                           (i32.and
                             (i32.load offset=36
-                              (get_local $c)
+                              (get_local $2)
                             )
                             (i32.const 3)
                           )
                           (i32.const 2)
                         )
-                        (get_local $c)
-                        (get_local $a)
-                        (get_local $q)
+                        (get_local $2)
+                        (get_local $0)
+                        (get_local $4)
                       )
-                      (get_local $q)
+                      (get_local $4)
                     )
                     (block
-                      (set_local $h
-                        (get_local $q)
+                      (set_local $7
+                        (get_local $4)
                       )
                       (br $label$break$a)
                     )
                   )
-                  (set_local $m
+                  (set_local $2
                     (i32.add
-                      (get_local $a)
-                      (get_local $q)
+                      (get_local $0)
+                      (get_local $4)
                     )
                   )
-                  (set_local $n
+                  (set_local $3
                     (i32.load
-                      (get_local $e)
+                      (get_local $6)
                     )
                   )
-                  (set_local $o
-                    (get_local $q)
+                  (set_local $5
+                    (get_local $4)
                   )
                   (i32.sub
-                    (get_local $b)
-                    (get_local $q)
+                    (get_local $1)
+                    (get_local $4)
                   )
                 )
                 (block
-                  (set_local $m
-                    (get_local $a)
+                  (set_local $2
+                    (get_local $0)
                   )
-                  (set_local $n
-                    (get_local $j)
+                  (set_local $3
+                    (get_local $4)
                   )
-                  (set_local $o
+                  (set_local $5
                     (i32.const 0)
                   )
-                  (get_local $b)
+                  (get_local $1)
                 )
               )
             )
           )
           (call $jb
-            (get_local $n)
-            (get_local $m)
-            (get_local $l)
+            (get_local $3)
+            (get_local $2)
+            (get_local $0)
           )
           (i32.store
-            (get_local $e)
+            (get_local $6)
             (i32.add
               (i32.load
-                (get_local $e)
+                (get_local $6)
               )
-              (get_local $l)
+              (get_local $0)
             )
           )
-          (set_local $h
+          (set_local $7
             (i32.add
-              (get_local $o)
-              (get_local $l)
+              (get_local $5)
+              (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $h)
+    (get_local $7)
   )
-  (func $Za (param $a i32) (result i32)
-    (local $d i32)
-    (local $c i32)
-    (local $l i32)
-    (local $j i32)
-    (local $e i32)
-    (local $b i32)
-    (local $f i32)
-    (local $g i32)
-    (local $h i32)
-    (local $m i32)
+  (func $Za (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
     (block $label$break$a
       (if
         (i32.and
-          (set_local $b
-            (get_local $a)
+          (set_local $3
+            (get_local $0)
           )
           (i32.const 3)
         )
         (block
-          (set_local $e
-            (get_local $a)
-          )
-          (set_local $f
-            (get_local $b)
+          (get_local $0)
+          (set_local $4
+            (get_local $3)
           )
           (loop $while-out$1 $while-in$2
             (if
               (i32.eqz
                 (i32.load8_s
-                  (get_local $e)
+                  (get_local $0)
                 )
               )
               (block
-                (set_local $g
-                  (get_local $f)
+                (set_local $5
+                  (get_local $4)
                 )
                 (br $label$break$a)
               )
             )
             (if
               (i32.and
-                (set_local $f
-                  (set_local $h
+                (set_local $4
+                  (set_local $0
                     (i32.add
-                      (get_local $e)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
                 (i32.const 3)
               )
-              (set_local $e
-                (get_local $h)
-              )
+              (get_local $0)
               (block
-                (set_local $c
-                  (get_local $h)
+                (set_local $1
+                  (get_local $0)
                 )
-                (set_local $d
+                (set_local $2
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8700,10 +8588,10 @@
           )
         )
         (block
-          (set_local $c
-            (get_local $a)
+          (set_local $1
+            (get_local $0)
           )
-          (set_local $d
+          (set_local $2
             (i32.const 4)
           )
         )
@@ -8711,21 +8599,21 @@
     )
     (if
       (i32.eq
-        (get_local $d)
+        (get_local $2)
         (i32.const 4)
       )
       (block
-        (set_local $d
-          (get_local $c)
+        (set_local $2
+          (get_local $1)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $c
+                  (set_local $1
                     (i32.load
-                      (get_local $d)
+                      (get_local $2)
                     )
                   )
                   (i32.const -2139062144)
@@ -8733,22 +8621,22 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $c)
+                (get_local $1)
                 (i32.const -16843009)
               )
             )
             (block
-              (set_local $j
-                (get_local $c)
+              (set_local $0
+                (get_local $1)
               )
-              (set_local $l
-                (get_local $d)
+              (set_local $1
+                (get_local $2)
               )
               (br $while-out$3)
             )
-            (set_local $d
+            (set_local $2
               (i32.add
-                (get_local $d)
+                (get_local $2)
                 (i32.const 4)
               )
             )
@@ -8759,7 +8647,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $j)
+                (get_local $0)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8767,25 +8655,25 @@
             (i32.const 24)
           )
           (block
-            (set_local $j
-              (get_local $l)
+            (set_local $0
+              (get_local $1)
             )
             (loop $while-out$5 $while-in$6
               (if
                 (i32.load8_s
-                  (set_local $l
+                  (set_local $1
                     (i32.add
-                      (get_local $j)
+                      (get_local $0)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $j
-                  (get_local $l)
+                (set_local $0
+                  (get_local $1)
                 )
                 (block
-                  (set_local $m
-                    (get_local $l)
+                  (set_local $0
+                    (get_local $1)
                   )
                   (br $while-out$5)
                 )
@@ -8793,70 +8681,66 @@
               (br $while-in$6)
             )
           )
-          (set_local $m
-            (get_local $l)
+          (set_local $0
+            (get_local $1)
           )
         )
-        (set_local $g
-          (get_local $m)
+        (set_local $5
+          (get_local $0)
         )
       )
     )
     (i32.sub
-      (get_local $g)
-      (get_local $b)
+      (get_local $5)
+      (get_local $3)
     )
   )
-  (func $_a (param $a i32) (result i32)
-    (local $e i32)
-    (local $c i32)
-    (local $b i32)
-    (local $d i32)
-    (local $g i32)
-    (local $f i32)
+  (func $_a (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
     (block $do-once$0
       (if
-        (get_local $a)
+        (get_local $0)
         (block
           (if
             (i32.le_s
               (i32.load offset=76
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const -1)
             )
             (br $do-once$0
               (call $$a
-                (get_local $a)
+                (get_local $0)
               )
             )
           )
-          (set_local $c
+          (set_local $2
             (i32.eq
               (call $Ya
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const 0)
             )
           )
-          (set_local $e
+          (set_local $1
             (call $$a
-              (get_local $a)
+              (get_local $0)
             )
           )
           (if
-            (get_local $c)
-            (get_local $e)
+            (get_local $2)
+            (get_local $1)
             (block
               (call $Ta
-                (get_local $a)
+                (get_local $0)
               )
-              (get_local $e)
+              (get_local $1)
             )
           )
         )
         (block
-          (set_local $b
+          (set_local $0
             (if
               (i32.load
                 (i32.const 1140)
@@ -8873,70 +8757,68 @@
             (i32.const 1188)
           )
           (if
-            (set_local $c
+            (set_local $2
               (i32.load
                 (i32.const 1184)
               )
             )
             (block
-              (set_local $e
-                (get_local $c)
+              (set_local $1
+                (get_local $2)
               )
-              (set_local $c
-                (get_local $b)
+              (set_local $2
+                (get_local $0)
               )
               (loop $while-out$2 $while-in$3
-                (set_local $f
+                (set_local $0
                   (if
                     (i32.gt_s
                       (i32.load offset=76
-                        (get_local $e)
+                        (get_local $1)
                       )
                       (i32.const -1)
                     )
                     (call $Ya
-                      (get_local $e)
+                      (get_local $1)
                     )
                     (i32.const 0)
                   )
                 )
-                (set_local $g
+                (set_local $2
                   (if
                     (i32.gt_u
                       (i32.load offset=20
-                        (get_local $e)
+                        (get_local $1)
                       )
                       (i32.load offset=28
-                        (get_local $e)
+                        (get_local $1)
                       )
                     )
                     (i32.or
                       (call $$a
-                        (get_local $e)
+                        (get_local $1)
                       )
-                      (get_local $c)
+                      (get_local $2)
                     )
-                    (get_local $c)
+                    (get_local $2)
                   )
                 )
                 (if
-                  (get_local $f)
+                  (get_local $0)
                   (call $Ta
-                    (get_local $e)
+                    (get_local $1)
                   )
                 )
                 (if
-                  (set_local $e
+                  (set_local $1
                     (i32.load offset=56
-                      (get_local $e)
+                      (get_local $1)
                     )
                   )
-                  (set_local $c
-                    (get_local $g)
-                  )
+                  (get_local $2)
                   (block
-                    (set_local $d
-                      (get_local $g)
+                    (set_local $0
+                      (get_local $2)
                     )
                     (br $while-out$2)
                   )
@@ -8944,29 +8826,26 @@
                 (br $while-in$3)
               )
             )
-            (set_local $d
-              (get_local $b)
-            )
+            (get_local $0)
           )
           (call_import $xa
             (i32.const 1188)
           )
-          (get_local $d)
+          (get_local $0)
         )
       )
     )
   )
-  (func $ab (param $a i32) (param $b i32) (result i32)
-    (local $f i32)
-    (local $g i32)
-    (local $m i32)
-    (local $c i32)
-    (local $d i32)
-    (local $h i32)
-    (local $j i32)
-    (local $e i32)
-    (local $n i32)
-    (set_local $c
+  (func $ab (param $0 i32) (param $1 i32) (result i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (local $7 i32)
+    (local $8 i32)
+    (local $9 i32)
+    (set_local $5
       (i32.load
         (i32.const 8)
       )
@@ -8981,49 +8860,49 @@
       )
     )
     (i32.store8
-      (set_local $d
-        (get_local $c)
+      (set_local $6
+        (get_local $5)
       )
-      (set_local $e
+      (set_local $9
         (i32.and
-          (get_local $b)
+          (get_local $1)
           (i32.const 255)
         )
       )
     )
     (if
-      (set_local $g
+      (set_local $3
         (i32.load
-          (set_local $f
+          (set_local $2
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 16)
             )
           )
         )
       )
       (block
-        (set_local $h
-          (get_local $g)
+        (set_local $7
+          (get_local $3)
         )
-        (set_local $j
+        (set_local $8
           (i32.const 4)
         )
       )
       (if
         (call $Xa
-          (get_local $a)
+          (get_local $0)
         )
-        (set_local $m
+        (set_local $4
           (i32.const -1)
         )
         (block
-          (set_local $h
+          (set_local $7
             (i32.load
-              (get_local $f)
+              (get_local $2)
             )
           )
-          (set_local $j
+          (set_local $8
             (i32.const 4)
           )
         )
@@ -9032,76 +8911,76 @@
     (block $do-once$0
       (if
         (i32.eq
-          (get_local $j)
+          (get_local $8)
           (i32.const 4)
         )
         (block
           (if
             (i32.lt_u
-              (set_local $f
+              (set_local $2
                 (i32.load
-                  (set_local $g
+                  (set_local $3
                     (i32.add
-                      (get_local $a)
+                      (get_local $0)
                       (i32.const 20)
                     )
                   )
                 )
               )
-              (get_local $h)
+              (get_local $7)
             )
             (if
               (i32.ne
-                (set_local $n
+                (set_local $1
                   (i32.and
-                    (get_local $b)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.load8_s offset=75
-                  (get_local $a)
+                  (get_local $0)
                 )
               )
               (block
                 (i32.store
-                  (get_local $g)
+                  (get_local $3)
                   (i32.add
-                    (get_local $f)
+                    (get_local $2)
                     (i32.const 1)
                   )
                 )
                 (i32.store8
-                  (get_local $f)
-                  (get_local $e)
+                  (get_local $2)
+                  (get_local $9)
                 )
-                (set_local $m
-                  (get_local $n)
+                (set_local $4
+                  (get_local $1)
                 )
                 (br $do-once$0)
               )
             )
           )
-          (set_local $m
+          (set_local $4
             (if
               (i32.eq
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
                       (i32.load offset=36
-                        (get_local $a)
+                        (get_local $0)
                       )
                       (i32.const 3)
                     )
                     (i32.const 2)
                   )
-                  (get_local $a)
-                  (get_local $d)
+                  (get_local $0)
+                  (get_local $6)
                   (i32.const 1)
                 )
                 (i32.const 1)
               )
               (i32.load8_u
-                (get_local $d)
+                (get_local $6)
               )
               (i32.const -1)
             )
@@ -9111,32 +8990,31 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $c)
+      (get_local $5)
     )
-    (get_local $m)
+    (get_local $4)
   )
-  (func $$a (param $a i32) (result i32)
-    (local $e i32)
-    (local $b i32)
-    (local $d i32)
-    (local $c i32)
-    (local $f i32)
-    (local $g i32)
-    (local $h i32)
+  (func $$a (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
     (if
       (i32.gt_u
         (i32.load
-          (set_local $b
+          (set_local $3
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 20)
             )
           )
         )
         (i32.load
-          (set_local $c
+          (set_local $4
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 28)
             )
           )
@@ -9147,55 +9025,55 @@
           (i32.add
             (i32.and
               (i32.load offset=36
-                (get_local $a)
+                (get_local $0)
               )
               (i32.const 3)
             )
             (i32.const 2)
           )
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
           (i32.const 0)
         )
         (if
           (i32.load
-            (get_local $b)
+            (get_local $3)
           )
-          (set_local $e
+          (set_local $2
             (i32.const 3)
           )
-          (set_local $d
+          (set_local $1
             (i32.const -1)
           )
         )
       )
-      (set_local $e
+      (set_local $2
         (i32.const 3)
       )
     )
     (if
       (i32.eq
-        (get_local $e)
+        (get_local $2)
         (i32.const 3)
       )
       (block
         (if
           (i32.lt_u
-            (set_local $f
+            (set_local $1
               (i32.load
-                (set_local $e
+                (set_local $2
                   (i32.add
-                    (get_local $a)
+                    (get_local $0)
                     (i32.const 4)
                   )
                 )
               )
             )
-            (set_local $h
+            (set_local $6
               (i32.load
-                (set_local $g
+                (set_local $5
                   (i32.add
-                    (get_local $a)
+                    (get_local $0)
                     (i32.const 8)
                   )
                 )
@@ -9206,73 +9084,73 @@
             (i32.add
               (i32.and
                 (i32.load offset=40
-                  (get_local $a)
+                  (get_local $0)
                 )
                 (i32.const 3)
               )
               (i32.const 2)
             )
-            (get_local $a)
+            (get_local $0)
             (i32.sub
-              (get_local $f)
-              (get_local $h)
+              (get_local $1)
+              (get_local $6)
             )
             (i32.const 1)
           )
         )
         (i32.store offset=16
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store
-          (get_local $c)
+          (get_local $4)
           (i32.const 0)
         )
         (i32.store
-          (get_local $b)
+          (get_local $3)
           (i32.const 0)
         )
         (i32.store
-          (get_local $g)
+          (get_local $5)
           (i32.const 0)
         )
         (i32.store
-          (get_local $e)
+          (get_local $2)
           (i32.const 0)
         )
-        (set_local $d
+        (set_local $1
           (i32.const 0)
         )
       )
     )
-    (get_local $d)
+    (get_local $1)
   )
-  (func $jb (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $d i32)
+  (func $jb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
     (if
       (i32.ge_s
-        (get_local $c)
+        (get_local $2)
         (i32.const 4096)
       )
       (return
         (call_import $va
-          (get_local $a)
-          (get_local $b)
-          (get_local $c)
+          (get_local $0)
+          (get_local $1)
+          (get_local $2)
         )
       )
     )
-    (set_local $d
-      (get_local $a)
+    (set_local $3
+      (get_local $0)
     )
     (if
       (i32.eq
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.and
-          (get_local $b)
+          (get_local $1)
           (i32.const 3)
         )
       )
@@ -9281,40 +9159,40 @@
           (br_if $while-out$0
             (i32.eqz
               (i32.and
-                (get_local $a)
+                (get_local $0)
                 (i32.const 3)
               )
             )
           )
           (if
             (i32.eqz
-              (get_local $c)
+              (get_local $2)
             )
             (return
-              (get_local $d)
+              (get_local $3)
             )
           )
           (i32.store8
-            (get_local $a)
+            (get_local $0)
             (i32.load8_s
-              (get_local $b)
+              (get_local $1)
             )
           )
-          (set_local $a
+          (set_local $0
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 1)
             )
           )
-          (set_local $b
+          (set_local $1
             (i32.add
-              (get_local $b)
+              (get_local $1)
               (i32.const 1)
             )
           )
-          (set_local $c
+          (set_local $2
             (i32.sub
-              (get_local $c)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -9323,31 +9201,31 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.lt_s
-              (get_local $c)
+              (get_local $2)
               (i32.const 4)
             )
           )
           (i32.store
-            (get_local $a)
+            (get_local $0)
             (i32.load
-              (get_local $b)
+              (get_local $1)
             )
           )
-          (set_local $a
+          (set_local $0
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 4)
             )
           )
-          (set_local $b
+          (set_local $1
             (i32.add
-              (get_local $b)
+              (get_local $1)
               (i32.const 4)
             )
           )
-          (set_local $c
+          (set_local $2
             (i32.sub
-              (get_local $c)
+              (get_local $2)
               (i32.const 4)
             )
           )
@@ -9358,87 +9236,87 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.le_s
-          (get_local $c)
+          (get_local $2)
           (i32.const 0)
         )
       )
       (i32.store8
-        (get_local $a)
+        (get_local $0)
         (i32.load8_s
-          (get_local $b)
+          (get_local $1)
         )
       )
-      (set_local $a
+      (set_local $0
         (i32.add
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
       )
-      (set_local $b
+      (set_local $1
         (i32.add
-          (get_local $b)
+          (get_local $1)
           (i32.const 1)
         )
       )
-      (set_local $c
+      (set_local $2
         (i32.sub
-          (get_local $c)
+          (get_local $2)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
-    (get_local $d)
+    (get_local $3)
   )
   (func $gb
     (nop)
   )
-  (func $hb (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $e i32)
-    (local $d i32)
-    (local $f i32)
-    (local $g i32)
-    (set_local $d
+  (func $hb (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (local $5 i32)
+    (local $6 i32)
+    (set_local $4
       (i32.add
-        (get_local $a)
-        (get_local $c)
+        (get_local $0)
+        (get_local $2)
       )
     )
     (if
       (i32.ge_s
-        (get_local $c)
+        (get_local $2)
         (i32.const 20)
       )
       (block
-        (set_local $f
+        (set_local $5
           (i32.or
             (i32.or
               (i32.or
-                (set_local $b
+                (set_local $1
                   (i32.and
-                    (get_local $b)
+                    (get_local $1)
                     (i32.const 255)
                   )
                 )
                 (i32.shl
-                  (get_local $b)
+                  (get_local $1)
                   (i32.const 8)
                 )
               )
               (i32.shl
-                (get_local $b)
+                (get_local $1)
                 (i32.const 16)
               )
             )
             (i32.shl
-              (get_local $b)
+              (get_local $1)
               (i32.const 24)
             )
           )
         )
-        (set_local $g
+        (set_local $6
           (i32.and
-            (get_local $d)
+            (get_local $4)
             (i32.xor
               (i32.const 3)
               (i32.const -1)
@@ -9446,36 +9324,36 @@
           )
         )
         (if
-          (set_local $e
+          (set_local $3
             (i32.and
-              (get_local $a)
+              (get_local $0)
               (i32.const 3)
             )
           )
           (block
-            (set_local $e
+            (set_local $3
               (i32.sub
                 (i32.add
-                  (get_local $a)
+                  (get_local $0)
                   (i32.const 4)
                 )
-                (get_local $e)
+                (get_local $3)
               )
             )
             (loop $while-out$0 $while-in$1
               (br_if $while-out$0
                 (i32.ge_s
-                  (get_local $a)
-                  (get_local $e)
+                  (get_local $0)
+                  (get_local $3)
                 )
               )
               (i32.store8
-                (get_local $a)
-                (get_local $b)
+                (get_local $0)
+                (get_local $1)
               )
-              (set_local $a
+              (set_local $0
                 (i32.add
-                  (get_local $a)
+                  (get_local $0)
                   (i32.const 1)
                 )
               )
@@ -9486,17 +9364,17 @@
         (loop $while-out$2 $while-in$3
           (br_if $while-out$2
             (i32.ge_s
-              (get_local $a)
-              (get_local $g)
+              (get_local $0)
+              (get_local $6)
             )
           )
           (i32.store
-            (get_local $a)
-            (get_local $f)
+            (get_local $0)
+            (get_local $5)
           )
-          (set_local $a
+          (set_local $0
             (i32.add
-              (get_local $a)
+              (get_local $0)
               (i32.const 4)
             )
           )
@@ -9507,38 +9385,36 @@
     (loop $while-out$4 $while-in$5
       (br_if $while-out$4
         (i32.ge_s
-          (get_local $a)
-          (get_local $d)
+          (get_local $0)
+          (get_local $4)
         )
       )
       (i32.store8
-        (get_local $a)
-        (get_local $b)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $a
+      (set_local $0
         (i32.add
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $while-in$5)
     )
     (i32.sub
-      (get_local $a)
-      (get_local $c)
+      (get_local $0)
+      (get_local $2)
     )
   )
-  (func $db (param $a i32) (result i32)
-    (local $b i32)
-    (local $f i32)
-    (local $c i32)
-    (local $d i32)
-    (local $e i32)
-    (set_local $c
+  (func $db (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (local $3 i32)
+    (set_local $3
       (if
         (i32.gt_s
           (i32.load offset=76
-            (set_local $b
+            (set_local $1
               (i32.load
                 (i32.const 1024)
               )
@@ -9547,18 +9423,18 @@
           (i32.const -1)
         )
         (call $Ya
-          (get_local $b)
+          (get_local $1)
         )
         (i32.const 0)
       )
     )
-    (set_local $d
+    (set_local $0
       (block $do-once$0
         (if
           (i32.lt_s
             (call $cb
-              (get_local $a)
-              (get_local $b)
+              (get_local $0)
+              (get_local $1)
             )
             (i32.const 0)
           )
@@ -9567,36 +9443,36 @@
             (if
               (i32.ne
                 (i32.load8_s offset=75
-                  (get_local $b)
+                  (get_local $1)
                 )
                 (i32.const 10)
               )
               (if
                 (i32.lt_u
-                  (set_local $f
+                  (set_local $2
                     (i32.load
-                      (set_local $e
+                      (set_local $0
                         (i32.add
-                          (get_local $b)
+                          (get_local $1)
                           (i32.const 20)
                         )
                       )
                     )
                   )
                   (i32.load offset=16
-                    (get_local $b)
+                    (get_local $1)
                   )
                 )
                 (block
                   (i32.store
-                    (get_local $e)
+                    (get_local $0)
                     (i32.add
-                      (get_local $f)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
                   (i32.store8
-                    (get_local $f)
+                    (get_local $2)
                     (i32.const 10)
                   )
                   (br $do-once$0
@@ -9607,7 +9483,7 @@
             )
             (i32.lt_s
               (call $ab
-                (get_local $b)
+                (get_local $1)
                 (i32.const 10)
               )
               (i32.const 0)
@@ -9617,56 +9493,56 @@
       )
     )
     (if
-      (get_local $c)
+      (get_local $3)
       (call $Ta
-        (get_local $b)
+        (get_local $1)
       )
     )
     (i32.shr_s
       (i32.shl
-        (get_local $d)
+        (get_local $0)
         (i32.const 31)
       )
       (i32.const 31)
     )
   )
-  (func $Xa (param $a i32) (result i32)
-    (local $b i32)
-    (local $c i32)
-    (set_local $c
+  (func $Xa (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $2
       (i32.load8_s
-        (set_local $b
+        (set_local $1
           (i32.add
-            (get_local $a)
+            (get_local $0)
             (i32.const 74)
           )
         )
       )
     )
     (i32.store8
-      (get_local $b)
+      (get_local $1)
       (i32.or
         (i32.add
-          (get_local $c)
+          (get_local $2)
           (i32.const 255)
         )
-        (get_local $c)
+        (get_local $2)
       )
     )
     (if
       (i32.and
-        (set_local $c
+        (set_local $2
           (i32.load
-            (get_local $a)
+            (get_local $0)
           )
         )
         (i32.const 8)
       )
       (block
         (i32.store
-          (get_local $a)
+          (get_local $0)
           (i32.or
-            (get_local $c)
+            (get_local $2)
             (i32.const 32)
           )
         )
@@ -9674,31 +9550,31 @@
       )
       (block
         (i32.store offset=8
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=4
-          (get_local $a)
+          (get_local $0)
           (i32.const 0)
         )
         (i32.store offset=28
-          (get_local $a)
-          (set_local $b
+          (get_local $0)
+          (set_local $1
             (i32.load offset=44
-              (get_local $a)
+              (get_local $0)
             )
           )
         )
         (i32.store offset=20
-          (get_local $a)
-          (get_local $b)
+          (get_local $0)
+          (get_local $1)
         )
         (i32.store offset=16
-          (get_local $a)
+          (get_local $0)
           (i32.add
-            (get_local $b)
+            (get_local $1)
             (i32.load offset=48
-              (get_local $a)
+              (get_local $0)
             )
           )
         )
@@ -9706,76 +9582,72 @@
       )
     )
   )
-  (func $bb (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
-    (local $e i32)
-    (local $g i32)
-    (local $f i32)
-    (local $h i32)
-    (set_local $e
+  (func $bb (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+    (local $4 i32)
+    (local $5 i32)
+    (set_local $4
       (i32.mul
-        (get_local $c)
-        (get_local $b)
+        (get_local $2)
+        (get_local $1)
       )
     )
     (if
       (i32.eq
-        (set_local $h
+        (set_local $0
           (if
             (i32.gt_s
               (i32.load offset=76
-                (get_local $d)
+                (get_local $3)
               )
               (i32.const -1)
             )
             (block
-              (set_local $f
+              (set_local $5
                 (i32.eq
                   (call $Ya
-                    (get_local $d)
+                    (get_local $3)
                   )
                   (i32.const 0)
                 )
               )
-              (set_local $g
+              (set_local $0
                 (call $Wa
-                  (get_local $a)
-                  (get_local $e)
-                  (get_local $d)
+                  (get_local $0)
+                  (get_local $4)
+                  (get_local $3)
                 )
               )
               (if
-                (get_local $f)
-                (get_local $g)
+                (get_local $5)
+                (get_local $0)
                 (block
                   (call $Ta
-                    (get_local $d)
+                    (get_local $3)
                   )
-                  (get_local $g)
+                  (get_local $0)
                 )
               )
             )
             (call $Wa
-              (get_local $a)
-              (get_local $e)
-              (get_local $d)
+              (get_local $0)
+              (get_local $4)
+              (get_local $3)
             )
           )
         )
-        (get_local $e)
+        (get_local $4)
       )
-      (get_local $c)
+      (get_local $2)
       (i32.div_u
-        (get_local $h)
-        (get_local $b)
+        (get_local $0)
+        (get_local $1)
       )
     )
   )
-  (func $Ua (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $e i32)
-    (local $d i32)
-    (local $f i32)
-    (local $g i32)
-    (set_local $d
+  (func $Ua (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9790,67 +9662,67 @@
       )
     )
     (i32.store
-      (set_local $e
-        (get_local $d)
+      (set_local $3
+        (get_local $4)
       )
       (i32.load offset=60
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store offset=4
-      (get_local $e)
+      (get_local $3)
       (i32.const 0)
     )
     (i32.store offset=8
-      (get_local $e)
-      (get_local $b)
+      (get_local $3)
+      (get_local $1)
     )
     (i32.store offset=12
-      (get_local $e)
-      (set_local $f
+      (get_local $3)
+      (set_local $0
         (i32.add
-          (get_local $d)
+          (get_local $4)
           (i32.const 20)
         )
       )
     )
     (i32.store offset=16
-      (get_local $e)
-      (get_local $c)
+      (get_local $3)
+      (get_local $2)
     )
-    (set_local $g
+    (set_local $0
       (if
         (i32.lt_s
           (call $Pa
             (call_import $ua
               (i32.const 140)
-              (get_local $e)
+              (get_local $3)
             )
           )
           (i32.const 0)
         )
         (block
           (i32.store
-            (get_local $f)
+            (get_local $0)
             (i32.const -1)
           )
           (i32.const -1)
         )
         (i32.load
-          (get_local $f)
+          (get_local $0)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $d)
+      (get_local $4)
     )
-    (get_local $g)
+    (get_local $0)
   )
-  (func $Va (param $a i32) (param $b i32) (param $c i32) (result i32)
-    (local $e i32)
-    (local $d i32)
-    (set_local $d
+  (func $Va (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (local $4 i32)
+    (set_local $4
       (i32.load
         (i32.const 8)
       )
@@ -9864,72 +9736,72 @@
         (i32.const 80)
       )
     )
-    (set_local $e
-      (get_local $d)
+    (set_local $3
+      (get_local $4)
     )
     (i32.store offset=36
-      (get_local $a)
+      (get_local $0)
       (i32.const 3)
     )
     (if
       (i32.eqz
         (i32.and
           (i32.load
-            (get_local $a)
+            (get_local $0)
           )
           (i32.const 64)
         )
       )
       (block
         (i32.store
-          (get_local $e)
+          (get_local $3)
           (i32.load offset=60
-            (get_local $a)
+            (get_local $0)
           )
         )
         (i32.store offset=4
-          (get_local $e)
+          (get_local $3)
           (i32.const 21505)
         )
         (i32.store offset=8
-          (get_local $e)
+          (get_local $3)
           (i32.add
-            (get_local $d)
+            (get_local $4)
             (i32.const 12)
           )
         )
         (if
           (call_import $wa
             (i32.const 54)
-            (get_local $e)
+            (get_local $3)
           )
           (i32.store8 offset=75
-            (get_local $a)
+            (get_local $0)
             (i32.const -1)
           )
         )
       )
     )
-    (set_local $e
+    (set_local $3
       (call $Ra
-        (get_local $a)
-        (get_local $b)
-        (get_local $c)
+        (get_local $0)
+        (get_local $1)
+        (get_local $2)
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $d)
+      (get_local $4)
     )
-    (get_local $e)
+    (get_local $3)
   )
-  (func $Ka (param $a i32)
+  (func $Ka (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -9937,7 +9809,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -9945,7 +9817,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -9953,7 +9825,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=4
@@ -9961,7 +9833,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=4
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=5
@@ -9969,7 +9841,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=5
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=6
@@ -9977,7 +9849,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=6
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=7
@@ -9985,14 +9857,14 @@
         (i32.const 24)
       )
       (i32.load8_s offset=7
-        (get_local $a)
+        (get_local $0)
       )
     )
   )
-  (func $Oa (param $a i32) (result i32)
-    (local $b i32)
-    (local $c i32)
-    (set_local $b
+  (func $Oa (param $0 i32) (result i32)
+    (local $1 i32)
+    (local $2 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -10007,31 +9879,31 @@
       )
     )
     (i32.store
-      (set_local $c
-        (get_local $b)
+      (set_local $2
+        (get_local $1)
       )
       (i32.load offset=60
-        (get_local $a)
+        (get_local $0)
       )
     )
-    (set_local $a
+    (set_local $0
       (call $Pa
         (call_import $sa
           (i32.const 6)
-          (get_local $c)
+          (get_local $2)
         )
       )
     )
     (i32.store
       (i32.const 8)
-      (get_local $b)
+      (get_local $1)
     )
-    (get_local $a)
+    (get_local $0)
   )
-  (func $Pa (param $a i32) (result i32)
+  (func $Pa (param $0 i32) (result i32)
     (if
       (i32.gt_u
-        (get_local $a)
+        (get_local $0)
         (i32.const -4096)
       )
       (block
@@ -10039,21 +9911,21 @@
           (call $Qa)
           (i32.sub
             (i32.const 0)
-            (get_local $a)
+            (get_local $0)
           )
         )
         (i32.const -1)
       )
-      (get_local $a)
+      (get_local $0)
     )
   )
-  (func $Ja (param $a i32)
+  (func $Ja (param $0 i32)
     (i32.store8
       (i32.load
         (i32.const 24)
       )
       (i32.load8_s
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=1
@@ -10061,7 +9933,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=1
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=2
@@ -10069,7 +9941,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=2
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store8 offset=3
@@ -10077,7 +9949,7 @@
         (i32.const 24)
       )
       (i32.load8_s offset=3
-        (get_local $a)
+        (get_local $0)
       )
     )
   )
@@ -10092,23 +9964,23 @@
       (i32.const 1204)
     )
   )
-  (func $lb (param $a i32) (param $b i32) (param $c i32) (param $d i32) (result i32)
+  (func $lb (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
     (call_indirect $FUNCSIG$iiii
       (i32.add
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 3)
         )
         (i32.const 2)
       )
-      (get_local $b)
-      (get_local $c)
-      (get_local $d)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
     )
   )
-  (func $Ea (param $a i32) (result i32)
-    (local $b i32)
-    (set_local $b
+  (func $Ea (param $0 i32) (result i32)
+    (local $1 i32)
+    (set_local $1
       (i32.load
         (i32.const 8)
       )
@@ -10119,7 +9991,7 @@
         (i32.load
           (i32.const 8)
         )
-        (get_local $a)
+        (get_local $0)
       )
     )
     (i32.store
@@ -10134,28 +10006,28 @@
         (i32.const -16)
       )
     )
-    (get_local $b)
+    (get_local $1)
   )
-  (func $cb (param $a i32) (param $b i32) (result i32)
+  (func $cb (param $0 i32) (param $1 i32) (result i32)
     (i32.add
       (call $bb
-        (get_local $a)
+        (get_local $0)
         (call $Za
-          (get_local $a)
+          (get_local $0)
         )
         (i32.const 1)
-        (get_local $b)
+        (get_local $1)
       )
       (i32.const -1)
     )
   )
-  (func $ob (param $a i32) (param $b i32) (param $c i32) (result i32)
+  (func $ob (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
     (call_import $ja
       (i32.const 1)
     )
     (i32.const 0)
   )
-  (func $Ia (param $a i32) (param $b i32)
+  (func $Ia (param $0 i32) (param $1 i32)
     (if
       (i32.eqz
         (i32.load
@@ -10165,62 +10037,62 @@
       (block
         (i32.store
           (i32.const 40)
-          (get_local $a)
+          (get_local $0)
         )
         (i32.store
           (i32.const 48)
-          (get_local $b)
+          (get_local $1)
         )
       )
     )
   )
-  (func $kb (param $a i32) (param $b i32) (result i32)
+  (func $kb (param $0 i32) (param $1 i32) (result i32)
     (call_indirect $FUNCSIG$ii
       (i32.add
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 0)
       )
-      (get_local $b)
+      (get_local $1)
     )
   )
-  (func $Sa (param $a i32)
+  (func $Sa (param $0 i32)
     (if
       (i32.eqz
         (i32.load offset=68
-          (get_local $a)
+          (get_local $0)
         )
       )
       (call $Ta
-        (get_local $a)
+        (get_local $0)
       )
     )
   )
-  (func $mb (param $a i32) (param $b i32)
+  (func $mb (param $0 i32) (param $1 i32)
     (call_indirect $FUNCSIG$vi
       (i32.add
         (i32.and
-          (get_local $a)
+          (get_local $0)
           (i32.const 1)
         )
         (i32.const 6)
       )
-      (get_local $b)
+      (get_local $1)
     )
   )
-  (func $Ha (param $a i32) (param $b i32)
+  (func $Ha (param $0 i32) (param $1 i32)
     (i32.store
       (i32.const 8)
-      (get_local $a)
+      (get_local $0)
     )
     (i32.store
       (i32.const 16)
-      (get_local $b)
+      (get_local $1)
     )
   )
-  (func $nb (param $a i32) (result i32)
+  (func $nb (param $0 i32) (result i32)
     (call_import $ja
       (i32.const 0)
     )
@@ -10232,27 +10104,27 @@
     )
     (i32.const 0)
   )
-  (func $Ya (param $a i32) (result i32)
+  (func $Ya (param $0 i32) (result i32)
     (i32.const 0)
   )
-  (func $Ta (param $a i32)
+  (func $Ta (param $0 i32)
     (nop)
   )
-  (func $pb (param $a i32)
+  (func $pb (param $0 i32)
     (call_import $ja
       (i32.const 2)
     )
   )
-  (func $La (param $a i32)
+  (func $La (param $0 i32)
     (i32.store
       (i32.const 160)
-      (get_local $a)
+      (get_local $0)
     )
   )
-  (func $Ga (param $a i32)
+  (func $Ga (param $0 i32)
     (i32.store
       (i32.const 8)
-      (get_local $a)
+      (get_local $0)
     )
   )
   (func $Ma (result i32)
@@ -10268,9 +10140,9 @@
   (func $ib (result i32)
     (i32.const 0)
   )
-  (func $__growWasmMemory (param $newSize i32)
+  (func $__growWasmMemory (param $0 i32)
     (grow_memory
-      (get_local $newSize)
+      (get_local $0)
     )
   )
 )

--- a/test/min.fromasm
+++ b/test/min.fromasm
@@ -2,37 +2,37 @@
   (memory 256 256)
   (export "memory" memory)
   (export "floats" $floats)
-  (func $floats (param $f f32) (result f32)
-    (local $t f32)
+  (func $floats (param $0 f32) (result f32)
+    (local $1 f32)
     (f32.add
-      (get_local $t)
-      (get_local $f)
+      (get_local $1)
+      (get_local $0)
     )
   )
-  (func $neg (param $k i32) (param $p i32) (result f32)
+  (func $neg (param $0 i32) (param $1 i32) (result f32)
     (f32.neg
       (block
         (i32.store
-          (get_local $k)
-          (get_local $p)
+          (get_local $0)
+          (get_local $1)
         )
         (f32.load
-          (get_local $k)
+          (get_local $0)
         )
       )
     )
   )
-  (func $bitcasts (param $i i32) (param $f f32)
+  (func $bitcasts (param $0 i32) (param $1 f32)
     (f32.reinterpret/i32
-      (get_local $i)
+      (get_local $0)
     )
     (f64.promote/f32
       (f32.reinterpret/i32
-        (get_local $i)
+        (get_local $0)
       )
     )
     (i32.reinterpret/f32
-      (get_local $f)
+      (get_local $1)
     )
   )
   (func $ctzzzz (result i32)

--- a/test/min.fromasm.imprecise
+++ b/test/min.fromasm.imprecise
@@ -2,37 +2,37 @@
   (memory 256 256)
   (export "memory" memory)
   (export "floats" $floats)
-  (func $floats (param $f f32) (result f32)
-    (local $t f32)
+  (func $floats (param $0 f32) (result f32)
+    (local $1 f32)
     (f32.add
-      (get_local $t)
-      (get_local $f)
+      (get_local $1)
+      (get_local $0)
     )
   )
-  (func $neg (param $k i32) (param $p i32) (result f32)
+  (func $neg (param $0 i32) (param $1 i32) (result f32)
     (f32.neg
       (block
         (i32.store
-          (get_local $k)
-          (get_local $p)
+          (get_local $0)
+          (get_local $1)
         )
         (f32.load
-          (get_local $k)
+          (get_local $0)
         )
       )
     )
   )
-  (func $bitcasts (param $i i32) (param $f f32)
+  (func $bitcasts (param $0 i32) (param $1 f32)
     (f32.reinterpret/i32
-      (get_local $i)
+      (get_local $0)
     )
     (f64.promote/f32
       (f32.reinterpret/i32
-        (get_local $i)
+        (get_local $0)
       )
     )
     (i32.reinterpret/f32
-      (get_local $f)
+      (get_local $1)
     )
   )
   (func $ctzzzz (result i32)

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -1,0 +1,681 @@
+(module
+  (memory 10)
+  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+  (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
+  (import $_emscripten_autodebug_i32 "env" "_emscripten_autodebug_i32" (param i32 i32) (result i32))
+  (func $nothing-to-do
+    (local $0 i32)
+    (nop)
+  )
+  (func $merge
+    (local $0 i32)
+    (nop)
+  )
+  (func $leave-type
+    (local $0 i32)
+    (local $1 f32)
+    (nop)
+  )
+  (func $leave-interfere
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (set_local $1
+      (i32.const 0)
+    )
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $almost-interfere
+    (local $0 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (get_local $0)
+    (set_local $0
+      (i32.const 0)
+    )
+    (get_local $0)
+  )
+  (func $redundant-copy
+    (local $0 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (get_local $0)
+    (get_local $0)
+  )
+  (func $ineffective-store
+    (local $0 i32)
+    (i32.const 0)
+    (set_local $0
+      (i32.const 0)
+    )
+    (get_local $0)
+  )
+  (func $block
+    (local $0 i32)
+    (block $block0
+      (set_local $0
+        (i32.const 0)
+      )
+    )
+    (get_local $0)
+  )
+  (func $see-both-sides
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (block $block0
+      (set_local $1
+        (i32.const 0)
+      )
+    )
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $see-br-and-ignore-dead
+    (local $0 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (block $block
+      (br $block)
+      (i32.const 0)
+      (get_local $0)
+      (i32.const -1)
+    )
+    (get_local $0)
+  )
+  (func $see-block-body
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (block $block
+      (set_local $1
+        (i32.const 0)
+      )
+      (get_local $1)
+      (br $block)
+    )
+    (get_local $0)
+  )
+  (func $zero-init
+    (local $0 i32)
+    (local $1 i32)
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $multi
+    (local $0 i32)
+    (local $1 i32)
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $if-else
+    (local $0 i32)
+    (local $1 i32)
+    (if
+      (i32.const 0)
+      (get_local $0)
+      (get_local $1)
+    )
+  )
+  (func $if-else-parallel
+    (local $0 i32)
+    (if
+      (i32.const 0)
+      (block $block1
+        (set_local $0
+          (i32.const 0)
+        )
+        (get_local $0)
+      )
+      (block $block3
+        (set_local $0
+          (i32.const 1)
+        )
+        (get_local $0)
+      )
+    )
+  )
+  (func $if-else-after
+    (local $0 i32)
+    (local $1 i32)
+    (if
+      (i32.const 0)
+      (set_local $0
+        (i32.const 0)
+      )
+      (set_local $1
+        (i32.const 1)
+      )
+    )
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $if-else-through
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (set_local $1
+      (i32.const 1)
+    )
+    (if
+      (i32.const 0)
+      (i32.const 1)
+      (i32.const 2)
+    )
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $if-through
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (set_local $1
+      (i32.const 1)
+    )
+    (if
+      (i32.const 0)
+      (i32.const 1)
+    )
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $if-through2
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (if
+      (i32.const 0)
+      (set_local $1
+        (i32.const 1)
+      )
+    )
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $if-through2
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (if
+      (i32.const 0)
+      (block $block1
+        (get_local $0)
+        (get_local $1)
+      )
+    )
+  )
+  (func $if2
+    (local $0 i32)
+    (local $1 i32)
+    (if
+      (set_local $0
+        (i32.const 0)
+      )
+      (block $block1
+        (get_local $0)
+        (get_local $1)
+      )
+    )
+  )
+  (func $if3
+    (local $0 i32)
+    (local $1 i32)
+    (if
+      (i32.const 0)
+      (block $block1
+        (set_local $0
+          (i32.const 0)
+        )
+        (get_local $0)
+      )
+    )
+    (get_local $1)
+  )
+  (func $if4
+    (local $0 i32)
+    (if
+      (i32.const 0)
+      (block $block1
+        (set_local $0
+          (i32.const 0)
+        )
+        (get_local $0)
+        (set_local $0
+          (i32.const 1)
+        )
+      )
+    )
+    (get_local $0)
+  )
+  (func $if5
+    (local $0 i32)
+    (local $1 i32)
+    (if
+      (i32.const 0)
+      (block $block1
+        (get_local $0)
+        (set_local $1
+          (i32.const 1)
+        )
+      )
+    )
+    (get_local $1)
+  )
+  (func $loop
+    (local $0 i32)
+    (local $1 i32)
+    (loop $out $in
+      (get_local $0)
+      (set_local $0
+        (i32.const 0)
+      )
+      (get_local $1)
+      (br $in)
+    )
+  )
+  (func $interfere-in-dead
+    (local $0 i32)
+    (block $block
+      (br $block)
+      (get_local $0)
+      (get_local $0)
+    )
+  )
+  (func $interfere-in-dead2
+    (local $0 i32)
+    (block $block
+      (unreachable)
+      (get_local $0)
+      (get_local $0)
+    )
+  )
+  (func $interfere-in-dead3
+    (local $0 i32)
+    (block $block
+      (return)
+      (get_local $0)
+      (get_local $0)
+    )
+  )
+  (func $params (param $0 i32) (param $1 f32)
+    (local $2 i32)
+    (local $3 i32)
+    (get_local $0)
+    (get_local $2)
+    (get_local $3)
+  )
+  (func $interfere-in-dead
+    (local $0 i32)
+    (local $1 i32)
+    (block $block
+      (br_if $block
+        (i32.const 0)
+      )
+      (get_local $0)
+      (get_local $1)
+    )
+  )
+  (func $switch
+    (local $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (block $switch$def
+      (block $switch-case$1
+        (block $switch-case$2
+          (br_table $switch-case$1 $switch-case$2 $switch-case$1 $switch-case$1 $switch$def
+            (i32.const 100)
+          )
+          (get_local $0)
+        )
+        (get_local $0)
+      )
+      (get_local $1)
+    )
+    (get_local $2)
+  )
+  (func $greedy-can-be-happy
+    (local $0 i32)
+    (local $1 i32)
+    (if
+      (i32.const 0)
+      (if
+        (i32.const 1)
+        (if
+          (i32.const 2)
+          (block $block3
+            (set_local $0
+              (i32.const 100)
+            )
+            (set_local $1
+              (i32.const 101)
+            )
+            (get_local $0)
+            (get_local $1)
+          )
+          (block $block5
+            (set_local $0
+              (i32.const 102)
+            )
+            (set_local $1
+              (i32.const 103)
+            )
+            (get_local $0)
+            (get_local $1)
+          )
+        )
+        (if
+          (i32.const 3)
+          (block $block8
+            (set_local $0
+              (i32.const 104)
+            )
+            (set_local $1
+              (i32.const 105)
+            )
+            (get_local $0)
+            (get_local $1)
+          )
+          (block $block10
+            (set_local $0
+              (i32.const 106)
+            )
+            (set_local $1
+              (i32.const 107)
+            )
+            (get_local $0)
+            (get_local $1)
+          )
+        )
+      )
+      (if
+        (i32.const 4)
+        (block $block13
+          (set_local $0
+            (i32.const 108)
+          )
+          (set_local $1
+            (i32.const 109)
+          )
+          (get_local $0)
+          (get_local $1)
+        )
+        (block $block15
+          (set_local $0
+            (i32.const 110)
+          )
+          (set_local $1
+            (i32.const 111)
+          )
+          (get_local $0)
+          (get_local $1)
+        )
+      )
+    )
+  )
+  (func $greedy-can-be-sad
+    (local $0 i32)
+    (local $1 i32)
+    (local $2 i32)
+    (if
+      (i32.const 0)
+      (if
+        (i32.const 1)
+        (if
+          (i32.const 2)
+          (block $block3
+            (set_local $0
+              (i32.const 100)
+            )
+            (set_local $1
+              (i32.const 101)
+            )
+            (get_local $0)
+            (get_local $1)
+          )
+          (block $block5
+            (set_local $0
+              (i32.const 102)
+            )
+            (set_local $2
+              (i32.const 103)
+            )
+            (get_local $0)
+            (get_local $2)
+          )
+        )
+        (if
+          (i32.const 3)
+          (block $block8
+            (set_local $1
+              (i32.const 104)
+            )
+            (set_local $0
+              (i32.const 105)
+            )
+            (get_local $1)
+            (get_local $0)
+          )
+          (block $block10
+            (set_local $1
+              (i32.const 106)
+            )
+            (set_local $2
+              (i32.const 107)
+            )
+            (get_local $1)
+            (get_local $2)
+          )
+        )
+      )
+      (if
+        (i32.const 4)
+        (block $block13
+          (set_local $2
+            (i32.const 108)
+          )
+          (set_local $0
+            (i32.const 109)
+          )
+          (get_local $2)
+          (get_local $0)
+        )
+        (block $block15
+          (set_local $2
+            (i32.const 110)
+          )
+          (set_local $1
+            (i32.const 111)
+          )
+          (get_local $2)
+          (get_local $1)
+        )
+      )
+    )
+  )
+  (func $_memcpy (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
+    (local $3 i32)
+    (if
+      (i32.ge_s
+        (get_local $2)
+        (i32.const 4096)
+      )
+      (get_local $0)
+    )
+    (set_local $3
+      (get_local $0)
+    )
+    (if
+      (i32.eq
+        (i32.and
+          (get_local $0)
+          (i32.const 3)
+        )
+        (i32.and
+          (get_local $1)
+          (i32.const 3)
+        )
+      )
+      (block $block2
+        (loop $while-out$0 $while-in$1
+          (if
+            (i32.eqz
+              (i32.and
+                (get_local $0)
+                (i32.const 3)
+              )
+            )
+            (br $while-out$0)
+          )
+          (block $block4
+            (if
+              (i32.eqz
+                (get_local $2)
+              )
+              (return
+                (get_local $3)
+              )
+            )
+            (i32.store8
+              (get_local $0)
+              (i32.load8_s
+                (get_local $1)
+              )
+            )
+            (set_local $0
+              (i32.add
+                (get_local $0)
+                (i32.const 1)
+              )
+            )
+            (set_local $1
+              (i32.add
+                (get_local $1)
+                (i32.const 1)
+              )
+            )
+            (set_local $2
+              (i32.sub
+                (get_local $2)
+                (i32.const 1)
+              )
+            )
+          )
+          (br $while-in$1)
+        )
+        (loop $while-out$2 $while-in$3
+          (if
+            (i32.eqz
+              (i32.ge_s
+                (get_local $2)
+                (i32.const 4)
+              )
+            )
+            (br $while-out$2)
+          )
+          (block $block7
+            (i32.store
+              (get_local $0)
+              (i32.load
+                (get_local $1)
+              )
+            )
+            (set_local $0
+              (i32.add
+                (get_local $0)
+                (i32.const 4)
+              )
+            )
+            (set_local $1
+              (i32.add
+                (get_local $1)
+                (i32.const 4)
+              )
+            )
+            (set_local $2
+              (i32.sub
+                (get_local $2)
+                (i32.const 4)
+              )
+            )
+          )
+          (br $while-in$3)
+        )
+      )
+    )
+    (loop $while-out$4 $while-in$5
+      (if
+        (i32.eqz
+          (i32.gt_s
+            (get_local $2)
+            (i32.const 0)
+          )
+        )
+        (br $while-out$4)
+      )
+      (block $block9
+        (i32.store8
+          (get_local $0)
+          (i32.load8_s
+            (get_local $1)
+          )
+        )
+        (set_local $0
+          (i32.add
+            (get_local $0)
+            (i32.const 1)
+          )
+        )
+        (set_local $1
+          (i32.add
+            (get_local $1)
+            (i32.const 1)
+          )
+        )
+        (set_local $2
+          (i32.sub
+            (get_local $2)
+            (i32.const 1)
+          )
+        )
+      )
+      (br $while-in$5)
+    )
+    (return
+      (get_local $3)
+    )
+  )
+  (func $this-is-effective-i-tell-you (param $0 i32)
+    (if
+      (i32.const -1)
+      (block $block1
+        (if
+          (i32.const 0)
+          (nop)
+        )
+        (set_local $0
+          (i32.const 1)
+        )
+      )
+      (nop)
+    )
+    (get_local $0)
+  )
+)

--- a/test/passes/coalesce-locals.wast
+++ b/test/passes/coalesce-locals.wast
@@ -1,0 +1,594 @@
+(module
+  (memory 10)
+  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
+  (import $_emscripten_autodebug_i32 "env" "_emscripten_autodebug_i32" (param i32 i32) (result i32))
+  (table)
+  (func $nothing-to-do
+    (local $x i32)
+  )
+  (func $merge
+    (local $x i32)
+    (local $y i32)
+  )
+  (func $leave-type
+    (local $x i32)
+    (local $y f32)
+  )
+  (func $leave-interfere
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (set_local $y (i32.const 0))
+    (get_local $x)
+    (get_local $y)
+  )
+  (func $almost-interfere
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (get_local $x)
+    (set_local $y (i32.const 0))
+    (get_local $y)
+  )
+  (func $redundant-copy
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (set_local $y (get_local $x))
+    (get_local $y)
+  )
+  (func $ineffective-store
+    (local $x i32)
+    (set_local $x (i32.const 0))
+    (set_local $x (i32.const 0))
+    (get_local $x)
+  )
+  (func $block
+    (local $x i32)
+    (block
+      (set_local $x (i32.const 0))
+    )
+    (get_local $x)
+  )
+  (func $see-both-sides
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (block
+      (set_local $y (i32.const 0))
+    )
+    (get_local $x)
+    (get_local $y)
+  )
+  (func $see-br-and-ignore-dead
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (block $block
+      (br $block)
+      (set_local $y (i32.const 0))
+      (get_local $y)
+      (set_local $x (i32.const -1))
+    )
+    (get_local $x)
+  )
+  (func $see-block-body
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (block $block
+      (set_local $y (i32.const 0))
+      (get_local $y)
+      (br $block)
+    )
+    (get_local $x)
+  )
+  (func $zero-init
+    (local $x i32)
+    (local $y i32)
+    (get_local $x)
+    (get_local $y)
+  )
+  (func $multi
+    (local $x i32) ;; x is free, but y and z conflict
+    (local $y i32)
+    (local $z i32)
+    (get_local $y)
+    (get_local $z)
+  )
+  (func $if-else
+    (local $x i32)
+    (local $y i32)
+    (if ;; x and y conflict when they are merged into their shared predecessor
+      (i32.const 0)
+      (get_local $x)
+      (get_local $y)
+    )
+  )
+  (func $if-else-parallel
+    (local $x i32)
+    (local $y i32)
+    (if
+      (i32.const 0)
+      (block
+        (set_local $x (i32.const 0))
+        (get_local $x)
+      )
+      (block
+        (set_local $y (i32.const 1))
+        (get_local $y)
+      )
+    )
+  )
+  (func $if-else-after
+    (local $x i32)
+    (local $y i32)
+    (if
+      (i32.const 0)
+      (set_local $x (i32.const 0))
+      (set_local $y (i32.const 1))
+    )
+    (get_local $x)
+    (get_local $y)
+  )
+  (func $if-else-through
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (set_local $y (i32.const 1))
+    (if
+      (i32.const 0)
+      (i32.const 1)
+      (i32.const 2)
+    )
+    (get_local $x)
+    (get_local $y)
+  )
+  (func $if-through
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (set_local $y (i32.const 1))
+    (if
+      (i32.const 0)
+      (i32.const 1)
+    )
+    (get_local $x)
+    (get_local $y)
+  )
+  (func $if-through2
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (if
+      (i32.const 0)
+      (set_local $y (i32.const 1))
+    )
+    (get_local $x)
+    (get_local $y)
+  )
+  (func $if-through2
+    (local $x i32)
+    (local $y i32)
+    (set_local $x (i32.const 0))
+    (if
+      (i32.const 0)
+      (block
+        (get_local $x)
+        (get_local $y)
+      )
+    )
+  )
+  (func $if2
+    (local $x i32)
+    (local $y i32)
+    (if
+      (set_local $x (i32.const 0))
+      (block
+        (get_local $x)
+        (get_local $y)
+      )
+    )
+  )
+  (func $if3
+    (local $x i32)
+    (local $y i32)
+    (if
+      (i32.const 0)
+      (block
+        (set_local $x (i32.const 0))
+        (get_local $x)
+      )
+    )
+    (get_local $y)
+  )
+  (func $if4
+    (local $x i32)
+    (local $y i32)
+    (if
+      (i32.const 0)
+      (block
+        (set_local $x (i32.const 0))
+        (get_local $x)
+        (set_local $y (i32.const 1)) ;; we might not go through here, but it's ok
+      )
+    )
+    (get_local $y)
+  )
+  (func $if5
+    (local $x i32)
+    (local $y i32)
+    (if
+      (i32.const 0)
+      (block
+        (get_local $x) ;; we might go through here, and it causes interference
+        (set_local $y (i32.const 1))
+      )
+    )
+    (get_local $y)
+  )
+  (func $loop
+    (local $x i32)
+    (local $y i32)
+    (loop $out $in
+      (get_local $x)
+      (set_local $x (i32.const 0)) ;; effective, due to looping
+      (get_local $y)
+      (br $in)
+    )
+  )
+  (func $interfere-in-dead
+    (local $x i32)
+    (local $y i32)
+    (block $block
+      (br $block)
+      (get_local $x)
+      (get_local $y)
+    )
+  )
+  (func $interfere-in-dead2
+    (local $x i32)
+    (local $y i32)
+    (block $block
+      (unreachable)
+      (get_local $x)
+      (get_local $y)
+    )
+  )
+  (func $interfere-in-dead3
+    (local $x i32)
+    (local $y i32)
+    (block $block
+      (return)
+      (get_local $x)
+      (get_local $y)
+    )
+  )
+  (func $params (param $p i32) (param $q f32)
+    (local $x i32) ;; x is free, but others conflict
+    (local $y i32)
+    (local $z i32)
+    (local $w i32)
+    (get_local $y)
+    (get_local $z)
+    (get_local $w)
+  )
+  (func $interfere-in-dead
+    (local $x i32)
+    (local $y i32)
+    (block $block
+      (br_if $block (i32.const 0))
+      (get_local $x)
+      (get_local $y)
+    )
+  )
+  (func $switch
+    (local $x i32)
+    (local $y i32)
+    (local $z i32)
+    (local $w i32)
+    (block $switch$def
+      (block $switch-case$1
+        (block $switch-case$2
+          (br_table $switch-case$1 $switch-case$2 $switch-case$1 $switch-case$1 $switch$def
+            (i32.const 100)
+          )
+          (get_local $x) ;; unreachable
+        )
+        (get_local $y)
+      )
+      (get_local $z)
+    )
+    (get_local $w)
+  )
+  (func $greedy-can-be-happy
+    (local $x1 i32)
+    (local $x2 i32)
+    (local $x3 i32)
+    (local $y1 i32)
+    (local $y2 i32)
+    (local $y3 i32)
+    (if
+      (i32.const 0)
+      (if
+        (i32.const 1)
+        (if
+          (i32.const 2)
+          (block
+            (set_local $x1 (i32.const 100))
+            (set_local $y2 (i32.const 101))
+            (get_local $x1)
+            (get_local $y2)
+          )
+          (block
+            (set_local $x1 (i32.const 102))
+            (set_local $y3 (i32.const 103))
+            (get_local $x1)
+            (get_local $y3)
+          )
+        )
+        (if
+          (i32.const 3)
+          (block
+            (set_local $x2 (i32.const 104))
+            (set_local $y1 (i32.const 105))
+            (get_local $x2)
+            (get_local $y1)
+          )
+          (block
+            (set_local $x2 (i32.const 106))
+            (set_local $y3 (i32.const 107))
+            (get_local $x2)
+            (get_local $y3)
+          )
+        )
+      )
+      (if
+        (i32.const 4)
+        (block
+          (set_local $x3 (i32.const 108))
+          (set_local $y1 (i32.const 109))
+          (get_local $x3)
+          (get_local $y1)
+        )
+        (block
+          (set_local $x3 (i32.const 110))
+          (set_local $y2 (i32.const 111))
+          (get_local $x3)
+          (get_local $y2)
+        )
+      )
+    )
+  )
+  (func $greedy-can-be-sad
+    (local $x1 i32)
+    (local $y1 i32)
+    (local $x2 i32)
+    (local $y2 i32)
+    (local $x3 i32)
+    (local $y3 i32)
+    (if
+      (i32.const 0)
+      (if
+        (i32.const 1)
+        (if
+          (i32.const 2)
+          (block
+            (set_local $x1 (i32.const 100))
+            (set_local $y2 (i32.const 101))
+            (get_local $x1)
+            (get_local $y2)
+          )
+          (block
+            (set_local $x1 (i32.const 102))
+            (set_local $y3 (i32.const 103))
+            (get_local $x1)
+            (get_local $y3)
+          )
+        )
+        (if
+          (i32.const 3)
+          (block
+            (set_local $x2 (i32.const 104))
+            (set_local $y1 (i32.const 105))
+            (get_local $x2)
+            (get_local $y1)
+          )
+          (block
+            (set_local $x2 (i32.const 106))
+            (set_local $y3 (i32.const 107))
+            (get_local $x2)
+            (get_local $y3)
+          )
+        )
+      )
+      (if
+        (i32.const 4)
+        (block
+          (set_local $x3 (i32.const 108))
+          (set_local $y1 (i32.const 109))
+          (get_local $x3)
+          (get_local $y1)
+        )
+        (block
+          (set_local $x3 (i32.const 110))
+          (set_local $y2 (i32.const 111))
+          (get_local $x3)
+          (get_local $y2)
+        )
+      )
+    )
+  )
+  (func $_memcpy (param $i1 i32) (param $i2 i32) (param $i3 i32) (result i32)
+    (local $i4 i32)
+    (if
+      (i32.ge_s
+        (get_local $i3)
+        (i32.const 4096)
+      )
+      (get_local $i1)
+      (get_local $i2)
+      (get_local $i3)
+      (return)
+    )
+    (set_local $i4
+      (get_local $i1)
+    )
+    (if
+      (i32.eq
+        (i32.and
+          (get_local $i1)
+          (i32.const 3)
+        )
+        (i32.and
+          (get_local $i2)
+          (i32.const 3)
+        )
+      )
+      (block
+        (loop $while-out$0 $while-in$1
+          (if
+            (i32.eqz
+              (i32.and
+                (get_local $i1)
+                (i32.const 3)
+              )
+            )
+            (br $while-out$0)
+          )
+          (block
+            (if
+              (i32.eqz
+                (get_local $i3)
+              )
+              (return
+                (get_local $i4)
+              )
+            )
+            (i32.store8
+              (get_local $i1)
+              (i32.load8_s
+                (get_local $i2)
+              )
+            )
+            (set_local $i1
+              (i32.add
+                (get_local $i1)
+                (i32.const 1)
+              )
+            )
+            (set_local $i2
+              (i32.add
+                (get_local $i2)
+                (i32.const 1)
+              )
+            )
+            (set_local $i3
+              (i32.sub
+                (get_local $i3)
+                (i32.const 1)
+              )
+            )
+          )
+          (br $while-in$1)
+        )
+        (loop $while-out$2 $while-in$3
+          (if
+            (i32.eqz
+              (i32.ge_s
+                (get_local $i3)
+                (i32.const 4)
+              )
+            )
+            (br $while-out$2)
+          )
+          (block
+            (i32.store
+              (get_local $i1)
+              (i32.load
+                (get_local $i2)
+              )
+            )
+            (set_local $i1
+              (i32.add
+                (get_local $i1)
+                (i32.const 4)
+              )
+            )
+            (set_local $i2
+              (i32.add
+                (get_local $i2)
+                (i32.const 4)
+              )
+            )
+            (set_local $i3
+              (i32.sub
+                (get_local $i3)
+                (i32.const 4)
+              )
+            )
+          )
+          (br $while-in$3)
+        )
+      )
+    )
+    (loop $while-out$4 $while-in$5
+      (if
+        (i32.eqz
+          (i32.gt_s
+            (get_local $i3)
+            (i32.const 0)
+          )
+        )
+        (br $while-out$4)
+      )
+      (block
+        (i32.store8
+          (get_local $i1)
+          (i32.load8_s
+            (get_local $i2)
+          )
+        )
+        (set_local $i1
+          (i32.add
+            (get_local $i1)
+            (i32.const 1)
+          )
+        )
+        (set_local $i2
+          (i32.add
+            (get_local $i2)
+            (i32.const 1)
+          )
+        )
+        (set_local $i3
+          (i32.sub
+            (get_local $i3)
+            (i32.const 1)
+          )
+        )
+      )
+      (br $while-in$5)
+    )
+    (return
+      (get_local $i4)
+    )
+  )
+  (func $this-is-effective-i-tell-you (param $x i32)
+    (if
+      (i32.const -1)
+      (block
+        (if ;; this is important for the bug
+          (i32.const 0)
+          (nop)
+        )
+        (set_local $x ;; this set is effective!
+          (i32.const 1)
+        )
+      )
+      (nop) ;; this is enough for the bug
+    )
+    (get_local $x) ;; this ends up with the wrong value in the test
+  )
+)
+

--- a/test/two_sides.fromasm
+++ b/test/two_sides.fromasm
@@ -4,64 +4,56 @@
   (type $FUNCSIG$id (func (param f64) (result i32)))
   (import $f64-to-int "asm2wasm" "f64-to-int" (param f64) (result i32))
   (export "_test" $_test)
-  (func $_test (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (param $i5 i32) (result i32)
-    (local $d6 f64)
+  (func $_test (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+    (local $5 f64)
     (if
-      (get_local $i5)
+      (get_local $4)
       (return
-        (set_local $i5
-          (call_import $f64-to-int
-            (set_local $d6
-              (f64.mul
-                (f64.add
-                  (f64.convert_s/i32
-                    (get_local $i3)
-                  )
-                  (set_local $d6
-                    (f64.convert_s/i32
-                      (i32.mul
-                        (get_local $i2)
-                        (get_local $i1)
-                      )
-                    )
+        (call_import $f64-to-int
+          (f64.mul
+            (f64.add
+              (f64.convert_s/i32
+                (get_local $2)
+              )
+              (set_local $5
+                (f64.convert_s/i32
+                  (i32.mul
+                    (get_local $1)
+                    (get_local $0)
                   )
                 )
-                (f64.add
-                  (get_local $d6)
-                  (f64.convert_s/i32
-                    (get_local $i4)
-                  )
-                )
+              )
+            )
+            (f64.add
+              (get_local $5)
+              (f64.convert_s/i32
+                (get_local $3)
               )
             )
           )
         )
       )
       (return
-        (set_local $i5
-          (call_import $f64-to-int
-            (set_local $d6
-              (f64.mul
-                (f64.add
-                  (f64.convert_s/i32
-                    (get_local $i3)
+        (call_import $f64-to-int
+          (f64.mul
+            (f64.add
+              (f64.convert_s/i32
+                (get_local $2)
+              )
+              (set_local $5
+                (f64.convert_s/i32
+                  (i32.mul
+                    (get_local $3)
+                    (get_local $2)
                   )
-                  (set_local $d6
-                    (f64.convert_s/i32
-                      (i32.mul
-                        (get_local $i4)
-                        (get_local $i3)
-                      )
-                    )
-                  )
-                )
-                (f64.add
-                  (f64.convert_s/i32
-                    (get_local $i4)
-                  )
-                  (get_local $d6)
                 )
               )
+            )
+            (f64.add
+              (f64.convert_s/i32
+                (get_local $3)
+              )
+              (get_local $5)
             )
           )
         )

--- a/test/two_sides.fromasm.imprecise
+++ b/test/two_sides.fromasm.imprecise
@@ -2,64 +2,56 @@
   (memory 256 256)
   (export "memory" memory)
   (export "_test" $_test)
-  (func $_test (param $i1 i32) (param $i2 i32) (param $i3 i32) (param $i4 i32) (param $i5 i32) (result i32)
-    (local $d6 f64)
+  (func $_test (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (param $4 i32) (result i32)
+    (local $5 f64)
     (if
-      (get_local $i5)
+      (get_local $4)
       (return
-        (set_local $i5
-          (i32.trunc_s/f64
-            (set_local $d6
-              (f64.mul
-                (f64.add
-                  (f64.convert_s/i32
-                    (get_local $i3)
-                  )
-                  (set_local $d6
-                    (f64.convert_s/i32
-                      (i32.mul
-                        (get_local $i2)
-                        (get_local $i1)
-                      )
-                    )
+        (i32.trunc_s/f64
+          (f64.mul
+            (f64.add
+              (f64.convert_s/i32
+                (get_local $2)
+              )
+              (set_local $5
+                (f64.convert_s/i32
+                  (i32.mul
+                    (get_local $1)
+                    (get_local $0)
                   )
                 )
-                (f64.add
-                  (get_local $d6)
-                  (f64.convert_s/i32
-                    (get_local $i4)
-                  )
-                )
+              )
+            )
+            (f64.add
+              (get_local $5)
+              (f64.convert_s/i32
+                (get_local $3)
               )
             )
           )
         )
       )
       (return
-        (set_local $i5
-          (i32.trunc_s/f64
-            (set_local $d6
-              (f64.mul
-                (f64.add
-                  (f64.convert_s/i32
-                    (get_local $i3)
+        (i32.trunc_s/f64
+          (f64.mul
+            (f64.add
+              (f64.convert_s/i32
+                (get_local $2)
+              )
+              (set_local $5
+                (f64.convert_s/i32
+                  (i32.mul
+                    (get_local $3)
+                    (get_local $2)
                   )
-                  (set_local $d6
-                    (f64.convert_s/i32
-                      (i32.mul
-                        (get_local $i4)
-                        (get_local $i3)
-                      )
-                    )
-                  )
-                )
-                (f64.add
-                  (f64.convert_s/i32
-                    (get_local $i4)
-                  )
-                  (get_local $d6)
                 )
               )
+            )
+            (f64.add
+              (f64.convert_s/i32
+                (get_local $3)
+              )
+              (get_local $5)
             )
           )
         )

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -66,12 +66,12 @@
     )
     (f64.const 1.2)
   )
-  (func $doubleCompares (param $x f64) (param $y f64) (result f64)
-    (local $Int f64)
-    (local $Double i32)
+  (func $doubleCompares (param $0 f64) (param $1 f64) (result f64)
+    (local $2 f64)
+    (local $3 i32)
     (if
       (f64.gt
-        (get_local $x)
+        (get_local $0)
         (f64.const 0)
       )
       (return
@@ -80,7 +80,7 @@
     )
     (if
       (f64.gt
-        (get_local $Int)
+        (get_local $2)
         (f64.const 0)
       )
       (return
@@ -89,7 +89,7 @@
     )
     (if
       (i32.gt_s
-        (get_local $Double)
+        (get_local $3)
         (i32.const 0)
       )
       (return
@@ -98,19 +98,19 @@
     )
     (if
       (f64.lt
-        (get_local $x)
-        (get_local $y)
+        (get_local $0)
+        (get_local $1)
       )
       (return
-        (get_local $x)
+        (get_local $0)
       )
     )
-    (get_local $y)
+    (get_local $1)
   )
   (func $intOps (result i32)
-    (local $x i32)
+    (local $0 i32)
     (i32.eqz
-      (get_local $x)
+      (get_local $0)
     )
   )
   (func $hexLiterals
@@ -123,29 +123,23 @@
     )
   )
   (func $conversions
-    (local $i i32)
-    (local $d f64)
-    (local $f f32)
-    (set_local $i
-      (call_import $f64-to-int
-        (get_local $d)
-      )
+    (local $0 i32)
+    (local $1 f64)
+    (local $2 f32)
+    (call_import $f64-to-int
+      (get_local $1)
     )
-    (set_local $d
-      (f64.convert_s/i32
-        (set_local $i
-          (call_import $f64-to-int
-            (f64.promote/f32
-              (get_local $f)
-            )
+    (f64.convert_s/i32
+      (set_local $0
+        (call_import $f64-to-int
+          (f64.promote/f32
+            (get_local $2)
           )
         )
       )
     )
-    (set_local $d
-      (f64.convert_u/i32
-        (get_local $i)
-      )
+    (f64.convert_u/i32
+      (get_local $0)
     )
   )
   (func $seq
@@ -160,13 +154,13 @@
       )
     )
   )
-  (func $switcher (param $x i32) (result i32)
+  (func $switcher (param $0 i32) (result i32)
     (block $switch-default$3
       (block $switch-case$2
         (block $switch-case$1
           (br_table $switch-case$1 $switch-case$2 $switch-default$3
             (i32.sub
-              (get_local $x)
+              (get_local $0)
               (i32.const 1)
             )
           )
@@ -184,7 +178,7 @@
         (block $switch-case$5
           (br_table $switch-case$6 $switch-default$7 $switch-default$7 $switch-default$7 $switch-default$7 $switch-default$7 $switch-default$7 $switch-case$5 $switch-default$7
             (i32.sub
-              (get_local $x)
+              (get_local $0)
               (i32.const 5)
             )
           )
@@ -205,7 +199,7 @@
               (block $switch-case$8
                 (br_table $switch-case$15 $switch-default$16 $switch-default$16 $switch-case$12 $switch-default$16 $switch-default$16 $switch-default$16 $switch-default$16 $switch-case$9 $switch-default$16 $switch-case$8 $switch-default$16
                   (i32.sub
-                    (get_local $x)
+                    (get_local $0)
                     (i32.const 2)
                   )
                 )
@@ -234,7 +228,7 @@
                   (block $switch-case$18
                     (br_table $switch-case$18 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$20 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$19 $switch-default$21
                       (i32.sub
-                        (get_local $x)
+                        (get_local $0)
                         (i32.const -1)
                       )
                     )
@@ -276,13 +270,12 @@
       (i32.const -1)
     )
   )
-  (func $fr (param $x f32)
-    (local $y f32)
-    (local $z f64)
+  (func $fr (param $0 f32)
+    (local $1 f64)
     (f32.demote/f64
-      (get_local $z)
+      (get_local $1)
     )
-    (get_local $y)
+    (get_local $0)
     (f32.const 5)
     (f32.const 0)
     (f32.const 5)
@@ -292,17 +285,17 @@
     (f64.const -0)
   )
   (func $abs
-    (local $asm2wasm_i32_temp i32)
+    (local $0 i32)
     (select
       (i32.sub
         (i32.const 0)
-        (set_local $asm2wasm_i32_temp
+        (set_local $0
           (i32.const 0)
         )
       )
-      (get_local $asm2wasm_i32_temp)
+      (get_local $0)
       (i32.lt_s
-        (get_local $asm2wasm_i32_temp)
+        (get_local $0)
         (i32.const 0)
       )
     )
@@ -314,7 +307,7 @@
     )
   )
   (func $neg
-    (local $x f32)
+    (local $0 f32)
     (call_indirect $FUNCSIG$vf
       (i32.add
         (i32.and
@@ -323,14 +316,12 @@
         )
         (i32.const 8)
       )
-      (set_local $x
-        (f32.neg
-          (get_local $x)
-        )
+      (f32.neg
+        (get_local $0)
       )
     )
   )
-  (func $cneg (param $x f32)
+  (func $cneg (param $0 f32)
     (call_indirect $FUNCSIG$vf
       (i32.add
         (i32.and
@@ -339,44 +330,44 @@
         )
         (i32.const 8)
       )
-      (get_local $x)
+      (get_local $0)
     )
   )
   (func $___syscall_ret
-    (local $$0 i32)
+    (local $0 i32)
     (i32.gt_u
-      (get_local $$0)
+      (get_local $0)
       (i32.const -4096)
     )
   )
   (func $smallCompare (result i32)
-    (local $i i32)
-    (local $j i32)
+    (local $0 i32)
+    (local $1 i32)
     (if
       (i32.lt_s
-        (get_local $i)
-        (get_local $j)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $i
+      (set_local $0
         (i32.add
-          (get_local $i)
+          (get_local $0)
           (i32.const 1)
         )
       )
     )
     (if
       (i32.lt_u
-        (get_local $i)
-        (get_local $j)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $i
+      (set_local $0
         (i32.add
-          (get_local $i)
+          (get_local $0)
           (i32.const 1)
         )
       )
     )
-    (get_local $i)
+    (get_local $0)
   )
   (func $cneg_nosemicolon
     (call_indirect $FUNCSIG$vi
@@ -391,40 +382,40 @@
     )
   )
   (func $forLoop
-    (local $i i32)
-    (set_local $i
+    (local $0 i32)
+    (set_local $0
       (i32.const 1)
     )
     (loop $for-out$0 $for-in$1
       (br_if $for-out$0
         (i32.ge_s
-          (get_local $i)
+          (get_local $0)
           (i32.const 200)
         )
       )
       (call_import $h
-        (get_local $i)
+        (get_local $0)
       )
-      (set_local $i
+      (set_local $0
         (i32.add
-          (get_local $i)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $for-in$1)
     )
   )
-  (func $ceiling_32_64 (param $u f32) (param $B f64)
+  (func $ceiling_32_64 (param $0 f32) (param $1 f64)
     (f32.demote/f64
       (f64.ceil
-        (get_local $B)
+        (get_local $1)
       )
     )
     (f32.mul
-      (get_local $u)
+      (get_local $0)
       (f32.ceil
         (f32.demote/f64
-          (get_local $B)
+          (get_local $1)
         )
       )
     )
@@ -459,22 +450,22 @@
       (br $while-in$1)
     )
   )
-  (func $bitcasts (param $i i32) (param $f f32)
-    (local $d f64)
+  (func $bitcasts (param $0 i32) (param $1 f32)
+    (local $2 f64)
     (f32.reinterpret/i32
-      (get_local $i)
+      (get_local $0)
     )
     (f64.promote/f32
       (f32.reinterpret/i32
-        (get_local $i)
+        (get_local $0)
       )
     )
     (i32.reinterpret/f32
-      (get_local $f)
+      (get_local $1)
     )
     (i32.reinterpret/f32
       (f32.demote/f64
-        (get_local $d)
+        (get_local $2)
       )
     )
   )

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -64,12 +64,12 @@
     )
     (f64.const 1.2)
   )
-  (func $doubleCompares (param $x f64) (param $y f64) (result f64)
-    (local $Int f64)
-    (local $Double i32)
+  (func $doubleCompares (param $0 f64) (param $1 f64) (result f64)
+    (local $2 f64)
+    (local $3 i32)
     (if
       (f64.gt
-        (get_local $x)
+        (get_local $0)
         (f64.const 0)
       )
       (return
@@ -78,7 +78,7 @@
     )
     (if
       (f64.gt
-        (get_local $Int)
+        (get_local $2)
         (f64.const 0)
       )
       (return
@@ -87,7 +87,7 @@
     )
     (if
       (i32.gt_s
-        (get_local $Double)
+        (get_local $3)
         (i32.const 0)
       )
       (return
@@ -96,19 +96,19 @@
     )
     (if
       (f64.lt
-        (get_local $x)
-        (get_local $y)
+        (get_local $0)
+        (get_local $1)
       )
       (return
-        (get_local $x)
+        (get_local $0)
       )
     )
-    (get_local $y)
+    (get_local $1)
   )
   (func $intOps (result i32)
-    (local $x i32)
+    (local $0 i32)
     (i32.eqz
-      (get_local $x)
+      (get_local $0)
     )
   )
   (func $hexLiterals
@@ -121,25 +121,21 @@
     )
   )
   (func $conversions
-    (local $d f64)
-    (local $i i32)
-    (local $f f32)
+    (local $0 i32)
+    (local $1 f64)
+    (local $2 f32)
     (i32.trunc_s/f64
-      (get_local $d)
+      (get_local $1)
     )
-    (set_local $d
-      (f64.convert_s/i32
-        (set_local $i
-          (i32.trunc_s/f32
-            (get_local $f)
-          )
+    (f64.convert_s/i32
+      (set_local $0
+        (i32.trunc_s/f32
+          (get_local $2)
         )
       )
     )
-    (set_local $d
-      (f64.convert_u/i32
-        (get_local $i)
-      )
+    (f64.convert_u/i32
+      (get_local $0)
     )
   )
   (func $seq
@@ -154,13 +150,13 @@
       )
     )
   )
-  (func $switcher (param $x i32) (result i32)
+  (func $switcher (param $0 i32) (result i32)
     (block $switch-default$3
       (block $switch-case$2
         (block $switch-case$1
           (br_table $switch-case$1 $switch-case$2 $switch-default$3
             (i32.sub
-              (get_local $x)
+              (get_local $0)
               (i32.const 1)
             )
           )
@@ -178,7 +174,7 @@
         (block $switch-case$5
           (br_table $switch-case$6 $switch-default$7 $switch-default$7 $switch-default$7 $switch-default$7 $switch-default$7 $switch-default$7 $switch-case$5 $switch-default$7
             (i32.sub
-              (get_local $x)
+              (get_local $0)
               (i32.const 5)
             )
           )
@@ -199,7 +195,7 @@
               (block $switch-case$8
                 (br_table $switch-case$15 $switch-default$16 $switch-default$16 $switch-case$12 $switch-default$16 $switch-default$16 $switch-default$16 $switch-default$16 $switch-case$9 $switch-default$16 $switch-case$8 $switch-default$16
                   (i32.sub
-                    (get_local $x)
+                    (get_local $0)
                     (i32.const 2)
                   )
                 )
@@ -228,7 +224,7 @@
                   (block $switch-case$18
                     (br_table $switch-case$18 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$20 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-default$21 $switch-case$19 $switch-default$21
                       (i32.sub
-                        (get_local $x)
+                        (get_local $0)
                         (i32.const -1)
                       )
                     )
@@ -270,13 +266,12 @@
       (i32.const -1)
     )
   )
-  (func $fr (param $x f32)
-    (local $y f32)
-    (local $z f64)
+  (func $fr (param $0 f32)
+    (local $1 f64)
     (f32.demote/f64
-      (get_local $z)
+      (get_local $1)
     )
-    (get_local $y)
+    (get_local $0)
     (f32.const 5)
     (f32.const 0)
     (f32.const 5)
@@ -286,17 +281,17 @@
     (f64.const -0)
   )
   (func $abs
-    (local $asm2wasm_i32_temp i32)
+    (local $0 i32)
     (select
       (i32.sub
         (i32.const 0)
-        (set_local $asm2wasm_i32_temp
+        (set_local $0
           (i32.const 0)
         )
       )
-      (get_local $asm2wasm_i32_temp)
+      (get_local $0)
       (i32.lt_s
-        (get_local $asm2wasm_i32_temp)
+        (get_local $0)
         (i32.const 0)
       )
     )
@@ -308,7 +303,7 @@
     )
   )
   (func $neg
-    (local $x f32)
+    (local $0 f32)
     (call_indirect $FUNCSIG$vf
       (i32.add
         (i32.and
@@ -317,14 +312,12 @@
         )
         (i32.const 8)
       )
-      (set_local $x
-        (f32.neg
-          (get_local $x)
-        )
+      (f32.neg
+        (get_local $0)
       )
     )
   )
-  (func $cneg (param $x f32)
+  (func $cneg (param $0 f32)
     (call_indirect $FUNCSIG$vf
       (i32.add
         (i32.and
@@ -333,44 +326,44 @@
         )
         (i32.const 8)
       )
-      (get_local $x)
+      (get_local $0)
     )
   )
   (func $___syscall_ret
-    (local $$0 i32)
+    (local $0 i32)
     (i32.gt_u
-      (get_local $$0)
+      (get_local $0)
       (i32.const -4096)
     )
   )
   (func $smallCompare (result i32)
-    (local $i i32)
-    (local $j i32)
+    (local $0 i32)
+    (local $1 i32)
     (if
       (i32.lt_s
-        (get_local $i)
-        (get_local $j)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $i
+      (set_local $0
         (i32.add
-          (get_local $i)
+          (get_local $0)
           (i32.const 1)
         )
       )
     )
     (if
       (i32.lt_u
-        (get_local $i)
-        (get_local $j)
+        (get_local $0)
+        (get_local $1)
       )
-      (set_local $i
+      (set_local $0
         (i32.add
-          (get_local $i)
+          (get_local $0)
           (i32.const 1)
         )
       )
     )
-    (get_local $i)
+    (get_local $0)
   )
   (func $cneg_nosemicolon
     (call_indirect $FUNCSIG$vi
@@ -385,40 +378,40 @@
     )
   )
   (func $forLoop
-    (local $i i32)
-    (set_local $i
+    (local $0 i32)
+    (set_local $0
       (i32.const 1)
     )
     (loop $for-out$0 $for-in$1
       (br_if $for-out$0
         (i32.ge_s
-          (get_local $i)
+          (get_local $0)
           (i32.const 200)
         )
       )
       (call_import $h
-        (get_local $i)
+        (get_local $0)
       )
-      (set_local $i
+      (set_local $0
         (i32.add
-          (get_local $i)
+          (get_local $0)
           (i32.const 1)
         )
       )
       (br $for-in$1)
     )
   )
-  (func $ceiling_32_64 (param $u f32) (param $B f64)
+  (func $ceiling_32_64 (param $0 f32) (param $1 f64)
     (f32.demote/f64
       (f64.ceil
-        (get_local $B)
+        (get_local $1)
       )
     )
     (f32.mul
-      (get_local $u)
+      (get_local $0)
       (f32.ceil
         (f32.demote/f64
-          (get_local $B)
+          (get_local $1)
         )
       )
     )
@@ -453,22 +446,22 @@
       (br $while-in$1)
     )
   )
-  (func $bitcasts (param $i i32) (param $f f32)
-    (local $d f64)
+  (func $bitcasts (param $0 i32) (param $1 f32)
+    (local $2 f64)
     (f32.reinterpret/i32
-      (get_local $i)
+      (get_local $0)
     )
     (f64.promote/f32
       (f32.reinterpret/i32
-        (get_local $i)
+        (get_local $0)
       )
     )
     (i32.reinterpret/f32
-      (get_local $f)
+      (get_local $1)
     )
     (i32.reinterpret/f32
       (f32.demote/f64
-        (get_local $d)
+        (get_local $2)
       )
     )
   )


### PR DESCRIPTION
This generates a CFG from the AST, finds live ranges, and does local coloring.

Currently it does simple greedy coloring, which obviously should be improved on. However it currently removes 2% of local definitions on BananaBread from asm2wasm and 1% from wasm-backend, so it's already useful. Further work can also focus on stuff like the distribution of locals (gzip would do better on 99 accesses of 0 and 1 of 1, as opposed to 50 of each, even though the total number of locals is the same, etc.).

This is the slowest optimization pass we have so far. I didn't do much tuning yet. Currently it uses sorted vectors for the sets of live locals, which is good for functions with many locals but short average lists. Suggestions are very welcome.