### PR TITLE
Use WASM_UNUSED in some places

### DIFF
--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -148,8 +148,7 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
   }
 
   static void doAfterIfElseTrue(DeadCodeElimination* self, Expression** currp) {
-    auto* curr = (*currp)->cast<If>();
-    assert(curr->ifFalse);
+    assert((*currp)->cast<If>()->ifFalse);
     bool reachableBefore = self->ifStack.back();
     self->ifStack.pop_back();
     self->ifStack.push_back(self->reachable);

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "threads.h"
+#include "compiler-support.h"
 
 
 // debugging tools
@@ -178,6 +179,7 @@ void ThreadPool::notifyThreadIsReady() {
 void ThreadPool::resetThreadsAreReady() {
   DEBUG_POOL("reset threads are ready\n";)
   auto old = ready.exchange(0);
+  WASM_UNUSED(old);
   assert(old == threads.size());
 }
 

--- a/src/tools/binaryen-shell.cpp
+++ b/src/tools/binaryen-shell.cpp
@@ -131,6 +131,7 @@ static void run_asserts(size_t* i, bool* checked, Module* wasm,
       // an invoke test
       assert(wasm);
       bool trapped = false;
+      WASM_UNUSED(trapped);
       Literal result;
       try {
         Invocation invocation(*curr[1], instance.get(), *builder->get());

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1416,6 +1416,7 @@ public:
       if (debug) std::cerr << "read one" << std::endl;
       auto curr = new FunctionType;
       auto form = getInt8();
+      WASM_UNUSED(form);
       assert(form == BinaryConsts::TypeForms::Basic);
       size_t numParams = getU32LEB();
       if (debug) std::cerr << "num params: " << numParams << std::endl;
@@ -1638,6 +1639,7 @@ public:
     for (size_t i = 0; i < num; i++) {
       functions[i]->name = getInlineString();
       auto numLocals = getU32LEB();
+      WASM_UNUSED(numLocals);
       assert(numLocals == 0); // TODO
     }
   }
@@ -1806,6 +1808,7 @@ public:
   void visitCall(Call *curr) {
     if (debug) std::cerr << "zz node: Call" << std::endl;
     auto arity = getU32LEB();
+    WASM_UNUSED(arity);
     auto index = getU32LEB();
     assert(index < functionTypes.size());
     auto type = functionTypes[index];
@@ -1821,6 +1824,7 @@ public:
   void visitCallImport(CallImport *curr) {
     if (debug) std::cerr << "zz node: CallImport" << std::endl;
     auto arity = getU32LEB();
+    WASM_UNUSED(arity);
     auto import = wasm.getImport(getU32LEB());
     curr->target = import->name;
     auto type = import->type;
@@ -1837,6 +1841,7 @@ public:
   void visitCallIndirect(CallIndirect *curr) {
     if (debug) std::cerr << "zz node: CallIndirect" << std::endl;
     auto arity = getU32LEB();
+    WASM_UNUSED(arity);
     auto* fullType = wasm.getFunctionType(getU32LEB());
     curr->fullType = fullType->name;
     auto num = fullType->params.size();


### PR DESCRIPTION
Fixes compiler warnings/errors on variables we only use in asserts.