### PR TITLE
Make the wasm AST's Index type a class like Address

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -438,9 +438,9 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
   }
   // update type list
   auto numParams = getFunction()->getNumParams();
-  Index::value_type newNumLocals = 0;
+  Index newNumLocals = 0;
   for (auto index : indices) {
-    newNumLocals = std::max(newNumLocals, index + 1);
+    newNumLocals = std::max((Index::value_type)newNumLocals, index + 1);
   }
   auto oldVars = getFunction()->vars;
   getFunction()->vars.resize(newNumLocals - numParams);

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -438,7 +438,7 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
   }
   // update type list
   auto numParams = getFunction()->getNumParams();
-  Index newNumLocals = 0;
+  Index::value_type newNumLocals = 0;
   for (auto index : indices) {
     newNumLocals = std::max(newNumLocals, index + 1);
   }

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -440,7 +440,7 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
   auto numParams = getFunction()->getNumParams();
   Index newNumLocals = 0;
   for (auto index : indices) {
-    newNumLocals = std::max((Index::value_type)newNumLocals, index + 1);
+    newNumLocals = std::max(newNumLocals, (Index)(index + 1));
   }
   auto oldVars = getFunction()->vars;
   getFunction()->vars.resize(newNumLocals - numParams);

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -440,7 +440,7 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
   auto numParams = getFunction()->getNumParams();
   Index newNumLocals = 0;
   for (auto index : indices) {
-    newNumLocals = std::max(newNumLocals, (Index)(index + 1));
+    newNumLocals = std::max<Index>(newNumLocals, index + 1);
   }
   auto oldVars = getFunction()->vars;
   getFunction()->vars.resize(newNumLocals - numParams);

--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -669,7 +669,7 @@ class S2WasmBuilder {
       curr->signed_ = match("_s");
       match("_u");
       Name assign = getAssign();
-      getRelocatableConst(&curr->offset.addr);
+      getRelocatableConst(&curr->offset.value);
       mustMatch("(");
       auto attributes = getAttributes(1);
       curr->ptr = getInput();
@@ -687,7 +687,7 @@ class S2WasmBuilder {
       int32_t bytes = getInt() / CHAR_BIT;
       curr->bytes = bytes > 0 ? bytes : getWasmTypeSize(type);
       Name assign = getAssign();
-      getRelocatableConst(&curr->offset.addr);
+      getRelocatableConst(&curr->offset.value);
       mustMatch("(");
       auto attributes = getAttributes(2);
       auto inputs = getInputs(2);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -44,7 +44,7 @@ struct LEB {
   T value;
 
   LEB() {}
-  LEB(T value) : value(value) {}
+  LEB(size_t v) : value(v) {}
 
   bool hasMore(T temp, MiniT byte) {
     // for signed, we must ensure the last bit has the right sign, as it will zero extend
@@ -514,7 +514,7 @@ public:
   }
 
   void finishSection(int32_t start) {
-    int32_t size = o.size() - start - 5; // section size does not include the 5 bytes of the size field itself
+    size_t size = o.size() - start - 5; // section size does not include the 5 bytes of the size field itself
     o.writeAt(start, U32LEB(size));
   }
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -44,7 +44,7 @@ struct LEB {
   T value;
 
   LEB() {}
-  LEB(size_t v) : value(v) {}
+  LEB(T value) : value(value) {}
 
   bool hasMore(T temp, MiniT byte) {
     // for signed, we must ensure the last bit has the right sign, as it will zero extend
@@ -514,7 +514,7 @@ public:
   }
 
   void finishSection(int32_t start) {
-    size_t size = o.size() - start - 5; // section size does not include the 5 bytes of the size field itself
+    int32_t size = o.size() - start - 5; // section size does not include the 5 bytes of the size field itself
     o.writeAt(start, U32LEB(size));
   }
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -93,25 +93,25 @@ struct Name : public cashew::IString {
 template <typename T>
 struct WasmIndex {
   typedef T value_type;
-  T addr;
-  WasmIndex() : addr(0) {}
-  static void CheckValid(uint64_t v) {
+  T value;
+  WasmIndex() : value(0) {}
+  static void checkValid(uint64_t v) {
     // Allow -1 as an invalid sentinel value
     assert(v <= std::numeric_limits<T>::max() ||
-	   v == static_cast<uint64_t>(-1));
+	   v == -1ULL);
   }
-  WasmIndex(uint64_t a) : addr(static_cast<T>(a)) {
-    CheckValid(a);
+  WasmIndex(uint64_t a) : value(static_cast<T>(a)) {
+    checkValid(a);
   }
   WasmIndex& operator=(uint64_t a) {
-    CheckValid(a);
-    addr = static_cast<T>(a);
+    checkValid(a);
+    value = static_cast<T>(a);
     return *this;
   }
-  operator T() const { return addr; }
-  WasmIndex& operator++() { ++addr; return *this; }
+  operator T() const { return value; }
+  WasmIndex& operator++() { ++value; return *this; }
   WasmIndex operator++(int) {
-    WasmIndex temp(addr);
+    WasmIndex temp(value);
     ++(*this);
     return temp;
   }
@@ -1523,7 +1523,7 @@ private:
 namespace std {
 template<> struct hash<wasm::Address> {
   size_t operator()(const wasm::Address a) const {
-    return std::hash<wasm::Address::value_type>()(a.addr);
+    return std::hash<wasm::Address::value_type>()(a);
   }
 };
 }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -88,25 +88,37 @@ struct Name : public cashew::IString {
   }
 };
 
-// An index in a wasm module
-typedef uint32_t Index;
-
-// An address in linear memory. For now only wasm32
-struct Address {
-  typedef uint32_t address_t;
-  address_t addr;
-  Address() : addr(0) {}
-  Address(uint64_t a) : addr(static_cast<address_t>(a)) {
-    assert(a <= std::numeric_limits<address_t>::max());
+// An index in a wasm module. This could be e.g. a local index or an index in
+// linear memory (i.e. an address).
+template <typename T>
+struct WasmIndex {
+  typedef T value_type;
+  T addr;
+  WasmIndex() : addr(0) {}
+  static void CheckValid(uint64_t v) {
+    // Allow -1 as an invalid sentinel value
+    assert(v <= std::numeric_limits<T>::max() ||
+	   v == static_cast<uint64_t>(-1));
   }
-  Address& operator=(uint64_t a) {
-    assert(a <= std::numeric_limits<address_t>::max());
-    addr = static_cast<address_t>(a);
+  WasmIndex(uint64_t a) : addr(static_cast<T>(a)) {
+    CheckValid(a);
+  }
+  WasmIndex& operator=(uint64_t a) {
+    CheckValid(a);
+    addr = static_cast<T>(a);
     return *this;
   }
-  operator address_t() const { return addr; }
-  Address& operator++() { ++addr; return *this; }
+  operator T() const { return addr; }
+  WasmIndex& operator++() { ++addr; return *this; }
+  WasmIndex operator++(int) {
+    WasmIndex temp(addr);
+    ++(*this);
+    return temp;
+  }
 };
+// For now we just support wasm32
+using Address = WasmIndex<uint32_t>;
+using Index = WasmIndex<uint32_t>;
 
 // Types
 
@@ -1386,9 +1398,9 @@ public:
 
 class Memory {
 public:
-  static const Address::address_t kPageSize = 64 * 1024;
-  static const Address::address_t kMaxSize = ~Address::address_t(0) / kPageSize;
-  static const Address::address_t kPageMask = ~(kPageSize - 1);
+  static const Address::value_type kPageSize = 64 * 1024;
+  static const Address::value_type kMaxSize = ~Address::value_type(0) / kPageSize;
+  static const Address::value_type kPageMask = ~(kPageSize - 1);
   struct Segment {
     Address offset;
     std::vector<char> data; // TODO: optimize
@@ -1511,7 +1523,7 @@ private:
 namespace std {
 template<> struct hash<wasm::Address> {
   size_t operator()(const wasm::Address a) const {
-    return std::hash<wasm::Address::address_t>()(a.addr);
+    return std::hash<wasm::Address::value_type>()(a.addr);
   }
 };
 }


### PR DESCRIPTION
Generalize the previous Address class for use with local indices too. This
should allow more implicit conversions and less casting, with extra
assertions.
