### PR TITLE
Notice only branches out in EffectAnalyzer

### DIFF
--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -3120,387 +3120,6 @@
         (i32.const 0)
       )
     )
-    (set_local $8
-      (block $label$break$L257
-        (if
-          (i32.and
-            (i32.load
-              (i32.const 620)
-            )
-            (i32.const 4)
-          )
-          (i32.const 190)
-          (block
-            (block $label$break$L259
-              (if
-                (set_local $9
-                  (i32.load
-                    (i32.const 200)
-                  )
-                )
-                (block
-                  (set_local $14
-                    (i32.const 624)
-                  )
-                  (loop $while-out$37 $while-in$38
-                    (if
-                      (if
-                        (i32.le_u
-                          (i32.load
-                            (get_local $14)
-                          )
-                          (get_local $9)
-                        )
-                        (i32.load
-                          (set_local $11
-                            (i32.add
-                              (get_local $14)
-                              (i32.const 4)
-                            )
-                          )
-                        )
-                        (i32.const 0)
-                      )
-                      (block
-                        (set_local $4
-                          (get_local $14)
-                        )
-                        (set_local $5
-                          (get_local $11)
-                        )
-                        (br $while-out$37)
-                      )
-                    )
-                    (if
-                      (i32.eqz
-                        (set_local $14
-                          (i32.load offset=8
-                            (get_local $14)
-                          )
-                        )
-                      )
-                      (block
-                        (set_local $8
-                          (i32.const 173)
-                        )
-                        (br $label$break$L259)
-                      )
-                    )
-                    (br $while-in$38)
-                  )
-                  (if
-                    (i32.lt_u
-                      (set_local $14
-                        (i32.and
-                          (i32.sub
-                            (get_local $21)
-                            (i32.load
-                              (i32.const 188)
-                            )
-                          )
-                          (get_local $23)
-                        )
-                      )
-                      (i32.const 2147483647)
-                    )
-                    (if
-                      (i32.eq
-                        (set_local $11
-                          (call_import $_sbrk
-                            (get_local $14)
-                          )
-                        )
-                        (i32.add
-                          (i32.load
-                            (get_local $4)
-                          )
-                          (i32.load
-                            (get_local $5)
-                          )
-                        )
-                      )
-                      (if
-                        (i32.ne
-                          (get_local $11)
-                          (i32.const -1)
-                        )
-                        (block
-                          (set_local $20
-                            (get_local $11)
-                          )
-                          (set_local $22
-                            (get_local $14)
-                          )
-                          (br $label$break$L257
-                            (i32.const 193)
-                          )
-                        )
-                      )
-                      (block
-                        (set_local $13
-                          (get_local $11)
-                        )
-                        (set_local $17
-                          (get_local $14)
-                        )
-                        (set_local $8
-                          (i32.const 183)
-                        )
-                      )
-                    )
-                  )
-                )
-                (set_local $8
-                  (i32.const 173)
-                )
-              )
-            )
-            (block $do-once$39
-              (if
-                (if
-                  (i32.eq
-                    (get_local $8)
-                    (i32.const 173)
-                  )
-                  (set_local $9
-                    (call_import $_sbrk
-                      (i32.const 0)
-                    )
-                  )
-                  (i32.const 0)
-                )
-                (block
-                  (set_local $1
-                    (if
-                      (i32.and
-                        (set_local $11
-                          (i32.add
-                            (set_local $14
-                              (i32.load
-                                (i32.const 652)
-                              )
-                            )
-                            (i32.const -1)
-                          )
-                        )
-                        (set_local $2
-                          (get_local $9)
-                        )
-                      )
-                      (i32.add
-                        (i32.sub
-                          (get_local $7)
-                          (get_local $2)
-                        )
-                        (i32.and
-                          (i32.add
-                            (get_local $11)
-                            (get_local $2)
-                          )
-                          (i32.sub
-                            (i32.const 0)
-                            (get_local $14)
-                          )
-                        )
-                      )
-                      (get_local $7)
-                    )
-                  )
-                  (set_local $2
-                    (i32.add
-                      (set_local $14
-                        (i32.load
-                          (i32.const 608)
-                        )
-                      )
-                      (get_local $1)
-                    )
-                  )
-                  (if
-                    (i32.and
-                      (i32.gt_u
-                        (get_local $1)
-                        (get_local $0)
-                      )
-                      (i32.lt_u
-                        (get_local $1)
-                        (i32.const 2147483647)
-                      )
-                    )
-                    (block
-                      (br_if $do-once$39
-                        (select
-                          (i32.or
-                            (i32.le_u
-                              (get_local $2)
-                              (get_local $14)
-                            )
-                            (i32.gt_u
-                              (get_local $2)
-                              (set_local $11
-                                (i32.load
-                                  (i32.const 616)
-                                )
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                          (i32.ne
-                            (get_local $11)
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                      (if
-                        (i32.eq
-                          (set_local $11
-                            (call_import $_sbrk
-                              (get_local $1)
-                            )
-                          )
-                          (get_local $9)
-                        )
-                        (block
-                          (set_local $20
-                            (get_local $9)
-                          )
-                          (set_local $22
-                            (get_local $1)
-                          )
-                          (br $label$break$L257
-                            (i32.const 193)
-                          )
-                        )
-                        (block
-                          (set_local $13
-                            (get_local $11)
-                          )
-                          (set_local $17
-                            (get_local $1)
-                          )
-                          (set_local $8
-                            (i32.const 183)
-                          )
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-            (block $label$break$L279
-              (if
-                (i32.eq
-                  (get_local $8)
-                  (i32.const 183)
-                )
-                (block
-                  (set_local $11
-                    (i32.sub
-                      (i32.const 0)
-                      (get_local $17)
-                    )
-                  )
-                  (if
-                    (if
-                      (i32.and
-                        (i32.gt_u
-                          (get_local $16)
-                          (get_local $17)
-                        )
-                        (i32.and
-                          (i32.lt_u
-                            (get_local $17)
-                            (i32.const 2147483647)
-                          )
-                          (i32.ne
-                            (get_local $13)
-                            (i32.const -1)
-                          )
-                        )
-                      )
-                      (i32.lt_u
-                        (set_local $2
-                          (i32.and
-                            (i32.add
-                              (i32.sub
-                                (get_local $12)
-                                (get_local $17)
-                              )
-                              (set_local $9
-                                (i32.load
-                                  (i32.const 656)
-                                )
-                              )
-                            )
-                            (i32.sub
-                              (i32.const 0)
-                              (get_local $9)
-                            )
-                          )
-                        )
-                        (i32.const 2147483647)
-                      )
-                      (i32.const 0)
-                    )
-                    (if
-                      (i32.eq
-                        (call_import $_sbrk
-                          (get_local $2)
-                        )
-                        (i32.const -1)
-                      )
-                      (block
-                        (call_import $_sbrk
-                          (get_local $11)
-                        )
-                        (br $label$break$L279)
-                      )
-                      (set_local $3
-                        (i32.add
-                          (get_local $2)
-                          (get_local $17)
-                        )
-                      )
-                    )
-                    (set_local $3
-                      (get_local $17)
-                    )
-                  )
-                  (if
-                    (i32.ne
-                      (get_local $13)
-                      (i32.const -1)
-                    )
-                    (block
-                      (set_local $20
-                        (get_local $13)
-                      )
-                      (set_local $22
-                        (get_local $3)
-                      )
-                      (br $label$break$L257
-                        (i32.const 193)
-                      )
-                    )
-                  )
-                )
-              )
-            )
-            (i32.store
-              (i32.const 620)
-              (i32.or
-                (i32.load
-                  (i32.const 620)
-                )
-                (i32.const 4)
-              )
-            )
-            (i32.const 190)
-          )
-        )
-      )
-    )
     (if
       (if
         (if
@@ -3511,7 +3130,387 @@
             )
             (i32.const 0)
             (i32.eq
-              (get_local $8)
+              (set_local $8
+                (block $label$break$L257
+                  (if
+                    (i32.and
+                      (i32.load
+                        (i32.const 620)
+                      )
+                      (i32.const 4)
+                    )
+                    (i32.const 190)
+                    (block
+                      (block $label$break$L259
+                        (if
+                          (set_local $9
+                            (i32.load
+                              (i32.const 200)
+                            )
+                          )
+                          (block
+                            (set_local $14
+                              (i32.const 624)
+                            )
+                            (loop $while-out$37 $while-in$38
+                              (if
+                                (if
+                                  (i32.le_u
+                                    (i32.load
+                                      (get_local $14)
+                                    )
+                                    (get_local $9)
+                                  )
+                                  (i32.load
+                                    (set_local $11
+                                      (i32.add
+                                        (get_local $14)
+                                        (i32.const 4)
+                                      )
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                                (block
+                                  (set_local $4
+                                    (get_local $14)
+                                  )
+                                  (set_local $5
+                                    (get_local $11)
+                                  )
+                                  (br $while-out$37)
+                                )
+                              )
+                              (if
+                                (i32.eqz
+                                  (set_local $14
+                                    (i32.load offset=8
+                                      (get_local $14)
+                                    )
+                                  )
+                                )
+                                (block
+                                  (set_local $8
+                                    (i32.const 173)
+                                  )
+                                  (br $label$break$L259)
+                                )
+                              )
+                              (br $while-in$38)
+                            )
+                            (if
+                              (i32.lt_u
+                                (set_local $14
+                                  (i32.and
+                                    (i32.sub
+                                      (get_local $21)
+                                      (i32.load
+                                        (i32.const 188)
+                                      )
+                                    )
+                                    (get_local $23)
+                                  )
+                                )
+                                (i32.const 2147483647)
+                              )
+                              (if
+                                (i32.eq
+                                  (set_local $11
+                                    (call_import $_sbrk
+                                      (get_local $14)
+                                    )
+                                  )
+                                  (i32.add
+                                    (i32.load
+                                      (get_local $4)
+                                    )
+                                    (i32.load
+                                      (get_local $5)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.ne
+                                    (get_local $11)
+                                    (i32.const -1)
+                                  )
+                                  (block
+                                    (set_local $20
+                                      (get_local $11)
+                                    )
+                                    (set_local $22
+                                      (get_local $14)
+                                    )
+                                    (br $label$break$L257
+                                      (i32.const 193)
+                                    )
+                                  )
+                                )
+                                (block
+                                  (set_local $13
+                                    (get_local $11)
+                                  )
+                                  (set_local $17
+                                    (get_local $14)
+                                  )
+                                  (set_local $8
+                                    (i32.const 183)
+                                  )
+                                )
+                              )
+                            )
+                          )
+                          (set_local $8
+                            (i32.const 173)
+                          )
+                        )
+                      )
+                      (block $do-once$39
+                        (if
+                          (if
+                            (i32.eq
+                              (get_local $8)
+                              (i32.const 173)
+                            )
+                            (set_local $9
+                              (call_import $_sbrk
+                                (i32.const 0)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                          (block
+                            (set_local $1
+                              (if
+                                (i32.and
+                                  (set_local $11
+                                    (i32.add
+                                      (set_local $14
+                                        (i32.load
+                                          (i32.const 652)
+                                        )
+                                      )
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (set_local $2
+                                    (get_local $9)
+                                  )
+                                )
+                                (i32.add
+                                  (i32.sub
+                                    (get_local $7)
+                                    (get_local $2)
+                                  )
+                                  (i32.and
+                                    (i32.add
+                                      (get_local $11)
+                                      (get_local $2)
+                                    )
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $14)
+                                    )
+                                  )
+                                )
+                                (get_local $7)
+                              )
+                            )
+                            (set_local $2
+                              (i32.add
+                                (set_local $14
+                                  (i32.load
+                                    (i32.const 608)
+                                  )
+                                )
+                                (get_local $1)
+                              )
+                            )
+                            (if
+                              (i32.and
+                                (i32.gt_u
+                                  (get_local $1)
+                                  (get_local $0)
+                                )
+                                (i32.lt_u
+                                  (get_local $1)
+                                  (i32.const 2147483647)
+                                )
+                              )
+                              (block
+                                (br_if $do-once$39
+                                  (select
+                                    (i32.or
+                                      (i32.le_u
+                                        (get_local $2)
+                                        (get_local $14)
+                                      )
+                                      (i32.gt_u
+                                        (get_local $2)
+                                        (set_local $11
+                                          (i32.load
+                                            (i32.const 616)
+                                          )
+                                        )
+                                      )
+                                    )
+                                    (i32.const 0)
+                                    (i32.ne
+                                      (get_local $11)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (set_local $11
+                                      (call_import $_sbrk
+                                        (get_local $1)
+                                      )
+                                    )
+                                    (get_local $9)
+                                  )
+                                  (block
+                                    (set_local $20
+                                      (get_local $9)
+                                    )
+                                    (set_local $22
+                                      (get_local $1)
+                                    )
+                                    (br $label$break$L257
+                                      (i32.const 193)
+                                    )
+                                  )
+                                  (block
+                                    (set_local $13
+                                      (get_local $11)
+                                    )
+                                    (set_local $17
+                                      (get_local $1)
+                                    )
+                                    (set_local $8
+                                      (i32.const 183)
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                      (block $label$break$L279
+                        (if
+                          (i32.eq
+                            (get_local $8)
+                            (i32.const 183)
+                          )
+                          (block
+                            (set_local $11
+                              (i32.sub
+                                (i32.const 0)
+                                (get_local $17)
+                              )
+                            )
+                            (if
+                              (if
+                                (i32.and
+                                  (i32.gt_u
+                                    (get_local $16)
+                                    (get_local $17)
+                                  )
+                                  (i32.and
+                                    (i32.lt_u
+                                      (get_local $17)
+                                      (i32.const 2147483647)
+                                    )
+                                    (i32.ne
+                                      (get_local $13)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                )
+                                (i32.lt_u
+                                  (set_local $2
+                                    (i32.and
+                                      (i32.add
+                                        (i32.sub
+                                          (get_local $12)
+                                          (get_local $17)
+                                        )
+                                        (set_local $9
+                                          (i32.load
+                                            (i32.const 656)
+                                          )
+                                        )
+                                      )
+                                      (i32.sub
+                                        (i32.const 0)
+                                        (get_local $9)
+                                      )
+                                    )
+                                  )
+                                  (i32.const 2147483647)
+                                )
+                                (i32.const 0)
+                              )
+                              (if
+                                (i32.eq
+                                  (call_import $_sbrk
+                                    (get_local $2)
+                                  )
+                                  (i32.const -1)
+                                )
+                                (block
+                                  (call_import $_sbrk
+                                    (get_local $11)
+                                  )
+                                  (br $label$break$L279)
+                                )
+                                (set_local $3
+                                  (i32.add
+                                    (get_local $2)
+                                    (get_local $17)
+                                  )
+                                )
+                              )
+                              (set_local $3
+                                (get_local $17)
+                              )
+                            )
+                            (if
+                              (i32.ne
+                                (get_local $13)
+                                (i32.const -1)
+                              )
+                              (block
+                                (set_local $20
+                                  (get_local $13)
+                                )
+                                (set_local $22
+                                  (get_local $3)
+                                )
+                                (br $label$break$L257
+                                  (i32.const 193)
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                      (i32.store
+                        (i32.const 620)
+                        (i32.or
+                          (i32.load
+                            (i32.const 620)
+                          )
+                          (i32.const 4)
+                        )
+                      )
+                      (i32.const 190)
+                    )
+                  )
+                )
+              )
               (i32.const 190)
             )
           )
@@ -7892,71 +7891,70 @@
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $6
-        (if
-          (i32.load
-            (i32.const 8)
-          )
-          (block
-            (call_import $_pthread_cleanup_push
-              (i32.const 4)
-              (get_local $0)
-            )
-            (i32.store
-              (get_local $13)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $13)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $13)
-              (get_local $3)
-            )
-            (set_local $10
-              (call $___syscall_ret
-                (call_import $___syscall146
-                  (i32.const 146)
-                  (get_local $13)
-                )
-              )
-            )
-            (call_import $_pthread_cleanup_pop
-              (i32.const 0)
-            )
-            (get_local $10)
-          )
-          (block
-            (i32.store
-              (get_local $12)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $12)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $12)
-              (get_local $3)
-            )
-            (call $___syscall_ret
-              (call_import $___syscall146
-                (i32.const 146)
-                (get_local $12)
-              )
-            )
-          )
-        )
-      )
       (if
         (i32.eq
           (get_local $5)
-          (get_local $6)
+          (set_local $6
+            (if
+              (i32.load
+                (i32.const 8)
+              )
+              (block
+                (call_import $_pthread_cleanup_push
+                  (i32.const 4)
+                  (get_local $0)
+                )
+                (i32.store
+                  (get_local $13)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $13)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $13)
+                  (get_local $3)
+                )
+                (set_local $10
+                  (call $___syscall_ret
+                    (call_import $___syscall146
+                      (i32.const 146)
+                      (get_local $13)
+                    )
+                  )
+                )
+                (call_import $_pthread_cleanup_pop
+                  (i32.const 0)
+                )
+                (get_local $10)
+              )
+              (block
+                (i32.store
+                  (get_local $12)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $12)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $12)
+                  (get_local $3)
+                )
+                (call $___syscall_ret
+                  (call_import $___syscall146
+                    (i32.const 146)
+                    (get_local $12)
+                  )
+                )
+              )
+            )
+          )
         )
         (block
           (set_local $1

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -3120,387 +3120,6 @@
         (i32.const 0)
       )
     )
-    (set_local $8
-      (block $label$break$L257
-        (if
-          (i32.and
-            (i32.load
-              (i32.const 620)
-            )
-            (i32.const 4)
-          )
-          (i32.const 190)
-          (block
-            (block $label$break$L259
-              (if
-                (set_local $9
-                  (i32.load
-                    (i32.const 200)
-                  )
-                )
-                (block
-                  (set_local $14
-                    (i32.const 624)
-                  )
-                  (loop $while-out$37 $while-in$38
-                    (if
-                      (if
-                        (i32.le_u
-                          (i32.load
-                            (get_local $14)
-                          )
-                          (get_local $9)
-                        )
-                        (i32.load
-                          (set_local $11
-                            (i32.add
-                              (get_local $14)
-                              (i32.const 4)
-                            )
-                          )
-                        )
-                        (i32.const 0)
-                      )
-                      (block
-                        (set_local $4
-                          (get_local $14)
-                        )
-                        (set_local $5
-                          (get_local $11)
-                        )
-                        (br $while-out$37)
-                      )
-                    )
-                    (if
-                      (i32.eqz
-                        (set_local $14
-                          (i32.load offset=8
-                            (get_local $14)
-                          )
-                        )
-                      )
-                      (block
-                        (set_local $8
-                          (i32.const 173)
-                        )
-                        (br $label$break$L259)
-                      )
-                    )
-                    (br $while-in$38)
-                  )
-                  (if
-                    (i32.lt_u
-                      (set_local $14
-                        (i32.and
-                          (i32.sub
-                            (get_local $21)
-                            (i32.load
-                              (i32.const 188)
-                            )
-                          )
-                          (get_local $23)
-                        )
-                      )
-                      (i32.const 2147483647)
-                    )
-                    (if
-                      (i32.eq
-                        (set_local $11
-                          (call_import $_sbrk
-                            (get_local $14)
-                          )
-                        )
-                        (i32.add
-                          (i32.load
-                            (get_local $4)
-                          )
-                          (i32.load
-                            (get_local $5)
-                          )
-                        )
-                      )
-                      (if
-                        (i32.ne
-                          (get_local $11)
-                          (i32.const -1)
-                        )
-                        (block
-                          (set_local $20
-                            (get_local $11)
-                          )
-                          (set_local $22
-                            (get_local $14)
-                          )
-                          (br $label$break$L257
-                            (i32.const 193)
-                          )
-                        )
-                      )
-                      (block
-                        (set_local $13
-                          (get_local $11)
-                        )
-                        (set_local $17
-                          (get_local $14)
-                        )
-                        (set_local $8
-                          (i32.const 183)
-                        )
-                      )
-                    )
-                  )
-                )
-                (set_local $8
-                  (i32.const 173)
-                )
-              )
-            )
-            (block $do-once$39
-              (if
-                (if
-                  (i32.eq
-                    (get_local $8)
-                    (i32.const 173)
-                  )
-                  (set_local $9
-                    (call_import $_sbrk
-                      (i32.const 0)
-                    )
-                  )
-                  (i32.const 0)
-                )
-                (block
-                  (set_local $1
-                    (if
-                      (i32.and
-                        (set_local $11
-                          (i32.add
-                            (set_local $14
-                              (i32.load
-                                (i32.const 652)
-                              )
-                            )
-                            (i32.const -1)
-                          )
-                        )
-                        (set_local $2
-                          (get_local $9)
-                        )
-                      )
-                      (i32.add
-                        (i32.sub
-                          (get_local $7)
-                          (get_local $2)
-                        )
-                        (i32.and
-                          (i32.add
-                            (get_local $11)
-                            (get_local $2)
-                          )
-                          (i32.sub
-                            (i32.const 0)
-                            (get_local $14)
-                          )
-                        )
-                      )
-                      (get_local $7)
-                    )
-                  )
-                  (set_local $2
-                    (i32.add
-                      (set_local $14
-                        (i32.load
-                          (i32.const 608)
-                        )
-                      )
-                      (get_local $1)
-                    )
-                  )
-                  (if
-                    (i32.and
-                      (i32.gt_u
-                        (get_local $1)
-                        (get_local $0)
-                      )
-                      (i32.lt_u
-                        (get_local $1)
-                        (i32.const 2147483647)
-                      )
-                    )
-                    (block
-                      (br_if $do-once$39
-                        (select
-                          (i32.or
-                            (i32.le_u
-                              (get_local $2)
-                              (get_local $14)
-                            )
-                            (i32.gt_u
-                              (get_local $2)
-                              (set_local $11
-                                (i32.load
-                                  (i32.const 616)
-                                )
-                              )
-                            )
-                          )
-                          (i32.const 0)
-                          (i32.ne
-                            (get_local $11)
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                      (if
-                        (i32.eq
-                          (set_local $11
-                            (call_import $_sbrk
-                              (get_local $1)
-                            )
-                          )
-                          (get_local $9)
-                        )
-                        (block
-                          (set_local $20
-                            (get_local $9)
-                          )
-                          (set_local $22
-                            (get_local $1)
-                          )
-                          (br $label$break$L257
-                            (i32.const 193)
-                          )
-                        )
-                        (block
-                          (set_local $13
-                            (get_local $11)
-                          )
-                          (set_local $17
-                            (get_local $1)
-                          )
-                          (set_local $8
-                            (i32.const 183)
-                          )
-                        )
-                      )
-                    )
-                  )
-                )
-              )
-            )
-            (block $label$break$L279
-              (if
-                (i32.eq
-                  (get_local $8)
-                  (i32.const 183)
-                )
-                (block
-                  (set_local $11
-                    (i32.sub
-                      (i32.const 0)
-                      (get_local $17)
-                    )
-                  )
-                  (if
-                    (if
-                      (i32.and
-                        (i32.gt_u
-                          (get_local $16)
-                          (get_local $17)
-                        )
-                        (i32.and
-                          (i32.lt_u
-                            (get_local $17)
-                            (i32.const 2147483647)
-                          )
-                          (i32.ne
-                            (get_local $13)
-                            (i32.const -1)
-                          )
-                        )
-                      )
-                      (i32.lt_u
-                        (set_local $2
-                          (i32.and
-                            (i32.add
-                              (i32.sub
-                                (get_local $12)
-                                (get_local $17)
-                              )
-                              (set_local $9
-                                (i32.load
-                                  (i32.const 656)
-                                )
-                              )
-                            )
-                            (i32.sub
-                              (i32.const 0)
-                              (get_local $9)
-                            )
-                          )
-                        )
-                        (i32.const 2147483647)
-                      )
-                      (i32.const 0)
-                    )
-                    (if
-                      (i32.eq
-                        (call_import $_sbrk
-                          (get_local $2)
-                        )
-                        (i32.const -1)
-                      )
-                      (block
-                        (call_import $_sbrk
-                          (get_local $11)
-                        )
-                        (br $label$break$L279)
-                      )
-                      (set_local $3
-                        (i32.add
-                          (get_local $2)
-                          (get_local $17)
-                        )
-                      )
-                    )
-                    (set_local $3
-                      (get_local $17)
-                    )
-                  )
-                  (if
-                    (i32.ne
-                      (get_local $13)
-                      (i32.const -1)
-                    )
-                    (block
-                      (set_local $20
-                        (get_local $13)
-                      )
-                      (set_local $22
-                        (get_local $3)
-                      )
-                      (br $label$break$L257
-                        (i32.const 193)
-                      )
-                    )
-                  )
-                )
-              )
-            )
-            (i32.store
-              (i32.const 620)
-              (i32.or
-                (i32.load
-                  (i32.const 620)
-                )
-                (i32.const 4)
-              )
-            )
-            (i32.const 190)
-          )
-        )
-      )
-    )
     (if
       (if
         (if
@@ -3511,7 +3130,387 @@
             )
             (i32.const 0)
             (i32.eq
-              (get_local $8)
+              (set_local $8
+                (block $label$break$L257
+                  (if
+                    (i32.and
+                      (i32.load
+                        (i32.const 620)
+                      )
+                      (i32.const 4)
+                    )
+                    (i32.const 190)
+                    (block
+                      (block $label$break$L259
+                        (if
+                          (set_local $9
+                            (i32.load
+                              (i32.const 200)
+                            )
+                          )
+                          (block
+                            (set_local $14
+                              (i32.const 624)
+                            )
+                            (loop $while-out$37 $while-in$38
+                              (if
+                                (if
+                                  (i32.le_u
+                                    (i32.load
+                                      (get_local $14)
+                                    )
+                                    (get_local $9)
+                                  )
+                                  (i32.load
+                                    (set_local $11
+                                      (i32.add
+                                        (get_local $14)
+                                        (i32.const 4)
+                                      )
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                                (block
+                                  (set_local $4
+                                    (get_local $14)
+                                  )
+                                  (set_local $5
+                                    (get_local $11)
+                                  )
+                                  (br $while-out$37)
+                                )
+                              )
+                              (if
+                                (i32.eqz
+                                  (set_local $14
+                                    (i32.load offset=8
+                                      (get_local $14)
+                                    )
+                                  )
+                                )
+                                (block
+                                  (set_local $8
+                                    (i32.const 173)
+                                  )
+                                  (br $label$break$L259)
+                                )
+                              )
+                              (br $while-in$38)
+                            )
+                            (if
+                              (i32.lt_u
+                                (set_local $14
+                                  (i32.and
+                                    (i32.sub
+                                      (get_local $21)
+                                      (i32.load
+                                        (i32.const 188)
+                                      )
+                                    )
+                                    (get_local $23)
+                                  )
+                                )
+                                (i32.const 2147483647)
+                              )
+                              (if
+                                (i32.eq
+                                  (set_local $11
+                                    (call_import $_sbrk
+                                      (get_local $14)
+                                    )
+                                  )
+                                  (i32.add
+                                    (i32.load
+                                      (get_local $4)
+                                    )
+                                    (i32.load
+                                      (get_local $5)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.ne
+                                    (get_local $11)
+                                    (i32.const -1)
+                                  )
+                                  (block
+                                    (set_local $20
+                                      (get_local $11)
+                                    )
+                                    (set_local $22
+                                      (get_local $14)
+                                    )
+                                    (br $label$break$L257
+                                      (i32.const 193)
+                                    )
+                                  )
+                                )
+                                (block
+                                  (set_local $13
+                                    (get_local $11)
+                                  )
+                                  (set_local $17
+                                    (get_local $14)
+                                  )
+                                  (set_local $8
+                                    (i32.const 183)
+                                  )
+                                )
+                              )
+                            )
+                          )
+                          (set_local $8
+                            (i32.const 173)
+                          )
+                        )
+                      )
+                      (block $do-once$39
+                        (if
+                          (if
+                            (i32.eq
+                              (get_local $8)
+                              (i32.const 173)
+                            )
+                            (set_local $9
+                              (call_import $_sbrk
+                                (i32.const 0)
+                              )
+                            )
+                            (i32.const 0)
+                          )
+                          (block
+                            (set_local $1
+                              (if
+                                (i32.and
+                                  (set_local $11
+                                    (i32.add
+                                      (set_local $14
+                                        (i32.load
+                                          (i32.const 652)
+                                        )
+                                      )
+                                      (i32.const -1)
+                                    )
+                                  )
+                                  (set_local $2
+                                    (get_local $9)
+                                  )
+                                )
+                                (i32.add
+                                  (i32.sub
+                                    (get_local $7)
+                                    (get_local $2)
+                                  )
+                                  (i32.and
+                                    (i32.add
+                                      (get_local $11)
+                                      (get_local $2)
+                                    )
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $14)
+                                    )
+                                  )
+                                )
+                                (get_local $7)
+                              )
+                            )
+                            (set_local $2
+                              (i32.add
+                                (set_local $14
+                                  (i32.load
+                                    (i32.const 608)
+                                  )
+                                )
+                                (get_local $1)
+                              )
+                            )
+                            (if
+                              (i32.and
+                                (i32.gt_u
+                                  (get_local $1)
+                                  (get_local $0)
+                                )
+                                (i32.lt_u
+                                  (get_local $1)
+                                  (i32.const 2147483647)
+                                )
+                              )
+                              (block
+                                (br_if $do-once$39
+                                  (select
+                                    (i32.or
+                                      (i32.le_u
+                                        (get_local $2)
+                                        (get_local $14)
+                                      )
+                                      (i32.gt_u
+                                        (get_local $2)
+                                        (set_local $11
+                                          (i32.load
+                                            (i32.const 616)
+                                          )
+                                        )
+                                      )
+                                    )
+                                    (i32.const 0)
+                                    (i32.ne
+                                      (get_local $11)
+                                      (i32.const 0)
+                                    )
+                                  )
+                                )
+                                (if
+                                  (i32.eq
+                                    (set_local $11
+                                      (call_import $_sbrk
+                                        (get_local $1)
+                                      )
+                                    )
+                                    (get_local $9)
+                                  )
+                                  (block
+                                    (set_local $20
+                                      (get_local $9)
+                                    )
+                                    (set_local $22
+                                      (get_local $1)
+                                    )
+                                    (br $label$break$L257
+                                      (i32.const 193)
+                                    )
+                                  )
+                                  (block
+                                    (set_local $13
+                                      (get_local $11)
+                                    )
+                                    (set_local $17
+                                      (get_local $1)
+                                    )
+                                    (set_local $8
+                                      (i32.const 183)
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                      (block $label$break$L279
+                        (if
+                          (i32.eq
+                            (get_local $8)
+                            (i32.const 183)
+                          )
+                          (block
+                            (set_local $11
+                              (i32.sub
+                                (i32.const 0)
+                                (get_local $17)
+                              )
+                            )
+                            (if
+                              (if
+                                (i32.and
+                                  (i32.gt_u
+                                    (get_local $16)
+                                    (get_local $17)
+                                  )
+                                  (i32.and
+                                    (i32.lt_u
+                                      (get_local $17)
+                                      (i32.const 2147483647)
+                                    )
+                                    (i32.ne
+                                      (get_local $13)
+                                      (i32.const -1)
+                                    )
+                                  )
+                                )
+                                (i32.lt_u
+                                  (set_local $2
+                                    (i32.and
+                                      (i32.add
+                                        (i32.sub
+                                          (get_local $12)
+                                          (get_local $17)
+                                        )
+                                        (set_local $9
+                                          (i32.load
+                                            (i32.const 656)
+                                          )
+                                        )
+                                      )
+                                      (i32.sub
+                                        (i32.const 0)
+                                        (get_local $9)
+                                      )
+                                    )
+                                  )
+                                  (i32.const 2147483647)
+                                )
+                                (i32.const 0)
+                              )
+                              (if
+                                (i32.eq
+                                  (call_import $_sbrk
+                                    (get_local $2)
+                                  )
+                                  (i32.const -1)
+                                )
+                                (block
+                                  (call_import $_sbrk
+                                    (get_local $11)
+                                  )
+                                  (br $label$break$L279)
+                                )
+                                (set_local $3
+                                  (i32.add
+                                    (get_local $2)
+                                    (get_local $17)
+                                  )
+                                )
+                              )
+                              (set_local $3
+                                (get_local $17)
+                              )
+                            )
+                            (if
+                              (i32.ne
+                                (get_local $13)
+                                (i32.const -1)
+                              )
+                              (block
+                                (set_local $20
+                                  (get_local $13)
+                                )
+                                (set_local $22
+                                  (get_local $3)
+                                )
+                                (br $label$break$L257
+                                  (i32.const 193)
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                      (i32.store
+                        (i32.const 620)
+                        (i32.or
+                          (i32.load
+                            (i32.const 620)
+                          )
+                          (i32.const 4)
+                        )
+                      )
+                      (i32.const 190)
+                    )
+                  )
+                )
+              )
               (i32.const 190)
             )
           )
@@ -7892,71 +7891,70 @@
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $6
-        (if
-          (i32.load
-            (i32.const 8)
-          )
-          (block
-            (call_import $_pthread_cleanup_push
-              (i32.const 4)
-              (get_local $0)
-            )
-            (i32.store
-              (get_local $13)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $13)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $13)
-              (get_local $3)
-            )
-            (set_local $10
-              (call $___syscall_ret
-                (call_import $___syscall146
-                  (i32.const 146)
-                  (get_local $13)
-                )
-              )
-            )
-            (call_import $_pthread_cleanup_pop
-              (i32.const 0)
-            )
-            (get_local $10)
-          )
-          (block
-            (i32.store
-              (get_local $12)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $12)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $12)
-              (get_local $3)
-            )
-            (call $___syscall_ret
-              (call_import $___syscall146
-                (i32.const 146)
-                (get_local $12)
-              )
-            )
-          )
-        )
-      )
       (if
         (i32.eq
           (get_local $5)
-          (get_local $6)
+          (set_local $6
+            (if
+              (i32.load
+                (i32.const 8)
+              )
+              (block
+                (call_import $_pthread_cleanup_push
+                  (i32.const 4)
+                  (get_local $0)
+                )
+                (i32.store
+                  (get_local $13)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $13)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $13)
+                  (get_local $3)
+                )
+                (set_local $10
+                  (call $___syscall_ret
+                    (call_import $___syscall146
+                      (i32.const 146)
+                      (get_local $13)
+                    )
+                  )
+                )
+                (call_import $_pthread_cleanup_pop
+                  (i32.const 0)
+                )
+                (get_local $10)
+              )
+              (block
+                (i32.store
+                  (get_local $12)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $12)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $12)
+                  (get_local $3)
+                )
+                (call $___syscall_ret
+                  (call_import $___syscall146
+                    (i32.const 146)
+                    (get_local $12)
+                  )
+                )
+              )
+            )
+          )
         )
         (block
           (set_local $1

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -295,9 +295,9 @@
       )
       (get_local $0)
     )
-    (set_local $3
+    (set_local $2
       (call $_bitshift64Lshr
-        (set_local $2
+        (set_local $3
           (i32.load
             (i32.load
               (i32.const 24)
@@ -324,9 +324,9 @@
             (block $switch-case$1
               (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
                 (i32.sub
-                  (set_local $3
+                  (set_local $2
                     (i32.and
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 2047)
                     )
                   )
@@ -334,7 +334,8 @@
                 )
               )
             )
-            (set_local $2
+            (i32.store
+              (get_local $1)
               (if
                 (f64.ne
                   (get_local $0)
@@ -360,10 +361,6 @@
                 (i32.const 0)
               )
             )
-            (i32.store
-              (get_local $1)
-              (get_local $2)
-            )
             (br $switch$0
               (get_local $0)
             )
@@ -375,7 +372,7 @@
         (i32.store
           (get_local $1)
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const -1022)
           )
         )
@@ -383,7 +380,7 @@
           (i32.load
             (i32.const 24)
           )
-          (get_local $2)
+          (get_local $3)
         )
         (i32.store offset=4
           (i32.load
@@ -1151,74 +1148,73 @@
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $3
-        (if
-          (i32.eq
-            (i32.load
-              (i32.const 16)
-            )
-            (i32.const 0)
-          )
-          (block
-            (i32.store
-              (get_local $9)
-              (i32.load
-                (get_local $13)
-              )
-            )
-            (i32.store offset=4
-              (get_local $9)
-              (get_local $5)
-            )
-            (i32.store offset=8
-              (get_local $9)
-              (get_local $6)
-            )
-            (call $___syscall_ret
-              (call_import $___syscall146
-                (i32.const 146)
-                (get_local $9)
-              )
-            )
-          )
-          (block
-            (call_import $_pthread_cleanup_push
-              (i32.const 5)
-              (get_local $0)
-            )
-            (i32.store
-              (get_local $8)
-              (i32.load
-                (get_local $13)
-              )
-            )
-            (i32.store offset=4
-              (get_local $8)
-              (get_local $5)
-            )
-            (i32.store offset=8
-              (get_local $8)
-              (get_local $6)
-            )
-            (set_local $1
-              (call $___syscall_ret
-                (call_import $___syscall146
-                  (i32.const 146)
-                  (get_local $8)
-                )
-              )
-            )
-            (call_import $_pthread_cleanup_pop
-              (i32.const 0)
-            )
-            (get_local $1)
-          )
-        )
-      )
       (if
         (i32.eq
           (get_local $4)
-          (get_local $3)
+          (set_local $3
+            (if
+              (i32.eq
+                (i32.load
+                  (i32.const 16)
+                )
+                (i32.const 0)
+              )
+              (block
+                (i32.store
+                  (get_local $9)
+                  (i32.load
+                    (get_local $13)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $9)
+                  (get_local $5)
+                )
+                (i32.store offset=8
+                  (get_local $9)
+                  (get_local $6)
+                )
+                (call $___syscall_ret
+                  (call_import $___syscall146
+                    (i32.const 146)
+                    (get_local $9)
+                  )
+                )
+              )
+              (block
+                (call_import $_pthread_cleanup_push
+                  (i32.const 5)
+                  (get_local $0)
+                )
+                (i32.store
+                  (get_local $8)
+                  (i32.load
+                    (get_local $13)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $8)
+                  (get_local $5)
+                )
+                (i32.store offset=8
+                  (get_local $8)
+                  (get_local $6)
+                )
+                (set_local $1
+                  (call $___syscall_ret
+                    (call_import $___syscall146
+                      (i32.const 146)
+                      (get_local $8)
+                    )
+                  )
+                )
+                (call_import $_pthread_cleanup_pop
+                  (i32.const 0)
+                )
+                (get_local $1)
+              )
+            )
+          )
         )
         (block
           (set_local $1
@@ -2951,8 +2947,8 @@
     (local $11 i32)
     (local $12 i32)
     (local $13 i32)
-    (local $14 i32)
-    (local $15 f64)
+    (local $14 f64)
+    (local $15 i32)
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
@@ -3046,7 +3042,7 @@
       )
       (call_import $abort)
     )
-    (set_local $24
+    (set_local $25
       (i32.add
         (get_local $32)
         (i32.const 16)
@@ -3166,23 +3162,23 @@
         (i32.const 8)
       )
     )
-    (set_local $5
+    (set_local $19
       (i32.const 0)
     )
-    (set_local $12
+    (set_local $20
       (get_local $1)
     )
     (set_local $1
       (i32.const 0)
     )
-    (set_local $8
+    (set_local $11
       (i32.const 0)
     )
     (loop $label$break$L1 $label$continue$L1
-      (set_local $19
+      (set_local $8
         (if
           (i32.gt_s
-            (get_local $5)
+            (get_local $19)
             (i32.const -1)
           )
           (if
@@ -3190,7 +3186,7 @@
               (get_local $1)
               (i32.sub
                 (i32.const 2147483647)
-                (get_local $5)
+                (get_local $19)
               )
             )
             (block
@@ -3202,10 +3198,10 @@
             )
             (i32.add
               (get_local $1)
-              (get_local $5)
+              (get_local $19)
             )
           )
-          (get_local $5)
+          (get_local $19)
         )
       )
       (if
@@ -3214,7 +3210,7 @@
             (i32.shl
               (set_local $1
                 (i32.load8_s
-                  (get_local $12)
+                  (get_local $20)
                 )
               )
               (i32.const 24)
@@ -3225,18 +3221,18 @@
         )
         (block
           (set_local $79
-            (get_local $19)
-          )
-          (set_local $80
             (get_local $8)
           )
-          (set_local $13
+          (set_local $80
+            (get_local $11)
+          )
+          (set_local $12
             (i32.const 242)
           )
           (br $label$break$L1)
         )
         (set_local $5
-          (get_local $12)
+          (get_local $20)
         )
       )
       (loop $label$break$L9 $label$continue$L9
@@ -3264,7 +3260,7 @@
                 (set_local $70
                   (get_local $5)
                 )
-                (set_local $13
+                (set_local $12
                   (i32.const 9)
                 )
                 (br $label$break$L9)
@@ -3294,11 +3290,11 @@
       (block $label$break$L12
         (if
           (i32.eq
-            (get_local $13)
+            (get_local $12)
             (i32.const 9)
           )
           (loop $while-out$7 $while-in$8
-            (set_local $13
+            (set_local $12
               (i32.const 0)
             )
             (if
@@ -3370,10 +3366,10 @@
           )
         )
       )
-      (set_local $14
+      (set_local $16
         (i32.sub
           (get_local $62)
-          (get_local $12)
+          (get_local $20)
         )
       )
       (if
@@ -3389,8 +3385,8 @@
             (i32.const 0)
           )
           (call $___fwritex
-            (get_local $12)
-            (get_local $14)
+            (get_local $20)
+            (get_local $16)
             (get_local $0)
           )
         )
@@ -3398,17 +3394,17 @@
       (if
         (i32.ne
           (get_local $62)
-          (get_local $12)
+          (get_local $20)
         )
         (block
-          (set_local $5
-            (get_local $19)
+          (set_local $19
+            (get_local $8)
           )
-          (set_local $12
+          (set_local $20
             (get_local $41)
           )
           (set_local $1
-            (get_local $14)
+            (get_local $16)
           )
           (br $label$continue$L1)
         )
@@ -3467,14 +3463,14 @@
                 )
               )
             )
-            (set_local $11
+            (set_local $13
               (select
                 (i32.const 1)
-                (get_local $8)
+                (get_local $11)
                 (get_local $6)
               )
             )
-            (set_local $10
+            (set_local $9
               (get_local $5)
             )
             (select
@@ -3484,10 +3480,10 @@
             )
           )
           (block
-            (set_local $11
-              (get_local $8)
+            (set_local $13
+              (get_local $11)
             )
-            (set_local $10
+            (set_local $9
               (get_local $5)
             )
             (i32.const -1)
@@ -3531,7 +3527,7 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $8
+                  (set_local $11
                     (get_local $7)
                   )
                   (br $label$break$L25)
@@ -3563,9 +3559,9 @@
                         (i32.shl
                           (set_local $1
                             (i32.load8_s
-                              (set_local $10
+                              (set_local $9
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.const 1)
                                 )
                               )
@@ -3581,7 +3577,7 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $8
+                  (set_local $11
                     (get_local $7)
                   )
                   (br $while-out$10)
@@ -3590,7 +3586,7 @@
               (br $while-in$11)
             )
           )
-          (set_local $8
+          (set_local $11
             (i32.const 0)
           )
         )
@@ -3617,7 +3613,7 @@
                         (i32.load8_s
                           (set_local $7
                             (i32.add
-                              (get_local $10)
+                              (get_local $9)
                               (i32.const 1)
                             )
                           )
@@ -3636,7 +3632,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s offset=2
-                        (get_local $10)
+                        (get_local $9)
                       )
                       (i32.const 24)
                     )
@@ -3687,7 +3683,7 @@
                   )
                   (set_local $66
                     (i32.add
-                      (get_local $10)
+                      (get_local $9)
                       (i32.const 3)
                     )
                   )
@@ -3695,30 +3691,30 @@
                     (get_local $5)
                   )
                 )
-                (set_local $13
+                (set_local $12
                   (i32.const 24)
                 )
               )
-              (set_local $13
+              (set_local $12
                 (i32.const 24)
               )
             )
             (if
               (i32.eq
-                (get_local $13)
+                (get_local $12)
                 (i32.const 24)
               )
               (block
-                (set_local $13
+                (set_local $12
                   (i32.const 0)
                 )
                 (if
                   (i32.ne
-                    (get_local $11)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (block
-                    (set_local $22
+                    (set_local $23
                       (i32.const -1)
                     )
                     (br $label$break$L1)
@@ -3729,13 +3725,13 @@
                     (get_local $52)
                   )
                   (block
-                    (set_local $10
+                    (set_local $9
                       (get_local $7)
                     )
-                    (set_local $20
+                    (set_local $22
                       (i32.const 0)
                     )
-                    (set_local $16
+                    (set_local $15
                       (i32.const 0)
                     )
                     (br $do-once$12)
@@ -3789,41 +3785,41 @@
                 )
               )
             )
-            (set_local $8
+            (set_local $11
               (if
                 (i32.lt_s
                   (get_local $61)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $10
+                  (set_local $9
                     (get_local $66)
                   )
-                  (set_local $20
+                  (set_local $22
                     (get_local $63)
                   )
-                  (set_local $16
+                  (set_local $15
                     (i32.sub
                       (i32.const 0)
                       (get_local $61)
                     )
                   )
                   (i32.or
-                    (get_local $8)
+                    (get_local $11)
                     (i32.const 8192)
                   )
                 )
                 (block
-                  (set_local $10
+                  (set_local $9
                     (get_local $66)
                   )
-                  (set_local $20
+                  (set_local $22
                     (get_local $63)
                   )
-                  (set_local $16
+                  (set_local $15
                     (get_local $61)
                   )
-                  (get_local $8)
+                  (get_local $11)
                 )
               )
             )
@@ -3846,7 +3842,7 @@
             )
             (block
               (set_local $1
-                (get_local $10)
+                (get_local $9)
               )
               (set_local $5
                 (i32.const 0)
@@ -3863,7 +3859,7 @@
                 )
                 (if
                   (i32.lt_u
-                    (set_local $10
+                    (set_local $9
                       (i32.add
                         (i32.shr_s
                           (i32.shl
@@ -3889,7 +3885,7 @@
                       (get_local $7)
                     )
                     (set_local $7
-                      (get_local $10)
+                      (get_local $9)
                     )
                   )
                   (block
@@ -3910,43 +3906,43 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $22
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
                 (block
-                  (set_local $10
+                  (set_local $9
                     (get_local $5)
                   )
-                  (set_local $20
-                    (get_local $11)
+                  (set_local $22
+                    (get_local $13)
                   )
-                  (set_local $16
+                  (set_local $15
                     (get_local $1)
                   )
                 )
               )
             )
             (block
-              (set_local $20
-                (get_local $11)
+              (set_local $22
+                (get_local $13)
               )
-              (set_local $16
+              (set_local $15
                 (i32.const 0)
               )
             )
           )
         )
       )
-      (set_local $11
+      (set_local $13
         (block $label$break$L46
           (if
             (i32.eq
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $10)
+                    (get_local $9)
                   )
                   (i32.const 24)
                 )
@@ -3963,7 +3959,7 @@
                         (i32.load8_s
                           (set_local $5
                             (i32.add
-                              (get_local $10)
+                              (get_local $9)
                               (i32.const 1)
                             )
                           )
@@ -4001,7 +3997,7 @@
                       )
                     )
                     (block
-                      (set_local $9
+                      (set_local $10
                         (i32.const 0)
                       )
                       (br $label$break$L46
@@ -4043,7 +4039,7 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $9
+                        (set_local $10
                           (get_local $5)
                         )
                         (br $label$break$L46
@@ -4064,7 +4060,7 @@
                           (i32.load8_s
                             (set_local $7
                               (i32.add
-                                (get_local $10)
+                                (get_local $9)
                                 (i32.const 2)
                               )
                             )
@@ -4083,7 +4079,7 @@
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s offset=3
-                          (get_local $10)
+                          (get_local $9)
                         )
                         (i32.const 24)
                       )
@@ -4129,12 +4125,12 @@
                     (i32.load offset=4
                       (get_local $1)
                     )
-                    (set_local $9
+                    (set_local $10
                       (get_local $5)
                     )
                     (br $label$break$L46
                       (i32.add
-                        (get_local $10)
+                        (get_local $9)
                         (i32.const 4)
                       )
                     )
@@ -4143,11 +4139,11 @@
               )
               (if
                 (i32.ne
-                  (get_local $20)
+                  (get_local $22)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $22
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
@@ -4193,13 +4189,13 @@
                       (i32.const 4)
                     )
                   )
-                  (set_local $9
+                  (set_local $10
                     (get_local $5)
                   )
                   (get_local $7)
                 )
                 (block
-                  (set_local $9
+                  (set_local $10
                     (i32.const 0)
                   )
                   (get_local $7)
@@ -4207,15 +4203,15 @@
               )
             )
             (block
-              (set_local $9
+              (set_local $10
                 (i32.const -1)
               )
-              (get_local $10)
+              (get_local $9)
             )
           )
         )
       )
-      (set_local $21
+      (set_local $19
         (i32.const 0)
       )
       (loop $while-out$19 $while-in$20
@@ -4226,7 +4222,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $11)
+                      (get_local $13)
                     )
                     (i32.const 24)
                   )
@@ -4238,15 +4234,15 @@
             (i32.const 57)
           )
           (block
-            (set_local $22
+            (set_local $23
               (i32.const -1)
             )
             (br $label$break$L1)
           )
         )
-        (set_local $10
+        (set_local $9
           (i32.add
-            (get_local $11)
+            (get_local $13)
             (i32.const 1)
           )
         )
@@ -4261,7 +4257,7 @@
                         (i32.add
                           (i32.const 3611)
                           (i32.mul
-                            (get_local $21)
+                            (get_local $19)
                             (i32.const 58)
                           )
                         )
@@ -4277,25 +4273,16 @@
             (i32.const 8)
           )
           (block
-            (set_local $11
-              (get_local $10)
+            (set_local $13
+              (get_local $9)
             )
-            (set_local $21
+            (set_local $19
               (get_local $5)
             )
           )
           (block
             (set_local $7
               (get_local $5)
-            )
-            (set_local $25
-              (get_local $10)
-            )
-            (set_local $10
-              (get_local $11)
-            )
-            (set_local $11
-              (get_local $21)
             )
             (br $while-out$19)
           )
@@ -4314,7 +4301,7 @@
           (i32.const 0)
         )
         (block
-          (set_local $22
+          (set_local $23
             (i32.const -1)
           )
           (br $label$break$L1)
@@ -4341,12 +4328,12 @@
           (if
             (get_local $5)
             (block
-              (set_local $22
+              (set_local $23
                 (i32.const -1)
               )
               (br $label$break$L1)
             )
-            (set_local $13
+            (set_local $12
               (i32.const 52)
             )
           )
@@ -4392,7 +4379,7 @@
                   (get_local $6)
                   (get_local $1)
                 )
-                (set_local $13
+                (set_local $12
                   (i32.const 52)
                 )
                 (br $do-once$21)
@@ -4403,7 +4390,7 @@
                 (get_local $52)
               )
               (block
-                (set_local $22
+                (set_local $23
                   (i32.const 0)
                 )
                 (br $label$break$L1)
@@ -4419,11 +4406,11 @@
       )
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 52)
         )
         (block
-          (set_local $13
+          (set_local $12
             (i32.const 0)
           )
           (if
@@ -4431,17 +4418,17 @@
               (get_local $52)
             )
             (block
-              (set_local $5
-                (get_local $19)
+              (set_local $19
+                (get_local $8)
               )
-              (set_local $12
-                (get_local $25)
+              (set_local $20
+                (get_local $9)
               )
               (set_local $1
-                (get_local $14)
+                (get_local $16)
               )
-              (set_local $8
-                (get_local $20)
+              (set_local $11
+                (get_local $22)
               )
               (br $label$continue$L1)
             )
@@ -4451,7 +4438,7 @@
       (set_local $5
         (i32.and
           (i32.ne
-            (get_local $11)
+            (get_local $19)
             (i32.const 0)
           )
           (i32.eq
@@ -4460,7 +4447,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $10)
+                      (get_local $13)
                     )
                     (i32.const 24)
                   )
@@ -4475,16 +4462,16 @@
       )
       (set_local $17
         (select
-          (get_local $8)
+          (get_local $11)
           (set_local $7
             (i32.and
-              (get_local $8)
+              (get_local $11)
               (i32.const -65537)
             )
           )
           (i32.eq
             (i32.and
-              (get_local $8)
+              (get_local $11)
               (i32.const 8192)
             )
             (i32.const 0)
@@ -4544,7 +4531,7 @@
                                                                         (block $switch-case$26
                                                                           (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
                                                                             (i32.sub
-                                                                              (get_local $11)
+                                                                              (get_local $19)
                                                                               (i32.const 0)
                                                                             )
                                                                           )
@@ -4553,19 +4540,19 @@
                                                                           (i32.load
                                                                             (get_local $18)
                                                                           )
-                                                                          (get_local $19)
+                                                                          (get_local $8)
                                                                         )
-                                                                        (set_local $5
-                                                                          (get_local $19)
+                                                                        (set_local $19
+                                                                          (get_local $8)
                                                                         )
-                                                                        (set_local $12
-                                                                          (get_local $25)
+                                                                        (set_local $20
+                                                                          (get_local $9)
                                                                         )
                                                                         (set_local $1
-                                                                          (get_local $14)
+                                                                          (get_local $16)
                                                                         )
-                                                                        (set_local $8
-                                                                          (get_local $20)
+                                                                        (set_local $11
+                                                                          (get_local $22)
                                                                         )
                                                                         (br $label$continue$L1)
                                                                       )
@@ -4573,19 +4560,19 @@
                                                                         (i32.load
                                                                           (get_local $18)
                                                                         )
-                                                                        (get_local $19)
+                                                                        (get_local $8)
                                                                       )
-                                                                      (set_local $5
-                                                                        (get_local $19)
+                                                                      (set_local $19
+                                                                        (get_local $8)
                                                                       )
-                                                                      (set_local $12
-                                                                        (get_local $25)
+                                                                      (set_local $20
+                                                                        (get_local $9)
                                                                       )
                                                                       (set_local $1
-                                                                        (get_local $14)
+                                                                        (get_local $16)
                                                                       )
-                                                                      (set_local $8
-                                                                        (get_local $20)
+                                                                      (set_local $11
+                                                                        (get_local $22)
                                                                       )
                                                                       (br $label$continue$L1)
                                                                     )
@@ -4595,14 +4582,14 @@
                                                                           (get_local $18)
                                                                         )
                                                                       )
-                                                                      (get_local $19)
+                                                                      (get_local $8)
                                                                     )
                                                                     (i32.store offset=4
                                                                       (get_local $1)
                                                                       (i32.shr_s
                                                                         (i32.shl
                                                                           (i32.lt_s
-                                                                            (get_local $19)
+                                                                            (get_local $8)
                                                                             (i32.const 0)
                                                                           )
                                                                           (i32.const 31)
@@ -4610,17 +4597,17 @@
                                                                         (i32.const 31)
                                                                       )
                                                                     )
-                                                                    (set_local $5
-                                                                      (get_local $19)
+                                                                    (set_local $19
+                                                                      (get_local $8)
                                                                     )
-                                                                    (set_local $12
-                                                                      (get_local $25)
+                                                                    (set_local $20
+                                                                      (get_local $9)
                                                                     )
                                                                     (set_local $1
-                                                                      (get_local $14)
+                                                                      (get_local $16)
                                                                     )
-                                                                    (set_local $8
-                                                                      (get_local $20)
+                                                                    (set_local $11
+                                                                      (get_local $22)
                                                                     )
                                                                     (br $label$continue$L1)
                                                                   )
@@ -4629,21 +4616,21 @@
                                                                       (get_local $18)
                                                                     )
                                                                     (i32.and
-                                                                      (get_local $19)
+                                                                      (get_local $8)
                                                                       (i32.const 65535)
                                                                     )
                                                                   )
-                                                                  (set_local $5
-                                                                    (get_local $19)
+                                                                  (set_local $19
+                                                                    (get_local $8)
                                                                   )
-                                                                  (set_local $12
-                                                                    (get_local $25)
+                                                                  (set_local $20
+                                                                    (get_local $9)
                                                                   )
                                                                   (set_local $1
-                                                                    (get_local $14)
+                                                                    (get_local $16)
                                                                   )
-                                                                  (set_local $8
-                                                                    (get_local $20)
+                                                                  (set_local $11
+                                                                    (get_local $22)
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
@@ -4652,21 +4639,21 @@
                                                                     (get_local $18)
                                                                   )
                                                                   (i32.and
-                                                                    (get_local $19)
+                                                                    (get_local $8)
                                                                     (i32.const 255)
                                                                   )
                                                                 )
-                                                                (set_local $5
-                                                                  (get_local $19)
+                                                                (set_local $19
+                                                                  (get_local $8)
                                                                 )
-                                                                (set_local $12
-                                                                  (get_local $25)
+                                                                (set_local $20
+                                                                  (get_local $9)
                                                                 )
                                                                 (set_local $1
-                                                                  (get_local $14)
+                                                                  (get_local $16)
                                                                 )
-                                                                (set_local $8
-                                                                  (get_local $20)
+                                                                (set_local $11
+                                                                  (get_local $22)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
@@ -4674,19 +4661,19 @@
                                                                 (i32.load
                                                                   (get_local $18)
                                                                 )
-                                                                (get_local $19)
+                                                                (get_local $8)
                                                               )
-                                                              (set_local $5
-                                                                (get_local $19)
+                                                              (set_local $19
+                                                                (get_local $8)
                                                               )
-                                                              (set_local $12
-                                                                (get_local $25)
+                                                              (set_local $20
+                                                                (get_local $9)
                                                               )
                                                               (set_local $1
-                                                                (get_local $14)
+                                                                (get_local $16)
                                                               )
-                                                              (set_local $8
-                                                                (get_local $20)
+                                                              (set_local $11
+                                                                (get_local $22)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
@@ -4696,14 +4683,14 @@
                                                                   (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $19)
+                                                              (get_local $8)
                                                             )
                                                             (i32.store offset=4
                                                               (get_local $1)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $19)
+                                                                    (get_local $8)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -4711,31 +4698,31 @@
                                                                 (i32.const 31)
                                                               )
                                                             )
-                                                            (set_local $5
-                                                              (get_local $19)
+                                                            (set_local $19
+                                                              (get_local $8)
                                                             )
-                                                            (set_local $12
-                                                              (get_local $25)
+                                                            (set_local $20
+                                                              (get_local $9)
                                                             )
                                                             (set_local $1
-                                                              (get_local $14)
+                                                              (get_local $16)
                                                             )
-                                                            (set_local $8
-                                                              (get_local $20)
+                                                            (set_local $11
+                                                              (get_local $22)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
-                                                          (set_local $5
-                                                            (get_local $19)
+                                                          (set_local $19
+                                                            (get_local $8)
                                                           )
-                                                          (set_local $12
-                                                            (get_local $25)
+                                                          (set_local $20
+                                                            (get_local $9)
                                                           )
                                                           (set_local $1
-                                                            (get_local $14)
+                                                            (get_local $16)
                                                           )
-                                                          (set_local $8
-                                                            (get_local $20)
+                                                          (set_local $11
+                                                            (get_local $22)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
@@ -4750,10 +4737,10 @@
                                                     )
                                                     (set_local $58
                                                       (select
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (i32.const 8)
                                                         (i32.gt_u
-                                                          (get_local $9)
+                                                          (get_local $10)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -4761,7 +4748,7 @@
                                                     (set_local $69
                                                       (i32.const 120)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (i32.const 64)
                                                     )
                                                     (br $switch$24)
@@ -4771,12 +4758,12 @@
                                                   (get_local $17)
                                                 )
                                                 (set_local $58
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                 )
                                                 (set_local $69
                                                   (get_local $33)
                                                 )
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.const 64)
                                                 )
                                                 (br $switch$24)
@@ -4885,7 +4872,7 @@
                                                       (get_local $17)
                                                     )
                                                     (set_local $31
-                                                      (get_local $9)
+                                                      (get_local $10)
                                                     )
                                                     (set_local $38
                                                       (i32.const 0)
@@ -4893,7 +4880,7 @@
                                                     (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (i32.const 77)
                                                     )
                                                     (get_local $6)
@@ -4901,7 +4888,7 @@
                                                   (block
                                                     (set_local $5
                                                       (i32.lt_s
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (set_local $1
                                                           (i32.add
                                                             (i32.sub
@@ -4919,7 +4906,7 @@
                                                     (set_local $31
                                                       (select
                                                         (get_local $1)
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (get_local $5)
                                                       )
                                                     )
@@ -4929,7 +4916,7 @@
                                                     (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (i32.const 77)
                                                     )
                                                     (get_local $6)
@@ -4991,7 +4978,7 @@
                                               (set_local $60
                                                 (i32.const 4091)
                                               )
-                                              (set_local $13
+                                              (set_local $12
                                                 (i32.const 76)
                                               )
                                               (br $label$break$L75)
@@ -5031,7 +5018,7 @@
                                                 (set_local $60
                                                   (get_local $1)
                                                 )
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.const 76)
                                                 )
                                                 (get_local $5)
@@ -5046,7 +5033,7 @@
                                                 (set_local $60
                                                   (i32.const 4092)
                                                 )
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.const 76)
                                                 )
                                                 (get_local $5)
@@ -5073,7 +5060,7 @@
                                         (set_local $60
                                           (i32.const 4091)
                                         )
-                                        (set_local $13
+                                        (set_local $12
                                           (i32.const 76)
                                         )
                                         (br $switch$24)
@@ -5122,7 +5109,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.const 82)
                                     )
                                     (br $switch$24)
@@ -5144,7 +5131,7 @@
                                       (get_local $5)
                                     )
                                   )
-                                  (set_local $13
+                                  (set_local $12
                                     (i32.const 82)
                                   )
                                   (br $switch$24)
@@ -5174,22 +5161,22 @@
                                 (set_local $65
                                   (i32.const -1)
                                 )
-                                (set_local $13
+                                (set_local $12
                                   (i32.const 86)
                                 )
                                 (br $switch$24)
                               )
-                              (set_local $13
+                              (set_local $12
                                 (if
                                   (i32.eq
-                                    (get_local $9)
+                                    (get_local $10)
                                     (i32.const 0)
                                   )
                                   (block
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $16)
+                                      (get_local $15)
                                       (i32.const 0)
                                       (get_local $17)
                                     )
@@ -5200,7 +5187,7 @@
                                   )
                                   (block
                                     (set_local $65
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                     (i32.const 86)
                                   )
@@ -5215,20 +5202,20 @@
                   )
                 )
               )
-              (set_local $15
+              (set_local $14
                 (f64.load
                   (get_local $18)
                 )
               )
               (i32.store
-                (get_local $24)
+                (get_local $25)
                 (i32.const 0)
               )
               (f64.store
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $15)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
@@ -5249,9 +5236,9 @@
                     (set_local $39
                       (i32.const 4108)
                     )
-                    (set_local $15
+                    (set_local $14
                       (f64.neg
-                        (get_local $15)
+                        (get_local $14)
                       )
                     )
                     (i32.const 1)
@@ -5295,12 +5282,18 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $15)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
+              )
+              (set_local $19
+                (get_local $8)
+              )
+              (set_local $20
+                (get_local $9)
               )
               (set_local $1
                 (block $do-once$56
@@ -5334,11 +5327,11 @@
                       (if
                         (set_local $5
                           (f64.ne
-                            (set_local $15
+                            (set_local $14
                               (f64.mul
                                 (call $_frexpl
-                                  (get_local $15)
-                                  (get_local $24)
+                                  (get_local $14)
+                                  (get_local $25)
                                 )
                                 (f64.const 2)
                               )
@@ -5347,10 +5340,10 @@
                           )
                         )
                         (i32.store
-                          (get_local $24)
+                          (get_local $25)
                           (i32.add
                             (i32.load
-                              (get_local $24)
+                              (get_local $25)
                             )
                             (i32.const -1)
                           )
@@ -5358,7 +5351,7 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $14
+                          (set_local $21
                             (i32.or
                               (get_local $33)
                               (i32.const 32)
@@ -5367,7 +5360,7 @@
                           (i32.const 97)
                         )
                         (block
-                          (set_local $10
+                          (set_local $11
                             (select
                               (get_local $39)
                               (i32.add
@@ -5391,24 +5384,24 @@
                               (i32.const 2)
                             )
                           )
-                          (set_local $15
+                          (set_local $14
                             (if
                               (i32.or
                                 (i32.gt_u
-                                  (get_local $9)
+                                  (get_local $10)
                                   (i32.const 11)
                                 )
                                 (i32.eq
                                   (set_local $1
                                     (i32.sub
                                       (i32.const 12)
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                               )
-                              (get_local $15)
+                              (get_local $14)
                               (block
                                 (set_local $29
                                   (f64.const 8)
@@ -5439,7 +5432,7 @@
                                     (i32.shr_s
                                       (i32.shl
                                         (i32.load8_s
-                                          (get_local $10)
+                                          (get_local $11)
                                         )
                                         (i32.const 24)
                                       )
@@ -5452,7 +5445,7 @@
                                       (get_local $29)
                                       (f64.sub
                                         (f64.neg
-                                          (get_local $15)
+                                          (get_local $14)
                                         )
                                         (get_local $29)
                                       )
@@ -5460,7 +5453,7 @@
                                   )
                                   (f64.sub
                                     (f64.add
-                                      (get_local $15)
+                                      (get_local $14)
                                       (get_local $29)
                                     )
                                     (get_local $29)
@@ -5473,7 +5466,7 @@
                             (i32.lt_s
                               (set_local $1
                                 (i32.load
-                                  (get_local $24)
+                                  (get_local $25)
                                 )
                               )
                               (i32.const 0)
@@ -5557,11 +5550,11 @@
                           )
                           (set_local $5
                             (i32.lt_s
-                              (get_local $9)
+                              (get_local $10)
                               (i32.const 1)
                             )
                           )
-                          (set_local $12
+                          (set_local $13
                             (i32.eq
                               (i32.and
                                 (get_local $17)
@@ -5570,12 +5563,12 @@
                               (i32.const 0)
                             )
                           )
-                          (set_local $11
+                          (set_local $9
                             (get_local $28)
                           )
                           (loop $while-out$62 $while-in$63
                             (i32.store8
-                              (get_local $11)
+                              (get_local $9)
                               (i32.and
                                 (i32.or
                                   (i32.and
@@ -5583,7 +5576,7 @@
                                       (i32.add
                                         (set_local $1
                                           (call_import $f64-to-int
-                                            (get_local $15)
+                                            (get_local $14)
                                           )
                                         )
                                         (i32.const 4075)
@@ -5596,10 +5589,10 @@
                                 (i32.const 255)
                               )
                             )
-                            (set_local $15
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $15)
+                                  (get_local $14)
                                   (f64.convert_s/i32
                                     (get_local $1)
                                   )
@@ -5614,7 +5607,7 @@
                                     (i32.sub
                                       (set_local $1
                                         (i32.add
-                                          (get_local $11)
+                                          (get_local $9)
                                           (i32.const 1)
                                         )
                                       )
@@ -5625,11 +5618,11 @@
                                   (block
                                     (if
                                       (i32.and
-                                        (get_local $12)
+                                        (get_local $13)
                                         (i32.and
                                           (get_local $5)
                                           (f64.eq
-                                            (get_local $15)
+                                            (get_local $14)
                                             (f64.const 0)
                                           )
                                         )
@@ -5643,7 +5636,7 @@
                                       (i32.const 46)
                                     )
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $9)
                                       (i32.const 2)
                                     )
                                   )
@@ -5653,10 +5646,10 @@
                             )
                             (if
                               (f64.ne
-                                (get_local $15)
+                                (get_local $14)
                                 (f64.const 0)
                               )
-                              (set_local $11
+                              (set_local $9
                                 (get_local $1)
                               )
                               (br $while-out$62)
@@ -5666,7 +5659,7 @@
                           (set_local $5
                             (i32.and
                               (i32.ne
-                                (get_local $9)
+                                (get_local $10)
                                 (i32.const 0)
                               )
                               (i32.lt_s
@@ -5674,14 +5667,14 @@
                                   (get_local $81)
                                   (get_local $1)
                                 )
-                                (get_local $9)
+                                (get_local $10)
                               )
                             )
                           )
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $16)
+                            (get_local $15)
                             (set_local $5
                               (i32.add
                                 (set_local $7
@@ -5689,7 +5682,7 @@
                                     (i32.sub
                                       (i32.add
                                         (get_local $82)
-                                        (get_local $9)
+                                        (get_local $10)
                                       )
                                       (get_local $8)
                                     )
@@ -5719,7 +5712,7 @@
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $10)
+                              (get_local $11)
                               (get_local $6)
                               (get_local $0)
                             )
@@ -5727,7 +5720,7 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 48)
-                            (get_local $16)
+                            (get_local $15)
                             (get_local $5)
                             (i32.xor
                               (get_local $17)
@@ -5793,7 +5786,7 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $16)
+                            (get_local $15)
                             (get_local $5)
                             (i32.xor
                               (get_local $17)
@@ -5802,11 +5795,11 @@
                           )
                           (br $do-once$56
                             (select
-                              (get_local $16)
+                              (get_local $15)
                               (get_local $5)
                               (i32.lt_s
                                 (get_local $5)
-                                (get_local $16)
+                                (get_local $15)
                               )
                             )
                           )
@@ -5815,62 +5808,59 @@
                       (set_local $1
                         (select
                           (i32.const 6)
-                          (get_local $9)
+                          (get_local $10)
                           (i32.lt_s
-                            (get_local $9)
+                            (get_local $10)
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $5
-                        (if
-                          (get_local $5)
-                          (block
-                            (i32.store
-                              (get_local $24)
-                              (set_local $5
-                                (i32.add
-                                  (i32.load
-                                    (get_local $24)
-                                  )
-                                  (i32.const -28)
-                                )
-                              )
-                            )
-                            (set_local $15
-                              (f64.mul
-                                (get_local $15)
-                                (f64.const 268435456)
-                              )
-                            )
-                            (get_local $5)
-                          )
-                          (i32.load
-                            (get_local $24)
-                          )
-                        )
-                      )
                       (set_local $30
-                        (set_local $10
+                        (set_local $11
                           (select
                             (get_local $78)
                             (get_local $76)
                             (i32.lt_s
-                              (get_local $5)
+                              (if
+                                (get_local $5)
+                                (block
+                                  (i32.store
+                                    (get_local $25)
+                                    (set_local $5
+                                      (i32.add
+                                        (i32.load
+                                          (get_local $25)
+                                        )
+                                        (i32.const -28)
+                                      )
+                                    )
+                                  )
+                                  (set_local $14
+                                    (f64.mul
+                                      (get_local $14)
+                                      (f64.const 268435456)
+                                    )
+                                  )
+                                  (get_local $5)
+                                )
+                                (i32.load
+                                  (get_local $25)
+                                )
+                              )
                               (i32.const 0)
                             )
                           )
                         )
                       )
                       (set_local $6
-                        (get_local $10)
+                        (get_local $11)
                       )
                       (loop $while-out$66 $while-in$67
                         (i32.store
                           (get_local $6)
                           (set_local $5
                             (call_import $f64-to-int
-                              (get_local $15)
+                              (get_local $14)
                             )
                           )
                         )
@@ -5882,10 +5872,10 @@
                         )
                         (if
                           (f64.eq
-                            (set_local $15
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $15)
+                                  (get_local $14)
                                   (f64.convert_u/i32
                                     (get_local $5)
                                   )
@@ -5908,20 +5898,20 @@
                         (i32.gt_s
                           (set_local $5
                             (i32.load
-                              (get_local $24)
+                              (get_local $25)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
                           (set_local $8
-                            (get_local $10)
+                            (get_local $11)
                           )
-                          (set_local $9
+                          (set_local $10
                             (get_local $7)
                           )
                           (loop $while-out$68 $while-in$69
-                            (set_local $11
+                            (set_local $9
                               (select
                                 (i32.const 29)
                                 (get_local $5)
@@ -5937,7 +5927,7 @@
                                   (i32.lt_u
                                     (set_local $6
                                       (i32.add
-                                        (get_local $9)
+                                        (get_local $10)
                                         (i32.const -4)
                                       )
                                     )
@@ -5948,7 +5938,7 @@
                                     (set_local $5
                                       (i32.const 0)
                                     )
-                                    (set_local $12
+                                    (set_local $13
                                       (get_local $6)
                                     )
                                     (loop $while-out$72 $while-in$73
@@ -5958,10 +5948,10 @@
                                             (call $_i64Add
                                               (call $_bitshift64Shl
                                                 (i32.load
-                                                  (get_local $12)
+                                                  (get_local $13)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $11)
+                                                (get_local $9)
                                               )
                                               (i32.load
                                                 (i32.const 168)
@@ -5983,7 +5973,7 @@
                                         (i32.const 168)
                                       )
                                       (i32.store
-                                        (get_local $12)
+                                        (get_local $13)
                                         (get_local $7)
                                       )
                                       (set_local $5
@@ -6001,14 +5991,14 @@
                                         (i32.lt_u
                                           (set_local $6
                                             (i32.add
-                                              (get_local $12)
+                                              (get_local $13)
                                               (i32.const -4)
                                             )
                                           )
                                           (get_local $8)
                                         )
                                         (br $while-out$72)
-                                        (set_local $12
+                                        (set_local $13
                                           (get_local $6)
                                         )
                                       )
@@ -6038,7 +6028,7 @@
                               )
                             )
                             (set_local $7
-                              (get_local $9)
+                              (get_local $10)
                             )
                             (loop $while-out$74 $while-in$75
                               (if
@@ -6068,13 +6058,13 @@
                               (br $while-in$75)
                             )
                             (i32.store
-                              (get_local $24)
+                              (get_local $25)
                               (set_local $5
                                 (i32.sub
                                   (i32.load
-                                    (get_local $24)
+                                    (get_local $25)
                                   )
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -6087,7 +6077,7 @@
                                 (set_local $8
                                   (get_local $6)
                                 )
-                                (set_local $9
+                                (set_local $10
                                   (get_local $7)
                                 )
                               )
@@ -6097,7 +6087,7 @@
                           )
                         )
                         (set_local $6
-                          (get_local $10)
+                          (get_local $11)
                         )
                       )
                       (if
@@ -6121,13 +6111,13 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $12
+                          (set_local $13
                             (i32.eq
-                              (get_local $14)
+                              (get_local $21)
                               (i32.const 102)
                             )
                           )
-                          (set_local $23
+                          (set_local $24
                             (get_local $7)
                           )
                           (loop $while-out$76 $while-in$77
@@ -6142,26 +6132,26 @@
                                 (i32.const 9)
                               )
                             )
-                            (set_local $9
+                            (set_local $10
                               (select
                                 (i32.const 9)
                                 (get_local $7)
                                 (get_local $5)
                               )
                             )
-                            (set_local $11
+                            (set_local $9
                               (block $do-once$78
                                 (if
                                   (i32.lt_u
                                     (get_local $6)
-                                    (get_local $23)
+                                    (get_local $24)
                                   )
                                   (block
                                     (set_local $68
                                       (i32.add
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $9)
+                                          (get_local $10)
                                         )
                                         (i32.const -1)
                                       )
@@ -6169,13 +6159,13 @@
                                     (set_local $26
                                       (i32.shr_u
                                         (i32.const 1000000000)
-                                        (get_local $9)
+                                        (get_local $10)
                                       )
                                     )
-                                    (set_local $11
+                                    (set_local $9
                                       (i32.const 0)
                                     )
-                                    (set_local $21
+                                    (set_local $16
                                       (get_local $6)
                                     )
                                     (loop $while-out$80 $while-in$81
@@ -6183,20 +6173,20 @@
                                         (i32.and
                                           (set_local $5
                                             (i32.load
-                                              (get_local $21)
+                                              (get_local $16)
                                             )
                                           )
                                           (get_local $68)
                                         )
                                       )
                                       (i32.store
-                                        (get_local $21)
+                                        (get_local $16)
                                         (i32.add
                                           (i32.shr_u
                                             (get_local $5)
-                                            (get_local $9)
+                                            (get_local $10)
                                           )
-                                          (get_local $11)
+                                          (get_local $9)
                                         )
                                       )
                                       (set_local $7
@@ -6209,17 +6199,17 @@
                                         (i32.lt_u
                                           (set_local $5
                                             (i32.add
-                                              (get_local $21)
+                                              (get_local $16)
                                               (i32.const 4)
                                             )
                                           )
-                                          (get_local $23)
+                                          (get_local $24)
                                         )
                                         (block
-                                          (set_local $11
+                                          (set_local $9
                                             (get_local $7)
                                           )
-                                          (set_local $21
+                                          (set_local $16
                                             (get_local $5)
                                           )
                                         )
@@ -6249,7 +6239,7 @@
                                       )
                                       (block
                                         (set_local $7
-                                          (get_local $23)
+                                          (get_local $24)
                                         )
                                         (br $do-once$78
                                           (get_local $5)
@@ -6257,12 +6247,12 @@
                                       )
                                     )
                                     (i32.store
-                                      (get_local $23)
+                                      (get_local $24)
                                       (get_local $7)
                                     )
                                     (set_local $7
                                       (i32.add
-                                        (get_local $23)
+                                        (get_local $24)
                                         (i32.const 4)
                                       )
                                     )
@@ -6270,7 +6260,7 @@
                                   )
                                   (block
                                     (set_local $7
-                                      (get_local $23)
+                                      (get_local $24)
                                     )
                                     (select
                                       (i32.add
@@ -6296,9 +6286,9 @@
                                     (get_local $7)
                                     (set_local $6
                                       (select
-                                        (get_local $10)
                                         (get_local $11)
-                                        (get_local $12)
+                                        (get_local $9)
+                                        (get_local $13)
                                       )
                                     )
                                   )
@@ -6321,13 +6311,13 @@
                               )
                             )
                             (i32.store
-                              (get_local $24)
+                              (get_local $25)
                               (set_local $5
                                 (i32.add
                                   (i32.load
-                                    (get_local $24)
+                                    (get_local $25)
                                   )
-                                  (get_local $9)
+                                  (get_local $10)
                                 )
                               )
                             )
@@ -6338,15 +6328,15 @@
                               )
                               (block
                                 (set_local $6
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
-                                (set_local $23
+                                (set_local $24
                                   (get_local $7)
                                 )
                               )
                               (block
                                 (set_local $6
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
                                 (set_local $26
                                   (get_local $7)
@@ -6390,7 +6380,7 @@
                                 (i32.const 10)
                               )
                               (block
-                                (set_local $9
+                                (set_local $10
                                   (get_local $7)
                                 )
                                 (br $do-once$82)
@@ -6417,7 +6407,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $9
+                                  (set_local $10
                                     (get_local $7)
                                   )
                                   (br $while-out$84)
@@ -6426,7 +6416,7 @@
                               (br $while-in$85)
                             )
                           )
-                          (set_local $9
+                          (set_local $10
                             (i32.const 0)
                           )
                         )
@@ -6439,10 +6429,10 @@
                                 (i32.sub
                                   (get_local $1)
                                   (select
-                                    (get_local $9)
+                                    (get_local $10)
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $14)
+                                      (get_local $21)
                                       (i32.const 102)
                                     )
                                   )
@@ -6458,7 +6448,7 @@
                                       )
                                       (set_local $8
                                         (i32.eq
-                                          (get_local $14)
+                                          (get_local $21)
                                           (i32.const 103)
                                         )
                                       )
@@ -6487,7 +6477,7 @@
                             (set_local $7
                               (i32.add
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $11)
                                   (i32.const 4)
                                 )
                                 (i32.shl
@@ -6512,7 +6502,7 @@
                             )
                             (if
                               (i32.lt_s
-                                (set_local $11
+                                (set_local $9
                                   (i32.add
                                     (i32.and
                                       (i32.rem_s
@@ -6539,16 +6529,16 @@
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $11
+                                      (set_local $9
                                         (i32.add
-                                          (get_local $11)
+                                          (get_local $9)
                                           (i32.const 1)
                                         )
                                       )
                                       (i32.const 9)
                                     )
                                     (block
-                                      (set_local $21
+                                      (set_local $16
                                         (get_local $5)
                                       )
                                       (br $while-out$86)
@@ -6557,14 +6547,14 @@
                                   (br $while-in$87)
                                 )
                               )
-                              (set_local $21
+                              (set_local $16
                                 (i32.const 10)
                               )
                             )
                             (block $do-once$88
                               (if
                                 (i32.and
-                                  (set_local $11
+                                  (set_local $9
                                     (i32.eq
                                       (i32.add
                                         (get_local $7)
@@ -6574,7 +6564,7 @@
                                     )
                                   )
                                   (i32.eq
-                                    (set_local $14
+                                    (set_local $21
                                       (i32.and
                                         (i32.rem_u
                                           (set_local $5
@@ -6582,7 +6572,7 @@
                                               (get_local $7)
                                             )
                                           )
-                                          (get_local $21)
+                                          (get_local $16)
                                         )
                                         (i32.const -1)
                                       )
@@ -6597,12 +6587,12 @@
                                   (set_local $6
                                     (get_local $7)
                                   )
-                                  (set_local $11
-                                    (get_local $9)
+                                  (set_local $9
+                                    (get_local $10)
                                   )
                                 )
                                 (block
-                                  (set_local $15
+                                  (set_local $14
                                     (select
                                       (f64.const 9007199254740992)
                                       (f64.const 9007199254740994)
@@ -6611,7 +6601,7 @@
                                           (i32.and
                                             (i32.div_u
                                               (get_local $5)
-                                              (get_local $21)
+                                              (get_local $16)
                                             )
                                             (i32.const -1)
                                           )
@@ -6624,11 +6614,11 @@
                                   (set_local $29
                                     (if
                                       (i32.lt_u
-                                        (get_local $14)
-                                        (set_local $12
+                                        (get_local $21)
+                                        (set_local $13
                                           (i32.and
                                             (i32.div_s
-                                              (get_local $21)
+                                              (get_local $16)
                                               (i32.const 2)
                                             )
                                             (i32.const -1)
@@ -6640,23 +6630,23 @@
                                         (f64.const 1)
                                         (f64.const 1.5)
                                         (i32.and
-                                          (get_local $11)
+                                          (get_local $9)
                                           (i32.eq
-                                            (get_local $14)
-                                            (get_local $12)
+                                            (get_local $21)
+                                            (get_local $13)
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $15
+                                  (set_local $14
                                     (block $do-once$90
                                       (if
                                         (i32.eq
                                           (get_local $50)
                                           (i32.const 0)
                                         )
-                                        (get_local $15)
+                                        (get_local $14)
                                         (block
                                           (if
                                             (i32.ne
@@ -6672,7 +6662,7 @@
                                               (i32.const 45)
                                             )
                                             (br $do-once$90
-                                              (get_local $15)
+                                              (get_local $14)
                                             )
                                           )
                                           (set_local $29
@@ -6681,7 +6671,7 @@
                                             )
                                           )
                                           (f64.neg
-                                            (get_local $15)
+                                            (get_local $14)
                                           )
                                         )
                                       )
@@ -6692,17 +6682,17 @@
                                     (set_local $5
                                       (i32.sub
                                         (get_local $5)
-                                        (get_local $14)
+                                        (get_local $21)
                                       )
                                     )
                                   )
                                   (if
                                     (f64.eq
                                       (f64.add
-                                        (get_local $15)
+                                        (get_local $14)
                                         (get_local $29)
                                       )
-                                      (get_local $15)
+                                      (get_local $14)
                                     )
                                     (block
                                       (set_local $5
@@ -6711,8 +6701,8 @@
                                       (set_local $6
                                         (get_local $7)
                                       )
-                                      (set_local $11
-                                        (get_local $9)
+                                      (set_local $9
+                                        (get_local $10)
                                       )
                                       (br $do-once$88)
                                     )
@@ -6722,7 +6712,7 @@
                                     (set_local $5
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $21)
+                                        (get_local $16)
                                       )
                                     )
                                   )
@@ -6799,7 +6789,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $11
+                                  (set_local $9
                                     (i32.mul
                                       (i32.shr_s
                                         (i32.sub
@@ -6829,23 +6819,23 @@
                                       )
                                       (br $do-once$88)
                                     )
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.const 10)
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
-                                    (set_local $11
+                                    (set_local $9
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                     )
                                     (if
                                       (i32.lt_u
                                         (get_local $5)
-                                        (set_local $12
+                                        (set_local $13
                                           (i32.mul
-                                            (get_local $12)
+                                            (get_local $13)
                                             (i32.const 10)
                                           )
                                         )
@@ -6876,8 +6866,8 @@
                                 )
                               )
                             )
-                            (set_local $9
-                              (get_local $11)
+                            (set_local $10
+                              (get_local $9)
                             )
                             (set_local $7
                               (select
@@ -6899,7 +6889,7 @@
                       (set_local $26
                         (i32.sub
                           (i32.const 0)
-                          (get_local $9)
+                          (get_local $10)
                         )
                       )
                       (loop $while-out$96 $while-in$97
@@ -6909,10 +6899,10 @@
                             (get_local $6)
                           )
                           (block
-                            (set_local $11
+                            (set_local $9
                               (i32.const 0)
                             )
-                            (set_local $23
+                            (set_local $24
                               (get_local $7)
                             )
                             (br $while-out$96)
@@ -6934,10 +6924,10 @@
                             (get_local $5)
                           )
                           (block
-                            (set_local $11
+                            (set_local $9
                               (i32.const 1)
                             )
-                            (set_local $23
+                            (set_local $24
                               (get_local $7)
                             )
                             (br $while-out$96)
@@ -6966,15 +6956,15 @@
                                           (get_local $1)
                                         )
                                       )
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                     (i32.gt_s
-                                      (get_local $9)
+                                      (get_local $10)
                                       (i32.const -5)
                                     )
                                   )
                                   (block
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.add
                                         (get_local $33)
                                         (i32.const -1)
@@ -6985,11 +6975,11 @@
                                         (get_local $1)
                                         (i32.const -1)
                                       )
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                   )
                                   (block
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.add
                                         (get_local $33)
                                         (i32.const -2)
@@ -7013,11 +7003,11 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $14
+                                  (set_local $21
                                     (get_local $8)
                                   )
                                   (set_local $30
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (br $do-once$98
                                     (get_local $1)
@@ -7026,14 +7016,14 @@
                               )
                               (block $do-once$100
                                 (if
-                                  (get_local $11)
+                                  (get_local $9)
                                   (block
                                     (if
                                       (i32.eq
                                         (set_local $1
                                           (i32.load
                                             (i32.add
-                                              (get_local $23)
+                                              (get_local $24)
                                               (i32.const -4)
                                             )
                                           )
@@ -7116,7 +7106,7 @@
                                   (i32.mul
                                     (i32.shr_s
                                       (i32.sub
-                                        (get_local $23)
+                                        (get_local $24)
                                         (get_local $30)
                                       )
                                       (i32.const 2)
@@ -7129,7 +7119,7 @@
                               (if
                                 (i32.eq
                                   (i32.or
-                                    (get_local $12)
+                                    (get_local $13)
                                     (i32.const 32)
                                   )
                                   (i32.const 102)
@@ -7158,7 +7148,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $21
                                     (select
                                       (get_local $8)
                                       (get_local $1)
@@ -7166,7 +7156,7 @@
                                     )
                                   )
                                   (set_local $30
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.const 0)
                                 )
@@ -7177,7 +7167,7 @@
                                         (i32.sub
                                           (i32.add
                                             (get_local $5)
-                                            (get_local $9)
+                                            (get_local $10)
                                           )
                                           (get_local $1)
                                         )
@@ -7197,7 +7187,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $21
                                     (select
                                       (get_local $8)
                                       (get_local $1)
@@ -7205,14 +7195,14 @@
                                     )
                                   )
                                   (set_local $30
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.const 0)
                                 )
                               )
                             )
                             (block
-                              (set_local $14
+                              (set_local $21
                                 (get_local $1)
                               )
                               (set_local $30
@@ -7226,12 +7216,12 @@
                           )
                         )
                       )
-                      (set_local $21
+                      (set_local $16
                         (i32.and
                           (i32.ne
                             (set_local $1
                               (i32.or
-                                (get_local $14)
+                                (get_local $21)
                                 (get_local $8)
                               )
                             )
@@ -7240,9 +7230,9 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $9
+                      (set_local $10
                         (if
-                          (set_local $12
+                          (set_local $13
                             (i32.eq
                               (i32.or
                                 (get_local $30)
@@ -7254,10 +7244,10 @@
                           (block
                             (set_local $7
                               (select
-                                (get_local $9)
+                                (get_local $10)
                                 (i32.const 0)
                                 (i32.gt_s
-                                  (get_local $9)
+                                  (get_local $10)
                                   (i32.const 0)
                                 )
                               )
@@ -7272,9 +7262,9 @@
                                     (set_local $7
                                       (select
                                         (get_local $26)
-                                        (get_local $9)
+                                        (get_local $10)
                                         (i32.lt_s
-                                          (get_local $9)
+                                          (get_local $10)
                                           (i32.const 0)
                                         )
                                       )
@@ -7334,7 +7324,7 @@
                                 (i32.add
                                   (i32.and
                                     (i32.shr_s
-                                      (get_local $9)
+                                      (get_local $10)
                                       (i32.const 31)
                                     )
                                     (i32.const 2)
@@ -7369,7 +7359,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (set_local $7
                           (i32.add
                             (i32.add
@@ -7378,9 +7368,9 @@
                                   (get_local $50)
                                   (i32.const 1)
                                 )
-                                (get_local $14)
+                                (get_local $21)
                               )
-                              (get_local $21)
+                              (get_local $16)
                             )
                             (get_local $7)
                           )
@@ -7406,7 +7396,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 48)
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $7)
                         (i32.xor
                           (get_local $17)
@@ -7415,16 +7405,16 @@
                       )
                       (block $do-once$106
                         (if
-                          (get_local $12)
+                          (get_local $13)
                           (block
                             (set_local $6
                               (set_local $8
                                 (select
-                                  (get_local $10)
+                                  (get_local $11)
                                   (get_local $6)
                                   (i32.gt_u
                                     (get_local $6)
-                                    (get_local $10)
+                                    (get_local $11)
                                   )
                                 )
                               )
@@ -7520,7 +7510,7 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $10)
+                                  (get_local $11)
                                 )
                                 (br $while-out$108)
                                 (set_local $6
@@ -7558,17 +7548,17 @@
                             (if
                               (i32.and
                                 (i32.gt_s
-                                  (get_local $14)
+                                  (get_local $21)
                                   (i32.const 0)
                                 )
                                 (i32.lt_u
                                   (get_local $5)
-                                  (get_local $23)
+                                  (get_local $24)
                                 )
                               )
                               (block
                                 (set_local $6
-                                  (get_local $14)
+                                  (get_local $21)
                                 )
                                 (loop $while-out$116 $while-in$117
                                   (if
@@ -7648,7 +7638,7 @@
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $23)
+                                        (get_local $24)
                                       )
                                     )
                                     (block
@@ -7670,7 +7660,7 @@
                                 )
                               )
                               (set_local $1
-                                (get_local $14)
+                                (get_local $21)
                               )
                             )
                             (call $_pad
@@ -7685,23 +7675,23 @@
                             )
                           )
                           (block
-                            (set_local $12
+                            (set_local $13
                               (select
-                                (get_local $23)
+                                (get_local $24)
                                 (i32.add
                                   (get_local $6)
                                   (i32.const 4)
                                 )
-                                (get_local $11)
+                                (get_local $9)
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $14)
+                                (get_local $21)
                                 (i32.const -1)
                               )
                               (block
-                                (set_local $11
+                                (set_local $9
                                   (i32.eq
                                     (get_local $8)
                                     (i32.const 0)
@@ -7711,10 +7701,10 @@
                                   (get_local $6)
                                 )
                                 (set_local $8
-                                  (get_local $14)
+                                  (get_local $21)
                                 )
                                 (loop $while-out$120 $while-in$121
-                                  (set_local $10
+                                  (set_local $11
                                     (if
                                       (i32.eq
                                         (set_local $1
@@ -7747,7 +7737,7 @@
                                       (block
                                         (set_local $1
                                           (i32.add
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 1)
                                           )
                                         )
@@ -7762,14 +7752,14 @@
                                             (i32.const 0)
                                           )
                                           (call $___fwritex
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 1)
                                             (get_local $0)
                                           )
                                         )
                                         (if
                                           (i32.and
-                                            (get_local $11)
+                                            (get_local $9)
                                             (i32.lt_s
                                               (get_local $8)
                                               (i32.const 1)
@@ -7798,15 +7788,15 @@
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $10)
+                                            (get_local $11)
                                             (get_local $28)
                                           )
                                           (set_local $1
-                                            (get_local $10)
+                                            (get_local $11)
                                           )
                                           (block
                                             (set_local $1
-                                              (get_local $10)
+                                              (get_local $11)
                                             )
                                             (br $do-once$122)
                                           )
@@ -7834,7 +7824,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $10
+                                  (set_local $11
                                     (i32.sub
                                       (get_local $74)
                                       (get_local $1)
@@ -7853,11 +7843,11 @@
                                     (call $___fwritex
                                       (get_local $1)
                                       (select
-                                        (get_local $10)
+                                        (get_local $11)
                                         (get_local $8)
                                         (i32.gt_s
                                           (get_local $8)
-                                          (get_local $10)
+                                          (get_local $11)
                                         )
                                       )
                                       (get_local $0)
@@ -7872,13 +7862,13 @@
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $12)
+                                        (get_local $13)
                                       )
                                       (i32.gt_s
                                         (set_local $8
                                           (i32.sub
                                             (get_local $8)
-                                            (get_local $10)
+                                            (get_local $11)
                                           )
                                         )
                                         (i32.const -1)
@@ -7898,7 +7888,7 @@
                                 )
                               )
                               (set_local $1
-                                (get_local $14)
+                                (get_local $21)
                               )
                             )
                             (call $_pad
@@ -7923,10 +7913,10 @@
                               )
                             )
                             (call $___fwritex
-                              (get_local $9)
+                              (get_local $10)
                               (i32.sub
                                 (get_local $44)
-                                (get_local $9)
+                                (get_local $10)
                               )
                               (get_local $0)
                             )
@@ -7936,7 +7926,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $7)
                         (i32.xor
                           (get_local $17)
@@ -7944,11 +7934,11 @@
                         )
                       )
                       (select
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $7)
                         (i32.lt_s
                           (get_local $7)
-                          (get_local $16)
+                          (get_local $15)
                         )
                       )
                     )
@@ -7975,8 +7965,8 @@
                           (set_local $1
                             (i32.or
                               (f64.ne
-                                (get_local $15)
-                                (get_local $15)
+                                (get_local $14)
+                                (get_local $14)
                               )
                               (f64.ne
                                 (f64.const 0)
@@ -8000,7 +7990,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (set_local $5
                           (i32.add
                             (get_local $6)
@@ -8049,7 +8039,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $5)
                         (i32.xor
                           (get_local $17)
@@ -8057,36 +8047,30 @@
                         )
                       )
                       (select
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $5)
                         (i32.lt_s
                           (get_local $5)
-                          (get_local $16)
+                          (get_local $15)
                         )
                       )
                     )
                   )
                 )
               )
-              (set_local $5
-                (get_local $19)
-              )
-              (set_local $12
-                (get_local $25)
-              )
-              (set_local $8
-                (get_local $20)
+              (set_local $11
+                (get_local $22)
               )
               (br $label$continue$L1)
             )
             (set_local $47
-              (get_local $12)
+              (get_local $20)
             )
             (set_local $36
               (get_local $17)
             )
             (set_local $42
-              (get_local $9)
+              (get_local $10)
             )
             (set_local $43
               (i32.const 0)
@@ -8103,7 +8087,7 @@
       (block $label$break$L308
         (if
           (i32.eq
-            (get_local $13)
+            (get_local $12)
             (i32.const 64)
           )
           (block
@@ -8148,7 +8132,7 @@
                   (set_local $40
                     (i32.const 4091)
                   )
-                  (set_local $13
+                  (set_local $12
                     (i32.const 77)
                   )
                   (get_local $27)
@@ -8253,7 +8237,7 @@
                       (set_local $40
                         (i32.const 4091)
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.const 77)
                       )
                       (get_local $5)
@@ -8277,7 +8261,7 @@
                           )
                         )
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.const 77)
                       )
                       (get_local $5)
@@ -8289,7 +8273,7 @@
           )
           (if
             (i32.eq
-              (get_local $13)
+              (get_local $12)
               (i32.const 76)
             )
             (block
@@ -8304,7 +8288,7 @@
                 (get_local $17)
               )
               (set_local $31
-                (get_local $9)
+                (get_local $10)
               )
               (set_local $38
                 (get_local $59)
@@ -8312,17 +8296,17 @@
               (set_local $40
                 (get_local $60)
               )
-              (set_local $13
+              (set_local $12
                 (i32.const 77)
               )
             )
             (if
               (i32.eq
-                (get_local $13)
+                (get_local $12)
                 (i32.const 82)
               )
               (block
-                (set_local $13
+                (set_local $12
                   (i32.const 0)
                 )
                 (set_local $5
@@ -8331,7 +8315,7 @@
                       (call $_memchr
                         (get_local $46)
                         (i32.const 0)
-                        (get_local $9)
+                        (get_local $10)
                       )
                     )
                     (i32.const 0)
@@ -8345,7 +8329,7 @@
                 )
                 (set_local $42
                   (select
-                    (get_local $9)
+                    (get_local $10)
                     (i32.sub
                       (get_local $1)
                       (get_local $46)
@@ -8363,7 +8347,7 @@
                   (select
                     (i32.add
                       (get_local $46)
-                      (get_local $9)
+                      (get_local $10)
                     )
                     (get_local $1)
                     (get_local $5)
@@ -8372,11 +8356,11 @@
               )
               (if
                 (i32.eq
-                  (get_local $13)
+                  (get_local $12)
                   (i32.const 86)
                 )
                 (block
-                  (set_local $13
+                  (set_local $12
                     (i32.const 0)
                   )
                   (set_local $6
@@ -8470,7 +8454,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $22
+                      (set_local $23
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -8479,7 +8463,7 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $16)
+                    (get_local $15)
                     (get_local $6)
                     (get_local $17)
                   )
@@ -8492,7 +8476,7 @@
                       (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.const 98)
                       )
                     )
@@ -8519,13 +8503,13 @@
                             (set_local $37
                               (get_local $6)
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.const 98)
                             )
                             (br $label$break$L308)
                           )
                         )
-                        (set_local $8
+                        (set_local $11
                           (i32.add
                             (get_local $5)
                             (i32.const 4)
@@ -8550,7 +8534,7 @@
                             (set_local $37
                               (get_local $6)
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.const 98)
                             )
                             (br $label$break$L308)
@@ -8582,14 +8566,14 @@
                               (get_local $1)
                             )
                             (set_local $5
-                              (get_local $8)
+                              (get_local $11)
                             )
                           )
                           (block
                             (set_local $37
                               (get_local $6)
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.const 98)
                             )
                             (br $while-out$133)
@@ -8607,52 +8591,52 @@
       )
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 98)
         )
         (block
-          (set_local $13
+          (set_local $12
             (i32.const 0)
           )
           (call $_pad
             (get_local $0)
             (i32.const 32)
-            (get_local $16)
+            (get_local $15)
             (get_local $37)
             (i32.xor
               (get_local $17)
               (i32.const 8192)
             )
           )
-          (set_local $5
-            (get_local $19)
+          (set_local $19
+            (get_local $8)
           )
-          (set_local $12
-            (get_local $25)
+          (set_local $20
+            (get_local $9)
           )
           (set_local $1
             (select
-              (get_local $16)
+              (get_local $15)
               (get_local $37)
               (i32.gt_s
-                (get_local $16)
+                (get_local $15)
                 (get_local $37)
               )
             )
           )
-          (set_local $8
-            (get_local $20)
+          (set_local $11
+            (get_local $22)
           )
           (br $label$continue$L1)
         )
       )
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 77)
         )
         (block
-          (set_local $13
+          (set_local $12
             (i32.const 0)
           )
           (set_local $5
@@ -8771,7 +8755,7 @@
       )
       (set_local $5
         (i32.lt_s
-          (get_local $16)
+          (get_local $15)
           (set_local $1
             (i32.add
               (get_local $43)
@@ -8789,10 +8773,10 @@
       (call $_pad
         (get_local $0)
         (i32.const 32)
-        (set_local $8
+        (set_local $5
           (select
             (get_local $1)
-            (get_local $16)
+            (get_local $15)
             (get_local $5)
           )
         )
@@ -8818,7 +8802,7 @@
       (call $_pad
         (get_local $0)
         (i32.const 48)
-        (get_local $8)
+        (get_local $5)
         (get_local $1)
         (i32.xor
           (get_local $36)
@@ -8851,31 +8835,31 @@
       (call $_pad
         (get_local $0)
         (i32.const 32)
-        (get_local $8)
+        (get_local $5)
         (get_local $1)
         (i32.xor
           (get_local $36)
           (i32.const 8192)
         )
       )
-      (set_local $5
-        (get_local $19)
-      )
-      (set_local $12
-        (get_local $25)
-      )
-      (set_local $1
+      (set_local $19
         (get_local $8)
       )
-      (set_local $8
-        (get_local $20)
+      (set_local $20
+        (get_local $9)
+      )
+      (set_local $1
+        (get_local $5)
+      )
+      (set_local $11
+        (get_local $22)
       )
       (br $label$continue$L1)
     )
     (block $label$break$L343
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 242)
         )
         (if
@@ -8888,7 +8872,7 @@
               (get_local $80)
               (i32.const 0)
             )
-            (set_local $22
+            (set_local $23
               (i32.const 0)
             )
             (block
@@ -8943,7 +8927,7 @@
                     (get_local $0)
                   )
                   (block
-                    (set_local $22
+                    (set_local $23
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -8977,7 +8961,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $22
+                      (set_local $23
                         (i32.const -1)
                       )
                       (br $label$break$L343)
@@ -8992,7 +8976,7 @@
                       (get_local $1)
                     )
                     (block
-                      (set_local $22
+                      (set_local $23
                         (i32.const 1)
                       )
                       (br $while-out$138)
@@ -9000,13 +8984,13 @@
                   )
                   (br $while-in$139)
                 )
-                (set_local $22
+                (set_local $23
                   (i32.const 1)
                 )
               )
             )
           )
-          (set_local $22
+          (set_local $23
             (get_local $79)
           )
         )
@@ -9016,7 +9000,7 @@
       (i32.const 8)
       (get_local $32)
     )
-    (get_local $22)
+    (get_local $23)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -13101,7 +13085,7 @@
         (call_import $_abort)
       )
     )
-    (set_local $3
+    (set_local $5
       (i32.add
         (get_local $8)
         (i32.const 48)
@@ -13152,7 +13136,7 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $5
+            (set_local $3
               (i32.add
                 (set_local $4
                   (i32.load
@@ -13165,7 +13149,7 @@
             (get_local $4)
           )
           (i32.gt_u
-            (get_local $5)
+            (get_local $3)
             (get_local $0)
           )
         )
@@ -13221,7 +13205,7 @@
                               (i32.add
                                 (get_local $4)
                                 (i32.load
-                                  (set_local $5
+                                  (set_local $3
                                     (i32.add
                                       (get_local $14)
                                       (i32.const 4)
@@ -13236,7 +13220,7 @@
                                 (get_local $14)
                               )
                               (set_local $14
-                                (get_local $5)
+                                (get_local $3)
                               )
                               (br $while-out$37)
                             )
@@ -13280,7 +13264,7 @@
                         )
                         (if
                           (i32.eq
-                            (set_local $5
+                            (set_local $3
                               (call_import $_sbrk
                                 (get_local $0)
                               )
@@ -13296,12 +13280,12 @@
                           )
                           (if
                             (i32.ne
-                              (get_local $5)
+                              (get_local $3)
                               (i32.const -1)
                             )
                             (block
                               (set_local $16
-                                (get_local $5)
+                                (get_local $3)
                               )
                               (set_local $19
                                 (get_local $0)
@@ -13313,7 +13297,7 @@
                           )
                           (block
                             (set_local $28
-                              (get_local $5)
+                              (get_local $3)
                             )
                             (set_local $21
                               (get_local $0)
@@ -13343,53 +13327,52 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $13
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (set_local $5
-                                  (i32.add
-                                    (set_local $4
-                                      (i32.load
-                                        (i32.const 652)
-                                      )
-                                    )
-                                    (i32.const -1)
-                                  )
-                                )
-                                (set_local $0
-                                  (get_local $6)
-                                )
-                              )
-                              (i32.const 0)
-                            )
-                            (get_local $10)
-                            (i32.add
-                              (i32.sub
-                                (get_local $10)
-                                (get_local $0)
-                              )
-                              (i32.and
-                                (i32.add
-                                  (get_local $5)
-                                  (get_local $0)
-                                )
-                                (i32.sub
-                                  (i32.const 0)
-                                  (get_local $4)
-                                )
-                              )
-                            )
-                          )
-                        )
-                        (set_local $5
+                        (set_local $4
                           (i32.add
-                            (set_local $0
+                            (set_local $3
                               (i32.load
                                 (i32.const 608)
                               )
                             )
-                            (get_local $13)
+                            (set_local $13
+                              (if
+                                (i32.eq
+                                  (i32.and
+                                    (set_local $13
+                                      (i32.add
+                                        (set_local $4
+                                          (i32.load
+                                            (i32.const 652)
+                                          )
+                                        )
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (set_local $0
+                                      (get_local $6)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                                (get_local $10)
+                                (i32.add
+                                  (i32.sub
+                                    (get_local $10)
+                                    (get_local $0)
+                                  )
+                                  (i32.and
+                                    (i32.add
+                                      (get_local $13)
+                                      (get_local $0)
+                                    )
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $4)
+                                    )
+                                  )
+                                )
+                              )
+                            )
                           )
                         )
                         (if
@@ -13406,7 +13389,7 @@
                           (block
                             (if
                               (i32.ne
-                                (set_local $4
+                                (set_local $0
                                   (i32.load
                                     (i32.const 616)
                                   )
@@ -13416,12 +13399,12 @@
                               (br_if $do-once$39
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $5)
-                                    (get_local $0)
+                                    (get_local $4)
+                                    (get_local $3)
                                   )
                                   (i32.gt_u
-                                    (get_local $5)
                                     (get_local $4)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -13480,7 +13463,7 @@
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $3)
+                            (get_local $5)
                             (get_local $21)
                           )
                           (i32.and

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -293,9 +293,9 @@
       )
       (get_local $0)
     )
-    (set_local $3
+    (set_local $2
       (call $_bitshift64Lshr
-        (set_local $2
+        (set_local $3
           (i32.load
             (i32.load
               (i32.const 24)
@@ -322,9 +322,9 @@
             (block $switch-case$1
               (br_table $switch-case$1 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-default$3 $switch-case$2 $switch-default$3
                 (i32.sub
-                  (set_local $3
+                  (set_local $2
                     (i32.and
-                      (get_local $3)
+                      (get_local $2)
                       (i32.const 2047)
                     )
                   )
@@ -332,7 +332,8 @@
                 )
               )
             )
-            (set_local $2
+            (i32.store
+              (get_local $1)
               (if
                 (f64.ne
                   (get_local $0)
@@ -358,10 +359,6 @@
                 (i32.const 0)
               )
             )
-            (i32.store
-              (get_local $1)
-              (get_local $2)
-            )
             (br $switch$0
               (get_local $0)
             )
@@ -373,7 +370,7 @@
         (i32.store
           (get_local $1)
           (i32.add
-            (get_local $3)
+            (get_local $2)
             (i32.const -1022)
           )
         )
@@ -381,7 +378,7 @@
           (i32.load
             (i32.const 24)
           )
-          (get_local $2)
+          (get_local $3)
         )
         (i32.store offset=4
           (i32.load
@@ -1149,74 +1146,73 @@
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $3
-        (if
-          (i32.eq
-            (i32.load
-              (i32.const 16)
-            )
-            (i32.const 0)
-          )
-          (block
-            (i32.store
-              (get_local $9)
-              (i32.load
-                (get_local $13)
-              )
-            )
-            (i32.store offset=4
-              (get_local $9)
-              (get_local $5)
-            )
-            (i32.store offset=8
-              (get_local $9)
-              (get_local $6)
-            )
-            (call $___syscall_ret
-              (call_import $___syscall146
-                (i32.const 146)
-                (get_local $9)
-              )
-            )
-          )
-          (block
-            (call_import $_pthread_cleanup_push
-              (i32.const 5)
-              (get_local $0)
-            )
-            (i32.store
-              (get_local $8)
-              (i32.load
-                (get_local $13)
-              )
-            )
-            (i32.store offset=4
-              (get_local $8)
-              (get_local $5)
-            )
-            (i32.store offset=8
-              (get_local $8)
-              (get_local $6)
-            )
-            (set_local $1
-              (call $___syscall_ret
-                (call_import $___syscall146
-                  (i32.const 146)
-                  (get_local $8)
-                )
-              )
-            )
-            (call_import $_pthread_cleanup_pop
-              (i32.const 0)
-            )
-            (get_local $1)
-          )
-        )
-      )
       (if
         (i32.eq
           (get_local $4)
-          (get_local $3)
+          (set_local $3
+            (if
+              (i32.eq
+                (i32.load
+                  (i32.const 16)
+                )
+                (i32.const 0)
+              )
+              (block
+                (i32.store
+                  (get_local $9)
+                  (i32.load
+                    (get_local $13)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $9)
+                  (get_local $5)
+                )
+                (i32.store offset=8
+                  (get_local $9)
+                  (get_local $6)
+                )
+                (call $___syscall_ret
+                  (call_import $___syscall146
+                    (i32.const 146)
+                    (get_local $9)
+                  )
+                )
+              )
+              (block
+                (call_import $_pthread_cleanup_push
+                  (i32.const 5)
+                  (get_local $0)
+                )
+                (i32.store
+                  (get_local $8)
+                  (i32.load
+                    (get_local $13)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $8)
+                  (get_local $5)
+                )
+                (i32.store offset=8
+                  (get_local $8)
+                  (get_local $6)
+                )
+                (set_local $1
+                  (call $___syscall_ret
+                    (call_import $___syscall146
+                      (i32.const 146)
+                      (get_local $8)
+                    )
+                  )
+                )
+                (call_import $_pthread_cleanup_pop
+                  (i32.const 0)
+                )
+                (get_local $1)
+              )
+            )
+          )
         )
         (block
           (set_local $1
@@ -2949,8 +2945,8 @@
     (local $11 i32)
     (local $12 i32)
     (local $13 i32)
-    (local $14 i32)
-    (local $15 f64)
+    (local $14 f64)
+    (local $15 i32)
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
@@ -3044,7 +3040,7 @@
       )
       (call_import $abort)
     )
-    (set_local $24
+    (set_local $25
       (i32.add
         (get_local $32)
         (i32.const 16)
@@ -3164,23 +3160,23 @@
         (i32.const 8)
       )
     )
-    (set_local $5
+    (set_local $19
       (i32.const 0)
     )
-    (set_local $12
+    (set_local $20
       (get_local $1)
     )
     (set_local $1
       (i32.const 0)
     )
-    (set_local $8
+    (set_local $11
       (i32.const 0)
     )
     (loop $label$break$L1 $label$continue$L1
-      (set_local $19
+      (set_local $8
         (if
           (i32.gt_s
-            (get_local $5)
+            (get_local $19)
             (i32.const -1)
           )
           (if
@@ -3188,7 +3184,7 @@
               (get_local $1)
               (i32.sub
                 (i32.const 2147483647)
-                (get_local $5)
+                (get_local $19)
               )
             )
             (block
@@ -3200,10 +3196,10 @@
             )
             (i32.add
               (get_local $1)
-              (get_local $5)
+              (get_local $19)
             )
           )
-          (get_local $5)
+          (get_local $19)
         )
       )
       (if
@@ -3212,7 +3208,7 @@
             (i32.shl
               (set_local $1
                 (i32.load8_s
-                  (get_local $12)
+                  (get_local $20)
                 )
               )
               (i32.const 24)
@@ -3223,18 +3219,18 @@
         )
         (block
           (set_local $79
-            (get_local $19)
-          )
-          (set_local $80
             (get_local $8)
           )
-          (set_local $13
+          (set_local $80
+            (get_local $11)
+          )
+          (set_local $12
             (i32.const 242)
           )
           (br $label$break$L1)
         )
         (set_local $5
-          (get_local $12)
+          (get_local $20)
         )
       )
       (loop $label$break$L9 $label$continue$L9
@@ -3262,7 +3258,7 @@
                 (set_local $70
                   (get_local $5)
                 )
-                (set_local $13
+                (set_local $12
                   (i32.const 9)
                 )
                 (br $label$break$L9)
@@ -3292,11 +3288,11 @@
       (block $label$break$L12
         (if
           (i32.eq
-            (get_local $13)
+            (get_local $12)
             (i32.const 9)
           )
           (loop $while-out$7 $while-in$8
-            (set_local $13
+            (set_local $12
               (i32.const 0)
             )
             (if
@@ -3368,10 +3364,10 @@
           )
         )
       )
-      (set_local $14
+      (set_local $16
         (i32.sub
           (get_local $62)
-          (get_local $12)
+          (get_local $20)
         )
       )
       (if
@@ -3387,8 +3383,8 @@
             (i32.const 0)
           )
           (call $___fwritex
-            (get_local $12)
-            (get_local $14)
+            (get_local $20)
+            (get_local $16)
             (get_local $0)
           )
         )
@@ -3396,17 +3392,17 @@
       (if
         (i32.ne
           (get_local $62)
-          (get_local $12)
+          (get_local $20)
         )
         (block
-          (set_local $5
-            (get_local $19)
+          (set_local $19
+            (get_local $8)
           )
-          (set_local $12
+          (set_local $20
             (get_local $41)
           )
           (set_local $1
-            (get_local $14)
+            (get_local $16)
           )
           (br $label$continue$L1)
         )
@@ -3465,14 +3461,14 @@
                 )
               )
             )
-            (set_local $11
+            (set_local $13
               (select
                 (i32.const 1)
-                (get_local $8)
+                (get_local $11)
                 (get_local $6)
               )
             )
-            (set_local $10
+            (set_local $9
               (get_local $5)
             )
             (select
@@ -3482,10 +3478,10 @@
             )
           )
           (block
-            (set_local $11
-              (get_local $8)
+            (set_local $13
+              (get_local $11)
             )
-            (set_local $10
+            (set_local $9
               (get_local $5)
             )
             (i32.const -1)
@@ -3529,7 +3525,7 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $8
+                  (set_local $11
                     (get_local $7)
                   )
                   (br $label$break$L25)
@@ -3561,9 +3557,9 @@
                         (i32.shl
                           (set_local $1
                             (i32.load8_s
-                              (set_local $10
+                              (set_local $9
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $9)
                                   (i32.const 1)
                                 )
                               )
@@ -3579,7 +3575,7 @@
                   (i32.const 32)
                 )
                 (block
-                  (set_local $8
+                  (set_local $11
                     (get_local $7)
                   )
                   (br $while-out$10)
@@ -3588,7 +3584,7 @@
               (br $while-in$11)
             )
           )
-          (set_local $8
+          (set_local $11
             (i32.const 0)
           )
         )
@@ -3615,7 +3611,7 @@
                         (i32.load8_s
                           (set_local $7
                             (i32.add
-                              (get_local $10)
+                              (get_local $9)
                               (i32.const 1)
                             )
                           )
@@ -3634,7 +3630,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s offset=2
-                        (get_local $10)
+                        (get_local $9)
                       )
                       (i32.const 24)
                     )
@@ -3685,7 +3681,7 @@
                   )
                   (set_local $66
                     (i32.add
-                      (get_local $10)
+                      (get_local $9)
                       (i32.const 3)
                     )
                   )
@@ -3693,30 +3689,30 @@
                     (get_local $5)
                   )
                 )
-                (set_local $13
+                (set_local $12
                   (i32.const 24)
                 )
               )
-              (set_local $13
+              (set_local $12
                 (i32.const 24)
               )
             )
             (if
               (i32.eq
-                (get_local $13)
+                (get_local $12)
                 (i32.const 24)
               )
               (block
-                (set_local $13
+                (set_local $12
                   (i32.const 0)
                 )
                 (if
                   (i32.ne
-                    (get_local $11)
+                    (get_local $13)
                     (i32.const 0)
                   )
                   (block
-                    (set_local $22
+                    (set_local $23
                       (i32.const -1)
                     )
                     (br $label$break$L1)
@@ -3727,13 +3723,13 @@
                     (get_local $52)
                   )
                   (block
-                    (set_local $10
+                    (set_local $9
                       (get_local $7)
                     )
-                    (set_local $20
+                    (set_local $22
                       (i32.const 0)
                     )
-                    (set_local $16
+                    (set_local $15
                       (i32.const 0)
                     )
                     (br $do-once$12)
@@ -3787,41 +3783,41 @@
                 )
               )
             )
-            (set_local $8
+            (set_local $11
               (if
                 (i32.lt_s
                   (get_local $61)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $10
+                  (set_local $9
                     (get_local $66)
                   )
-                  (set_local $20
+                  (set_local $22
                     (get_local $63)
                   )
-                  (set_local $16
+                  (set_local $15
                     (i32.sub
                       (i32.const 0)
                       (get_local $61)
                     )
                   )
                   (i32.or
-                    (get_local $8)
+                    (get_local $11)
                     (i32.const 8192)
                   )
                 )
                 (block
-                  (set_local $10
+                  (set_local $9
                     (get_local $66)
                   )
-                  (set_local $20
+                  (set_local $22
                     (get_local $63)
                   )
-                  (set_local $16
+                  (set_local $15
                     (get_local $61)
                   )
-                  (get_local $8)
+                  (get_local $11)
                 )
               )
             )
@@ -3844,7 +3840,7 @@
             )
             (block
               (set_local $1
-                (get_local $10)
+                (get_local $9)
               )
               (set_local $5
                 (i32.const 0)
@@ -3861,7 +3857,7 @@
                 )
                 (if
                   (i32.lt_u
-                    (set_local $10
+                    (set_local $9
                       (i32.add
                         (i32.shr_s
                           (i32.shl
@@ -3887,7 +3883,7 @@
                       (get_local $7)
                     )
                     (set_local $7
-                      (get_local $10)
+                      (get_local $9)
                     )
                   )
                   (block
@@ -3908,43 +3904,43 @@
                   (i32.const 0)
                 )
                 (block
-                  (set_local $22
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
                 (block
-                  (set_local $10
+                  (set_local $9
                     (get_local $5)
                   )
-                  (set_local $20
-                    (get_local $11)
+                  (set_local $22
+                    (get_local $13)
                   )
-                  (set_local $16
+                  (set_local $15
                     (get_local $1)
                   )
                 )
               )
             )
             (block
-              (set_local $20
-                (get_local $11)
+              (set_local $22
+                (get_local $13)
               )
-              (set_local $16
+              (set_local $15
                 (i32.const 0)
               )
             )
           )
         )
       )
-      (set_local $11
+      (set_local $13
         (block $label$break$L46
           (if
             (i32.eq
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $10)
+                    (get_local $9)
                   )
                   (i32.const 24)
                 )
@@ -3961,7 +3957,7 @@
                         (i32.load8_s
                           (set_local $5
                             (i32.add
-                              (get_local $10)
+                              (get_local $9)
                               (i32.const 1)
                             )
                           )
@@ -3999,7 +3995,7 @@
                       )
                     )
                     (block
-                      (set_local $9
+                      (set_local $10
                         (i32.const 0)
                       )
                       (br $label$break$L46
@@ -4041,7 +4037,7 @@
                         (i32.const 10)
                       )
                       (block
-                        (set_local $9
+                        (set_local $10
                           (get_local $5)
                         )
                         (br $label$break$L46
@@ -4062,7 +4058,7 @@
                           (i32.load8_s
                             (set_local $7
                               (i32.add
-                                (get_local $10)
+                                (get_local $9)
                                 (i32.const 2)
                               )
                             )
@@ -4081,7 +4077,7 @@
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s offset=3
-                          (get_local $10)
+                          (get_local $9)
                         )
                         (i32.const 24)
                       )
@@ -4127,12 +4123,12 @@
                     (i32.load offset=4
                       (get_local $1)
                     )
-                    (set_local $9
+                    (set_local $10
                       (get_local $5)
                     )
                     (br $label$break$L46
                       (i32.add
-                        (get_local $10)
+                        (get_local $9)
                         (i32.const 4)
                       )
                     )
@@ -4141,11 +4137,11 @@
               )
               (if
                 (i32.ne
-                  (get_local $20)
+                  (get_local $22)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $22
+                  (set_local $23
                     (i32.const -1)
                   )
                   (br $label$break$L1)
@@ -4191,13 +4187,13 @@
                       (i32.const 4)
                     )
                   )
-                  (set_local $9
+                  (set_local $10
                     (get_local $5)
                   )
                   (get_local $7)
                 )
                 (block
-                  (set_local $9
+                  (set_local $10
                     (i32.const 0)
                   )
                   (get_local $7)
@@ -4205,15 +4201,15 @@
               )
             )
             (block
-              (set_local $9
+              (set_local $10
                 (i32.const -1)
               )
-              (get_local $10)
+              (get_local $9)
             )
           )
         )
       )
-      (set_local $21
+      (set_local $19
         (i32.const 0)
       )
       (loop $while-out$19 $while-in$20
@@ -4224,7 +4220,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $11)
+                      (get_local $13)
                     )
                     (i32.const 24)
                   )
@@ -4236,15 +4232,15 @@
             (i32.const 57)
           )
           (block
-            (set_local $22
+            (set_local $23
               (i32.const -1)
             )
             (br $label$break$L1)
           )
         )
-        (set_local $10
+        (set_local $9
           (i32.add
-            (get_local $11)
+            (get_local $13)
             (i32.const 1)
           )
         )
@@ -4259,7 +4255,7 @@
                         (i32.add
                           (i32.const 3611)
                           (i32.mul
-                            (get_local $21)
+                            (get_local $19)
                             (i32.const 58)
                           )
                         )
@@ -4275,25 +4271,16 @@
             (i32.const 8)
           )
           (block
-            (set_local $11
-              (get_local $10)
+            (set_local $13
+              (get_local $9)
             )
-            (set_local $21
+            (set_local $19
               (get_local $5)
             )
           )
           (block
             (set_local $7
               (get_local $5)
-            )
-            (set_local $25
-              (get_local $10)
-            )
-            (set_local $10
-              (get_local $11)
-            )
-            (set_local $11
-              (get_local $21)
             )
             (br $while-out$19)
           )
@@ -4312,7 +4299,7 @@
           (i32.const 0)
         )
         (block
-          (set_local $22
+          (set_local $23
             (i32.const -1)
           )
           (br $label$break$L1)
@@ -4339,12 +4326,12 @@
           (if
             (get_local $5)
             (block
-              (set_local $22
+              (set_local $23
                 (i32.const -1)
               )
               (br $label$break$L1)
             )
-            (set_local $13
+            (set_local $12
               (i32.const 52)
             )
           )
@@ -4390,7 +4377,7 @@
                   (get_local $6)
                   (get_local $1)
                 )
-                (set_local $13
+                (set_local $12
                   (i32.const 52)
                 )
                 (br $do-once$21)
@@ -4401,7 +4388,7 @@
                 (get_local $52)
               )
               (block
-                (set_local $22
+                (set_local $23
                   (i32.const 0)
                 )
                 (br $label$break$L1)
@@ -4417,11 +4404,11 @@
       )
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 52)
         )
         (block
-          (set_local $13
+          (set_local $12
             (i32.const 0)
           )
           (if
@@ -4429,17 +4416,17 @@
               (get_local $52)
             )
             (block
-              (set_local $5
-                (get_local $19)
+              (set_local $19
+                (get_local $8)
               )
-              (set_local $12
-                (get_local $25)
+              (set_local $20
+                (get_local $9)
               )
               (set_local $1
-                (get_local $14)
+                (get_local $16)
               )
-              (set_local $8
-                (get_local $20)
+              (set_local $11
+                (get_local $22)
               )
               (br $label$continue$L1)
             )
@@ -4449,7 +4436,7 @@
       (set_local $5
         (i32.and
           (i32.ne
-            (get_local $11)
+            (get_local $19)
             (i32.const 0)
           )
           (i32.eq
@@ -4458,7 +4445,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $10)
+                      (get_local $13)
                     )
                     (i32.const 24)
                   )
@@ -4473,16 +4460,16 @@
       )
       (set_local $17
         (select
-          (get_local $8)
+          (get_local $11)
           (set_local $7
             (i32.and
-              (get_local $8)
+              (get_local $11)
               (i32.const -65537)
             )
           )
           (i32.eq
             (i32.and
-              (get_local $8)
+              (get_local $11)
               (i32.const 8192)
             )
             (i32.const 0)
@@ -4542,7 +4529,7 @@
                                                                         (block $switch-case$26
                                                                           (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
                                                                             (i32.sub
-                                                                              (get_local $11)
+                                                                              (get_local $19)
                                                                               (i32.const 0)
                                                                             )
                                                                           )
@@ -4551,19 +4538,19 @@
                                                                           (i32.load
                                                                             (get_local $18)
                                                                           )
-                                                                          (get_local $19)
+                                                                          (get_local $8)
                                                                         )
-                                                                        (set_local $5
-                                                                          (get_local $19)
+                                                                        (set_local $19
+                                                                          (get_local $8)
                                                                         )
-                                                                        (set_local $12
-                                                                          (get_local $25)
+                                                                        (set_local $20
+                                                                          (get_local $9)
                                                                         )
                                                                         (set_local $1
-                                                                          (get_local $14)
+                                                                          (get_local $16)
                                                                         )
-                                                                        (set_local $8
-                                                                          (get_local $20)
+                                                                        (set_local $11
+                                                                          (get_local $22)
                                                                         )
                                                                         (br $label$continue$L1)
                                                                       )
@@ -4571,19 +4558,19 @@
                                                                         (i32.load
                                                                           (get_local $18)
                                                                         )
-                                                                        (get_local $19)
+                                                                        (get_local $8)
                                                                       )
-                                                                      (set_local $5
-                                                                        (get_local $19)
+                                                                      (set_local $19
+                                                                        (get_local $8)
                                                                       )
-                                                                      (set_local $12
-                                                                        (get_local $25)
+                                                                      (set_local $20
+                                                                        (get_local $9)
                                                                       )
                                                                       (set_local $1
-                                                                        (get_local $14)
+                                                                        (get_local $16)
                                                                       )
-                                                                      (set_local $8
-                                                                        (get_local $20)
+                                                                      (set_local $11
+                                                                        (get_local $22)
                                                                       )
                                                                       (br $label$continue$L1)
                                                                     )
@@ -4593,14 +4580,14 @@
                                                                           (get_local $18)
                                                                         )
                                                                       )
-                                                                      (get_local $19)
+                                                                      (get_local $8)
                                                                     )
                                                                     (i32.store offset=4
                                                                       (get_local $1)
                                                                       (i32.shr_s
                                                                         (i32.shl
                                                                           (i32.lt_s
-                                                                            (get_local $19)
+                                                                            (get_local $8)
                                                                             (i32.const 0)
                                                                           )
                                                                           (i32.const 31)
@@ -4608,17 +4595,17 @@
                                                                         (i32.const 31)
                                                                       )
                                                                     )
-                                                                    (set_local $5
-                                                                      (get_local $19)
+                                                                    (set_local $19
+                                                                      (get_local $8)
                                                                     )
-                                                                    (set_local $12
-                                                                      (get_local $25)
+                                                                    (set_local $20
+                                                                      (get_local $9)
                                                                     )
                                                                     (set_local $1
-                                                                      (get_local $14)
+                                                                      (get_local $16)
                                                                     )
-                                                                    (set_local $8
-                                                                      (get_local $20)
+                                                                    (set_local $11
+                                                                      (get_local $22)
                                                                     )
                                                                     (br $label$continue$L1)
                                                                   )
@@ -4627,21 +4614,21 @@
                                                                       (get_local $18)
                                                                     )
                                                                     (i32.and
-                                                                      (get_local $19)
+                                                                      (get_local $8)
                                                                       (i32.const 65535)
                                                                     )
                                                                   )
-                                                                  (set_local $5
-                                                                    (get_local $19)
+                                                                  (set_local $19
+                                                                    (get_local $8)
                                                                   )
-                                                                  (set_local $12
-                                                                    (get_local $25)
+                                                                  (set_local $20
+                                                                    (get_local $9)
                                                                   )
                                                                   (set_local $1
-                                                                    (get_local $14)
+                                                                    (get_local $16)
                                                                   )
-                                                                  (set_local $8
-                                                                    (get_local $20)
+                                                                  (set_local $11
+                                                                    (get_local $22)
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
@@ -4650,21 +4637,21 @@
                                                                     (get_local $18)
                                                                   )
                                                                   (i32.and
-                                                                    (get_local $19)
+                                                                    (get_local $8)
                                                                     (i32.const 255)
                                                                   )
                                                                 )
-                                                                (set_local $5
-                                                                  (get_local $19)
+                                                                (set_local $19
+                                                                  (get_local $8)
                                                                 )
-                                                                (set_local $12
-                                                                  (get_local $25)
+                                                                (set_local $20
+                                                                  (get_local $9)
                                                                 )
                                                                 (set_local $1
-                                                                  (get_local $14)
+                                                                  (get_local $16)
                                                                 )
-                                                                (set_local $8
-                                                                  (get_local $20)
+                                                                (set_local $11
+                                                                  (get_local $22)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
@@ -4672,19 +4659,19 @@
                                                                 (i32.load
                                                                   (get_local $18)
                                                                 )
-                                                                (get_local $19)
+                                                                (get_local $8)
                                                               )
-                                                              (set_local $5
-                                                                (get_local $19)
+                                                              (set_local $19
+                                                                (get_local $8)
                                                               )
-                                                              (set_local $12
-                                                                (get_local $25)
+                                                              (set_local $20
+                                                                (get_local $9)
                                                               )
                                                               (set_local $1
-                                                                (get_local $14)
+                                                                (get_local $16)
                                                               )
-                                                              (set_local $8
-                                                                (get_local $20)
+                                                              (set_local $11
+                                                                (get_local $22)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
@@ -4694,14 +4681,14 @@
                                                                   (get_local $18)
                                                                 )
                                                               )
-                                                              (get_local $19)
+                                                              (get_local $8)
                                                             )
                                                             (i32.store offset=4
                                                               (get_local $1)
                                                               (i32.shr_s
                                                                 (i32.shl
                                                                   (i32.lt_s
-                                                                    (get_local $19)
+                                                                    (get_local $8)
                                                                     (i32.const 0)
                                                                   )
                                                                   (i32.const 31)
@@ -4709,31 +4696,31 @@
                                                                 (i32.const 31)
                                                               )
                                                             )
-                                                            (set_local $5
-                                                              (get_local $19)
+                                                            (set_local $19
+                                                              (get_local $8)
                                                             )
-                                                            (set_local $12
-                                                              (get_local $25)
+                                                            (set_local $20
+                                                              (get_local $9)
                                                             )
                                                             (set_local $1
-                                                              (get_local $14)
+                                                              (get_local $16)
                                                             )
-                                                            (set_local $8
-                                                              (get_local $20)
+                                                            (set_local $11
+                                                              (get_local $22)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
-                                                          (set_local $5
-                                                            (get_local $19)
+                                                          (set_local $19
+                                                            (get_local $8)
                                                           )
-                                                          (set_local $12
-                                                            (get_local $25)
+                                                          (set_local $20
+                                                            (get_local $9)
                                                           )
                                                           (set_local $1
-                                                            (get_local $14)
+                                                            (get_local $16)
                                                           )
-                                                          (set_local $8
-                                                            (get_local $20)
+                                                          (set_local $11
+                                                            (get_local $22)
                                                           )
                                                           (br $label$continue$L1)
                                                         )
@@ -4748,10 +4735,10 @@
                                                     )
                                                     (set_local $58
                                                       (select
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (i32.const 8)
                                                         (i32.gt_u
-                                                          (get_local $9)
+                                                          (get_local $10)
                                                           (i32.const 8)
                                                         )
                                                       )
@@ -4759,7 +4746,7 @@
                                                     (set_local $69
                                                       (i32.const 120)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (i32.const 64)
                                                     )
                                                     (br $switch$24)
@@ -4769,12 +4756,12 @@
                                                   (get_local $17)
                                                 )
                                                 (set_local $58
-                                                  (get_local $9)
+                                                  (get_local $10)
                                                 )
                                                 (set_local $69
                                                   (get_local $33)
                                                 )
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.const 64)
                                                 )
                                                 (br $switch$24)
@@ -4883,7 +4870,7 @@
                                                       (get_local $17)
                                                     )
                                                     (set_local $31
-                                                      (get_local $9)
+                                                      (get_local $10)
                                                     )
                                                     (set_local $38
                                                       (i32.const 0)
@@ -4891,7 +4878,7 @@
                                                     (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (i32.const 77)
                                                     )
                                                     (get_local $6)
@@ -4899,7 +4886,7 @@
                                                   (block
                                                     (set_local $5
                                                       (i32.lt_s
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (set_local $1
                                                           (i32.add
                                                             (i32.sub
@@ -4917,7 +4904,7 @@
                                                     (set_local $31
                                                       (select
                                                         (get_local $1)
-                                                        (get_local $9)
+                                                        (get_local $10)
                                                         (get_local $5)
                                                       )
                                                     )
@@ -4927,7 +4914,7 @@
                                                     (set_local $40
                                                       (i32.const 4091)
                                                     )
-                                                    (set_local $13
+                                                    (set_local $12
                                                       (i32.const 77)
                                                     )
                                                     (get_local $6)
@@ -4989,7 +4976,7 @@
                                               (set_local $60
                                                 (i32.const 4091)
                                               )
-                                              (set_local $13
+                                              (set_local $12
                                                 (i32.const 76)
                                               )
                                               (br $label$break$L75)
@@ -5029,7 +5016,7 @@
                                                 (set_local $60
                                                   (get_local $1)
                                                 )
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.const 76)
                                                 )
                                                 (get_local $5)
@@ -5044,7 +5031,7 @@
                                                 (set_local $60
                                                   (i32.const 4092)
                                                 )
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.const 76)
                                                 )
                                                 (get_local $5)
@@ -5071,7 +5058,7 @@
                                         (set_local $60
                                           (i32.const 4091)
                                         )
-                                        (set_local $13
+                                        (set_local $12
                                           (i32.const 76)
                                         )
                                         (br $switch$24)
@@ -5120,7 +5107,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.const 82)
                                     )
                                     (br $switch$24)
@@ -5142,7 +5129,7 @@
                                       (get_local $5)
                                     )
                                   )
-                                  (set_local $13
+                                  (set_local $12
                                     (i32.const 82)
                                   )
                                   (br $switch$24)
@@ -5172,22 +5159,22 @@
                                 (set_local $65
                                   (i32.const -1)
                                 )
-                                (set_local $13
+                                (set_local $12
                                   (i32.const 86)
                                 )
                                 (br $switch$24)
                               )
-                              (set_local $13
+                              (set_local $12
                                 (if
                                   (i32.eq
-                                    (get_local $9)
+                                    (get_local $10)
                                     (i32.const 0)
                                   )
                                   (block
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $16)
+                                      (get_local $15)
                                       (i32.const 0)
                                       (get_local $17)
                                     )
@@ -5198,7 +5185,7 @@
                                   )
                                   (block
                                     (set_local $65
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                     (i32.const 86)
                                   )
@@ -5213,20 +5200,20 @@
                   )
                 )
               )
-              (set_local $15
+              (set_local $14
                 (f64.load
                   (get_local $18)
                 )
               )
               (i32.store
-                (get_local $24)
+                (get_local $25)
                 (i32.const 0)
               )
               (f64.store
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $15)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
@@ -5247,9 +5234,9 @@
                     (set_local $39
                       (i32.const 4108)
                     )
-                    (set_local $15
+                    (set_local $14
                       (f64.neg
-                        (get_local $15)
+                        (get_local $14)
                       )
                     )
                     (i32.const 1)
@@ -5293,12 +5280,18 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $15)
+                (get_local $14)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
+              )
+              (set_local $19
+                (get_local $8)
+              )
+              (set_local $20
+                (get_local $9)
               )
               (set_local $1
                 (block $do-once$56
@@ -5332,11 +5325,11 @@
                       (if
                         (set_local $5
                           (f64.ne
-                            (set_local $15
+                            (set_local $14
                               (f64.mul
                                 (call $_frexpl
-                                  (get_local $15)
-                                  (get_local $24)
+                                  (get_local $14)
+                                  (get_local $25)
                                 )
                                 (f64.const 2)
                               )
@@ -5345,10 +5338,10 @@
                           )
                         )
                         (i32.store
-                          (get_local $24)
+                          (get_local $25)
                           (i32.add
                             (i32.load
-                              (get_local $24)
+                              (get_local $25)
                             )
                             (i32.const -1)
                           )
@@ -5356,7 +5349,7 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $14
+                          (set_local $21
                             (i32.or
                               (get_local $33)
                               (i32.const 32)
@@ -5365,7 +5358,7 @@
                           (i32.const 97)
                         )
                         (block
-                          (set_local $10
+                          (set_local $11
                             (select
                               (get_local $39)
                               (i32.add
@@ -5389,24 +5382,24 @@
                               (i32.const 2)
                             )
                           )
-                          (set_local $15
+                          (set_local $14
                             (if
                               (i32.or
                                 (i32.gt_u
-                                  (get_local $9)
+                                  (get_local $10)
                                   (i32.const 11)
                                 )
                                 (i32.eq
                                   (set_local $1
                                     (i32.sub
                                       (i32.const 12)
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                               )
-                              (get_local $15)
+                              (get_local $14)
                               (block
                                 (set_local $29
                                   (f64.const 8)
@@ -5437,7 +5430,7 @@
                                     (i32.shr_s
                                       (i32.shl
                                         (i32.load8_s
-                                          (get_local $10)
+                                          (get_local $11)
                                         )
                                         (i32.const 24)
                                       )
@@ -5450,7 +5443,7 @@
                                       (get_local $29)
                                       (f64.sub
                                         (f64.neg
-                                          (get_local $15)
+                                          (get_local $14)
                                         )
                                         (get_local $29)
                                       )
@@ -5458,7 +5451,7 @@
                                   )
                                   (f64.sub
                                     (f64.add
-                                      (get_local $15)
+                                      (get_local $14)
                                       (get_local $29)
                                     )
                                     (get_local $29)
@@ -5471,7 +5464,7 @@
                             (i32.lt_s
                               (set_local $1
                                 (i32.load
-                                  (get_local $24)
+                                  (get_local $25)
                                 )
                               )
                               (i32.const 0)
@@ -5555,11 +5548,11 @@
                           )
                           (set_local $5
                             (i32.lt_s
-                              (get_local $9)
+                              (get_local $10)
                               (i32.const 1)
                             )
                           )
-                          (set_local $12
+                          (set_local $13
                             (i32.eq
                               (i32.and
                                 (get_local $17)
@@ -5568,12 +5561,12 @@
                               (i32.const 0)
                             )
                           )
-                          (set_local $11
+                          (set_local $9
                             (get_local $28)
                           )
                           (loop $while-out$62 $while-in$63
                             (i32.store8
-                              (get_local $11)
+                              (get_local $9)
                               (i32.and
                                 (i32.or
                                   (i32.and
@@ -5581,7 +5574,7 @@
                                       (i32.add
                                         (set_local $1
                                           (i32.trunc_s/f64
-                                            (get_local $15)
+                                            (get_local $14)
                                           )
                                         )
                                         (i32.const 4075)
@@ -5594,10 +5587,10 @@
                                 (i32.const 255)
                               )
                             )
-                            (set_local $15
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $15)
+                                  (get_local $14)
                                   (f64.convert_s/i32
                                     (get_local $1)
                                   )
@@ -5612,7 +5605,7 @@
                                     (i32.sub
                                       (set_local $1
                                         (i32.add
-                                          (get_local $11)
+                                          (get_local $9)
                                           (i32.const 1)
                                         )
                                       )
@@ -5623,11 +5616,11 @@
                                   (block
                                     (if
                                       (i32.and
-                                        (get_local $12)
+                                        (get_local $13)
                                         (i32.and
                                           (get_local $5)
                                           (f64.eq
-                                            (get_local $15)
+                                            (get_local $14)
                                             (f64.const 0)
                                           )
                                         )
@@ -5641,7 +5634,7 @@
                                       (i32.const 46)
                                     )
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $9)
                                       (i32.const 2)
                                     )
                                   )
@@ -5651,10 +5644,10 @@
                             )
                             (if
                               (f64.ne
-                                (get_local $15)
+                                (get_local $14)
                                 (f64.const 0)
                               )
-                              (set_local $11
+                              (set_local $9
                                 (get_local $1)
                               )
                               (br $while-out$62)
@@ -5664,7 +5657,7 @@
                           (set_local $5
                             (i32.and
                               (i32.ne
-                                (get_local $9)
+                                (get_local $10)
                                 (i32.const 0)
                               )
                               (i32.lt_s
@@ -5672,14 +5665,14 @@
                                   (get_local $81)
                                   (get_local $1)
                                 )
-                                (get_local $9)
+                                (get_local $10)
                               )
                             )
                           )
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $16)
+                            (get_local $15)
                             (set_local $5
                               (i32.add
                                 (set_local $7
@@ -5687,7 +5680,7 @@
                                     (i32.sub
                                       (i32.add
                                         (get_local $82)
-                                        (get_local $9)
+                                        (get_local $10)
                                       )
                                       (get_local $8)
                                     )
@@ -5717,7 +5710,7 @@
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $10)
+                              (get_local $11)
                               (get_local $6)
                               (get_local $0)
                             )
@@ -5725,7 +5718,7 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 48)
-                            (get_local $16)
+                            (get_local $15)
                             (get_local $5)
                             (i32.xor
                               (get_local $17)
@@ -5791,7 +5784,7 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $16)
+                            (get_local $15)
                             (get_local $5)
                             (i32.xor
                               (get_local $17)
@@ -5800,11 +5793,11 @@
                           )
                           (br $do-once$56
                             (select
-                              (get_local $16)
+                              (get_local $15)
                               (get_local $5)
                               (i32.lt_s
                                 (get_local $5)
-                                (get_local $16)
+                                (get_local $15)
                               )
                             )
                           )
@@ -5813,62 +5806,59 @@
                       (set_local $1
                         (select
                           (i32.const 6)
-                          (get_local $9)
+                          (get_local $10)
                           (i32.lt_s
-                            (get_local $9)
+                            (get_local $10)
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $5
-                        (if
-                          (get_local $5)
-                          (block
-                            (i32.store
-                              (get_local $24)
-                              (set_local $5
-                                (i32.add
-                                  (i32.load
-                                    (get_local $24)
-                                  )
-                                  (i32.const -28)
-                                )
-                              )
-                            )
-                            (set_local $15
-                              (f64.mul
-                                (get_local $15)
-                                (f64.const 268435456)
-                              )
-                            )
-                            (get_local $5)
-                          )
-                          (i32.load
-                            (get_local $24)
-                          )
-                        )
-                      )
                       (set_local $30
-                        (set_local $10
+                        (set_local $11
                           (select
                             (get_local $78)
                             (get_local $76)
                             (i32.lt_s
-                              (get_local $5)
+                              (if
+                                (get_local $5)
+                                (block
+                                  (i32.store
+                                    (get_local $25)
+                                    (set_local $5
+                                      (i32.add
+                                        (i32.load
+                                          (get_local $25)
+                                        )
+                                        (i32.const -28)
+                                      )
+                                    )
+                                  )
+                                  (set_local $14
+                                    (f64.mul
+                                      (get_local $14)
+                                      (f64.const 268435456)
+                                    )
+                                  )
+                                  (get_local $5)
+                                )
+                                (i32.load
+                                  (get_local $25)
+                                )
+                              )
                               (i32.const 0)
                             )
                           )
                         )
                       )
                       (set_local $6
-                        (get_local $10)
+                        (get_local $11)
                       )
                       (loop $while-out$66 $while-in$67
                         (i32.store
                           (get_local $6)
                           (set_local $5
                             (i32.trunc_s/f64
-                              (get_local $15)
+                              (get_local $14)
                             )
                           )
                         )
@@ -5880,10 +5870,10 @@
                         )
                         (if
                           (f64.eq
-                            (set_local $15
+                            (set_local $14
                               (f64.mul
                                 (f64.sub
-                                  (get_local $15)
+                                  (get_local $14)
                                   (f64.convert_u/i32
                                     (get_local $5)
                                   )
@@ -5906,20 +5896,20 @@
                         (i32.gt_s
                           (set_local $5
                             (i32.load
-                              (get_local $24)
+                              (get_local $25)
                             )
                           )
                           (i32.const 0)
                         )
                         (block
                           (set_local $8
-                            (get_local $10)
+                            (get_local $11)
                           )
-                          (set_local $9
+                          (set_local $10
                             (get_local $7)
                           )
                           (loop $while-out$68 $while-in$69
-                            (set_local $11
+                            (set_local $9
                               (select
                                 (i32.const 29)
                                 (get_local $5)
@@ -5935,7 +5925,7 @@
                                   (i32.lt_u
                                     (set_local $6
                                       (i32.add
-                                        (get_local $9)
+                                        (get_local $10)
                                         (i32.const -4)
                                       )
                                     )
@@ -5946,7 +5936,7 @@
                                     (set_local $5
                                       (i32.const 0)
                                     )
-                                    (set_local $12
+                                    (set_local $13
                                       (get_local $6)
                                     )
                                     (loop $while-out$72 $while-in$73
@@ -5956,10 +5946,10 @@
                                             (call $_i64Add
                                               (call $_bitshift64Shl
                                                 (i32.load
-                                                  (get_local $12)
+                                                  (get_local $13)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $11)
+                                                (get_local $9)
                                               )
                                               (i32.load
                                                 (i32.const 168)
@@ -5981,7 +5971,7 @@
                                         (i32.const 168)
                                       )
                                       (i32.store
-                                        (get_local $12)
+                                        (get_local $13)
                                         (get_local $7)
                                       )
                                       (set_local $5
@@ -5999,14 +5989,14 @@
                                         (i32.lt_u
                                           (set_local $6
                                             (i32.add
-                                              (get_local $12)
+                                              (get_local $13)
                                               (i32.const -4)
                                             )
                                           )
                                           (get_local $8)
                                         )
                                         (br $while-out$72)
-                                        (set_local $12
+                                        (set_local $13
                                           (get_local $6)
                                         )
                                       )
@@ -6036,7 +6026,7 @@
                               )
                             )
                             (set_local $7
-                              (get_local $9)
+                              (get_local $10)
                             )
                             (loop $while-out$74 $while-in$75
                               (if
@@ -6066,13 +6056,13 @@
                               (br $while-in$75)
                             )
                             (i32.store
-                              (get_local $24)
+                              (get_local $25)
                               (set_local $5
                                 (i32.sub
                                   (i32.load
-                                    (get_local $24)
+                                    (get_local $25)
                                   )
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -6085,7 +6075,7 @@
                                 (set_local $8
                                   (get_local $6)
                                 )
-                                (set_local $9
+                                (set_local $10
                                   (get_local $7)
                                 )
                               )
@@ -6095,7 +6085,7 @@
                           )
                         )
                         (set_local $6
-                          (get_local $10)
+                          (get_local $11)
                         )
                       )
                       (if
@@ -6119,13 +6109,13 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $12
+                          (set_local $13
                             (i32.eq
-                              (get_local $14)
+                              (get_local $21)
                               (i32.const 102)
                             )
                           )
-                          (set_local $23
+                          (set_local $24
                             (get_local $7)
                           )
                           (loop $while-out$76 $while-in$77
@@ -6140,26 +6130,26 @@
                                 (i32.const 9)
                               )
                             )
-                            (set_local $9
+                            (set_local $10
                               (select
                                 (i32.const 9)
                                 (get_local $7)
                                 (get_local $5)
                               )
                             )
-                            (set_local $11
+                            (set_local $9
                               (block $do-once$78
                                 (if
                                   (i32.lt_u
                                     (get_local $6)
-                                    (get_local $23)
+                                    (get_local $24)
                                   )
                                   (block
                                     (set_local $68
                                       (i32.add
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $9)
+                                          (get_local $10)
                                         )
                                         (i32.const -1)
                                       )
@@ -6167,13 +6157,13 @@
                                     (set_local $26
                                       (i32.shr_u
                                         (i32.const 1000000000)
-                                        (get_local $9)
+                                        (get_local $10)
                                       )
                                     )
-                                    (set_local $11
+                                    (set_local $9
                                       (i32.const 0)
                                     )
-                                    (set_local $21
+                                    (set_local $16
                                       (get_local $6)
                                     )
                                     (loop $while-out$80 $while-in$81
@@ -6181,20 +6171,20 @@
                                         (i32.and
                                           (set_local $5
                                             (i32.load
-                                              (get_local $21)
+                                              (get_local $16)
                                             )
                                           )
                                           (get_local $68)
                                         )
                                       )
                                       (i32.store
-                                        (get_local $21)
+                                        (get_local $16)
                                         (i32.add
                                           (i32.shr_u
                                             (get_local $5)
-                                            (get_local $9)
+                                            (get_local $10)
                                           )
-                                          (get_local $11)
+                                          (get_local $9)
                                         )
                                       )
                                       (set_local $7
@@ -6207,17 +6197,17 @@
                                         (i32.lt_u
                                           (set_local $5
                                             (i32.add
-                                              (get_local $21)
+                                              (get_local $16)
                                               (i32.const 4)
                                             )
                                           )
-                                          (get_local $23)
+                                          (get_local $24)
                                         )
                                         (block
-                                          (set_local $11
+                                          (set_local $9
                                             (get_local $7)
                                           )
-                                          (set_local $21
+                                          (set_local $16
                                             (get_local $5)
                                           )
                                         )
@@ -6247,7 +6237,7 @@
                                       )
                                       (block
                                         (set_local $7
-                                          (get_local $23)
+                                          (get_local $24)
                                         )
                                         (br $do-once$78
                                           (get_local $5)
@@ -6255,12 +6245,12 @@
                                       )
                                     )
                                     (i32.store
-                                      (get_local $23)
+                                      (get_local $24)
                                       (get_local $7)
                                     )
                                     (set_local $7
                                       (i32.add
-                                        (get_local $23)
+                                        (get_local $24)
                                         (i32.const 4)
                                       )
                                     )
@@ -6268,7 +6258,7 @@
                                   )
                                   (block
                                     (set_local $7
-                                      (get_local $23)
+                                      (get_local $24)
                                     )
                                     (select
                                       (i32.add
@@ -6294,9 +6284,9 @@
                                     (get_local $7)
                                     (set_local $6
                                       (select
-                                        (get_local $10)
                                         (get_local $11)
-                                        (get_local $12)
+                                        (get_local $9)
+                                        (get_local $13)
                                       )
                                     )
                                   )
@@ -6319,13 +6309,13 @@
                               )
                             )
                             (i32.store
-                              (get_local $24)
+                              (get_local $25)
                               (set_local $5
                                 (i32.add
                                   (i32.load
-                                    (get_local $24)
+                                    (get_local $25)
                                   )
-                                  (get_local $9)
+                                  (get_local $10)
                                 )
                               )
                             )
@@ -6336,15 +6326,15 @@
                               )
                               (block
                                 (set_local $6
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
-                                (set_local $23
+                                (set_local $24
                                   (get_local $7)
                                 )
                               )
                               (block
                                 (set_local $6
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
                                 (set_local $26
                                   (get_local $7)
@@ -6388,7 +6378,7 @@
                                 (i32.const 10)
                               )
                               (block
-                                (set_local $9
+                                (set_local $10
                                   (get_local $7)
                                 )
                                 (br $do-once$82)
@@ -6415,7 +6405,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $9
+                                  (set_local $10
                                     (get_local $7)
                                   )
                                   (br $while-out$84)
@@ -6424,7 +6414,7 @@
                               (br $while-in$85)
                             )
                           )
-                          (set_local $9
+                          (set_local $10
                             (i32.const 0)
                           )
                         )
@@ -6437,10 +6427,10 @@
                                 (i32.sub
                                   (get_local $1)
                                   (select
-                                    (get_local $9)
+                                    (get_local $10)
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $14)
+                                      (get_local $21)
                                       (i32.const 102)
                                     )
                                   )
@@ -6456,7 +6446,7 @@
                                       )
                                       (set_local $8
                                         (i32.eq
-                                          (get_local $14)
+                                          (get_local $21)
                                           (i32.const 103)
                                         )
                                       )
@@ -6485,7 +6475,7 @@
                             (set_local $7
                               (i32.add
                                 (i32.add
-                                  (get_local $10)
+                                  (get_local $11)
                                   (i32.const 4)
                                 )
                                 (i32.shl
@@ -6510,7 +6500,7 @@
                             )
                             (if
                               (i32.lt_s
-                                (set_local $11
+                                (set_local $9
                                   (i32.add
                                     (i32.and
                                       (i32.rem_s
@@ -6537,16 +6527,16 @@
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $11
+                                      (set_local $9
                                         (i32.add
-                                          (get_local $11)
+                                          (get_local $9)
                                           (i32.const 1)
                                         )
                                       )
                                       (i32.const 9)
                                     )
                                     (block
-                                      (set_local $21
+                                      (set_local $16
                                         (get_local $5)
                                       )
                                       (br $while-out$86)
@@ -6555,14 +6545,14 @@
                                   (br $while-in$87)
                                 )
                               )
-                              (set_local $21
+                              (set_local $16
                                 (i32.const 10)
                               )
                             )
                             (block $do-once$88
                               (if
                                 (i32.and
-                                  (set_local $11
+                                  (set_local $9
                                     (i32.eq
                                       (i32.add
                                         (get_local $7)
@@ -6572,7 +6562,7 @@
                                     )
                                   )
                                   (i32.eq
-                                    (set_local $14
+                                    (set_local $21
                                       (i32.and
                                         (i32.rem_u
                                           (set_local $5
@@ -6580,7 +6570,7 @@
                                               (get_local $7)
                                             )
                                           )
-                                          (get_local $21)
+                                          (get_local $16)
                                         )
                                         (i32.const -1)
                                       )
@@ -6595,12 +6585,12 @@
                                   (set_local $6
                                     (get_local $7)
                                   )
-                                  (set_local $11
-                                    (get_local $9)
+                                  (set_local $9
+                                    (get_local $10)
                                   )
                                 )
                                 (block
-                                  (set_local $15
+                                  (set_local $14
                                     (select
                                       (f64.const 9007199254740992)
                                       (f64.const 9007199254740994)
@@ -6609,7 +6599,7 @@
                                           (i32.and
                                             (i32.div_u
                                               (get_local $5)
-                                              (get_local $21)
+                                              (get_local $16)
                                             )
                                             (i32.const -1)
                                           )
@@ -6622,11 +6612,11 @@
                                   (set_local $29
                                     (if
                                       (i32.lt_u
-                                        (get_local $14)
-                                        (set_local $12
+                                        (get_local $21)
+                                        (set_local $13
                                           (i32.and
                                             (i32.div_s
-                                              (get_local $21)
+                                              (get_local $16)
                                               (i32.const 2)
                                             )
                                             (i32.const -1)
@@ -6638,23 +6628,23 @@
                                         (f64.const 1)
                                         (f64.const 1.5)
                                         (i32.and
-                                          (get_local $11)
+                                          (get_local $9)
                                           (i32.eq
-                                            (get_local $14)
-                                            (get_local $12)
+                                            (get_local $21)
+                                            (get_local $13)
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $15
+                                  (set_local $14
                                     (block $do-once$90
                                       (if
                                         (i32.eq
                                           (get_local $50)
                                           (i32.const 0)
                                         )
-                                        (get_local $15)
+                                        (get_local $14)
                                         (block
                                           (if
                                             (i32.ne
@@ -6670,7 +6660,7 @@
                                               (i32.const 45)
                                             )
                                             (br $do-once$90
-                                              (get_local $15)
+                                              (get_local $14)
                                             )
                                           )
                                           (set_local $29
@@ -6679,7 +6669,7 @@
                                             )
                                           )
                                           (f64.neg
-                                            (get_local $15)
+                                            (get_local $14)
                                           )
                                         )
                                       )
@@ -6690,17 +6680,17 @@
                                     (set_local $5
                                       (i32.sub
                                         (get_local $5)
-                                        (get_local $14)
+                                        (get_local $21)
                                       )
                                     )
                                   )
                                   (if
                                     (f64.eq
                                       (f64.add
-                                        (get_local $15)
+                                        (get_local $14)
                                         (get_local $29)
                                       )
-                                      (get_local $15)
+                                      (get_local $14)
                                     )
                                     (block
                                       (set_local $5
@@ -6709,8 +6699,8 @@
                                       (set_local $6
                                         (get_local $7)
                                       )
-                                      (set_local $11
-                                        (get_local $9)
+                                      (set_local $9
+                                        (get_local $10)
                                       )
                                       (br $do-once$88)
                                     )
@@ -6720,7 +6710,7 @@
                                     (set_local $5
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $21)
+                                        (get_local $16)
                                       )
                                     )
                                   )
@@ -6797,7 +6787,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $11
+                                  (set_local $9
                                     (i32.mul
                                       (i32.shr_s
                                         (i32.sub
@@ -6827,23 +6817,23 @@
                                       )
                                       (br $do-once$88)
                                     )
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.const 10)
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
-                                    (set_local $11
+                                    (set_local $9
                                       (i32.add
-                                        (get_local $11)
+                                        (get_local $9)
                                         (i32.const 1)
                                       )
                                     )
                                     (if
                                       (i32.lt_u
                                         (get_local $5)
-                                        (set_local $12
+                                        (set_local $13
                                           (i32.mul
-                                            (get_local $12)
+                                            (get_local $13)
                                             (i32.const 10)
                                           )
                                         )
@@ -6874,8 +6864,8 @@
                                 )
                               )
                             )
-                            (set_local $9
-                              (get_local $11)
+                            (set_local $10
+                              (get_local $9)
                             )
                             (set_local $7
                               (select
@@ -6897,7 +6887,7 @@
                       (set_local $26
                         (i32.sub
                           (i32.const 0)
-                          (get_local $9)
+                          (get_local $10)
                         )
                       )
                       (loop $while-out$96 $while-in$97
@@ -6907,10 +6897,10 @@
                             (get_local $6)
                           )
                           (block
-                            (set_local $11
+                            (set_local $9
                               (i32.const 0)
                             )
-                            (set_local $23
+                            (set_local $24
                               (get_local $7)
                             )
                             (br $while-out$96)
@@ -6932,10 +6922,10 @@
                             (get_local $5)
                           )
                           (block
-                            (set_local $11
+                            (set_local $9
                               (i32.const 1)
                             )
-                            (set_local $23
+                            (set_local $24
                               (get_local $7)
                             )
                             (br $while-out$96)
@@ -6964,15 +6954,15 @@
                                           (get_local $1)
                                         )
                                       )
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                     (i32.gt_s
-                                      (get_local $9)
+                                      (get_local $10)
                                       (i32.const -5)
                                     )
                                   )
                                   (block
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.add
                                         (get_local $33)
                                         (i32.const -1)
@@ -6983,11 +6973,11 @@
                                         (get_local $1)
                                         (i32.const -1)
                                       )
-                                      (get_local $9)
+                                      (get_local $10)
                                     )
                                   )
                                   (block
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.add
                                         (get_local $33)
                                         (i32.const -2)
@@ -7011,11 +7001,11 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $14
+                                  (set_local $21
                                     (get_local $8)
                                   )
                                   (set_local $30
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (br $do-once$98
                                     (get_local $1)
@@ -7024,14 +7014,14 @@
                               )
                               (block $do-once$100
                                 (if
-                                  (get_local $11)
+                                  (get_local $9)
                                   (block
                                     (if
                                       (i32.eq
                                         (set_local $1
                                           (i32.load
                                             (i32.add
-                                              (get_local $23)
+                                              (get_local $24)
                                               (i32.const -4)
                                             )
                                           )
@@ -7114,7 +7104,7 @@
                                   (i32.mul
                                     (i32.shr_s
                                       (i32.sub
-                                        (get_local $23)
+                                        (get_local $24)
                                         (get_local $30)
                                       )
                                       (i32.const 2)
@@ -7127,7 +7117,7 @@
                               (if
                                 (i32.eq
                                   (i32.or
-                                    (get_local $12)
+                                    (get_local $13)
                                     (i32.const 32)
                                   )
                                   (i32.const 102)
@@ -7156,7 +7146,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $21
                                     (select
                                       (get_local $8)
                                       (get_local $1)
@@ -7164,7 +7154,7 @@
                                     )
                                   )
                                   (set_local $30
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.const 0)
                                 )
@@ -7175,7 +7165,7 @@
                                         (i32.sub
                                           (i32.add
                                             (get_local $5)
-                                            (get_local $9)
+                                            (get_local $10)
                                           )
                                           (get_local $1)
                                         )
@@ -7195,7 +7185,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $21
                                     (select
                                       (get_local $8)
                                       (get_local $1)
@@ -7203,14 +7193,14 @@
                                     )
                                   )
                                   (set_local $30
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.const 0)
                                 )
                               )
                             )
                             (block
-                              (set_local $14
+                              (set_local $21
                                 (get_local $1)
                               )
                               (set_local $30
@@ -7224,12 +7214,12 @@
                           )
                         )
                       )
-                      (set_local $21
+                      (set_local $16
                         (i32.and
                           (i32.ne
                             (set_local $1
                               (i32.or
-                                (get_local $14)
+                                (get_local $21)
                                 (get_local $8)
                               )
                             )
@@ -7238,9 +7228,9 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $9
+                      (set_local $10
                         (if
-                          (set_local $12
+                          (set_local $13
                             (i32.eq
                               (i32.or
                                 (get_local $30)
@@ -7252,10 +7242,10 @@
                           (block
                             (set_local $7
                               (select
-                                (get_local $9)
+                                (get_local $10)
                                 (i32.const 0)
                                 (i32.gt_s
-                                  (get_local $9)
+                                  (get_local $10)
                                   (i32.const 0)
                                 )
                               )
@@ -7270,9 +7260,9 @@
                                     (set_local $7
                                       (select
                                         (get_local $26)
-                                        (get_local $9)
+                                        (get_local $10)
                                         (i32.lt_s
-                                          (get_local $9)
+                                          (get_local $10)
                                           (i32.const 0)
                                         )
                                       )
@@ -7332,7 +7322,7 @@
                                 (i32.add
                                   (i32.and
                                     (i32.shr_s
-                                      (get_local $9)
+                                      (get_local $10)
                                       (i32.const 31)
                                     )
                                     (i32.const 2)
@@ -7367,7 +7357,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (set_local $7
                           (i32.add
                             (i32.add
@@ -7376,9 +7366,9 @@
                                   (get_local $50)
                                   (i32.const 1)
                                 )
-                                (get_local $14)
+                                (get_local $21)
                               )
-                              (get_local $21)
+                              (get_local $16)
                             )
                             (get_local $7)
                           )
@@ -7404,7 +7394,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 48)
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $7)
                         (i32.xor
                           (get_local $17)
@@ -7413,16 +7403,16 @@
                       )
                       (block $do-once$106
                         (if
-                          (get_local $12)
+                          (get_local $13)
                           (block
                             (set_local $6
                               (set_local $8
                                 (select
-                                  (get_local $10)
+                                  (get_local $11)
                                   (get_local $6)
                                   (i32.gt_u
                                     (get_local $6)
-                                    (get_local $10)
+                                    (get_local $11)
                                   )
                                 )
                               )
@@ -7518,7 +7508,7 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $10)
+                                  (get_local $11)
                                 )
                                 (br $while-out$108)
                                 (set_local $6
@@ -7556,17 +7546,17 @@
                             (if
                               (i32.and
                                 (i32.gt_s
-                                  (get_local $14)
+                                  (get_local $21)
                                   (i32.const 0)
                                 )
                                 (i32.lt_u
                                   (get_local $5)
-                                  (get_local $23)
+                                  (get_local $24)
                                 )
                               )
                               (block
                                 (set_local $6
-                                  (get_local $14)
+                                  (get_local $21)
                                 )
                                 (loop $while-out$116 $while-in$117
                                   (if
@@ -7646,7 +7636,7 @@
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $23)
+                                        (get_local $24)
                                       )
                                     )
                                     (block
@@ -7668,7 +7658,7 @@
                                 )
                               )
                               (set_local $1
-                                (get_local $14)
+                                (get_local $21)
                               )
                             )
                             (call $_pad
@@ -7683,23 +7673,23 @@
                             )
                           )
                           (block
-                            (set_local $12
+                            (set_local $13
                               (select
-                                (get_local $23)
+                                (get_local $24)
                                 (i32.add
                                   (get_local $6)
                                   (i32.const 4)
                                 )
-                                (get_local $11)
+                                (get_local $9)
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $14)
+                                (get_local $21)
                                 (i32.const -1)
                               )
                               (block
-                                (set_local $11
+                                (set_local $9
                                   (i32.eq
                                     (get_local $8)
                                     (i32.const 0)
@@ -7709,10 +7699,10 @@
                                   (get_local $6)
                                 )
                                 (set_local $8
-                                  (get_local $14)
+                                  (get_local $21)
                                 )
                                 (loop $while-out$120 $while-in$121
-                                  (set_local $10
+                                  (set_local $11
                                     (if
                                       (i32.eq
                                         (set_local $1
@@ -7745,7 +7735,7 @@
                                       (block
                                         (set_local $1
                                           (i32.add
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 1)
                                           )
                                         )
@@ -7760,14 +7750,14 @@
                                             (i32.const 0)
                                           )
                                           (call $___fwritex
-                                            (get_local $10)
+                                            (get_local $11)
                                             (i32.const 1)
                                             (get_local $0)
                                           )
                                         )
                                         (if
                                           (i32.and
-                                            (get_local $11)
+                                            (get_local $9)
                                             (i32.lt_s
                                               (get_local $8)
                                               (i32.const 1)
@@ -7796,15 +7786,15 @@
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $10)
+                                            (get_local $11)
                                             (get_local $28)
                                           )
                                           (set_local $1
-                                            (get_local $10)
+                                            (get_local $11)
                                           )
                                           (block
                                             (set_local $1
-                                              (get_local $10)
+                                              (get_local $11)
                                             )
                                             (br $do-once$122)
                                           )
@@ -7832,7 +7822,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $10
+                                  (set_local $11
                                     (i32.sub
                                       (get_local $74)
                                       (get_local $1)
@@ -7851,11 +7841,11 @@
                                     (call $___fwritex
                                       (get_local $1)
                                       (select
-                                        (get_local $10)
+                                        (get_local $11)
                                         (get_local $8)
                                         (i32.gt_s
                                           (get_local $8)
-                                          (get_local $10)
+                                          (get_local $11)
                                         )
                                       )
                                       (get_local $0)
@@ -7870,13 +7860,13 @@
                                             (i32.const 4)
                                           )
                                         )
-                                        (get_local $12)
+                                        (get_local $13)
                                       )
                                       (i32.gt_s
                                         (set_local $8
                                           (i32.sub
                                             (get_local $8)
-                                            (get_local $10)
+                                            (get_local $11)
                                           )
                                         )
                                         (i32.const -1)
@@ -7896,7 +7886,7 @@
                                 )
                               )
                               (set_local $1
-                                (get_local $14)
+                                (get_local $21)
                               )
                             )
                             (call $_pad
@@ -7921,10 +7911,10 @@
                               )
                             )
                             (call $___fwritex
-                              (get_local $9)
+                              (get_local $10)
                               (i32.sub
                                 (get_local $44)
-                                (get_local $9)
+                                (get_local $10)
                               )
                               (get_local $0)
                             )
@@ -7934,7 +7924,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $7)
                         (i32.xor
                           (get_local $17)
@@ -7942,11 +7932,11 @@
                         )
                       )
                       (select
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $7)
                         (i32.lt_s
                           (get_local $7)
-                          (get_local $16)
+                          (get_local $15)
                         )
                       )
                     )
@@ -7973,8 +7963,8 @@
                           (set_local $1
                             (i32.or
                               (f64.ne
-                                (get_local $15)
-                                (get_local $15)
+                                (get_local $14)
+                                (get_local $14)
                               )
                               (f64.ne
                                 (f64.const 0)
@@ -7998,7 +7988,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (set_local $5
                           (i32.add
                             (get_local $6)
@@ -8047,7 +8037,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $5)
                         (i32.xor
                           (get_local $17)
@@ -8055,36 +8045,30 @@
                         )
                       )
                       (select
-                        (get_local $16)
+                        (get_local $15)
                         (get_local $5)
                         (i32.lt_s
                           (get_local $5)
-                          (get_local $16)
+                          (get_local $15)
                         )
                       )
                     )
                   )
                 )
               )
-              (set_local $5
-                (get_local $19)
-              )
-              (set_local $12
-                (get_local $25)
-              )
-              (set_local $8
-                (get_local $20)
+              (set_local $11
+                (get_local $22)
               )
               (br $label$continue$L1)
             )
             (set_local $47
-              (get_local $12)
+              (get_local $20)
             )
             (set_local $36
               (get_local $17)
             )
             (set_local $42
-              (get_local $9)
+              (get_local $10)
             )
             (set_local $43
               (i32.const 0)
@@ -8101,7 +8085,7 @@
       (block $label$break$L308
         (if
           (i32.eq
-            (get_local $13)
+            (get_local $12)
             (i32.const 64)
           )
           (block
@@ -8146,7 +8130,7 @@
                   (set_local $40
                     (i32.const 4091)
                   )
-                  (set_local $13
+                  (set_local $12
                     (i32.const 77)
                   )
                   (get_local $27)
@@ -8251,7 +8235,7 @@
                       (set_local $40
                         (i32.const 4091)
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.const 77)
                       )
                       (get_local $5)
@@ -8275,7 +8259,7 @@
                           )
                         )
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.const 77)
                       )
                       (get_local $5)
@@ -8287,7 +8271,7 @@
           )
           (if
             (i32.eq
-              (get_local $13)
+              (get_local $12)
               (i32.const 76)
             )
             (block
@@ -8302,7 +8286,7 @@
                 (get_local $17)
               )
               (set_local $31
-                (get_local $9)
+                (get_local $10)
               )
               (set_local $38
                 (get_local $59)
@@ -8310,17 +8294,17 @@
               (set_local $40
                 (get_local $60)
               )
-              (set_local $13
+              (set_local $12
                 (i32.const 77)
               )
             )
             (if
               (i32.eq
-                (get_local $13)
+                (get_local $12)
                 (i32.const 82)
               )
               (block
-                (set_local $13
+                (set_local $12
                   (i32.const 0)
                 )
                 (set_local $5
@@ -8329,7 +8313,7 @@
                       (call $_memchr
                         (get_local $46)
                         (i32.const 0)
-                        (get_local $9)
+                        (get_local $10)
                       )
                     )
                     (i32.const 0)
@@ -8343,7 +8327,7 @@
                 )
                 (set_local $42
                   (select
-                    (get_local $9)
+                    (get_local $10)
                     (i32.sub
                       (get_local $1)
                       (get_local $46)
@@ -8361,7 +8345,7 @@
                   (select
                     (i32.add
                       (get_local $46)
-                      (get_local $9)
+                      (get_local $10)
                     )
                     (get_local $1)
                     (get_local $5)
@@ -8370,11 +8354,11 @@
               )
               (if
                 (i32.eq
-                  (get_local $13)
+                  (get_local $12)
                   (i32.const 86)
                 )
                 (block
-                  (set_local $13
+                  (set_local $12
                     (i32.const 0)
                   )
                   (set_local $6
@@ -8468,7 +8452,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $22
+                      (set_local $23
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -8477,7 +8461,7 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $16)
+                    (get_local $15)
                     (get_local $6)
                     (get_local $17)
                   )
@@ -8490,7 +8474,7 @@
                       (set_local $37
                         (i32.const 0)
                       )
-                      (set_local $13
+                      (set_local $12
                         (i32.const 98)
                       )
                     )
@@ -8517,13 +8501,13 @@
                             (set_local $37
                               (get_local $6)
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.const 98)
                             )
                             (br $label$break$L308)
                           )
                         )
-                        (set_local $8
+                        (set_local $11
                           (i32.add
                             (get_local $5)
                             (i32.const 4)
@@ -8548,7 +8532,7 @@
                             (set_local $37
                               (get_local $6)
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.const 98)
                             )
                             (br $label$break$L308)
@@ -8580,14 +8564,14 @@
                               (get_local $1)
                             )
                             (set_local $5
-                              (get_local $8)
+                              (get_local $11)
                             )
                           )
                           (block
                             (set_local $37
                               (get_local $6)
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.const 98)
                             )
                             (br $while-out$133)
@@ -8605,52 +8589,52 @@
       )
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 98)
         )
         (block
-          (set_local $13
+          (set_local $12
             (i32.const 0)
           )
           (call $_pad
             (get_local $0)
             (i32.const 32)
-            (get_local $16)
+            (get_local $15)
             (get_local $37)
             (i32.xor
               (get_local $17)
               (i32.const 8192)
             )
           )
-          (set_local $5
-            (get_local $19)
+          (set_local $19
+            (get_local $8)
           )
-          (set_local $12
-            (get_local $25)
+          (set_local $20
+            (get_local $9)
           )
           (set_local $1
             (select
-              (get_local $16)
+              (get_local $15)
               (get_local $37)
               (i32.gt_s
-                (get_local $16)
+                (get_local $15)
                 (get_local $37)
               )
             )
           )
-          (set_local $8
-            (get_local $20)
+          (set_local $11
+            (get_local $22)
           )
           (br $label$continue$L1)
         )
       )
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 77)
         )
         (block
-          (set_local $13
+          (set_local $12
             (i32.const 0)
           )
           (set_local $5
@@ -8769,7 +8753,7 @@
       )
       (set_local $5
         (i32.lt_s
-          (get_local $16)
+          (get_local $15)
           (set_local $1
             (i32.add
               (get_local $43)
@@ -8787,10 +8771,10 @@
       (call $_pad
         (get_local $0)
         (i32.const 32)
-        (set_local $8
+        (set_local $5
           (select
             (get_local $1)
-            (get_local $16)
+            (get_local $15)
             (get_local $5)
           )
         )
@@ -8816,7 +8800,7 @@
       (call $_pad
         (get_local $0)
         (i32.const 48)
-        (get_local $8)
+        (get_local $5)
         (get_local $1)
         (i32.xor
           (get_local $36)
@@ -8849,31 +8833,31 @@
       (call $_pad
         (get_local $0)
         (i32.const 32)
-        (get_local $8)
+        (get_local $5)
         (get_local $1)
         (i32.xor
           (get_local $36)
           (i32.const 8192)
         )
       )
-      (set_local $5
-        (get_local $19)
-      )
-      (set_local $12
-        (get_local $25)
-      )
-      (set_local $1
+      (set_local $19
         (get_local $8)
       )
-      (set_local $8
-        (get_local $20)
+      (set_local $20
+        (get_local $9)
+      )
+      (set_local $1
+        (get_local $5)
+      )
+      (set_local $11
+        (get_local $22)
       )
       (br $label$continue$L1)
     )
     (block $label$break$L343
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 242)
         )
         (if
@@ -8886,7 +8870,7 @@
               (get_local $80)
               (i32.const 0)
             )
-            (set_local $22
+            (set_local $23
               (i32.const 0)
             )
             (block
@@ -8941,7 +8925,7 @@
                     (get_local $0)
                   )
                   (block
-                    (set_local $22
+                    (set_local $23
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -8975,7 +8959,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $22
+                      (set_local $23
                         (i32.const -1)
                       )
                       (br $label$break$L343)
@@ -8990,7 +8974,7 @@
                       (get_local $1)
                     )
                     (block
-                      (set_local $22
+                      (set_local $23
                         (i32.const 1)
                       )
                       (br $while-out$138)
@@ -8998,13 +8982,13 @@
                   )
                   (br $while-in$139)
                 )
-                (set_local $22
+                (set_local $23
                   (i32.const 1)
                 )
               )
             )
           )
-          (set_local $22
+          (set_local $23
             (get_local $79)
           )
         )
@@ -9014,7 +8998,7 @@
       (i32.const 8)
       (get_local $32)
     )
-    (get_local $22)
+    (get_local $23)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -13099,7 +13083,7 @@
         (call_import $_abort)
       )
     )
-    (set_local $3
+    (set_local $5
       (i32.add
         (get_local $8)
         (i32.const 48)
@@ -13150,7 +13134,7 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $5
+            (set_local $3
               (i32.add
                 (set_local $4
                   (i32.load
@@ -13163,7 +13147,7 @@
             (get_local $4)
           )
           (i32.gt_u
-            (get_local $5)
+            (get_local $3)
             (get_local $0)
           )
         )
@@ -13219,7 +13203,7 @@
                               (i32.add
                                 (get_local $4)
                                 (i32.load
-                                  (set_local $5
+                                  (set_local $3
                                     (i32.add
                                       (get_local $14)
                                       (i32.const 4)
@@ -13234,7 +13218,7 @@
                                 (get_local $14)
                               )
                               (set_local $14
-                                (get_local $5)
+                                (get_local $3)
                               )
                               (br $while-out$37)
                             )
@@ -13278,7 +13262,7 @@
                         )
                         (if
                           (i32.eq
-                            (set_local $5
+                            (set_local $3
                               (call_import $_sbrk
                                 (get_local $0)
                               )
@@ -13294,12 +13278,12 @@
                           )
                           (if
                             (i32.ne
-                              (get_local $5)
+                              (get_local $3)
                               (i32.const -1)
                             )
                             (block
                               (set_local $16
-                                (get_local $5)
+                                (get_local $3)
                               )
                               (set_local $19
                                 (get_local $0)
@@ -13311,7 +13295,7 @@
                           )
                           (block
                             (set_local $28
-                              (get_local $5)
+                              (get_local $3)
                             )
                             (set_local $21
                               (get_local $0)
@@ -13341,53 +13325,52 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $13
-                          (if
-                            (i32.eq
-                              (i32.and
-                                (set_local $5
-                                  (i32.add
-                                    (set_local $4
-                                      (i32.load
-                                        (i32.const 652)
-                                      )
-                                    )
-                                    (i32.const -1)
-                                  )
-                                )
-                                (set_local $0
-                                  (get_local $6)
-                                )
-                              )
-                              (i32.const 0)
-                            )
-                            (get_local $10)
-                            (i32.add
-                              (i32.sub
-                                (get_local $10)
-                                (get_local $0)
-                              )
-                              (i32.and
-                                (i32.add
-                                  (get_local $5)
-                                  (get_local $0)
-                                )
-                                (i32.sub
-                                  (i32.const 0)
-                                  (get_local $4)
-                                )
-                              )
-                            )
-                          )
-                        )
-                        (set_local $5
+                        (set_local $4
                           (i32.add
-                            (set_local $0
+                            (set_local $3
                               (i32.load
                                 (i32.const 608)
                               )
                             )
-                            (get_local $13)
+                            (set_local $13
+                              (if
+                                (i32.eq
+                                  (i32.and
+                                    (set_local $13
+                                      (i32.add
+                                        (set_local $4
+                                          (i32.load
+                                            (i32.const 652)
+                                          )
+                                        )
+                                        (i32.const -1)
+                                      )
+                                    )
+                                    (set_local $0
+                                      (get_local $6)
+                                    )
+                                  )
+                                  (i32.const 0)
+                                )
+                                (get_local $10)
+                                (i32.add
+                                  (i32.sub
+                                    (get_local $10)
+                                    (get_local $0)
+                                  )
+                                  (i32.and
+                                    (i32.add
+                                      (get_local $13)
+                                      (get_local $0)
+                                    )
+                                    (i32.sub
+                                      (i32.const 0)
+                                      (get_local $4)
+                                    )
+                                  )
+                                )
+                              )
+                            )
                           )
                         )
                         (if
@@ -13404,7 +13387,7 @@
                           (block
                             (if
                               (i32.ne
-                                (set_local $4
+                                (set_local $0
                                   (i32.load
                                     (i32.const 616)
                                   )
@@ -13414,12 +13397,12 @@
                               (br_if $do-once$39
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $5)
-                                    (get_local $0)
+                                    (get_local $4)
+                                    (get_local $3)
                                   )
                                   (i32.gt_u
-                                    (get_local $5)
                                     (get_local $4)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -13478,7 +13461,7 @@
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $3)
+                            (get_local $5)
                             (get_local $21)
                           )
                           (i32.and

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -642,14 +642,10 @@ optimized:
     (nop)
   )
   (func $loop (type $v)
-    (loop $shape$0$break $shape$0$continue
-      (br $shape$0$continue)
-    )
+    (nop)
   )
   (func $loop-plus-code (type $v)
-    (loop $shape$0$break $shape$0$continue
-      (br $shape$0$continue)
-    )
+    (nop)
   )
   (func $split (type $v)
     (nop)
@@ -667,28 +663,10 @@ optimized:
     (nop)
   )
   (func $loop-tail (type $v)
-    (loop $shape$0$break $shape$0$continue
-      (if
-        (i32.const 10)
-        (br $shape$0$continue)
-        (br $shape$0$break)
-      )
-    )
+    (nop)
   )
   (func $nontrivial-loop-plus-phi-to-head (type $v)
-    (loop $shape$1$break $shape$1$continue
-      (if
-        (i32.eqz
-          (i32.const -2)
-        )
-        (br $shape$1$break)
-      )
-      (if
-        (i32.const -6)
-        (br $shape$1$break)
-        (br $shape$1$continue)
-      )
-    )
+    (nop)
   )
 )
 module loaded from binary form:

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -7981,71 +7981,70 @@
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $6
-        (if
-          (i32.load
-            (i32.const 1160)
-          )
-          (block
-            (call_import $ra
-              (i32.const 1)
-              (get_local $0)
-            )
-            (i32.store
-              (get_local $13)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $13)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $13)
-              (get_local $3)
-            )
-            (set_local $10
-              (call $Pa
-                (call_import $ya
-                  (i32.const 146)
-                  (get_local $13)
-                )
-              )
-            )
-            (call_import $oa
-              (i32.const 0)
-            )
-            (get_local $10)
-          )
-          (block
-            (i32.store
-              (get_local $12)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $12)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $12)
-              (get_local $3)
-            )
-            (call $Pa
-              (call_import $ya
-                (i32.const 146)
-                (get_local $12)
-              )
-            )
-          )
-        )
-      )
       (if
         (i32.eq
           (get_local $5)
-          (get_local $6)
+          (set_local $6
+            (if
+              (i32.load
+                (i32.const 1160)
+              )
+              (block
+                (call_import $ra
+                  (i32.const 1)
+                  (get_local $0)
+                )
+                (i32.store
+                  (get_local $13)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $13)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $13)
+                  (get_local $3)
+                )
+                (set_local $10
+                  (call $Pa
+                    (call_import $ya
+                      (i32.const 146)
+                      (get_local $13)
+                    )
+                  )
+                )
+                (call_import $oa
+                  (i32.const 0)
+                )
+                (get_local $10)
+              )
+              (block
+                (i32.store
+                  (get_local $12)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $12)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $12)
+                  (get_local $3)
+                )
+                (call $Pa
+                  (call_import $ya
+                    (i32.const 146)
+                    (get_local $12)
+                  )
+                )
+              )
+            )
+          )
         )
         (block
           (set_local $1

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -7981,71 +7981,70 @@
       )
     )
     (loop $while-out$0 $while-in$1
-      (set_local $6
-        (if
-          (i32.load
-            (i32.const 1160)
-          )
-          (block
-            (call_import $ra
-              (i32.const 1)
-              (get_local $0)
-            )
-            (i32.store
-              (get_local $13)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $13)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $13)
-              (get_local $3)
-            )
-            (set_local $10
-              (call $Pa
-                (call_import $ya
-                  (i32.const 146)
-                  (get_local $13)
-                )
-              )
-            )
-            (call_import $oa
-              (i32.const 0)
-            )
-            (get_local $10)
-          )
-          (block
-            (i32.store
-              (get_local $12)
-              (i32.load
-                (get_local $1)
-              )
-            )
-            (i32.store offset=4
-              (get_local $12)
-              (get_local $4)
-            )
-            (i32.store offset=8
-              (get_local $12)
-              (get_local $3)
-            )
-            (call $Pa
-              (call_import $ya
-                (i32.const 146)
-                (get_local $12)
-              )
-            )
-          )
-        )
-      )
       (if
         (i32.eq
           (get_local $5)
-          (get_local $6)
+          (set_local $6
+            (if
+              (i32.load
+                (i32.const 1160)
+              )
+              (block
+                (call_import $ra
+                  (i32.const 1)
+                  (get_local $0)
+                )
+                (i32.store
+                  (get_local $13)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $13)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $13)
+                  (get_local $3)
+                )
+                (set_local $10
+                  (call $Pa
+                    (call_import $ya
+                      (i32.const 146)
+                      (get_local $13)
+                    )
+                  )
+                )
+                (call_import $oa
+                  (i32.const 0)
+                )
+                (get_local $10)
+              )
+              (block
+                (i32.store
+                  (get_local $12)
+                  (i32.load
+                    (get_local $1)
+                  )
+                )
+                (i32.store offset=4
+                  (get_local $12)
+                  (get_local $4)
+                )
+                (i32.store offset=8
+                  (get_local $12)
+                  (get_local $3)
+                )
+                (call $Pa
+                  (call_import $ya
+                    (i32.const 146)
+                    (get_local $12)
+                  )
+                )
+              )
+            )
+          )
         )
         (block
           (set_local $1

--- a/test/passes/simplify-locals.txt
+++ b/test/passes/simplify-locals.txt
@@ -276,106 +276,63 @@
     (set_local $$rem
       (get_local $__stackBase__)
     )
-    (set_local $$1$0
-      (i32.or
-        (i32.shr_s
-          (get_local $$a$1)
-          (i32.const 31)
-        )
-        (i32.shl
-          (if
-            (i32.lt_s
-              (get_local $$a$1)
-              (i32.const 0)
-            )
-            (i32.const -1)
-            (i32.const 0)
-          )
-          (i32.const 1)
-        )
-      )
-    )
-    (set_local $$1$1
-      (i32.or
-        (i32.shr_s
-          (if
-            (i32.lt_s
-              (get_local $$a$1)
-              (i32.const 0)
-            )
-            (i32.const -1)
-            (i32.const 0)
-          )
-          (i32.const 31)
-        )
-        (i32.shl
-          (if
-            (i32.lt_s
-              (get_local $$a$1)
-              (i32.const 0)
-            )
-            (i32.const -1)
-            (i32.const 0)
-          )
-          (i32.const 1)
-        )
-      )
-    )
-    (set_local $$2$0
-      (i32.or
-        (i32.shr_s
-          (get_local $$b$1)
-          (i32.const 31)
-        )
-        (i32.shl
-          (if
-            (i32.lt_s
-              (get_local $$b$1)
-              (i32.const 0)
-            )
-            (i32.const -1)
-            (i32.const 0)
-          )
-          (i32.const 1)
-        )
-      )
-    )
-    (set_local $$2$1
-      (i32.or
-        (i32.shr_s
-          (if
-            (i32.lt_s
-              (get_local $$b$1)
-              (i32.const 0)
-            )
-            (i32.const -1)
-            (i32.const 0)
-          )
-          (i32.const 31)
-        )
-        (i32.shl
-          (if
-            (i32.lt_s
-              (get_local $$b$1)
-              (i32.const 0)
-            )
-            (i32.const -1)
-            (i32.const 0)
-          )
-          (i32.const 1)
-        )
-      )
-    )
+    (nop)
+    (nop)
+    (nop)
+    (nop)
     (nop)
     (nop)
     (call_import $___udivmoddi4
       (call_import $_i64Subtract
         (i32.xor
-          (get_local $$1$0)
+          (set_local $$1$0
+            (i32.or
+              (i32.shr_s
+                (get_local $$a$1)
+                (i32.const 31)
+              )
+              (i32.shl
+                (if
+                  (i32.lt_s
+                    (get_local $$a$1)
+                    (i32.const 0)
+                  )
+                  (i32.const -1)
+                  (i32.const 0)
+                )
+                (i32.const 1)
+              )
+            )
+          )
           (get_local $$a$0)
         )
         (i32.xor
-          (get_local $$1$1)
+          (set_local $$1$1
+            (i32.or
+              (i32.shr_s
+                (if
+                  (i32.lt_s
+                    (get_local $$a$1)
+                    (i32.const 0)
+                  )
+                  (i32.const -1)
+                  (i32.const 0)
+                )
+                (i32.const 31)
+              )
+              (i32.shl
+                (if
+                  (i32.lt_s
+                    (get_local $$a$1)
+                    (i32.const 0)
+                  )
+                  (i32.const -1)
+                  (i32.const 0)
+                )
+                (i32.const 1)
+              )
+            )
+          )
           (get_local $$a$1)
         )
         (get_local $$1$0)
@@ -386,11 +343,54 @@
       )
       (call_import $_i64Subtract
         (i32.xor
-          (get_local $$2$0)
+          (set_local $$2$0
+            (i32.or
+              (i32.shr_s
+                (get_local $$b$1)
+                (i32.const 31)
+              )
+              (i32.shl
+                (if
+                  (i32.lt_s
+                    (get_local $$b$1)
+                    (i32.const 0)
+                  )
+                  (i32.const -1)
+                  (i32.const 0)
+                )
+                (i32.const 1)
+              )
+            )
+          )
           (get_local $$b$0)
         )
         (i32.xor
-          (get_local $$2$1)
+          (set_local $$2$1
+            (i32.or
+              (i32.shr_s
+                (if
+                  (i32.lt_s
+                    (get_local $$b$1)
+                    (i32.const 0)
+                  )
+                  (i32.const -1)
+                  (i32.const 0)
+                )
+                (i32.const 31)
+              )
+              (i32.shl
+                (if
+                  (i32.lt_s
+                    (get_local $$b$1)
+                    (i32.const 0)
+                  )
+                  (i32.const -1)
+                  (i32.const 0)
+                )
+                (i32.const 1)
+              )
+            )
+          )
           (get_local $$b$1)
         )
         (get_local $$2$0)

--- a/test/passes/vacuum.txt
+++ b/test/passes/vacuum.txt
@@ -1,27 +1,7 @@
 (module
   (memory 256 256)
   (func $b
-    (block $waka1
-      (br $waka1)
-    )
-    (block $waka2
-      (br $waka2)
-    )
-    (block $waka3
-      (br_table $waka3 $waka3 $waka3
-        (i32.const 57)
-      )
-    )
-    (if
-      (i32.eqz
-        (i32.const 100)
-      )
-      (i32.const 101)
-    )
-    (if
-      (i32.const 102)
-      (i32.const 103)
-    )
+    (nop)
   )
   (func $l
     (local $x i32)


### PR DESCRIPTION
Previously it considered every branch to be an effect of the entire expression, but we can ignore internal control flow.

This makes entire ifs sinkable, etc., allowing more local operations to be removed.