### PR TITLE
Move function parallelism to pass and pass runner

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -159,7 +159,9 @@ struct Liveness {
 };
 
 struct CoalesceLocals : public WalkerPass<CFGWalker<CoalesceLocals, Visitor<CoalesceLocals>, Liveness>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new CoalesceLocals; }
 
   Index numLocals;
 
@@ -462,7 +464,7 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices, Expression* root)
 }
 
 struct CoalesceLocalsWithLearning : public CoalesceLocals {
-  virtual CoalesceLocals* create() override { return new CoalesceLocalsWithLearning; }
+  virtual Pass* create() override { return new CoalesceLocalsWithLearning; }
 
   virtual void pickIndices(std::vector<Index>& indices) override;
 };

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -35,7 +35,9 @@
 namespace wasm {
 
 struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, Visitor<DeadCodeElimination>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new DeadCodeElimination; }
 
   // whether the current code is actually reachable
   bool reachable = true;

--- a/src/passes/DropReturnValues.cpp
+++ b/src/passes/DropReturnValues.cpp
@@ -26,7 +26,9 @@
 namespace wasm {
 
 struct DropReturnValues : public WalkerPass<PostWalker<DropReturnValues, Visitor<DropReturnValues>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new DropReturnValues; }
 
   std::vector<Expression*> expressionStack;
 

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -68,7 +68,9 @@
 namespace wasm {
 
 struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks, Visitor<MergeBlocks>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new MergeBlocks; }
 
   void visitBlock(Block *curr) {
     bool more = true;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -26,7 +26,9 @@
 namespace wasm {
 
 struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions, Visitor<OptimizeInstructions>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new OptimizeInstructions; }
 
   void visitIf(If* curr) {
     // flip branches to get rid of an i32.eqz

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -25,7 +25,9 @@
 namespace wasm {
 
 struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten, Visitor<PostEmscripten>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new PostEmscripten; }
 
   // When we have a Load from a local value (typically a GetLocal) plus a constant offset,
   // we may be able to fold it in.

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -628,9 +628,9 @@ static RegisterPass<Printer> registerPass("print", "print in s-expression format
 // Prints out a minified module
 
 class MinifiedPrinter : public Printer {
-  public:
+public:
   MinifiedPrinter() : Printer() {}
-  MinifiedPrinter(std::ostream& o) : Printer(o) {}
+  MinifiedPrinter(std::ostream* o) : Printer(o) {}
 
   void run(PassRunner* runner, Module* module) override {
     PrintSExpression print(o);
@@ -644,9 +644,9 @@ static RegisterPass<MinifiedPrinter> registerMinifyPass("print-minified", "print
 // Prints out a module withough elision, i.e., the full ast
 
 class FullPrinter : public Printer {
-  public:
+public:
   FullPrinter() : Printer() {}
-  FullPrinter(std::ostream& o) : Printer(o) {}
+  FullPrinter(std::ostream* o) : Printer(o) {}
 
   void run(PassRunner* runner, Module* module) override {
     PrintSExpression print(o);

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -25,7 +25,9 @@
 namespace wasm {
 
 struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<RemoveUnusedBrs>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new RemoveUnusedBrs; }
 
   bool anotherCycle;
 

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -24,7 +24,9 @@
 namespace wasm {
 
 struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames, Visitor<RemoveUnusedNames>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new RemoveUnusedNames; }
 
   // We maintain a list of branches that we saw in children, then when we reach
   // a parent block, we know if it was branched to

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -28,7 +28,9 @@
 namespace wasm {
 
 struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals, Visitor<ReorderLocals>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new ReorderLocals; }
 
   std::map<Index, Index> counts; // local => times it is used
   std::map<Index, Index> firstUses; // local => index in the list of which local is first seen

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -42,7 +42,7 @@ namespace wasm {
 
 // Helper classes
 
-struct GetLocalCounter : public WalkerPass<PostWalker<GetLocalCounter, Visitor<GetLocalCounter>>> {
+struct GetLocalCounter : public PostWalker<GetLocalCounter, Visitor<GetLocalCounter>> {
   std::vector<int>* numGetLocals;
 
   void visitGetLocal(GetLocal *curr) {
@@ -50,7 +50,7 @@ struct GetLocalCounter : public WalkerPass<PostWalker<GetLocalCounter, Visitor<G
   }
 };
 
-struct SetLocalRemover : public WalkerPass<PostWalker<SetLocalRemover, Visitor<SetLocalRemover>>> {
+struct SetLocalRemover : public PostWalker<SetLocalRemover, Visitor<SetLocalRemover>> {
   std::vector<int>* numGetLocals;
 
   void visitSetLocal(SetLocal *curr) {
@@ -63,7 +63,9 @@ struct SetLocalRemover : public WalkerPass<PostWalker<SetLocalRemover, Visitor<S
 // Main class
 
 struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, Visitor<SimplifyLocals>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new SimplifyLocals; }
 
   // information for a set_local we can sink
   struct SinkableInfo {

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -26,7 +26,9 @@
 namespace wasm {
 
 struct Vacuum : public WalkerPass<PostWalker<Vacuum, Visitor<Vacuum>>> {
-  bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new Vacuum; }
 
   std::vector<Expression*> expressionStack;
 

--- a/src/wasm-printing.h
+++ b/src/wasm-printing.h
@@ -27,7 +27,7 @@ namespace wasm {
 struct WasmPrinter {
   static std::ostream& printModule(Module* module, std::ostream& o) {
     PassRunner passRunner(module);
-    passRunner.add<Printer>(o);
+    passRunner.add<Printer>(&o);
     passRunner.run();
     return o;
   }


### PR DESCRIPTION
By doing it at the pass/pass runner level, we can be smarter about things. Previously we ran each pass, in parallel, and waited for it to finish entirely before moving to the next. With this PR we run all the passes we can on a single function. This avoids the join after each pass, and also is good for locality.

This speeds up optimization by a few %. Also feels like a cleaner API, to let traversals worry just about traversing, and the pass runner deals with running multiple passes in a parallel and efficient manner.