### PR TITLE
Use clang from the waterfall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,35 +6,32 @@ python:
 matrix:
   include:
 
-    - env: COMPILER_VERSION=3.6
-      compiler: clang
-      addons: &clang36
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.6']
-          packages: ['cmake', 'nodejs', 'clang-3.6']
-
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fsanitize-blacklist=`pwd`/ubsan.blacklist"
-      compiler: clang
-      addons: *clang36
-
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=address"
-      compiler: clang
-      addons: *clang36
-
-    - env: COMPILER_VERSION=3.6 COMPILER_FLAGS="-fsanitize=thread"
-      compiler: clang
-      addons: *clang36
-
-    - env: COMPILER_VERSION=5
+    - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++"
       compiler: gcc
       addons: &gcc5
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['cmake', 'nodejs', 'g++-5']
 
+    - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fsanitize-blacklist=`pwd`/ubsan.blacklist"
+      compiler: gcc
+      addons: *gcc5
+
+    - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=address"
+      compiler: gcc
+      addons: *gcc5
+
+    - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=thread"
+      compiler: gcc
+      addons: *gcc5
+
+    - env: CC_COMPILER="gcc-5" CXX_COMPILER="g++-5"
+      compiler: gcc
+      addons: *gcc5
+
 before_install:
-  - export CC="${CC}-${COMPILER_VERSION}"
-  - export CXX="${CXX}-${COMPILER_VERSION}"
+  - export CC="${CC_COMPILER}"
+  - export CXX="${CXX_COMPILER}"
   - export ASAN_OPTIONS="symbolize=1"
 
 install:
@@ -45,6 +42,7 @@ before_script:
   - flake8 ./scripts/*
 
 script:
+  - ./check.py --only-prepare
   - cmake . -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS"
   - make -j2
   - ./check.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,22 @@ matrix:
   include:
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++"
-      compiler: gcc
+      compiler: clang
       addons: &gcc5
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['cmake', 'nodejs', 'g++-5']
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fsanitize-blacklist=`pwd`/ubsan.blacklist"
-      compiler: gcc
+      compiler: clang
       addons: *gcc5
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=address"
-      compiler: gcc
+      compiler: clang
       addons: *gcc5
 
     - env: CC_COMPILER="./test/wasm-install/wasm-install/bin/clang" CXX_COMPILER="./test/wasm-install/wasm-install/bin/clang++" COMPILER_FLAGS="-fsanitize=thread"
-      compiler: gcc
+      compiler: clang
       addons: *gcc5
 
     - env: CC_COMPILER="gcc-5" CXX_COMPILER="g++-5"

--- a/check.py
+++ b/check.py
@@ -22,6 +22,7 @@ import scripts.support
 interpreter = None
 requested = []
 torture = True
+only_prepare = False
 
 for arg in sys.argv[1:]:
   if arg.startswith('--interpreter='):
@@ -32,6 +33,8 @@ for arg in sys.argv[1:]:
     torture = True
   elif arg == '--no-torture':
     torture = False
+  elif arg == '--only-prepare':
+    only_prepare = True
   else:
     requested.append(arg)
 
@@ -78,15 +81,20 @@ def setup_waterfall():
   # if we can use the waterfall llvm, do so
   global has_vanilla_llvm
   CLANG = os.path.join(BIN_DIR, 'clang')
+  print 'trying waterfall clang at', CLANG
   try:
-    subprocess.check_call([CLANG, '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.check_call([CLANG, '-v'])
     has_vanilla_llvm = True
+    print '...success'
   except Exception, e:
     warn('could not run vanilla LLVM from waterfall: ' + str(e) + ', looked for clang at ' + CLANG)
 
 fetch_waterfall()
 setup_waterfall()
 
+if only_prepare:
+  print 'waterfall is fetched and setup, exiting since --only-prepare'
+  sys.exit(0)
 
 # external tools
 


### PR DESCRIPTION
LLVM have disabled clang's apt server (#553) which broke our clang builds. This is one option for an alternative, to use clang from the waterfall.

The waterfall clang doesn't have what we need for the sanitizers, though, so this unbreaks the clang build but not the 3 sanitizer builds. @dschuff, @jfbastien, would it be possible to add the sanitizer library to the waterfall (looks like some library called `libclang_rt.a`)? If not, then this route is not going to make sense.