### PR TITLE
Metrics improvements

### DIFF
--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -44,6 +44,8 @@ struct Metrics : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<
       keys.push_back(i.first);
       total += i.second;
     }
+    keys.push_back("[total]");
+    counts["[total]"] = total;
     sort(keys.begin(), keys.end(), [](const char* a, const char* b) -> bool {
       return strcmp(b, a) > 0;
     });
@@ -69,7 +71,6 @@ struct Metrics : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<
       }
       o << "\n";
     }
-    o << left << setw(16) << "Total" << ": " << setw(8) << total << '\n';
     lastMetricsPass = this;
   }
 };

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -44,8 +44,16 @@ struct Metrics : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<
       keys.push_back(i.first);
       total += i.second;
     }
+    // add total
     keys.push_back("[total]");
     counts["[total]"] = total;
+    // add vars
+    size_t vars = 0;
+    for (auto& func : module->functions) {
+      vars += func->getNumVars();
+    }
+    keys.push_back("[vars]");
+    counts["[vars]"] = vars;
     sort(keys.begin(), keys.end(), [](const char* a, const char* b) -> bool {
       return strcmp(b, a) > 0;
     });

--- a/test/passes/metrics.txt
+++ b/test/passes/metrics.txt
@@ -1,12 +1,14 @@
 Counts
  [total]        : 18      
+ [vars]         : 1       
  binary         : 1       
  block          : 1       
  const          : 12      
  if             : 4       
 (module
   (memory 256 256)
-  (func $ifs
+  (func $ifs (param $x i32)
+    (local $y f32)
     (block $block0
       (if
         (i32.const 0)

--- a/test/passes/metrics.txt
+++ b/test/passes/metrics.txt
@@ -1,9 +1,9 @@
 Counts
+ [total]        : 18      
  binary         : 1       
  block          : 1       
  const          : 12      
  if             : 4       
-Total           : 18      
 (module
   (memory 256 256)
   (func $ifs

--- a/test/passes/metrics.wast
+++ b/test/passes/metrics.wast
@@ -1,6 +1,7 @@
 (module
   (memory 256 256)
-  (func $ifs
+  (func $ifs (param $x i32)
+    (local $y f32)
     (block
       (if
         (i32.const 0)


### PR DESCRIPTION
Allows diffs on subsequent metrics calls for the total nodes, and also adds total vars (non-param-locals) to the metrics, as we have opts that can reduce them now.