### PR TITLE
Option to optimize while building modules

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -74,6 +74,25 @@ void PassRunner::addDefaultOptimizationPasses() {
   add("duplicate-function-elimination"); // optimizations show more functions as duplicate
 }
 
+void PassRunner::addDefaultFunctionOptimizationPasses() {
+  add("dce");
+  add("remove-unused-brs");
+  add("remove-unused-names");
+  add("optimize-instructions");
+  add("simplify-locals");
+  add("vacuum"); // previous pass creates garbage
+  add("coalesce-locals");
+  add("vacuum"); // previous pass creates garbage
+  add("reorder-locals");
+  add("merge-blocks");
+  add("optimize-instructions");
+  add("vacuum"); // should not be needed, last few passes do not create garbage, but just to be safe
+}
+
+void PassRunner::addDefaultGlobalOptimizationPasses() {
+  add("duplicate-function-elimination");
+}
+
 void PassRunner::run() {
   std::chrono::high_resolution_clock::time_point beforeEverything;
   size_t padding = 0;
@@ -105,6 +124,12 @@ void PassRunner::run() {
     auto after = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> diff = after - beforeEverything;
     std::cerr << "[PassRunner] passes took " << diff.count() << " seconds." << std::endl;
+  }
+}
+
+void PassRunner::runFunction(Function* func) {
+  for (auto pass : passes) {
+    pass->runFunction(this, wasm, func);
   }
 }
 

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -116,14 +116,18 @@ void ThreadPool::initialize(size_t num) {
   DEBUG_POOL("initialize() is done\n");
 }
 
+size_t ThreadPool::getNumCores() {
+  size_t num = std::max(1U, std::thread::hardware_concurrency());
+  if (getenv("BINARYEN_CORES")) {
+    num = std::stoi(getenv("BINARYEN_CORES"));
+  }
+  return num;
+}
+
 ThreadPool* ThreadPool::get() {
   if (!pool) {
-    size_t num = std::max(1U, std::thread::hardware_concurrency());
-    if (getenv("BINARYEN_CORES")) {
-      num = std::stoi(getenv("BINARYEN_CORES"));
-    }
     pool = std::unique_ptr<ThreadPool>(new ThreadPool());
-    pool->initialize(num);
+    pool->initialize(getNumCores());
   }
   return pool.get();
 }

--- a/src/support/threads.h
+++ b/src/support/threads.h
@@ -79,6 +79,9 @@ private:
   void initialize(size_t num);
 
 public:
+  // Get the number of cores we can use.
+  static size_t getNumCores();
+
   // Get the singleton threadpool. This can return null
   // if there is just one thread available.
   static ThreadPool* get();

--- a/src/tools/asm2wasm.cpp
+++ b/src/tools/asm2wasm.cpp
@@ -92,13 +92,8 @@ int main(int argc, const char *argv[]) {
   if (options.debug) std::cerr << "wasming..." << std::endl;
   Module wasm;
   wasm.memory.initial = wasm.memory.max = totalMemory / Memory::kPageSize;
-  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise);
+  Asm2WasmBuilder asm2wasm(wasm, pre.memoryGrowth, options.debug, imprecise, opts);
   asm2wasm.processAsm(asmjs);
-
-  if (opts) {
-    if (options.debug) std::cerr << "optimizing..." << std::endl;
-    asm2wasm.optimize();
-  }
 
   if (options.debug) std::cerr << "printing..." << std::endl;
   Output output(options.extra["output"], Flags::Text, options.debug ? Flags::Debug : Flags::Release);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -187,6 +187,7 @@ struct Walker : public VisitorType {
   void walkFunction(Function* func) {
     setFunction(func);
     static_cast<SubType*>(this)->doWalkFunction(func);
+    static_cast<SubType*>(this)->visitFunction(func);
   }
 
   // override this to provide custom functionality
@@ -197,6 +198,7 @@ struct Walker : public VisitorType {
   void walkModule(Module *module) {
     setModule(module);
     static_cast<SubType*>(this)->doWalkModule(module);
+    static_cast<SubType*>(this)->visitModule(module);
   }
 
   // override this to provide custom functionality
@@ -223,7 +225,6 @@ struct Walker : public VisitorType {
         allocated = std::unique_ptr<SubType>(instance);
       }
       instance->walkFunction(func);
-      instance->visitFunction(func);
     };
 
     // if this is not a function-parallel traversal, run
@@ -259,7 +260,6 @@ struct Walker : public VisitorType {
     }
     self->visitTable(&module->table);
     self->visitMemory(&module->memory);
-    self->visitModule(module);
   }
 
   // Walk implementation. We don't use recursion as ASTs may be highly

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -10114,9 +10114,9 @@
   (func $ib (result i32)
     (i32.const 0)
   )
-  (func $__growWasmMemory (param $0 i32)
+  (func $__growWasmMemory (param $newSize i32)
     (grow_memory
-      (get_local $0)
+      (get_local $newSize)
     )
   )
 )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -10114,9 +10114,9 @@
   (func $ib (result i32)
     (i32.const 0)
   )
-  (func $__growWasmMemory (param $0 i32)
+  (func $__growWasmMemory (param $newSize i32)
     (grow_memory
-      (get_local $0)
+      (get_local $newSize)
     )
   )
 )


### PR DESCRIPTION
Before this PR, asm2wasm builds asm.js into wasm, finishes the whole module, then runs the optimizer. The optimizer is multithreaded, but we use just a single core during the asm2wasm step, so this is inefficient.

This PR adds an option to optimize while still building: as soon as a function is ready, it goes in a list and workers can grab it and optimize it. Only function passes are relevant for this, of course (not LTO type things) but they still account for almost all the work.

This makes asm2wasm noticeably faster, e.g. 15% on one benchmark I tested.

We could use this in more places if it makes sense. For example, if s2wasm would optimize, we could get the same benefits there.