### PR TITLE
Specify version of python interpreter

### DIFF
--- a/check.py
+++ b/check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright 2015 WebAssembly Community Group participants
 #


### PR DESCRIPTION
Without this, the script won't work on distros that use python3 by default.