### PR TITLE
Make call_indirect type a name

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1367,8 +1367,9 @@ Function* Asm2WasmBuilder::processFunction(Ref ast) {
       for (unsigned i = 0; i < args->size(); i++) {
         ret->operands.push_back(process(args[i]));
       }
-      ret->fullType = getFunctionType(astStackHelper.getParent(), ret->operands);
-      ret->type = ret->fullType->result;
+      auto* fullType = getFunctionType(astStackHelper.getParent(), ret->operands);
+      ret->fullType = fullType->name;
+      ret->type = fullType->result;
       callIndirects[ret] = target[1][1]->getIString(); // we need to fix this up later, when we know how asm function tables are layed out inside the wasm table.
       return ret;
     } else if (what == RETURN) {

--- a/src/ast_utils.h
+++ b/src/ast_utils.h
@@ -539,7 +539,7 @@ struct ExpressionAnalyzer {
         }
         case Expression::Id::CallIndirectId: {
           PUSH(CallIndirect, target);
-          HASH_PTR(CallIndirect, fullType);
+          HASH_NAME(CallIndirect, fullType);
           HASH(CallIndirect, operands.size());
           for (Index i = 0; i < curr->cast<CallIndirect>()->operands.size(); i++) {
             PUSH(CallIndirect, operands[i]);

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -281,14 +281,15 @@ BinaryenExpressionRef BinaryenCallImport(BinaryenModuleRef module, const char *t
   ret->finalize();
   return static_cast<Expression*>(ret);
 }
-BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module, BinaryenExpressionRef target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, BinaryenFunctionTypeRef type) {
-  auto* ret = ((Module*)module)->allocator.alloc<CallIndirect>();
+BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module, BinaryenExpressionRef target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, const char* type) {
+  auto* wasm = (Module*)module;
+  auto* ret = wasm->allocator.alloc<CallIndirect>();
   ret->target = (Expression*)target;
   for (BinaryenIndex i = 0; i < numOperands; i++) {
     ret->operands.push_back((Expression*)operands[i]);
   }
-  ret->fullType = (FunctionType*)type;
-  ret->finalize();
+  ret->fullType = type;
+  ret->type = wasm->getFunctionType(ret->fullType)->result;
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenGetLocal(BinaryenModuleRef module, BinaryenIndex index, BinaryenType type) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -260,7 +260,7 @@ BinaryenExpressionRef BinaryenSwitch(BinaryenModuleRef module, const char **name
 //                   know what it is.
 BinaryenExpressionRef BinaryenCall(BinaryenModuleRef module, const char *target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, BinaryenType returnType);
 BinaryenExpressionRef BinaryenCallImport(BinaryenModuleRef module, const char *target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, BinaryenType returnType);
-BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module, BinaryenExpressionRef target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, BinaryenFunctionTypeRef type);
+BinaryenExpressionRef BinaryenCallIndirect(BinaryenModuleRef module, BinaryenExpressionRef target, BinaryenExpressionRef* operands, BinaryenIndex numOperands, const char* type);
 // GetLocal: Note the 'type' parameter. It might seem redundant, since the
 //           local at that index must have a type. However, this API lets you
 //           build code "top-down": create a node, then its parents, and so

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -209,7 +209,7 @@ struct PrintSExpression : public Visitor<PrintSExpression> {
     printCallBody(curr);
   }
   void visitCallIndirect(CallIndirect *curr) {
-    printOpening(o, "call_indirect ") << curr->fullType->name;
+    printOpening(o, "call_indirect ") << curr->fullType;
     incIndent();
     printFullLine(curr->target);
     for (auto operand : curr->operands) {

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -908,7 +908,7 @@ public:
     for (auto* operand : curr->operands) {
       recurse(operand);
     }
-    o << int8_t(BinaryConsts::CallIndirect) << U32LEB(curr->operands.size()) << U32LEB(getFunctionTypeIndex(curr->fullType->name));
+    o << int8_t(BinaryConsts::CallIndirect) << U32LEB(curr->operands.size()) << U32LEB(getFunctionTypeIndex(curr->fullType));
   }
   void visitGetLocal(GetLocal *curr) {
     if (debug) std::cerr << "zz node: GetLocal " << (o.size() + 1) << std::endl;
@@ -1837,15 +1837,16 @@ public:
   void visitCallIndirect(CallIndirect *curr) {
     if (debug) std::cerr << "zz node: CallIndirect" << std::endl;
     auto arity = getU32LEB();
-    curr->fullType = wasm.getFunctionType(getU32LEB());
-    auto num = curr->fullType->params.size();
+    auto* fullType = wasm.getFunctionType(getU32LEB());
+    curr->fullType = fullType->name;
+    auto num = fullType->params.size();
     assert(num == arity);
     curr->operands.resize(num);
     for (size_t i = 0; i < num; i++) {
       curr->operands[num - i - 1] = popExpression();
     }
     curr->target = popExpression();
-    curr->type = curr->fullType->result;
+    curr->type = fullType->result;
   }
   void visitGetLocal(GetLocal *curr) {
     if (debug) std::cerr << "zz node: GetLocal " << pos << std::endl;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -105,7 +105,7 @@ public:
   }
   CallIndirect* makeCallIndirect(FunctionType* type, Expression* target, const std::vector<Expression*>& args) {
     auto* call = allocator.alloc<CallIndirect>();
-    call->fullType = type;
+    call->fullType = type->name;
     call->type = type->result;
     call->target = target;
     call->operands.set(args);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -355,7 +355,7 @@ private:
         if (index >= instance.wasm.table.names.size()) trap("callIndirect: overflow");
         Name name = instance.wasm.table.names[index];
         Function *func = instance.wasm.getFunction(name);
-        if (func->type.is() && func->type != curr->fullType->name) trap("callIndirect: bad type");
+        if (func->type.is() && func->type != curr->fullType) trap("callIndirect: bad type");
         LiteralList arguments;
         Flow flow = generateArguments(curr->operands, arguments);
         if (flow.breaking()) return flow;

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -1094,10 +1094,10 @@ private:
   Expression* makeCallIndirect(Element& s) {
     auto ret = allocator.alloc<CallIndirect>();
     IString type = s[1]->str();
-    ret->fullType = wasm.checkFunctionType(type);
-    if (!ret->fullType) throw ParseException("invalid call_indirect type", s.line, s.col);
-    assert(ret->fullType);
-    ret->type = ret->fullType->result;
+    auto* fullType = wasm.checkFunctionType(type);
+    if (!fullType) throw ParseException("invalid call_indirect type", s.line, s.col);
+    ret->fullType = fullType->name;
+    ret->type = fullType->result;
     ret->target = parseExpression(s[2]);
     parseCallOperands(s, 3, ret);
     return ret;

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -110,7 +110,8 @@ public:
     }
   }
   void visitCallIndirect(CallIndirect *curr) {
-    auto* type = curr->fullType;
+    auto* type = getModule()->checkFunctionType(curr->fullType);
+    if (!shouldBeTrue(!!type, curr, "call_indirect type must exist")) return;
     shouldBeEqualOrFirstIsUnreachable(curr->target->type, i32, curr, "indirect call target must be an i32");
     if (!shouldBeTrue(curr->operands.size() == type->params.size(), curr, "call param number must match")) return;
     for (size_t i = 0; i < curr->operands.size(); i++) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1069,12 +1069,8 @@ public:
   CallIndirect(MixedArena& allocator) : operands(allocator) {}
 
   ExpressionList operands;
-  FunctionType *fullType;
+  Name fullType;
   Expression *target;
-
-  void finalize() {
-    type = fullType->result;
-  }
 };
 
 class GetLocal : public SpecificExpression<Expression::GetLocalId> {

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -175,7 +175,7 @@ void test_core() {
       )
     ),
     BinaryenUnary(module, BinaryenEqZInt32(), // check the output type of the call node
-      BinaryenCallIndirect(module, makeInt32(module, 2449), callOperands4, 4, iiIfF)
+      BinaryenCallIndirect(module, makeInt32(module, 2449), callOperands4, 4, "iiIfF")
     ),
     BinaryenGetLocal(module, 0, BinaryenInt32()),
     BinaryenSetLocal(module, 0, makeInt32(module, 101)),


### PR DESCRIPTION
This makes it like call and call_import, whose target info is also a name, instead of a raw pointer.

Avoiding a raw pointer makes parallel optimization passes simpler: to access global module data, it must be explicitly retrieved from the module object. Operating on a function by itself is always thread-safe.