### PR TITLE
Vacuum improvements

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -63,9 +63,9 @@ void PassRunner::addDefaultOptimizationPasses() {
   add("optimize-instructions");
   add("simplify-locals");
   add("coalesce-locals");
-  add("merge-blocks");
   add("reorder-locals");
   add("vacuum");
+  add("merge-blocks");
   add("optimize-instructions");
 }
 

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -889,11 +889,8 @@
                                 )
                               )
                             )
-                            (block
-                              (get_local $9)
-                              (set_local $8
-                                (get_local $10)
-                              )
+                            (set_local $8
+                              (get_local $10)
                             )
                             (block
                               (set_local $18
@@ -944,11 +941,7 @@
                                 (get_local $15)
                               )
                             )
-                            (block
-                              (get_local $9)
-                              (get_local $8)
-                              (br $while-out$10)
-                            )
+                            (br $while-out$10)
                           )
                           (br $while-in$11)
                         )
@@ -1585,11 +1578,8 @@
                               )
                             )
                           )
-                          (block
-                            (set_local $5
-                              (get_local $8)
-                            )
-                            (get_local $6)
+                          (set_local $5
+                            (get_local $8)
                           )
                         )
                         (set_local $18
@@ -1669,7 +1659,6 @@
                                 )
                               )
                             )
-                            (get_local $6)
                           )
                         )
                         (br $while-in$18)
@@ -2035,11 +2024,8 @@
                                   )
                                 )
                               )
-                              (block
-                                (set_local $1
-                                  (get_local $9)
-                                )
-                                (get_local $5)
+                              (set_local $1
+                                (get_local $9)
                               )
                               (block
                                 (set_local $11
@@ -2094,7 +2080,6 @@
                                 (set_local $0
                                   (get_local $1)
                                 )
-                                (get_local $5)
                                 (br $while-out$23)
                               )
                             )
@@ -4173,11 +4158,7 @@
                                                         (get_local $2)
                                                       )
                                                     )
-                                                    (block
-                                                      (get_local $0)
-                                                      (get_local $4)
-                                                      (br $while-out$55)
-                                                    )
+                                                    (br $while-out$55)
                                                   )
                                                   (br $while-in$56)
                                                 )
@@ -6349,14 +6330,12 @@
                     )
                   )
                   (if
-                    (set_local $1
-                      (i32.load
-                        (get_local $6)
+                    (i32.eqz
+                      (set_local $1
+                        (i32.load
+                          (get_local $6)
+                        )
                       )
-                    )
-                    (block
-                      (get_local $1)
-                      (get_local $6)
                     )
                     (block
                       (set_local $4
@@ -6908,11 +6887,8 @@
                             (get_local $6)
                           )
                         )
-                        (block
-                          (get_local $0)
-                          (set_local $12
-                            (get_local $6)
-                          )
+                        (set_local $12
+                          (get_local $6)
                         )
                         (block
                           (set_local $13
@@ -6964,7 +6940,6 @@
                           )
                         )
                         (block
-                          (get_local $0)
                           (set_local $1
                             (get_local $12)
                           )
@@ -8076,7 +8051,6 @@
                   (get_local $4)
                 )
               )
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8086,7 +8060,6 @@
               (get_local $6)
             )
             (block
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8635,7 +8608,6 @@
           (i32.const 3)
         )
         (block
-          (get_local $0)
           (set_local $4
             (get_local $3)
           )

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -889,11 +889,8 @@
                                 )
                               )
                             )
-                            (block
-                              (get_local $9)
-                              (set_local $8
-                                (get_local $10)
-                              )
+                            (set_local $8
+                              (get_local $10)
                             )
                             (block
                               (set_local $18
@@ -944,11 +941,7 @@
                                 (get_local $15)
                               )
                             )
-                            (block
-                              (get_local $9)
-                              (get_local $8)
-                              (br $while-out$10)
-                            )
+                            (br $while-out$10)
                           )
                           (br $while-in$11)
                         )
@@ -1585,11 +1578,8 @@
                               )
                             )
                           )
-                          (block
-                            (set_local $5
-                              (get_local $8)
-                            )
-                            (get_local $6)
+                          (set_local $5
+                            (get_local $8)
                           )
                         )
                         (set_local $18
@@ -1669,7 +1659,6 @@
                                 )
                               )
                             )
-                            (get_local $6)
                           )
                         )
                         (br $while-in$18)
@@ -2035,11 +2024,8 @@
                                   )
                                 )
                               )
-                              (block
-                                (set_local $1
-                                  (get_local $9)
-                                )
-                                (get_local $5)
+                              (set_local $1
+                                (get_local $9)
                               )
                               (block
                                 (set_local $11
@@ -2094,7 +2080,6 @@
                                 (set_local $0
                                   (get_local $1)
                                 )
-                                (get_local $5)
                                 (br $while-out$23)
                               )
                             )
@@ -4173,11 +4158,7 @@
                                                         (get_local $2)
                                                       )
                                                     )
-                                                    (block
-                                                      (get_local $0)
-                                                      (get_local $4)
-                                                      (br $while-out$55)
-                                                    )
+                                                    (br $while-out$55)
                                                   )
                                                   (br $while-in$56)
                                                 )
@@ -6349,14 +6330,12 @@
                     )
                   )
                   (if
-                    (set_local $1
-                      (i32.load
-                        (get_local $6)
+                    (i32.eqz
+                      (set_local $1
+                        (i32.load
+                          (get_local $6)
+                        )
                       )
-                    )
-                    (block
-                      (get_local $1)
-                      (get_local $6)
                     )
                     (block
                       (set_local $4
@@ -6908,11 +6887,8 @@
                             (get_local $6)
                           )
                         )
-                        (block
-                          (get_local $0)
-                          (set_local $12
-                            (get_local $6)
-                          )
+                        (set_local $12
+                          (get_local $6)
                         )
                         (block
                           (set_local $13
@@ -6964,7 +6940,6 @@
                           )
                         )
                         (block
-                          (get_local $0)
                           (set_local $1
                             (get_local $12)
                           )
@@ -8076,7 +8051,6 @@
                   (get_local $4)
                 )
               )
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8086,7 +8060,6 @@
               (get_local $6)
             )
             (block
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8635,7 +8608,6 @@
           (i32.const 3)
         )
         (block
-          (get_local $0)
           (set_local $4
             (get_local $3)
           )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -358,10 +358,7 @@
                     (i32.const -64)
                   )
                 )
-                (block
-                  (get_local $0)
-                  (i32.const 0)
-                )
+                (i32.const 0)
               )
             )
             (i32.store
@@ -867,7 +864,6 @@
             )
             (get_local $0)
             (block
-              (get_local $1)
               (set_local $2
                 (get_local $0)
               )
@@ -929,11 +925,8 @@
                     )
                     (br $while-out$2)
                   )
-                  (block
-                    (set_local $1
-                      (get_local $0)
-                    )
-                    (get_local $2)
+                  (set_local $1
+                    (get_local $0)
                   )
                 )
                 (br $while-in$3)
@@ -1341,7 +1334,6 @@
               (set_local $3
                 (get_local $5)
               )
-              (get_local $6)
               (get_local $1)
             )
           )
@@ -1366,7 +1358,6 @@
       (set_local $5
         (get_local $3)
       )
-      (get_local $6)
       (set_local $4
         (get_local $17)
       )
@@ -1859,7 +1850,6 @@
               (get_local $1)
             )
           )
-          (get_local $3)
           (if
             (get_local $4)
             (block
@@ -1911,8 +1901,6 @@
                         (set_local $2
                           (i32.const 0)
                         )
-                        (get_local $1)
-                        (get_local $0)
                         (br $label$break$L10
                           (get_local $3)
                         )
@@ -1999,8 +1987,6 @@
                   (set_local $2
                     (i32.const 0)
                   )
-                  (get_local $1)
-                  (get_local $0)
                   (get_local $3)
                 )
               )
@@ -2461,11 +2447,8 @@
                   (i32.const 0)
                 )
               )
-              (block
-                (set_local $3
-                  (get_local $0)
-                )
-                (get_local $2)
+              (set_local $3
+                (get_local $0)
               )
               (block
                 (set_local $11
@@ -2642,11 +2625,8 @@
                         )
                         (i32.const 3)
                       )
-                      (block
-                        (get_local $4)
-                        (set_local $5
-                          (get_local $1)
-                        )
+                      (set_local $5
+                        (get_local $1)
                       )
                       (block
                         (set_local $13
@@ -3260,11 +3240,8 @@
           )
           (br $label$break$L1)
         )
-        (block
-          (get_local $1)
-          (set_local $5
-            (get_local $12)
-          )
+        (set_local $5
+          (get_local $12)
         )
       )
       (loop $label$break$L9 $label$continue$L9
@@ -3317,7 +3294,6 @@
             )
           )
         )
-        (get_local $5)
         (br $label$continue$L9)
       )
       (block $label$break$L12
@@ -3440,7 +3416,6 @@
           (set_local $1
             (get_local $15)
           )
-          (get_local $8)
           (br $label$continue$L1)
         )
       )
@@ -3515,7 +3490,6 @@
             )
           )
           (block
-            (get_local $1)
             (set_local $11
               (get_local $8)
             )
@@ -3544,12 +3518,9 @@
             (i32.const 32)
           )
           (block
-            (get_local $1)
-            (get_local $5)
             (set_local $6
               (i32.const 0)
             )
-            (get_local $10)
             (loop $while-out$10 $while-in$11
               (if
                 (i32.eq
@@ -3566,11 +3537,9 @@
                   (i32.const 0)
                 )
                 (block
-                  (get_local $1)
                   (set_local $8
                     (get_local $6)
                   )
-                  (get_local $10)
                   (br $label$break$L25)
                 )
               )
@@ -3593,7 +3562,7 @@
                 )
               )
               (if
-                (i32.eq
+                (i32.ne
                   (i32.and
                     (set_local $5
                       (i32.shr_s
@@ -3618,29 +3587,17 @@
                   (i32.const 32)
                 )
                 (block
-                  (get_local $1)
-                  (get_local $5)
-                  (get_local $6)
-                  (get_local $10)
-                )
-                (block
-                  (get_local $1)
                   (set_local $8
                     (get_local $6)
                   )
-                  (get_local $10)
                   (br $while-out$10)
                 )
               )
               (br $while-in$11)
             )
           )
-          (block
-            (get_local $1)
-            (set_local $8
-              (i32.const 0)
-            )
-            (get_local $10)
+          (set_local $8
+            (i32.const 0)
           )
         )
       )
@@ -3778,7 +3735,6 @@
                     (get_local $52)
                   )
                   (block
-                    (get_local $8)
                     (set_local $10
                       (get_local $6)
                     )
@@ -3901,7 +3857,6 @@
               (set_local $5
                 (i32.const 0)
               )
-              (get_local $6)
               (loop $while-out$14 $while-in$15
                 (set_local $5
                   (i32.add
@@ -3939,7 +3894,6 @@
                     (set_local $1
                       (get_local $6)
                     )
-                    (get_local $5)
                     (set_local $6
                       (get_local $10)
                     )
@@ -3968,7 +3922,6 @@
                   (br $label$break$L1)
                 )
                 (block
-                  (get_local $8)
                   (set_local $10
                     (get_local $5)
                   )
@@ -3982,8 +3935,6 @@
               )
             )
             (block
-              (get_local $8)
-              (get_local $10)
               (set_local $20
                 (get_local $11)
               )
@@ -4054,7 +4005,6 @@
                       (set_local $5
                         (i32.const 0)
                       )
-                      (get_local $6)
                     )
                     (block
                       (set_local $9
@@ -4076,7 +4026,7 @@
                       )
                     )
                     (if
-                      (i32.lt_u
+                      (i32.ge_u
                         (set_local $6
                           (i32.add
                             (i32.shr_s
@@ -4097,11 +4047,6 @@
                           )
                         )
                         (i32.const 10)
-                      )
-                      (block
-                        (get_local $1)
-                        (get_local $5)
-                        (get_local $6)
                       )
                       (block
                         (set_local $9
@@ -4346,7 +4291,6 @@
             )
           )
           (block
-            (get_local $1)
             (set_local $6
               (get_local $5)
             )
@@ -4868,8 +4812,6 @@
                                                   (get_local $28)
                                                 )
                                                 (block
-                                                  (get_local $5)
-                                                  (get_local $1)
                                                   (set_local $7
                                                     (get_local $28)
                                                   )
@@ -5344,14 +5286,12 @@
                           )
                         )
                       )
-                      (get_local $14)
                       (get_local $1)
                     )
                     (block
                       (set_local $39
                         (i32.const 4111)
                       )
-                      (get_local $14)
                       (i32.const 1)
                     )
                   )
@@ -5476,7 +5416,6 @@
                               )
                               (get_local $14)
                               (block
-                                (get_local $1)
                                 (set_local $22
                                   (f64.const 8)
                                 )
@@ -5497,14 +5436,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (block
-                                      (get_local $22)
-                                      (br $while-out$60)
-                                    )
-                                    (block
-                                      (get_local $1)
-                                      (get_local $22)
-                                    )
+                                    (br $while-out$60)
                                   )
                                   (br $while-in$61)
                                 )
@@ -5647,7 +5579,6 @@
                           (set_local $11
                             (get_local $29)
                           )
-                          (get_local $14)
                           (loop $while-out$62 $while-in$63
                             (i32.store8
                               (get_local $11)
@@ -5731,16 +5662,10 @@
                                 (get_local $14)
                                 (f64.const 0)
                               )
-                              (block
-                                (set_local $11
-                                  (get_local $1)
-                                )
-                                (get_local $14)
-                              )
-                              (block
+                              (set_local $11
                                 (get_local $1)
-                                (br $while-out$62)
                               )
+                              (br $while-out$62)
                             )
                             (br $while-in$63)
                           )
@@ -5926,11 +5851,8 @@
                             )
                             (get_local $5)
                           )
-                          (block
-                            (get_local $14)
-                            (i32.load
-                              (get_local $25)
-                            )
+                          (i32.load
+                            (get_local $25)
                           )
                         )
                       )
@@ -5946,7 +5868,6 @@
                           )
                         )
                       )
-                      (get_local $14)
                       (set_local $7
                         (get_local $10)
                       )
@@ -5966,7 +5887,7 @@
                           )
                         )
                         (if
-                          (f64.ne
+                          (f64.eq
                             (set_local $14
                               (f64.mul
                                 (f64.sub
@@ -5979,10 +5900,6 @@
                               )
                             )
                             (f64.const 0)
-                          )
-                          (block
-                            (get_local $14)
-                            (get_local $7)
                           )
                           (block
                             (set_local $6
@@ -6003,7 +5920,6 @@
                           (i32.const 0)
                         )
                         (block
-                          (get_local $5)
                           (set_local $8
                             (get_local $10)
                           )
@@ -6097,15 +6013,9 @@
                                           )
                                           (get_local $8)
                                         )
-                                        (block
-                                          (get_local $5)
-                                          (br $while-out$72)
-                                        )
-                                        (block
-                                          (get_local $5)
-                                          (set_local $12
-                                            (get_local $7)
-                                          )
+                                        (br $while-out$72)
+                                        (set_local $12
+                                          (get_local $7)
                                         )
                                       )
                                       (br $while-in$73)
@@ -6142,10 +6052,7 @@
                                   (get_local $6)
                                   (get_local $7)
                                 )
-                                (block
-                                  (get_local $6)
-                                  (br $while-out$74)
-                                )
+                                (br $while-out$74)
                               )
                               (if
                                 (i32.eq
@@ -6162,10 +6069,7 @@
                                 (set_local $6
                                   (get_local $5)
                                 )
-                                (block
-                                  (get_local $6)
-                                  (br $while-out$74)
-                                )
+                                (br $while-out$74)
                               )
                               (br $while-in$75)
                             )
@@ -6186,7 +6090,6 @@
                                 (i32.const 0)
                               )
                               (block
-                                (get_local $5)
                                 (set_local $8
                                   (get_local $7)
                                 )
@@ -6194,22 +6097,13 @@
                                   (get_local $6)
                                 )
                               )
-                              (block
-                                (get_local $5)
-                                (get_local $7)
-                                (get_local $6)
-                                (br $while-out$68)
-                              )
+                              (br $while-out$68)
                             )
                             (br $while-in$69)
                           )
                         )
-                        (block
-                          (get_local $5)
-                          (set_local $7
-                            (get_local $10)
-                          )
-                          (get_local $6)
+                        (set_local $7
+                          (get_local $10)
                         )
                       )
                       (if
@@ -6239,8 +6133,6 @@
                               (i32.const 102)
                             )
                           )
-                          (get_local $5)
-                          (get_local $7)
                           (set_local $24
                             (get_local $6)
                           )
@@ -6337,10 +6229,7 @@
                                             (get_local $5)
                                           )
                                         )
-                                        (block
-                                          (get_local $6)
-                                          (br $while-out$80)
-                                        )
+                                        (br $while-out$80)
                                       )
                                       (br $while-in$81)
                                     )
@@ -6454,7 +6343,6 @@
                                 (i32.const 0)
                               )
                               (block
-                                (get_local $5)
                                 (set_local $7
                                   (get_local $11)
                                 )
@@ -6475,11 +6363,8 @@
                             (br $while-in$77)
                           )
                         )
-                        (block
-                          (get_local $7)
-                          (set_local $27
-                            (get_local $6)
-                          )
+                        (set_local $27
+                          (get_local $6)
                         )
                       )
                       (block $do-once$82
@@ -6516,11 +6401,8 @@
                                 )
                                 (br $do-once$82)
                               )
-                              (block
-                                (get_local $6)
-                                (set_local $8
-                                  (i32.const 10)
-                                )
+                              (set_local $8
+                                (i32.const 10)
                               )
                             )
                             (loop $while-out$84 $while-in$85
@@ -6545,10 +6427,6 @@
                                     (get_local $6)
                                   )
                                   (br $while-out$84)
-                                )
-                                (block
-                                  (get_local $6)
-                                  (get_local $8)
                                 )
                               )
                               (br $while-in$85)
@@ -6658,7 +6536,6 @@
                                 (set_local $5
                                   (i32.const 10)
                                 )
-                                (get_local $11)
                                 (loop $while-out$86 $while-in$87
                                   (set_local $5
                                     (i32.mul
@@ -6681,10 +6558,6 @@
                                         (get_local $5)
                                       )
                                       (br $while-out$86)
-                                    )
-                                    (block
-                                      (get_local $5)
-                                      (get_local $11)
                                     )
                                   )
                                   (br $while-in$87)
@@ -6789,10 +6662,7 @@
                                           (get_local $50)
                                           (i32.const 0)
                                         )
-                                        (block
-                                          (get_local $22)
-                                          (get_local $14)
-                                        )
+                                        (get_local $14)
                                         (block
                                           (if
                                             (i32.ne
@@ -6807,11 +6677,8 @@
                                               )
                                               (i32.const 45)
                                             )
-                                            (block
-                                              (get_local $22)
-                                              (br $do-once$90
-                                                (get_local $14)
-                                              )
+                                            (br $do-once$90
+                                              (get_local $14)
                                             )
                                           )
                                           (set_local $22
@@ -6924,26 +6791,18 @@
                                             (get_local $7)
                                             (i32.const 999999999)
                                           )
-                                          (block
-                                            (get_local $5)
-                                            (set_local $7
-                                              (get_local $6)
-                                            )
+                                          (set_local $7
+                                            (get_local $6)
                                           )
                                           (block
                                             (set_local $7
                                               (get_local $5)
                                             )
-                                            (get_local $6)
                                             (br $while-out$92)
                                           )
                                         )
                                         (br $while-in$93)
                                       )
-                                    )
-                                    (block
-                                      (get_local $7)
-                                      (get_local $6)
                                     )
                                   )
                                   (set_local $11
@@ -6974,14 +6833,10 @@
                                       (set_local $7
                                         (get_local $6)
                                       )
-                                      (get_local $11)
                                       (br $do-once$88)
                                     )
-                                    (block
-                                      (get_local $11)
-                                      (set_local $12
-                                        (i32.const 10)
-                                      )
+                                    (set_local $12
+                                      (i32.const 10)
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
@@ -7008,12 +6863,7 @@
                                         (set_local $7
                                           (get_local $6)
                                         )
-                                        (get_local $11)
                                         (br $while-out$94)
-                                      )
-                                      (block
-                                        (get_local $11)
-                                        (get_local $12)
                                       )
                                     )
                                     (br $while-in$95)
@@ -7045,7 +6895,6 @@
                             (get_local $5)
                           )
                           (block
-                            (get_local $9)
                             (set_local $6
                               (get_local $27)
                             )
@@ -7059,7 +6908,6 @@
                           (get_local $9)
                         )
                       )
-                      (get_local $6)
                       (loop $while-out$96 $while-in$97
                         (if
                           (i32.le_u
@@ -7239,7 +7087,7 @@
                                         )
                                       )
                                       (if
-                                        (i32.eq
+                                        (i32.ne
                                           (i32.and
                                             (i32.rem_u
                                               (get_local $1)
@@ -7253,10 +7101,6 @@
                                             (i32.const -1)
                                           )
                                           (i32.const 0)
-                                        )
-                                        (block
-                                          (get_local $5)
-                                          (get_local $6)
                                         )
                                         (block
                                           (set_local $1
@@ -7462,34 +7306,28 @@
                                 )
                                 (i32.const 2)
                               )
-                              (block
-                                (get_local $5)
-                                (loop $while-out$104 $while-in$105
-                                  (i32.store8
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $5)
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.const 48)
-                                  )
-                                  (if
-                                    (i32.lt_s
-                                      (i32.sub
-                                        (get_local $44)
-                                        (get_local $5)
-                                      )
-                                      (i32.const 2)
-                                    )
-                                    (get_local $5)
-                                    (block
+                              (loop $while-out$104 $while-in$105
+                                (i32.store8
+                                  (set_local $5
+                                    (i32.add
                                       (get_local $5)
-                                      (br $while-out$104)
+                                      (i32.const -1)
                                     )
                                   )
-                                  (br $while-in$105)
+                                  (i32.const 48)
                                 )
+                                (if
+                                  (i32.lt_s
+                                    (i32.sub
+                                      (get_local $44)
+                                      (get_local $5)
+                                    )
+                                    (i32.const 2)
+                                  )
+                                  (get_local $5)
+                                  (br $while-out$104)
+                                )
+                                (br $while-in$105)
                               )
                               (get_local $5)
                             )
@@ -7619,10 +7457,7 @@
                                         (get_local $5)
                                         (get_local $48)
                                       )
-                                      (block
-                                        (get_local $5)
-                                        (br $do-once$110)
-                                      )
+                                      (br $do-once$110)
                                     )
                                     (i32.store8
                                       (get_local $57)
@@ -7639,10 +7474,7 @@
                                         (get_local $29)
                                       )
                                       (get_local $5)
-                                      (block
-                                        (get_local $5)
-                                        (br $do-once$110)
-                                      )
+                                      (br $do-once$110)
                                     )
                                     (loop $while-out$112 $while-in$113
                                       (i32.store8
@@ -7660,10 +7492,7 @@
                                           (get_local $29)
                                         )
                                         (get_local $5)
-                                        (block
-                                          (get_local $5)
-                                          (br $while-out$112)
-                                        )
+                                        (br $while-out$112)
                                       )
                                       (br $while-in$113)
                                     )
@@ -7699,10 +7528,7 @@
                                   )
                                   (get_local $10)
                                 )
-                                (block
-                                  (get_local $5)
-                                  (br $while-out$108)
-                                )
+                                (br $while-out$108)
                                 (set_local $7
                                   (get_local $5)
                                 )
@@ -7747,7 +7573,6 @@
                                 )
                               )
                               (block
-                                (get_local $5)
                                 (set_local $7
                                   (get_local $15)
                                 )
@@ -7765,31 +7590,25 @@
                                       )
                                       (get_local $29)
                                     )
-                                    (block
-                                      (get_local $1)
-                                      (loop $while-out$118 $while-in$119
-                                        (i32.store8
-                                          (set_local $1
-                                            (i32.add
-                                              (get_local $1)
-                                              (i32.const -1)
-                                            )
-                                          )
-                                          (i32.const 48)
-                                        )
-                                        (if
-                                          (i32.gt_u
+                                    (loop $while-out$118 $while-in$119
+                                      (i32.store8
+                                        (set_local $1
+                                          (i32.add
                                             (get_local $1)
-                                            (get_local $29)
-                                          )
-                                          (get_local $1)
-                                          (block
-                                            (get_local $1)
-                                            (br $while-out$118)
+                                            (i32.const -1)
                                           )
                                         )
-                                        (br $while-in$119)
+                                        (i32.const 48)
                                       )
+                                      (if
+                                        (i32.gt_u
+                                          (get_local $1)
+                                          (get_local $29)
+                                        )
+                                        (get_local $1)
+                                        (br $while-out$118)
+                                      )
+                                      (br $while-in$119)
                                     )
                                     (get_local $1)
                                   )
@@ -7962,10 +7781,7 @@
                                               (i32.const 1)
                                             )
                                           )
-                                          (block
-                                            (get_local $1)
-                                            (br $do-once$122)
-                                          )
+                                          (br $do-once$122)
                                         )
                                         (if
                                           (i32.ne
@@ -7977,17 +7793,13 @@
                                             )
                                             (i32.const 0)
                                           )
-                                          (block
-                                            (get_local $1)
-                                            (br $do-once$122)
-                                          )
+                                          (br $do-once$122)
                                         )
                                         (call $___fwritex
                                           (i32.const 4143)
                                           (i32.const 1)
                                           (get_local $0)
                                         )
-                                        (get_local $1)
                                       )
                                       (block
                                         (if
@@ -8021,10 +7833,7 @@
                                               (get_local $29)
                                             )
                                             (get_local $1)
-                                            (block
-                                              (get_local $1)
-                                              (br $while-out$124)
-                                            )
+                                            (br $while-out$124)
                                           )
                                           (br $while-in$125)
                                         )
@@ -8081,11 +7890,8 @@
                                         (i32.const -1)
                                       )
                                     )
-                                    (block
-                                      (set_local $5
-                                        (get_local $1)
-                                      )
-                                      (get_local $8)
+                                    (set_local $5
+                                      (get_local $1)
                                     )
                                     (block
                                       (set_local $1
@@ -8274,7 +8080,6 @@
               (set_local $12
                 (get_local $26)
               )
-              (get_local $1)
               (set_local $8
                 (get_local $20)
               )
@@ -8356,8 +8161,6 @@
                   (get_local $28)
                 )
                 (block
-                  (get_local $1)
-                  (get_local $5)
                   (set_local $6
                     (get_local $28)
                   )
@@ -8414,11 +8217,6 @@
                           (get_local $6)
                         )
                         (br $while-out$129)
-                      )
-                      (block
-                        (get_local $1)
-                        (get_local $5)
-                        (get_local $6)
                       )
                     )
                     (br $while-in$130)
@@ -8611,7 +8409,6 @@
                         (i32.const 0)
                       )
                       (block
-                        (get_local $7)
                         (set_local $1
                           (get_local $5)
                         )
@@ -8638,7 +8435,6 @@
                         )
                       )
                       (block
-                        (get_local $7)
                         (set_local $1
                           (get_local $5)
                         )
@@ -8661,12 +8457,8 @@
                           )
                         )
                       )
-                      (block
-                        (set_local $7
-                          (get_local $1)
-                        )
-                        (get_local $5)
-                        (get_local $6)
+                      (set_local $7
+                        (get_local $1)
                       )
                       (block
                         (set_local $7
@@ -9172,52 +8964,49 @@
                   (get_local $0)
                   (i32.const 10)
                 )
-                (block
-                  (get_local $0)
-                  (loop $while-out$138 $while-in$139
-                    (set_local $1
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 1)
-                      )
+                (loop $while-out$138 $while-in$139
+                  (set_local $1
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 1)
                     )
-                    (if
-                      (i32.ne
-                        (i32.load
-                          (i32.add
-                            (get_local $4)
-                            (i32.shl
-                              (get_local $0)
-                              (i32.const 2)
-                            )
+                  )
+                  (if
+                    (i32.ne
+                      (i32.load
+                        (i32.add
+                          (get_local $4)
+                          (i32.shl
+                            (get_local $0)
+                            (i32.const 2)
                           )
                         )
-                        (i32.const 0)
                       )
-                      (block
-                        (set_local $23
-                          (i32.const -1)
-                        )
-                        (br $label$break$L343)
-                      )
+                      (i32.const 0)
                     )
-                    (if
-                      (i32.lt_s
-                        (get_local $1)
-                        (i32.const 10)
+                    (block
+                      (set_local $23
+                        (i32.const -1)
                       )
-                      (set_local $0
-                        (get_local $1)
-                      )
-                      (block
-                        (set_local $23
-                          (i32.const 1)
-                        )
-                        (br $while-out$138)
-                      )
+                      (br $label$break$L343)
                     )
-                    (br $while-in$139)
                   )
+                  (if
+                    (i32.lt_s
+                      (get_local $1)
+                      (i32.const 10)
+                    )
+                    (set_local $0
+                      (get_local $1)
+                    )
+                    (block
+                      (set_local $23
+                        (i32.const 1)
+                      )
+                      (br $while-out$138)
+                    )
+                  )
+                  (br $while-in$139)
                 )
                 (set_local $23
                   (i32.const 1)
@@ -9903,8 +9692,6 @@
                 )
               )
               (block
-                (get_local $0)
-                (get_local $1)
                 (set_local $1
                   (get_local $2)
                 )
@@ -9981,11 +9768,8 @@
               )
               (br $while-out$2)
             )
-            (block
-              (get_local $1)
-              (set_local $2
-                (get_local $0)
-              )
+            (set_local $2
+              (get_local $0)
             )
           )
           (br $while-in$3)
@@ -10087,11 +9871,9 @@
                   (get_local $3)
                 )
               )
-              (get_local $1)
               (set_local $3
                 (get_local $5)
               )
-              (get_local $4)
               (loop $while-out$2 $while-in$3
                 (set_local $4
                   (i32.eq
@@ -10118,7 +9900,7 @@
                   )
                 )
                 (if
-                  (i32.gt_u
+                  (i32.le_u
                     (set_local $3
                       (i32.add
                         (get_local $3)
@@ -10126,11 +9908,6 @@
                       )
                     )
                     (i32.const 255)
-                  )
-                  (block
-                    (get_local $1)
-                    (get_local $3)
-                    (get_local $4)
                   )
                   (br $while-out$2)
                 )
@@ -11049,18 +10826,12 @@
                               )
                               (br $do-once$8)
                             )
-                            (block
-                              (set_local $4
-                                (get_local $2)
-                              )
-                              (get_local $7)
-                            )
-                          )
-                          (block
                             (set_local $4
                               (get_local $2)
                             )
-                            (get_local $7)
+                          )
+                          (set_local $4
+                            (get_local $2)
                           )
                         )
                         (loop $while-out$10 $while-in$11
@@ -11801,18 +11572,12 @@
                               )
                               (br $label$break$L123)
                             )
-                            (block
-                              (get_local $13)
-                              (set_local $29
-                                (get_local $23)
-                              )
+                            (set_local $29
+                              (get_local $23)
                             )
                           )
-                          (block
-                            (set_local $13
-                              (get_local $6)
-                            )
-                            (get_local $29)
+                          (set_local $13
+                            (get_local $6)
                           )
                         )
                         (set_local $6
@@ -11892,12 +11657,9 @@
                             (set_local $6
                               (get_local $13)
                             )
-                            (get_local $14)
-                            (get_local $10)
                             (set_local $23
                               (get_local $3)
                             )
-                            (get_local $29)
                           )
                         )
                         (br $while-in$18)
@@ -12270,18 +12032,12 @@
                                   )
                                   (br $do-once$21)
                                 )
-                                (block
-                                  (set_local $7
-                                    (get_local $2)
-                                  )
-                                  (get_local $8)
-                                )
-                              )
-                              (block
                                 (set_local $7
                                   (get_local $2)
                                 )
-                                (get_local $8)
+                              )
+                              (set_local $7
+                                (get_local $2)
                               )
                             )
                             (loop $while-out$23 $while-in$24
@@ -14739,11 +14495,8 @@
                                                           )
                                                         )
                                                       )
-                                                      (block
-                                                        (set_local $2
-                                                          (get_local $1)
-                                                        )
-                                                        (get_local $8)
+                                                      (set_local $2
+                                                        (get_local $1)
                                                       )
                                                     )
                                                     (loop $while-out$61 $while-in$62
@@ -16757,11 +16510,8 @@
                       )
                     )
                   )
-                  (block
-                    (set_local $2
-                      (get_local $0)
-                    )
-                    (get_local $7)
+                  (set_local $2
+                    (get_local $0)
                   )
                 )
                 (loop $while-out$4 $while-in$5
@@ -17442,11 +17192,8 @@
                           )
                         )
                       )
-                      (block
-                        (set_local $2
-                          (get_local $1)
-                        )
-                        (get_local $6)
+                      (set_local $2
+                        (get_local $1)
                       )
                     )
                     (loop $while-out$12 $while-in$13
@@ -20244,9 +19991,6 @@
                 (set_local $11
                   (get_local $0)
                 )
-                (get_local $5)
-                (get_local $6)
-                (get_local $9)
                 (set_local $0
                   (get_local $12)
                 )
@@ -20273,7 +20017,6 @@
         )
       )
     )
-    (get_local $7)
     (set_local $6
       (i32.or
         (get_local $9)

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -356,10 +356,7 @@
                     (i32.const -64)
                   )
                 )
-                (block
-                  (get_local $0)
-                  (i32.const 0)
-                )
+                (i32.const 0)
               )
             )
             (i32.store
@@ -865,7 +862,6 @@
             )
             (get_local $0)
             (block
-              (get_local $1)
               (set_local $2
                 (get_local $0)
               )
@@ -927,11 +923,8 @@
                     )
                     (br $while-out$2)
                   )
-                  (block
-                    (set_local $1
-                      (get_local $0)
-                    )
-                    (get_local $2)
+                  (set_local $1
+                    (get_local $0)
                   )
                 )
                 (br $while-in$3)
@@ -1339,7 +1332,6 @@
               (set_local $3
                 (get_local $5)
               )
-              (get_local $6)
               (get_local $1)
             )
           )
@@ -1364,7 +1356,6 @@
       (set_local $5
         (get_local $3)
       )
-      (get_local $6)
       (set_local $4
         (get_local $17)
       )
@@ -1857,7 +1848,6 @@
               (get_local $1)
             )
           )
-          (get_local $3)
           (if
             (get_local $4)
             (block
@@ -1909,8 +1899,6 @@
                         (set_local $2
                           (i32.const 0)
                         )
-                        (get_local $1)
-                        (get_local $0)
                         (br $label$break$L10
                           (get_local $3)
                         )
@@ -1997,8 +1985,6 @@
                   (set_local $2
                     (i32.const 0)
                   )
-                  (get_local $1)
-                  (get_local $0)
                   (get_local $3)
                 )
               )
@@ -2459,11 +2445,8 @@
                   (i32.const 0)
                 )
               )
-              (block
-                (set_local $3
-                  (get_local $0)
-                )
-                (get_local $2)
+              (set_local $3
+                (get_local $0)
               )
               (block
                 (set_local $11
@@ -2640,11 +2623,8 @@
                         )
                         (i32.const 3)
                       )
-                      (block
-                        (get_local $4)
-                        (set_local $5
-                          (get_local $1)
-                        )
+                      (set_local $5
+                        (get_local $1)
                       )
                       (block
                         (set_local $13
@@ -3258,11 +3238,8 @@
           )
           (br $label$break$L1)
         )
-        (block
-          (get_local $1)
-          (set_local $5
-            (get_local $12)
-          )
+        (set_local $5
+          (get_local $12)
         )
       )
       (loop $label$break$L9 $label$continue$L9
@@ -3315,7 +3292,6 @@
             )
           )
         )
-        (get_local $5)
         (br $label$continue$L9)
       )
       (block $label$break$L12
@@ -3438,7 +3414,6 @@
           (set_local $1
             (get_local $15)
           )
-          (get_local $8)
           (br $label$continue$L1)
         )
       )
@@ -3513,7 +3488,6 @@
             )
           )
           (block
-            (get_local $1)
             (set_local $11
               (get_local $8)
             )
@@ -3542,12 +3516,9 @@
             (i32.const 32)
           )
           (block
-            (get_local $1)
-            (get_local $5)
             (set_local $6
               (i32.const 0)
             )
-            (get_local $10)
             (loop $while-out$10 $while-in$11
               (if
                 (i32.eq
@@ -3564,11 +3535,9 @@
                   (i32.const 0)
                 )
                 (block
-                  (get_local $1)
                   (set_local $8
                     (get_local $6)
                   )
-                  (get_local $10)
                   (br $label$break$L25)
                 )
               )
@@ -3591,7 +3560,7 @@
                 )
               )
               (if
-                (i32.eq
+                (i32.ne
                   (i32.and
                     (set_local $5
                       (i32.shr_s
@@ -3616,29 +3585,17 @@
                   (i32.const 32)
                 )
                 (block
-                  (get_local $1)
-                  (get_local $5)
-                  (get_local $6)
-                  (get_local $10)
-                )
-                (block
-                  (get_local $1)
                   (set_local $8
                     (get_local $6)
                   )
-                  (get_local $10)
                   (br $while-out$10)
                 )
               )
               (br $while-in$11)
             )
           )
-          (block
-            (get_local $1)
-            (set_local $8
-              (i32.const 0)
-            )
-            (get_local $10)
+          (set_local $8
+            (i32.const 0)
           )
         )
       )
@@ -3776,7 +3733,6 @@
                     (get_local $52)
                   )
                   (block
-                    (get_local $8)
                     (set_local $10
                       (get_local $6)
                     )
@@ -3899,7 +3855,6 @@
               (set_local $5
                 (i32.const 0)
               )
-              (get_local $6)
               (loop $while-out$14 $while-in$15
                 (set_local $5
                   (i32.add
@@ -3937,7 +3892,6 @@
                     (set_local $1
                       (get_local $6)
                     )
-                    (get_local $5)
                     (set_local $6
                       (get_local $10)
                     )
@@ -3966,7 +3920,6 @@
                   (br $label$break$L1)
                 )
                 (block
-                  (get_local $8)
                   (set_local $10
                     (get_local $5)
                   )
@@ -3980,8 +3933,6 @@
               )
             )
             (block
-              (get_local $8)
-              (get_local $10)
               (set_local $20
                 (get_local $11)
               )
@@ -4052,7 +4003,6 @@
                       (set_local $5
                         (i32.const 0)
                       )
-                      (get_local $6)
                     )
                     (block
                       (set_local $9
@@ -4074,7 +4024,7 @@
                       )
                     )
                     (if
-                      (i32.lt_u
+                      (i32.ge_u
                         (set_local $6
                           (i32.add
                             (i32.shr_s
@@ -4095,11 +4045,6 @@
                           )
                         )
                         (i32.const 10)
-                      )
-                      (block
-                        (get_local $1)
-                        (get_local $5)
-                        (get_local $6)
                       )
                       (block
                         (set_local $9
@@ -4344,7 +4289,6 @@
             )
           )
           (block
-            (get_local $1)
             (set_local $6
               (get_local $5)
             )
@@ -4866,8 +4810,6 @@
                                                   (get_local $28)
                                                 )
                                                 (block
-                                                  (get_local $5)
-                                                  (get_local $1)
                                                   (set_local $7
                                                     (get_local $28)
                                                   )
@@ -5342,14 +5284,12 @@
                           )
                         )
                       )
-                      (get_local $14)
                       (get_local $1)
                     )
                     (block
                       (set_local $39
                         (i32.const 4111)
                       )
-                      (get_local $14)
                       (i32.const 1)
                     )
                   )
@@ -5474,7 +5414,6 @@
                               )
                               (get_local $14)
                               (block
-                                (get_local $1)
                                 (set_local $22
                                   (f64.const 8)
                                 )
@@ -5495,14 +5434,7 @@
                                       )
                                       (i32.const 0)
                                     )
-                                    (block
-                                      (get_local $22)
-                                      (br $while-out$60)
-                                    )
-                                    (block
-                                      (get_local $1)
-                                      (get_local $22)
-                                    )
+                                    (br $while-out$60)
                                   )
                                   (br $while-in$61)
                                 )
@@ -5645,7 +5577,6 @@
                           (set_local $11
                             (get_local $29)
                           )
-                          (get_local $14)
                           (loop $while-out$62 $while-in$63
                             (i32.store8
                               (get_local $11)
@@ -5729,16 +5660,10 @@
                                 (get_local $14)
                                 (f64.const 0)
                               )
-                              (block
-                                (set_local $11
-                                  (get_local $1)
-                                )
-                                (get_local $14)
-                              )
-                              (block
+                              (set_local $11
                                 (get_local $1)
-                                (br $while-out$62)
                               )
+                              (br $while-out$62)
                             )
                             (br $while-in$63)
                           )
@@ -5924,11 +5849,8 @@
                             )
                             (get_local $5)
                           )
-                          (block
-                            (get_local $14)
-                            (i32.load
-                              (get_local $25)
-                            )
+                          (i32.load
+                            (get_local $25)
                           )
                         )
                       )
@@ -5944,7 +5866,6 @@
                           )
                         )
                       )
-                      (get_local $14)
                       (set_local $7
                         (get_local $10)
                       )
@@ -5964,7 +5885,7 @@
                           )
                         )
                         (if
-                          (f64.ne
+                          (f64.eq
                             (set_local $14
                               (f64.mul
                                 (f64.sub
@@ -5977,10 +5898,6 @@
                               )
                             )
                             (f64.const 0)
-                          )
-                          (block
-                            (get_local $14)
-                            (get_local $7)
                           )
                           (block
                             (set_local $6
@@ -6001,7 +5918,6 @@
                           (i32.const 0)
                         )
                         (block
-                          (get_local $5)
                           (set_local $8
                             (get_local $10)
                           )
@@ -6095,15 +6011,9 @@
                                           )
                                           (get_local $8)
                                         )
-                                        (block
-                                          (get_local $5)
-                                          (br $while-out$72)
-                                        )
-                                        (block
-                                          (get_local $5)
-                                          (set_local $12
-                                            (get_local $7)
-                                          )
+                                        (br $while-out$72)
+                                        (set_local $12
+                                          (get_local $7)
                                         )
                                       )
                                       (br $while-in$73)
@@ -6140,10 +6050,7 @@
                                   (get_local $6)
                                   (get_local $7)
                                 )
-                                (block
-                                  (get_local $6)
-                                  (br $while-out$74)
-                                )
+                                (br $while-out$74)
                               )
                               (if
                                 (i32.eq
@@ -6160,10 +6067,7 @@
                                 (set_local $6
                                   (get_local $5)
                                 )
-                                (block
-                                  (get_local $6)
-                                  (br $while-out$74)
-                                )
+                                (br $while-out$74)
                               )
                               (br $while-in$75)
                             )
@@ -6184,7 +6088,6 @@
                                 (i32.const 0)
                               )
                               (block
-                                (get_local $5)
                                 (set_local $8
                                   (get_local $7)
                                 )
@@ -6192,22 +6095,13 @@
                                   (get_local $6)
                                 )
                               )
-                              (block
-                                (get_local $5)
-                                (get_local $7)
-                                (get_local $6)
-                                (br $while-out$68)
-                              )
+                              (br $while-out$68)
                             )
                             (br $while-in$69)
                           )
                         )
-                        (block
-                          (get_local $5)
-                          (set_local $7
-                            (get_local $10)
-                          )
-                          (get_local $6)
+                        (set_local $7
+                          (get_local $10)
                         )
                       )
                       (if
@@ -6237,8 +6131,6 @@
                               (i32.const 102)
                             )
                           )
-                          (get_local $5)
-                          (get_local $7)
                           (set_local $24
                             (get_local $6)
                           )
@@ -6335,10 +6227,7 @@
                                             (get_local $5)
                                           )
                                         )
-                                        (block
-                                          (get_local $6)
-                                          (br $while-out$80)
-                                        )
+                                        (br $while-out$80)
                                       )
                                       (br $while-in$81)
                                     )
@@ -6452,7 +6341,6 @@
                                 (i32.const 0)
                               )
                               (block
-                                (get_local $5)
                                 (set_local $7
                                   (get_local $11)
                                 )
@@ -6473,11 +6361,8 @@
                             (br $while-in$77)
                           )
                         )
-                        (block
-                          (get_local $7)
-                          (set_local $27
-                            (get_local $6)
-                          )
+                        (set_local $27
+                          (get_local $6)
                         )
                       )
                       (block $do-once$82
@@ -6514,11 +6399,8 @@
                                 )
                                 (br $do-once$82)
                               )
-                              (block
-                                (get_local $6)
-                                (set_local $8
-                                  (i32.const 10)
-                                )
+                              (set_local $8
+                                (i32.const 10)
                               )
                             )
                             (loop $while-out$84 $while-in$85
@@ -6543,10 +6425,6 @@
                                     (get_local $6)
                                   )
                                   (br $while-out$84)
-                                )
-                                (block
-                                  (get_local $6)
-                                  (get_local $8)
                                 )
                               )
                               (br $while-in$85)
@@ -6656,7 +6534,6 @@
                                 (set_local $5
                                   (i32.const 10)
                                 )
-                                (get_local $11)
                                 (loop $while-out$86 $while-in$87
                                   (set_local $5
                                     (i32.mul
@@ -6679,10 +6556,6 @@
                                         (get_local $5)
                                       )
                                       (br $while-out$86)
-                                    )
-                                    (block
-                                      (get_local $5)
-                                      (get_local $11)
                                     )
                                   )
                                   (br $while-in$87)
@@ -6787,10 +6660,7 @@
                                           (get_local $50)
                                           (i32.const 0)
                                         )
-                                        (block
-                                          (get_local $22)
-                                          (get_local $14)
-                                        )
+                                        (get_local $14)
                                         (block
                                           (if
                                             (i32.ne
@@ -6805,11 +6675,8 @@
                                               )
                                               (i32.const 45)
                                             )
-                                            (block
-                                              (get_local $22)
-                                              (br $do-once$90
-                                                (get_local $14)
-                                              )
+                                            (br $do-once$90
+                                              (get_local $14)
                                             )
                                           )
                                           (set_local $22
@@ -6922,26 +6789,18 @@
                                             (get_local $7)
                                             (i32.const 999999999)
                                           )
-                                          (block
-                                            (get_local $5)
-                                            (set_local $7
-                                              (get_local $6)
-                                            )
+                                          (set_local $7
+                                            (get_local $6)
                                           )
                                           (block
                                             (set_local $7
                                               (get_local $5)
                                             )
-                                            (get_local $6)
                                             (br $while-out$92)
                                           )
                                         )
                                         (br $while-in$93)
                                       )
-                                    )
-                                    (block
-                                      (get_local $7)
-                                      (get_local $6)
                                     )
                                   )
                                   (set_local $11
@@ -6972,14 +6831,10 @@
                                       (set_local $7
                                         (get_local $6)
                                       )
-                                      (get_local $11)
                                       (br $do-once$88)
                                     )
-                                    (block
-                                      (get_local $11)
-                                      (set_local $12
-                                        (i32.const 10)
-                                      )
+                                    (set_local $12
+                                      (i32.const 10)
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
@@ -7006,12 +6861,7 @@
                                         (set_local $7
                                           (get_local $6)
                                         )
-                                        (get_local $11)
                                         (br $while-out$94)
-                                      )
-                                      (block
-                                        (get_local $11)
-                                        (get_local $12)
                                       )
                                     )
                                     (br $while-in$95)
@@ -7043,7 +6893,6 @@
                             (get_local $5)
                           )
                           (block
-                            (get_local $9)
                             (set_local $6
                               (get_local $27)
                             )
@@ -7057,7 +6906,6 @@
                           (get_local $9)
                         )
                       )
-                      (get_local $6)
                       (loop $while-out$96 $while-in$97
                         (if
                           (i32.le_u
@@ -7237,7 +7085,7 @@
                                         )
                                       )
                                       (if
-                                        (i32.eq
+                                        (i32.ne
                                           (i32.and
                                             (i32.rem_u
                                               (get_local $1)
@@ -7251,10 +7099,6 @@
                                             (i32.const -1)
                                           )
                                           (i32.const 0)
-                                        )
-                                        (block
-                                          (get_local $5)
-                                          (get_local $6)
                                         )
                                         (block
                                           (set_local $1
@@ -7460,34 +7304,28 @@
                                 )
                                 (i32.const 2)
                               )
-                              (block
-                                (get_local $5)
-                                (loop $while-out$104 $while-in$105
-                                  (i32.store8
-                                    (set_local $5
-                                      (i32.add
-                                        (get_local $5)
-                                        (i32.const -1)
-                                      )
-                                    )
-                                    (i32.const 48)
-                                  )
-                                  (if
-                                    (i32.lt_s
-                                      (i32.sub
-                                        (get_local $44)
-                                        (get_local $5)
-                                      )
-                                      (i32.const 2)
-                                    )
-                                    (get_local $5)
-                                    (block
+                              (loop $while-out$104 $while-in$105
+                                (i32.store8
+                                  (set_local $5
+                                    (i32.add
                                       (get_local $5)
-                                      (br $while-out$104)
+                                      (i32.const -1)
                                     )
                                   )
-                                  (br $while-in$105)
+                                  (i32.const 48)
                                 )
+                                (if
+                                  (i32.lt_s
+                                    (i32.sub
+                                      (get_local $44)
+                                      (get_local $5)
+                                    )
+                                    (i32.const 2)
+                                  )
+                                  (get_local $5)
+                                  (br $while-out$104)
+                                )
+                                (br $while-in$105)
                               )
                               (get_local $5)
                             )
@@ -7617,10 +7455,7 @@
                                         (get_local $5)
                                         (get_local $48)
                                       )
-                                      (block
-                                        (get_local $5)
-                                        (br $do-once$110)
-                                      )
+                                      (br $do-once$110)
                                     )
                                     (i32.store8
                                       (get_local $57)
@@ -7637,10 +7472,7 @@
                                         (get_local $29)
                                       )
                                       (get_local $5)
-                                      (block
-                                        (get_local $5)
-                                        (br $do-once$110)
-                                      )
+                                      (br $do-once$110)
                                     )
                                     (loop $while-out$112 $while-in$113
                                       (i32.store8
@@ -7658,10 +7490,7 @@
                                           (get_local $29)
                                         )
                                         (get_local $5)
-                                        (block
-                                          (get_local $5)
-                                          (br $while-out$112)
-                                        )
+                                        (br $while-out$112)
                                       )
                                       (br $while-in$113)
                                     )
@@ -7697,10 +7526,7 @@
                                   )
                                   (get_local $10)
                                 )
-                                (block
-                                  (get_local $5)
-                                  (br $while-out$108)
-                                )
+                                (br $while-out$108)
                                 (set_local $7
                                   (get_local $5)
                                 )
@@ -7745,7 +7571,6 @@
                                 )
                               )
                               (block
-                                (get_local $5)
                                 (set_local $7
                                   (get_local $15)
                                 )
@@ -7763,31 +7588,25 @@
                                       )
                                       (get_local $29)
                                     )
-                                    (block
-                                      (get_local $1)
-                                      (loop $while-out$118 $while-in$119
-                                        (i32.store8
-                                          (set_local $1
-                                            (i32.add
-                                              (get_local $1)
-                                              (i32.const -1)
-                                            )
-                                          )
-                                          (i32.const 48)
-                                        )
-                                        (if
-                                          (i32.gt_u
+                                    (loop $while-out$118 $while-in$119
+                                      (i32.store8
+                                        (set_local $1
+                                          (i32.add
                                             (get_local $1)
-                                            (get_local $29)
-                                          )
-                                          (get_local $1)
-                                          (block
-                                            (get_local $1)
-                                            (br $while-out$118)
+                                            (i32.const -1)
                                           )
                                         )
-                                        (br $while-in$119)
+                                        (i32.const 48)
                                       )
+                                      (if
+                                        (i32.gt_u
+                                          (get_local $1)
+                                          (get_local $29)
+                                        )
+                                        (get_local $1)
+                                        (br $while-out$118)
+                                      )
+                                      (br $while-in$119)
                                     )
                                     (get_local $1)
                                   )
@@ -7960,10 +7779,7 @@
                                               (i32.const 1)
                                             )
                                           )
-                                          (block
-                                            (get_local $1)
-                                            (br $do-once$122)
-                                          )
+                                          (br $do-once$122)
                                         )
                                         (if
                                           (i32.ne
@@ -7975,17 +7791,13 @@
                                             )
                                             (i32.const 0)
                                           )
-                                          (block
-                                            (get_local $1)
-                                            (br $do-once$122)
-                                          )
+                                          (br $do-once$122)
                                         )
                                         (call $___fwritex
                                           (i32.const 4143)
                                           (i32.const 1)
                                           (get_local $0)
                                         )
-                                        (get_local $1)
                                       )
                                       (block
                                         (if
@@ -8019,10 +7831,7 @@
                                               (get_local $29)
                                             )
                                             (get_local $1)
-                                            (block
-                                              (get_local $1)
-                                              (br $while-out$124)
-                                            )
+                                            (br $while-out$124)
                                           )
                                           (br $while-in$125)
                                         )
@@ -8079,11 +7888,8 @@
                                         (i32.const -1)
                                       )
                                     )
-                                    (block
-                                      (set_local $5
-                                        (get_local $1)
-                                      )
-                                      (get_local $8)
+                                    (set_local $5
+                                      (get_local $1)
                                     )
                                     (block
                                       (set_local $1
@@ -8272,7 +8078,6 @@
               (set_local $12
                 (get_local $26)
               )
-              (get_local $1)
               (set_local $8
                 (get_local $20)
               )
@@ -8354,8 +8159,6 @@
                   (get_local $28)
                 )
                 (block
-                  (get_local $1)
-                  (get_local $5)
                   (set_local $6
                     (get_local $28)
                   )
@@ -8412,11 +8215,6 @@
                           (get_local $6)
                         )
                         (br $while-out$129)
-                      )
-                      (block
-                        (get_local $1)
-                        (get_local $5)
-                        (get_local $6)
                       )
                     )
                     (br $while-in$130)
@@ -8609,7 +8407,6 @@
                         (i32.const 0)
                       )
                       (block
-                        (get_local $7)
                         (set_local $1
                           (get_local $5)
                         )
@@ -8636,7 +8433,6 @@
                         )
                       )
                       (block
-                        (get_local $7)
                         (set_local $1
                           (get_local $5)
                         )
@@ -8659,12 +8455,8 @@
                           )
                         )
                       )
-                      (block
-                        (set_local $7
-                          (get_local $1)
-                        )
-                        (get_local $5)
-                        (get_local $6)
+                      (set_local $7
+                        (get_local $1)
                       )
                       (block
                         (set_local $7
@@ -9170,52 +8962,49 @@
                   (get_local $0)
                   (i32.const 10)
                 )
-                (block
-                  (get_local $0)
-                  (loop $while-out$138 $while-in$139
-                    (set_local $1
-                      (i32.add
-                        (get_local $0)
-                        (i32.const 1)
-                      )
+                (loop $while-out$138 $while-in$139
+                  (set_local $1
+                    (i32.add
+                      (get_local $0)
+                      (i32.const 1)
                     )
-                    (if
-                      (i32.ne
-                        (i32.load
-                          (i32.add
-                            (get_local $4)
-                            (i32.shl
-                              (get_local $0)
-                              (i32.const 2)
-                            )
+                  )
+                  (if
+                    (i32.ne
+                      (i32.load
+                        (i32.add
+                          (get_local $4)
+                          (i32.shl
+                            (get_local $0)
+                            (i32.const 2)
                           )
                         )
-                        (i32.const 0)
                       )
-                      (block
-                        (set_local $23
-                          (i32.const -1)
-                        )
-                        (br $label$break$L343)
-                      )
+                      (i32.const 0)
                     )
-                    (if
-                      (i32.lt_s
-                        (get_local $1)
-                        (i32.const 10)
+                    (block
+                      (set_local $23
+                        (i32.const -1)
                       )
-                      (set_local $0
-                        (get_local $1)
-                      )
-                      (block
-                        (set_local $23
-                          (i32.const 1)
-                        )
-                        (br $while-out$138)
-                      )
+                      (br $label$break$L343)
                     )
-                    (br $while-in$139)
                   )
+                  (if
+                    (i32.lt_s
+                      (get_local $1)
+                      (i32.const 10)
+                    )
+                    (set_local $0
+                      (get_local $1)
+                    )
+                    (block
+                      (set_local $23
+                        (i32.const 1)
+                      )
+                      (br $while-out$138)
+                    )
+                  )
+                  (br $while-in$139)
                 )
                 (set_local $23
                   (i32.const 1)
@@ -9901,8 +9690,6 @@
                 )
               )
               (block
-                (get_local $0)
-                (get_local $1)
                 (set_local $1
                   (get_local $2)
                 )
@@ -9979,11 +9766,8 @@
               )
               (br $while-out$2)
             )
-            (block
-              (get_local $1)
-              (set_local $2
-                (get_local $0)
-              )
+            (set_local $2
+              (get_local $0)
             )
           )
           (br $while-in$3)
@@ -10085,11 +9869,9 @@
                   (get_local $3)
                 )
               )
-              (get_local $1)
               (set_local $3
                 (get_local $5)
               )
-              (get_local $4)
               (loop $while-out$2 $while-in$3
                 (set_local $4
                   (i32.eq
@@ -10116,7 +9898,7 @@
                   )
                 )
                 (if
-                  (i32.gt_u
+                  (i32.le_u
                     (set_local $3
                       (i32.add
                         (get_local $3)
@@ -10124,11 +9906,6 @@
                       )
                     )
                     (i32.const 255)
-                  )
-                  (block
-                    (get_local $1)
-                    (get_local $3)
-                    (get_local $4)
                   )
                   (br $while-out$2)
                 )
@@ -11047,18 +10824,12 @@
                               )
                               (br $do-once$8)
                             )
-                            (block
-                              (set_local $4
-                                (get_local $2)
-                              )
-                              (get_local $7)
-                            )
-                          )
-                          (block
                             (set_local $4
                               (get_local $2)
                             )
-                            (get_local $7)
+                          )
+                          (set_local $4
+                            (get_local $2)
                           )
                         )
                         (loop $while-out$10 $while-in$11
@@ -11799,18 +11570,12 @@
                               )
                               (br $label$break$L123)
                             )
-                            (block
-                              (get_local $13)
-                              (set_local $29
-                                (get_local $23)
-                              )
+                            (set_local $29
+                              (get_local $23)
                             )
                           )
-                          (block
-                            (set_local $13
-                              (get_local $6)
-                            )
-                            (get_local $29)
+                          (set_local $13
+                            (get_local $6)
                           )
                         )
                         (set_local $6
@@ -11890,12 +11655,9 @@
                             (set_local $6
                               (get_local $13)
                             )
-                            (get_local $14)
-                            (get_local $10)
                             (set_local $23
                               (get_local $3)
                             )
-                            (get_local $29)
                           )
                         )
                         (br $while-in$18)
@@ -12268,18 +12030,12 @@
                                   )
                                   (br $do-once$21)
                                 )
-                                (block
-                                  (set_local $7
-                                    (get_local $2)
-                                  )
-                                  (get_local $8)
-                                )
-                              )
-                              (block
                                 (set_local $7
                                   (get_local $2)
                                 )
-                                (get_local $8)
+                              )
+                              (set_local $7
+                                (get_local $2)
                               )
                             )
                             (loop $while-out$23 $while-in$24
@@ -14737,11 +14493,8 @@
                                                           )
                                                         )
                                                       )
-                                                      (block
-                                                        (set_local $2
-                                                          (get_local $1)
-                                                        )
-                                                        (get_local $8)
+                                                      (set_local $2
+                                                        (get_local $1)
                                                       )
                                                     )
                                                     (loop $while-out$61 $while-in$62
@@ -16755,11 +16508,8 @@
                       )
                     )
                   )
-                  (block
-                    (set_local $2
-                      (get_local $0)
-                    )
-                    (get_local $7)
+                  (set_local $2
+                    (get_local $0)
                   )
                 )
                 (loop $while-out$4 $while-in$5
@@ -17440,11 +17190,8 @@
                           )
                         )
                       )
-                      (block
-                        (set_local $2
-                          (get_local $1)
-                        )
-                        (get_local $6)
+                      (set_local $2
+                        (get_local $1)
                       )
                     )
                     (loop $while-out$12 $while-in$13
@@ -20242,9 +19989,6 @@
                 (set_local $11
                   (get_local $0)
                 )
-                (get_local $5)
-                (get_local $6)
-                (get_local $9)
                 (set_local $0
                   (get_local $12)
                 )
@@ -20271,7 +20015,6 @@
         )
       )
     )
-    (get_local $7)
     (set_local $6
       (i32.or
         (get_local $9)

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -907,19 +907,17 @@
                             )
                           )
                           (if
-                            (set_local $14
-                              (i32.load
-                                (set_local $2
-                                  (i32.add
-                                    (get_local $1)
-                                    (i32.const 16)
+                            (i32.eqz
+                              (set_local $14
+                                (i32.load
+                                  (set_local $2
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const 16)
+                                    )
                                   )
                                 )
                               )
-                            )
-                            (block
-                              (get_local $14)
-                              (get_local $2)
                             )
                             (block
                               (set_local $23
@@ -970,11 +968,7 @@
                                 (get_local $9)
                               )
                             )
-                            (block
-                              (get_local $14)
-                              (get_local $2)
-                              (br $while-out$10)
-                            )
+                            (br $while-out$10)
                           )
                           (br $while-in$11)
                         )
@@ -1621,11 +1615,8 @@
                               )
                             )
                           )
-                          (block
-                            (set_local $2
-                              (get_local $20)
-                            )
-                            (get_local $1)
+                          (set_local $2
+                            (get_local $20)
                           )
                         )
                         (set_local $13
@@ -1705,7 +1696,6 @@
                                 )
                               )
                             )
-                            (get_local $1)
                           )
                         )
                         (br $while-in$18)
@@ -4358,11 +4348,7 @@
                                                         (get_local $12)
                                                       )
                                                     )
-                                                    (block
-                                                      (get_local $0)
-                                                      (get_local $4)
-                                                      (br $while-out$59)
-                                                    )
+                                                    (br $while-out$59)
                                                   )
                                                   (br $while-in$60)
                                                 )
@@ -6398,14 +6384,12 @@
                     )
                   )
                   (if
-                    (set_local $1
-                      (i32.load
-                        (get_local $6)
+                    (i32.eqz
+                      (set_local $1
+                        (i32.load
+                          (get_local $6)
+                        )
                       )
-                    )
-                    (block
-                      (get_local $1)
-                      (get_local $6)
                     )
                     (block
                       (set_local $3
@@ -7077,11 +7061,8 @@
                             (get_local $6)
                           )
                         )
-                        (block
-                          (get_local $0)
-                          (set_local $13
-                            (get_local $6)
-                          )
+                        (set_local $13
+                          (get_local $6)
                         )
                         (block
                           (set_local $12
@@ -7133,7 +7114,6 @@
                           )
                         )
                         (block
-                          (get_local $0)
                           (set_local $1
                             (get_local $13)
                           )
@@ -8160,7 +8140,6 @@
                   (get_local $4)
                 )
               )
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8170,7 +8149,6 @@
               (get_local $6)
             )
             (block
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8543,7 +8521,6 @@
           (i32.const 3)
         )
         (block
-          (get_local $0)
           (set_local $4
             (get_local $3)
           )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -907,19 +907,17 @@
                             )
                           )
                           (if
-                            (set_local $14
-                              (i32.load
-                                (set_local $2
-                                  (i32.add
-                                    (get_local $1)
-                                    (i32.const 16)
+                            (i32.eqz
+                              (set_local $14
+                                (i32.load
+                                  (set_local $2
+                                    (i32.add
+                                      (get_local $1)
+                                      (i32.const 16)
+                                    )
                                   )
                                 )
                               )
-                            )
-                            (block
-                              (get_local $14)
-                              (get_local $2)
                             )
                             (block
                               (set_local $23
@@ -970,11 +968,7 @@
                                 (get_local $9)
                               )
                             )
-                            (block
-                              (get_local $14)
-                              (get_local $2)
-                              (br $while-out$10)
-                            )
+                            (br $while-out$10)
                           )
                           (br $while-in$11)
                         )
@@ -1621,11 +1615,8 @@
                               )
                             )
                           )
-                          (block
-                            (set_local $2
-                              (get_local $20)
-                            )
-                            (get_local $1)
+                          (set_local $2
+                            (get_local $20)
                           )
                         )
                         (set_local $13
@@ -1705,7 +1696,6 @@
                                 )
                               )
                             )
-                            (get_local $1)
                           )
                         )
                         (br $while-in$18)
@@ -4358,11 +4348,7 @@
                                                         (get_local $12)
                                                       )
                                                     )
-                                                    (block
-                                                      (get_local $0)
-                                                      (get_local $4)
-                                                      (br $while-out$59)
-                                                    )
+                                                    (br $while-out$59)
                                                   )
                                                   (br $while-in$60)
                                                 )
@@ -6398,14 +6384,12 @@
                     )
                   )
                   (if
-                    (set_local $1
-                      (i32.load
-                        (get_local $6)
+                    (i32.eqz
+                      (set_local $1
+                        (i32.load
+                          (get_local $6)
+                        )
                       )
-                    )
-                    (block
-                      (get_local $1)
-                      (get_local $6)
                     )
                     (block
                       (set_local $3
@@ -7077,11 +7061,8 @@
                             (get_local $6)
                           )
                         )
-                        (block
-                          (get_local $0)
-                          (set_local $13
-                            (get_local $6)
-                          )
+                        (set_local $13
+                          (get_local $6)
                         )
                         (block
                           (set_local $12
@@ -7133,7 +7114,6 @@
                           )
                         )
                         (block
-                          (get_local $0)
                           (set_local $1
                             (get_local $13)
                           )
@@ -8160,7 +8140,6 @@
                   (get_local $4)
                 )
               )
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8170,7 +8149,6 @@
               (get_local $6)
             )
             (block
-              (get_local $4)
               (set_local $7
                 (get_local $5)
               )
@@ -8543,7 +8521,6 @@
           (i32.const 3)
         )
         (block
-          (get_local $0)
           (set_local $4
             (get_local $3)
           )

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -28,4 +28,25 @@
     )
     (i32.const 104)
   )
+  (func $l
+    (local $x i32)
+    (local $y i32)
+    (set_local $x
+      (get_local $x)
+    )
+    (block $in-a-block
+    )
+    (block $two-in-a-block
+    )
+    (set_local $x
+      (block $result-used
+        (get_local $x)
+      )
+    )
+    (set_local $x
+      (block $two-and-result-used
+        (get_local $y)
+      )
+    )
+  )
 )

--- a/test/passes/vacuum.wast
+++ b/test/passes/vacuum.wast
@@ -39,5 +39,29 @@
       (nop)
     )
   )
+  (func $l
+    (local $x i32)
+    (local $y i32)
+    (get_local $x)
+    (set_local $x (get_local $x))
+    (block $in-a-block
+      (get_local $x)
+    )
+    (block $two-in-a-block
+      (get_local $x)
+      (get_local $y)
+    )
+    (set_local $x
+      (block $result-used
+        (get_local $x)
+      )
+    )
+    (set_local $x
+      (block $two-and-result-used
+        (get_local $x)
+        (get_local $y)
+      )
+    )
+  )
 )
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -275,7 +275,6 @@
     (f32.demote/f64
       (get_local $1)
     )
-    (get_local $0)
     (f32.const 5)
     (f32.const 0)
     (f32.const 5)

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -271,7 +271,6 @@
     (f32.demote/f64
       (get_local $1)
     )
-    (get_local $0)
     (f32.const 5)
     (f32.const 0)
     (f32.const 5)


### PR DESCRIPTION
Get rid of more dead code in vacuum, in particular the dead code left by coalesce-locals.