### PR TITLE
Allow implicit function returns.

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -1002,6 +1002,10 @@ class S2WasmBuilder {
         abort_on("function element");
       }
     }
+    if (!estack.empty()) {
+      addToBlock(estack.back());
+      estack.pop_back();
+    }
     // finishing touches
     bstack.back()->cast<Block>()->finalize();
     bstack.pop_back(); // remove the base block for the function body

--- a/test/dot_s/return.s
+++ b/test/dot_s/return.s
@@ -1,0 +1,17 @@
+	.text
+	.globl	return_i32
+	.type	return_i32,@function
+return_i32:
+	.result 	i32
+	i32.const	$push0=, 5
+        .endfunc
+.Lfunc_end0:
+	.size	return_i32, .Lfunc_end0-return_i32
+
+	.globl	return_void
+	.type	return_void,@function
+return_void:
+        .endfunc
+.Lfunc_end0:
+	.size	return_void, .Lfunc_end0-return_void
+

--- a/test/dot_s/return.wast
+++ b/test/dot_s/return.wast
@@ -1,0 +1,12 @@
+(module
+  (memory 1)
+  (export "memory" memory)
+  (export "return_i32" $return_i32)
+  (export "return_void" $return_void)
+  (func $return_i32 (result i32)
+    (i32.const 5)
+  )
+  (func $return_void
+  )
+)
+;; METADATA: { "asmConsts": {},"staticBump": 12, "initializers": [] }


### PR DESCRIPTION
This allows .s producers to omit return opcodes at the ends of functions.