### PR TITLE
vs_pass_fixes

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -27,6 +27,7 @@
 #include "mixed_arena.h"
 #include "asmjs/shared-constants.h"
 #include "asm_v_wasm.h"
+#include "passes/passes.h"
 #include "pass.h"
 #include "ast_utils.h"
 #include "wasm-builder.h"

--- a/src/pass.h
+++ b/src/pass.h
@@ -32,6 +32,8 @@ class Pass;
 // Global registry of all passes in /passes/
 //
 struct PassRegistry {
+  PassRegistry();
+
   static PassRegistry* get();
 
   typedef std::function<Pass* ()> Creator;
@@ -42,6 +44,8 @@ struct PassRegistry {
   std::string getPassDescription(std::string name);
 
 private:
+  void registerPasses();
+
   struct PassInfo {
     std::string description;
     Creator create;
@@ -49,18 +53,6 @@ private:
     PassInfo(std::string description, Creator create) : description(description), create(create) {}
   };
   std::map<std::string, PassInfo> passInfos;
-};
-
-//
-// Utility class to register a pass. See pass files for usage.
-//
-template<class P>
-struct RegisterPass {
-  RegisterPass(const char* name, const char *description) {
-    PassRegistry::get()->registerPass(name, description, []() {
-      return new P();
-    });
-  }
 };
 
 //

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -595,8 +595,12 @@ void CoalesceLocalsWithLearning::pickIndices(std::vector<Index>& indices) {
 
 // declare passes
 
-static RegisterPass<CoalesceLocals> registerPass1("coalesce-locals", "reduce # of locals by coalescing");
+Pass *createCoalesceLocalsPass() {
+  return new CoalesceLocals();
+}
 
-static RegisterPass<CoalesceLocalsWithLearning> registerPass2("coalesce-locals-learning", "reduce # of locals by coalescing and learning");
+Pass *createCoalesceLocalsWithLearningPass() {
+  return new CoalesceLocalsWithLearning();
+}
 
 } // namespace wasm

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -346,7 +346,9 @@ struct DeadCodeElimination : public WalkerPass<PostWalker<DeadCodeElimination, V
   }
 };
 
-static RegisterPass<DeadCodeElimination> registerPass("dce", "removes unreachable code");
+Pass *createDeadCodeEliminationPass() {
+  return new DeadCodeElimination();
+}
 
 } // namespace wasm
 

--- a/src/passes/DropReturnValues.cpp
+++ b/src/passes/DropReturnValues.cpp
@@ -75,7 +75,9 @@ struct DropReturnValues : public WalkerPass<PostWalker<DropReturnValues, Visitor
   }
 };
 
-static RegisterPass<DropReturnValues> registerPass("drop-return-values", "stops relying on return values from set_local and store");
+Pass *createDropReturnValuesPass() {
+  return new DropReturnValues();
+}
 
 } // namespace wasm
 

--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -164,7 +164,9 @@ private:
   }
 };
 
-static RegisterPass<DuplicateFunctionElimination> registerPass("duplicate-function-elimination", "removes duplicate functions");
+Pass *createDuplicateFunctionEliminationPass() {
+  return new DuplicateFunctionElimination();
+}
 
 } // namespace wasm
 

--- a/src/passes/LowerIfElse.cpp
+++ b/src/passes/LowerIfElse.cpp
@@ -60,6 +60,8 @@ struct LowerIfElse : public WalkerPass<PostWalker<LowerIfElse, Visitor<LowerIfEl
   }
 };
 
-static RegisterPass<LowerIfElse> registerPass("lower-if-else", "lowers if-elses into ifs, blocks and branches");
+Pass *createLowerIfElsePass() {
+  return new LowerIfElse();
+}
 
 } // namespace wasm

--- a/src/passes/LowerInt64.cpp
+++ b/src/passes/LowerInt64.cpp
@@ -189,6 +189,8 @@ struct LowerInt64 : public Pass {
   }
 };
 
-static RegisterPass<LowerInt64> registerPass("lower-i64", "lowers i64 into pairs of i32s");
+Pass *createLowerInt64Pass() {
+  return new LowerInt64();
+}
 
 } // namespace wasm

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -178,7 +178,9 @@ struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks, Visitor<MergeBloc
   }
 };
 
-static RegisterPass<MergeBlocks> registerPass("merge-blocks", "merges blocks to their parents");
+Pass *createMergeBlocksPass() {
+  return new MergeBlocks();
+}
 
 } // namespace wasm
 

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -87,7 +87,10 @@ struct Metrics : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<
   }
 };
 
+Pass *createMetricsPass() {
+  return new Metrics();
+}
+
 Metrics *Metrics::lastMetricsPass;
-static RegisterPass<Metrics> registerPass("metrics", "reports metrics");
 
 } // namespace wasm

--- a/src/passes/NameList.cpp
+++ b/src/passes/NameList.cpp
@@ -32,7 +32,9 @@ struct NameList : public Pass {
   }
 };
 
-static RegisterPass<NameList> registerPass("nm", "name list");
+Pass *createNameListPass() {
+  return new NameList();
+}
 
 } // namespace wasm
 

--- a/src/passes/NameManager.cpp
+++ b/src/passes/NameManager.cpp
@@ -74,6 +74,8 @@ void NameManager::visitExport(Export* curr) {
   names.insert(curr->name);
 }
 
-static RegisterPass<NameManager> registerPass("name-manager", "utility pass to manage names in modules");
+Pass *createNameManagerPass() {
+  return new NameManager();
+}
 
 } // namespace wasm

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -86,6 +86,8 @@ struct OptimizeInstructions : public WalkerPass<PostWalker<OptimizeInstructions,
   }
 };
 
-static RegisterPass<OptimizeInstructions> registerPass("optimize-instructions", "optimizes instruction combinations");
+Pass *createOptimizeInstructionsPass() {
+  return new OptimizeInstructions();
+}
 
 } // namespace wasm

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -77,6 +77,8 @@ struct PostEmscripten : public WalkerPass<PostWalker<PostEmscripten, Visitor<Pos
   }
 };
 
-static RegisterPass<PostEmscripten> registerPass("post-emscripten", "miscellaneous optimizations for Emscripten-generated code");
+Pass *createPostEmscriptenPass() {
+  return new PostEmscripten();
+}
 
 } // namespace wasm

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -97,7 +97,9 @@ struct Precompute : public WalkerPass<PostWalker<Precompute, UnifiedExpressionVi
   }
 };
 
-static RegisterPass<Precompute> registerPass("precompute", "computes compile-time evaluatable expressions");
+Pass *createPrecomputePass() {
+  return new Precompute();
+}
 
 } // namespace wasm
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -623,7 +623,9 @@ void Printer::run(PassRunner* runner, Module* module) {
   print.visitModule(module);
 }
 
-static RegisterPass<Printer> registerPass("print", "print in s-expression format");
+Pass *createPrinterPass() {
+  return new Printer();
+}
 
 // Prints out a minified module
 
@@ -639,7 +641,9 @@ public:
   }
 };
 
-static RegisterPass<MinifiedPrinter> registerMinifyPass("print-minified", "print in minified s-expression format");
+Pass *createMinifiedPrinterPass() {
+  return new MinifiedPrinter();
+}
 
 // Prints out a module withough elision, i.e., the full ast
 
@@ -655,7 +659,9 @@ public:
   }
 };
 
-static RegisterPass<FullPrinter> registerFullASTPass("print-full", "print in full s-expression format");
+Pass *createFullPrinterPass() {
+  return new FullPrinter();
+}
 
 // Print individual expressions
 

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -58,6 +58,8 @@ struct RemoveImports : public WalkerPass<PostWalker<RemoveImports, Visitor<Remov
   }
 };
 
-static RegisterPass<RemoveImports> registerPass("remove-imports", "removes imports and replaces them with nops");
+Pass *createRemoveImportsPass() {
+  return new RemoveImports();
+}
 
 } // namespace wasm

--- a/src/passes/RemoveMemory.cpp
+++ b/src/passes/RemoveMemory.cpp
@@ -29,6 +29,8 @@ struct RemoveMemory : public Pass {
   }
 };
 
-static RegisterPass<RemoveMemory> registerPass("remove-memory", "removes memory segments");
+Pass *createRemoveMemoryPass() {
+  return new RemoveMemory();
+}
 
 } // namespace wasm

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -232,6 +232,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs, Visitor<R
   }
 };
 
-static RegisterPass<RemoveUnusedBrs> registerPass("remove-unused-brs", "removes breaks from locations that are not needed");
+Pass *createRemoveUnusedBrsPass() {
+  return new RemoveUnusedBrs();
+}
 
 } // namespace wasm

--- a/src/passes/RemoveUnusedFunctions.cpp
+++ b/src/passes/RemoveUnusedFunctions.cpp
@@ -54,6 +54,8 @@ struct RemoveUnusedFunctions : public Pass {
   }
 };
 
-static RegisterPass<RemoveUnusedFunctions> registerPass("remove-unused-functions", "removes unused functions");
+Pass *createRemoveUnusedFunctionsPass() {
+  return new RemoveUnusedFunctions();
+}
 
 } // namespace wasm

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -54,6 +54,8 @@ struct RemoveUnusedNames : public WalkerPass<PostWalker<RemoveUnusedNames, Visit
   }
 };
 
-static RegisterPass<RemoveUnusedNames> registerPass("remove-unused-names", "removes names from locations that are never branched to");
+Pass *createRemoveUnusedNamesPass() {
+  return new RemoveUnusedNames();
+}
 
 } // namespace wasm

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -57,6 +57,8 @@ struct ReorderFunctions : public WalkerPass<PostWalker<ReorderFunctions, Visitor
   }
 };
 
-static RegisterPass<ReorderFunctions> registerPass("reorder-functions", "sorts functions by access frequency");
+Pass *createReorderFunctionsPass() {
+  return new ReorderFunctions();
+}
 
 } // namespace wasm

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -134,6 +134,8 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals, Visitor<Reord
   }
 };
 
-static RegisterPass<ReorderLocals> registerPass("reorder-locals", "sorts locals by access frequency");
+Pass *createReorderLocalsPass() {
+  return new ReorderLocals();
+}
 
 } // namespace wasm

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -434,6 +434,8 @@ struct SimplifyLocals : public WalkerPass<LinearExecutionWalker<SimplifyLocals, 
   }
 };
 
-static RegisterPass<SimplifyLocals> registerPass("simplify-locals", "miscellaneous locals-related optimizations");
+Pass *createSimplifyLocalsPass() {
+  return new SimplifyLocals();
+}
 
 } // namespace wasm

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -228,7 +228,9 @@ struct Vacuum : public WalkerPass<PostWalker<Vacuum, Visitor<Vacuum>>> {
   }
 };
 
-static RegisterPass<Vacuum> registerPass("vacuum", "removes obviously unneeded code");
+Pass *createVacuumPass() {
+  return new Vacuum();
+}
 
 } // namespace wasm
 

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -16,11 +16,16 @@
 
 #include <chrono>
 
+#include <passes/passes.h>
 #include <pass.h>
 
 namespace wasm {
 
 // PassRegistry
+
+PassRegistry::PassRegistry() {
+  registerPasses();
+}
 
 PassRegistry* PassRegistry::get() {
   static PassRegistry* manager = nullptr;
@@ -56,6 +61,35 @@ std::string PassRegistry::getPassDescription(std::string name) {
 }
 
 // PassRunner
+
+void PassRegistry::registerPasses() {
+  registerPass("coalesce-locals", "reduce # of locals by coalescing", createCoalesceLocalsPass);
+  registerPass("coalesce-locals-learning", "reduce # of locals by coalescing and learning", createCoalesceLocalsWithLearningPass);
+  registerPass("dce", "removes unreachable code", createDeadCodeEliminationPass);
+  registerPass("drop-return-values", "stops relying on return values from set_local and store", createDropReturnValuesPass);
+  registerPass("duplicate-function-elimination", "removes duplicate functions", createDuplicateFunctionEliminationPass);
+  registerPass("lower-if-else", "lowers if-elses into ifs, blocks and branches", createLowerIfElsePass);
+  registerPass("merge-blocks", "merges blocks to their parents", createMergeBlocksPass);
+  registerPass("metrics", "reports metrics", createMetricsPass);
+  registerPass("nm", "name list", createNameListPass);
+  registerPass("name-manager", "utility pass to manage names in modules", createNameManagerPass);
+  registerPass("optimize-instructions", "optimizes instruction combinations", createOptimizeInstructionsPass);
+  registerPass("post-emscripten", "miscellaneous optimizations for Emscripten-generated code", createPostEmscriptenPass);
+  registerPass("print", "print in s-expression format", createPrinterPass);
+  registerPass("print-minified", "print in minified s-expression format", createMinifiedPrinterPass);
+  registerPass("print-full", "print in full s-expression format", createFullPrinterPass);
+  registerPass("remove-imports", "removes imports and replaces them with nops", createRemoveImportsPass);
+  registerPass("remove-memory", "removes memory segments", createRemoveMemoryPass);
+  registerPass("remove-unused-brs", "removes breaks from locations that are not needed", createRemoveUnusedBrsPass);
+  registerPass("remove-unused-functions", "removes unused functions", createRemoveUnusedFunctionsPass);
+  registerPass("remove-unused-names", "removes names from locations that are never branched to", createRemoveUnusedNamesPass);
+  registerPass("reorder-functions", "sorts functions by access frequency", createReorderFunctionsPass);
+  registerPass("reorder-locals", "sorts locals by access frequency", createReorderLocalsPass);
+  registerPass("simplify-locals", "miscellaneous locals-related optimizations", createSimplifyLocalsPass);
+  registerPass("vacuum", "removes obviously unneeded code", createVacuumPass);
+  registerPass("precompute", "computes compile-time evaluatable expressions", createPrecomputePass);
+//  registerPass("lower-i64", "lowers i64 into pairs of i32s", createLowerInt64Pass);
+}
 
 void PassRunner::addDefaultOptimizationPasses() {
   add("duplicate-function-elimination");

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_passes_h
+#define wasm_passes_h
+
+namespace wasm {
+
+class Pass;
+
+// All passes:
+Pass *createCoalesceLocalsPass();
+Pass *createCoalesceLocalsWithLearningPass();
+Pass *createDeadCodeEliminationPass();
+Pass *createDropReturnValuesPass();
+Pass *createDuplicateFunctionEliminationPass();
+Pass *createLowerIfElsePass();
+Pass *createMergeBlocksPass();
+Pass *createMetricsPass();
+Pass *createNameListPass();
+Pass *createNameManagerPass();
+Pass *createOptimizeInstructionsPass();
+Pass *createPostEmscriptenPass();
+Pass *createPrinterPass();
+Pass *createMinifiedPrinterPass();
+Pass *createFullPrinterPass();
+Pass *createRemoveImportsPass();
+Pass *createRemoveMemoryPass();
+Pass *createRemoveUnusedBrsPass();
+Pass *createRemoveUnusedFunctionsPass();
+Pass *createRemoveUnusedNamesPass();
+Pass *createReorderFunctionsPass();
+Pass *createReorderLocalsPass();
+Pass *createSimplifyLocalsPass();
+Pass *createVacuumPass();
+Pass *createPrecomputePass();
+//Pass *createLowerInt64Pass();
+
+}
+
+#endif

--- a/src/tools/binaryen-shell.cpp
+++ b/src/tools/binaryen-shell.cpp
@@ -77,8 +77,8 @@ static void run_asserts(size_t* i, bool* checked, Module* wasm,
   std::unique_ptr<ShellExternalInterface> interface;
   std::unique_ptr<ModuleInstance> instance;
   if (wasm) {
-    interface = make_unique<ShellExternalInterface>();
-    instance = make_unique<ModuleInstance>(*wasm, interface.get());
+    interface = wasm::make_unique<ShellExternalInterface>();
+    instance = wasm::make_unique<ModuleInstance>(*wasm, interface.get());
     if (entry.is()) {
       Function* function = wasm->getFunction(entry);
       if (!function) {
@@ -201,7 +201,7 @@ int main(int argc, const char* argv[]) {
 
   std::unique_ptr<Output> output;
   if (options.extra.count("output") > 0) {
-    output = make_unique<Output>(options.extra["output"], Flags::Text, options.debug ? Flags::Debug : Flags::Release);
+    output = wasm::make_unique<Output>(options.extra["output"], Flags::Text, options.debug ? Flags::Debug : Flags::Release);
   }
 
   bool checked = false;
@@ -220,7 +220,7 @@ int main(int argc, const char* argv[]) {
         if (options.debug) std::cerr << "parsing s-expressions to wasm...\n";
         Module wasm;
         std::unique_ptr<SExpressionWasmBuilder> builder;
-        builder = make_unique<SExpressionWasmBuilder>(wasm, *root[i]);
+        builder = wasm::make_unique<SExpressionWasmBuilder>(wasm, *root[i]);
         i++;
         assert(WasmValidator().validate(wasm));
 


### PR DESCRIPTION
Add initialization functions for passes to avoid missing pass registration due to linker dead code elimination. Fixes #577.
