### PR TITLE
Activate true learning in local coalescing

### DIFF
--- a/src/support/learning.h
+++ b/src/support/learning.h
@@ -59,8 +59,7 @@ class GeneticLearner {
   std::mt19937 noise;
 
   size_t randomIndex() {
-    // simple random index that favorizes low indexes TODO tweak
-    return std::min(noise() % population.size(), noise() % population.size());
+    return noise() % population.size();
   }
 
 public:

--- a/test/passes/coalesce-locals-learning.txt
+++ b/test/passes/coalesce-locals-learning.txt
@@ -440,71 +440,71 @@
         (if
           (i32.const 2)
           (block $block3
-            (set_local $1
+            (set_local $0
               (i32.const 100)
             )
-            (set_local $0
+            (set_local $1
               (i32.const 101)
             )
-            (get_local $1)
             (get_local $0)
+            (get_local $1)
           )
           (block $block5
-            (set_local $1
+            (set_local $0
               (i32.const 102)
             )
-            (set_local $0
+            (set_local $1
               (i32.const 103)
             )
-            (get_local $1)
             (get_local $0)
+            (get_local $1)
           )
         )
         (if
           (i32.const 3)
           (block $block8
-            (set_local $1
+            (set_local $0
               (i32.const 104)
             )
-            (set_local $0
+            (set_local $1
               (i32.const 105)
             )
-            (get_local $1)
             (get_local $0)
+            (get_local $1)
           )
           (block $block10
-            (set_local $1
+            (set_local $0
               (i32.const 106)
             )
-            (set_local $0
+            (set_local $1
               (i32.const 107)
             )
-            (get_local $1)
             (get_local $0)
+            (get_local $1)
           )
         )
       )
       (if
         (i32.const 4)
         (block $block13
-          (set_local $1
+          (set_local $0
             (i32.const 108)
           )
-          (set_local $0
+          (set_local $1
             (i32.const 109)
           )
-          (get_local $1)
           (get_local $0)
+          (get_local $1)
         )
         (block $block15
-          (set_local $1
+          (set_local $0
             (i32.const 110)
           )
-          (set_local $0
+          (set_local $1
             (i32.const 111)
           )
-          (get_local $1)
           (get_local $0)
+          (get_local $1)
         )
       )
     )


### PR DESCRIPTION
This turns on multi-generational learning using the genetic learner. It keeps running generations until it doesn't see an improvement.

It's hard to say if this generates better code quality than just doing more random orders, I see mixed results. However, it probably helps in some cases. And it provides a natural way to decide when to stop trying, which reduces run times. It may also matter more when the cost function is more complex (right now it is # of locals, and also a bonus for not reordering locals unnecessarily).