### PR TITLE
asm2wasm regression fixes

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -660,6 +660,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
       // exports
       Ref object = curr[1];
       Ref contents = object[1];
+      std::map<Name, Export*> exported;
       for (unsigned k = 0; k < contents->size(); k++) {
         Ref pair = contents[k];
         IString key = pair[0]->getIString();
@@ -675,10 +676,16 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
           getTempRet0 = value;
         }
         assert(wasm.checkFunction(value));
-        auto export_ = new Export;
-        export_->name = key;
-        export_->value = value;
-        wasm.addExport(export_);
+        if (exported.count(key) > 0) {
+          // asm.js allows duplicate exports, but not wasm. use the last, like asm.js
+          exported[key]->value = value;
+        } else {
+          auto* export_ = new Export;
+          export_->name = key;
+          export_->value = value;
+          wasm.addExport(export_);
+          exported[key] = export_;
+        }
       }
     }
   }

--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -227,6 +227,13 @@ function asm(global, env, buffer) {
    return 0;
   }
 
+  function forgetMe() {
+    123.456;
+  }
+  function exportMe() {
+    -3.14159;
+  }
+
   function z() {
   }
   function w() {
@@ -236,6 +243,6 @@ function asm(global, env, buffer) {
   var FUNCTION_TABLE_b = [ w, w, importedDoubles, w ];
   var FUNCTION_TABLE_c = [ z, cneg ];
 
-  return { big_negative: big_negative };
+  return { big_negative: big_negative, pick: forgetMe, pick: exportMe };
 }
 

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -11,6 +11,7 @@
   (import $f64-to-int "asm2wasm" "f64-to-int" (param f64) (result i32))
   (import $f64-rem "asm2wasm" "f64-rem" (param f64 f64) (result f64))
   (export "big_negative" $big_negative)
+  (export "pick" $big_negative)
   (table $big_negative $big_negative $big_negative $big_negative $big_negative $big_negative $importedDoubles $big_negative $big_negative $cneg)
   (func $big_negative
     (nop)

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -9,6 +9,7 @@
   (import $h "env" "h" (param i32))
   (import $f64-rem "asm2wasm" "f64-rem" (param f64 f64) (result f64))
   (export "big_negative" $big_negative)
+  (export "pick" $big_negative)
   (table $big_negative $big_negative $big_negative $big_negative $big_negative $big_negative $importedDoubles $big_negative $big_negative $cneg)
   (func $big_negative
     (nop)

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -9,6 +9,7 @@
   (import $h "env" "h" (param i32))
   (import $f64-rem "asm2wasm" "f64-rem" (param f64 f64) (result f64))
   (export "big_negative" $big_negative)
+  (export "pick" $exportMe)
   (table $z $big_negative $z $z $w $w $importedDoubles $w $z $cneg)
   (func $big_negative
     (local $temp f64)
@@ -685,6 +686,12 @@
     (return
       (i32.const 0)
     )
+  )
+  (func $forgetMe
+    (f64.const 123.456)
+  )
+  (func $exportMe
+    (f64.const -3.14159)
   )
   (func $z
     (nop)

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -11,6 +11,7 @@
   (import $f64-to-int "asm2wasm" "f64-to-int" (param f64) (result i32))
   (import $f64-rem "asm2wasm" "f64-rem" (param f64 f64) (result f64))
   (export "big_negative" $big_negative)
+  (export "pick" $exportMe)
   (table $z $big_negative $z $z $w $w $importedDoubles $w $z $cneg)
   (func $big_negative
     (local $temp f64)
@@ -689,6 +690,12 @@
     (return
       (i32.const 0)
     )
+  )
+  (func $forgetMe
+    (f64.const 123.456)
+  )
+  (func $exportMe
+    (f64.const -3.14159)
   )
   (func $z
     (nop)


### PR DESCRIPTION
From running the full emscripten test suite.

 * handle duplicate exports (ok in asm, not in wasm)
 * handle stack frame skipping (longjmp, exceptions) in manual stack frame management