### PR TITLE
Avoid a redundant return in dynCall functions.

### DIFF
--- a/src/wasm-linker.cpp
+++ b/src/wasm-linker.cpp
@@ -363,7 +363,7 @@ void Linker::makeDynCallThunks() {
       args.push_back(wasmBuilder.makeGetLocal(i + 1, funcType->params[i]));
     }
     Expression* call = wasmBuilder.makeCallIndirect(funcType, fptr, std::move(args));
-    f->body = funcType->result == none ? call : wasmBuilder.makeReturn(call);
+    f->body = call;
     out.wasm.addFunction(f);
     exportFunction(f->name, true);
   }

--- a/test/dot_s/basics.s
+++ b/test/dot_s/basics.s
@@ -50,7 +50,7 @@ main:                                   # @main
 	i32.add 	$0=, $0, $pop11
 	i32.const	$drop=, main@FUNCTION # just take address for testing
 	end_block
-	return  	$0
+	copy_local	$push24=, $0
 	.endfunc
 .Lfunc_end0:
 	.size	main, .Lfunc_end0-main

--- a/test/dot_s/basics.wast
+++ b/test/dot_s/basics.wast
@@ -88,17 +88,13 @@
       )
       (i32.const 0)
     )
-    (return
-      (get_local $0)
-    )
+    (get_local $0)
   )
   (func $dynCall_iii (param $fptr i32) (param $0 i32) (param $1 i32) (result i32)
-    (return
-      (call_indirect $FUNCSIG$iii
-        (get_local $fptr)
-        (get_local $0)
-        (get_local $1)
-      )
+    (call_indirect $FUNCSIG$iii
+      (get_local $fptr)
+      (get_local $0)
+      (get_local $1)
     )
   )
 )

--- a/test/dot_s/bcp-1.wast
+++ b/test/dot_s/bcp-1.wast
@@ -308,18 +308,14 @@
     (unreachable)
   )
   (func $dynCall_i (param $fptr i32) (result i32)
-    (return
-      (call_indirect $FUNCSIG$i
-        (get_local $fptr)
-      )
+    (call_indirect $FUNCSIG$i
+      (get_local $fptr)
     )
   )
   (func $dynCall_ii (param $fptr i32) (param $0 i32) (result i32)
-    (return
-      (call_indirect $FUNCSIG$ii
-        (get_local $fptr)
-        (get_local $0)
-      )
+    (call_indirect $FUNCSIG$ii
+      (get_local $fptr)
+      (get_local $0)
     )
   )
 )

--- a/test/dot_s/dyncall.wast
+++ b/test/dot_s/dyncall.wast
@@ -48,18 +48,14 @@
     )
   )
   (func $dynCall_i (param $fptr i32) (result i32)
-    (return
-      (call_indirect $FUNCSIG$i
-        (get_local $fptr)
-      )
+    (call_indirect $FUNCSIG$i
+      (get_local $fptr)
     )
   )
   (func $dynCall_jf (param $fptr i32) (param $0 f32) (result i64)
-    (return
-      (call_indirect $FUNCSIG$jf
-        (get_local $fptr)
-        (get_local $0)
-      )
+    (call_indirect $FUNCSIG$jf
+      (get_local $fptr)
+      (get_local $0)
     )
   )
   (func $dynCall_vd (param $fptr i32) (param $0 f64)
@@ -69,15 +65,13 @@
     )
   )
   (func $dynCall_ffjjdi (param $fptr i32) (param $0 f32) (param $1 i64) (param $2 i64) (param $3 f64) (param $4 i32) (result f32)
-    (return
-      (call_indirect $FUNCSIG$ffjjdi
-        (get_local $fptr)
-        (get_local $0)
-        (get_local $1)
-        (get_local $2)
-        (get_local $3)
-        (get_local $4)
-      )
+    (call_indirect $FUNCSIG$ffjjdi
+      (get_local $fptr)
+      (get_local $0)
+      (get_local $1)
+      (get_local $2)
+      (get_local $3)
+      (get_local $4)
     )
   )
 )


### PR DESCRIPTION
WebAssembly functions can return the last value in the function body implicitly, without an explicit `return` opcode.