### PR TITLE
Add mode to wasm validator to check for web-environment constraints

### DIFF
--- a/check.py
+++ b/check.py
@@ -555,6 +555,8 @@ cmd = [wasm_as, '--validate=web', os.path.join('test', 'validator', 'invalid_exp
 run_command(cmd, expected_status=1)
 cmd = [wasm_as, '--validate=web', os.path.join('test', 'validator', 'invalid_import.wast')]
 run_command(cmd, expected_status=1)
+cmd = [wasm_as, '--validate=none', os.path.join('test', 'validator', 'invalid_return.wast')]
+run_command(cmd)
 
 if torture:
 

--- a/check.py
+++ b/check.py
@@ -132,11 +132,11 @@ except:
 
 # utilities
 
-def run_command(cmd, stderr=None):
+def run_command(cmd, expected_status=0, stderr=None):
   print 'executing: ', ' '.join(cmd)
   proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr)
   out, err = proc.communicate()
-  if proc.returncode != 0: raise Exception(('run_command failed', err))
+  if proc.returncode != expected_status: raise Exception(('run_command failed', err))
   return out
 
 def fail(actual, expected):
@@ -544,6 +544,17 @@ output = run_command(cmd)
 # bar should be linked from the archive
 fail_if_not_contained(output, '(func $bar')
 
+print '\n[ running validation tests... ]\n'
+wasm_as = os.path.join('bin', 'wasm-as')
+# Ensure the tests validate by default
+cmd = [wasm_as, os.path.join('test', 'validator', 'invalid_export.wast')]
+run_command(cmd)
+cmd = [wasm_as, os.path.join('test', 'validator', 'invalid_import.wast')]
+run_command(cmd)
+cmd = [wasm_as, '--validate=web', os.path.join('test', 'validator', 'invalid_export.wast')]
+run_command(cmd, expected_status=1)
+cmd = [wasm_as, '--validate=web', os.path.join('test', 'validator', 'invalid_import.wast')]
+run_command(cmd, expected_status=1)
 
 if torture:
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1243,10 +1243,6 @@ public:
     }
 
     processFunctions();
-
-    if (!WasmValidator().validate(wasm)) {
-      abort();
-    }
   }
 
   bool more() {

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -28,14 +28,14 @@ namespace wasm {
 
 struct WasmValidator : public PostWalker<WasmValidator, Visitor<WasmValidator>> {
   bool valid = true;
-  bool validateWeb = false;
+  bool validateWebConstraints = false;
 
   std::map<Name, WasmType> breakTypes; // breaks to a label must all have the same type, and the right type
   WasmType returnType = unreachable; // type used in returns
 
 public:
-  bool validate(Module& module, bool validateWebConstraints=false) {
-    validateWeb = validateWebConstraints;
+  bool validate(Module& module, bool validateWeb=false) {
+    validateWebConstraints = validateWeb;
     walkModule(&module);
     return valid;
   }
@@ -236,7 +236,7 @@ public:
   }
 
   void visitImport(Import* curr) {
-    if (!validateWeb) return;
+    if (!validateWebConstraints) return;
     shouldBeUnequal(curr->type->result, i64, curr->name, "Imported function must not have i64 return type");
     for (WasmType param : curr->type->params) {
       shouldBeUnequal(param, i64, curr->name, "Imported function must not have i64 parameters");
@@ -244,7 +244,7 @@ public:
   }
 
   void visitExport(Export* curr) {
-    if (!validateWeb) return;
+    if (!validateWebConstraints) return;
     Function* f = getModule()->getFunction(curr->value);
     shouldBeUnequal(f->result, i64, f->name, "Exported function must not have i64 return type");
     for (auto param : f->params) {

--- a/test/validator/invalid_export.wast
+++ b/test/validator/invalid_export.wast
@@ -1,0 +1,1 @@
+(module (func $export64 (result i64) (i64.const 1)) (export "a" $export64))

--- a/test/validator/invalid_import.wast
+++ b/test/validator/invalid_import.wast
@@ -1,0 +1,1 @@
+(module (import $bad "test" "bad" (param i64)))

--- a/test/validator/invalid_return.wast
+++ b/test/validator/invalid_return.wast
@@ -1,0 +1,2 @@
+(module
+ (func $foo (result i32) (i64.const 1)))


### PR DESCRIPTION
In the web embedding, modules are not allowed to import or export
functions which have i64 params or return values. Add a mode to the
validator to check for this, and add flags to s2wasm and wasm-as to
enable or disable this check. Also add tests.