### PR TITLE
Fix leak of FunctionType from parseFuncType when not already in the module

### DIFF
--- a/src/s2wasm.h
+++ b/src/s2wasm.h
@@ -496,9 +496,15 @@ class S2WasmBuilder {
       decl->result = getType();
     }
     while (*s && skipComma()) decl->params.push_back(getType());
+    decl->name = "FUNCSIG$" + getSig(decl.get());
 
-    FunctionType *ty = wasm->checkFunctionType(getSig(decl.get()));
-    if (!ty) ty = decl.release();
+    FunctionType *ty = wasm->checkFunctionType(decl->name);
+    if (!ty) {
+      // The wasm module takes ownership of the FunctionType if we insert it.
+      // Otherwise it's already in the module and ours is freed.
+      ty = decl.release();
+      wasm->addFunctionType(ty);
+    }
     linkerObj->addExternType(name, ty);
   }
 

--- a/test/dot_s/indirect-import.wast
+++ b/test/dot_s/indirect-import.wast
@@ -1,10 +1,10 @@
 (module
   (memory 1)
   (export "memory" memory)
-  (type $FUNCSIG$ijidf (func (param i64 i32 f64 f32) (result i32)))
-  (type $FUNCSIG$v (func))
-  (type $FUNCSIG$vj (func (param i64)))
   (type $FUNCSIG$fd (func (param f64) (result f32)))
+  (type $FUNCSIG$vj (func (param i64)))
+  (type $FUNCSIG$v (func))
+  (type $FUNCSIG$ijidf (func (param i64 i32 f64 f32) (result i32)))
   (type $FUNCSIG$vi (func (param i32)))
   (import $extern_ijidf "env" "extern_ijidf" (param i64 i32 f64 f32) (result i32))
   (import $extern_v "env" "extern_v")


### PR DESCRIPTION
Pass ownership into the wasm module.