### PR TITLE
Do not generate duplicate import thunks at link time.

### DIFF
--- a/src/wasm-linker.h
+++ b/src/wasm-linker.h
@@ -277,7 +277,7 @@ class Linker {
     out.wasm.addExport(exp);
   }
 
-  Function* generateImportThunk(Name name, const FunctionType* t);
+  Function* getImportThunk(Name name, const FunctionType* t);
 
   // The output module (linked executable)
   LinkerObject out;

--- a/test/dot_s/indirect-import.c
+++ b/test/dot_s/indirect-import.c
@@ -23,5 +23,9 @@ intptr_t bar() {
   ijidf(1LL, 2, 3.0, 4.0f);
   void (*vs)(struct big) = &extern_struct;
   struct big (*s)(void) = &extern_sret;
-  return (intptr_t)fd;
+    return (intptr_t)fd;
+}
+
+intptr_t baz() {
+  return (intptr_t)extern_v;
 }

--- a/test/dot_s/indirect-import.s
+++ b/test/dot_s/indirect-import.s
@@ -45,8 +45,20 @@ bar:                                    # @bar
 .Lfunc_end0:
 	.size	bar, .Lfunc_end0-bar
 
+	.hidden	baz
+	.globl	baz
+	.type	baz,@function
+baz:                                    # @baz
+	.result 	i32
+# BB#0:                                 # %entry
+	i32.const	$push0=, extern_v@FUNCTION
+                                        # fallthrough-return: $pop0
+	.endfunc
+.Lfunc_end1:
+	.size	baz, .Lfunc_end1-baz
 
-	.ident	"clang version 3.9.0 (trunk 271427) (llvm/trunk 271429)"
+
+	.ident	"clang version 3.9.0 (trunk 271579) (llvm/trunk 271699)"
 	.functype	extern_fd, f32, f64
 	.functype	extern_vj, void, i64
 	.functype	extern_v, void

--- a/test/dot_s/indirect-import.wast
+++ b/test/dot_s/indirect-import.wast
@@ -13,6 +13,7 @@
   (import $extern_struct "env" "extern_struct" (param i32))
   (import $extern_sret "env" "extern_sret" (param i32))
   (export "bar" $bar)
+  (export "baz" $baz)
   (export "dynCall_fd" $dynCall_fd)
   (export "dynCall_vj" $dynCall_vj)
   (export "dynCall_v" $dynCall_v)
@@ -79,6 +80,9 @@
       )
     )
     (get_local $1)
+  )
+  (func $baz (result i32)
+    (i32.const 2)
   )
   (func $__importThunk_extern_fd (type $FUNCSIG$fd) (param $0 f64) (result f32)
     (call_import $extern_fd


### PR DESCRIPTION
Previously every address-take of an import would cause a new thunk to be
generated. Now check in getImportThunk if the thunk exists already and
just return it if so.