### PR TITLE
Fix if type

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -974,7 +974,15 @@ public:
   void finalize() {
     assert(ifTrue);
     if (ifFalse) {
-      type = getReachableWasmType(ifTrue->type, ifFalse->type);
+      if (ifTrue->type == ifFalse->type) {
+        type = ifTrue->type;
+      } else if (isConcreteWasmType(ifTrue->type) && ifFalse->type == unreachable) {
+        type = ifTrue->type;
+      } else if (isConcreteWasmType(ifFalse->type) && ifTrue->type == unreachable) {
+        type = ifFalse->type;
+      } else {
+        type = none;
+      }
     }
   }
 };


### PR DESCRIPTION
If one is none and the other is concrete, still none is the final result.

This isn't noticeable in tests, but is noticeable internally so it's worth fixing.