### PR TITLE
Finalize blocks properly in relooper

### DIFF
--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -55,6 +55,7 @@ wasm::Expression* Branch::Render(RelooperBuilder& Builder, Block *Target, bool S
       Ret->list.push_back(Builder.makeContinue(Ancestor->Id));
     }
   }
+  Ret->finalize();
   return Ret;
 }
 
@@ -85,7 +86,10 @@ wasm::Expression* Block::Render(RelooperBuilder& Builder, bool InLoop) {
   }
   if (Code) Ret->list.push_back(Code);
 
-  if (!ProcessedBranchesOut.size()) return Ret;
+  if (!ProcessedBranchesOut.size()) {
+    Ret->finalize();
+    return Ret;
+  }
 
   bool SetLabel = true; // in some cases it is clear we can avoid setting label, see later
   bool ForceSetLabel = Shape::IsEmulated(Parent) != nullptr;
@@ -218,6 +222,8 @@ wasm::Expression* Block::Render(RelooperBuilder& Builder, bool InLoop) {
     }
     Ret->list.push_back(Root);
   }
+
+  Ret->finalize();
 
   return Ret;
 }

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -378,6 +378,17 @@ void test_relooper() {
     BinaryenFunctionRef sinker = BinaryenAddFunction(module, "nontrivial-loop-plus-phi-to-head", v, localTypes, 1, body);
   }
 
+  BinaryenFunctionTypeRef i = BinaryenAddFunctionType(module, "i", BinaryenInt32(), NULL, 0);
+
+  { // return in a block
+    RelooperRef relooper = RelooperCreate();
+    BinaryenExpressionRef listList[] = { makeInt32(module, 42), BinaryenReturn(module, makeInt32(module, 1337)) };
+    BinaryenExpressionRef list = BinaryenBlock(module, "the-list", listList, 2);
+    RelooperBlockRef block = RelooperAddBlock(relooper, list);
+    BinaryenExpressionRef body = RelooperRenderAndDispose(relooper, block, 0, module);
+    BinaryenFunctionRef sinker = BinaryenAddFunction(module, "return", i, localTypes, 1, body);
+  }
+
   assert(BinaryenModuleValidate(module));
 
   printf("raw:\n");

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -370,6 +370,7 @@ raw:
 (module
   (memory 0)
   (type $v (func))
+  (type $i (func (result i32)))
   (func $just-one-block (type $v)
     (local $0 i32)
     (i32.const 1337)
@@ -630,13 +631,26 @@ raw:
       )
     )
   )
+  (func $return (type $i) (result i32)
+    (local $0 i32)
+    (block $the-list
+      (i32.const 42)
+      (return
+        (i32.const 1337)
+      )
+    )
+  )
 )
 optimized:
 (module
   (memory 0)
   (type $v (func))
+  (type $i (func (result i32)))
   (func $just-one-block (type $v)
     (nop)
+  )
+  (func $return (type $i) (result i32)
+    (i32.const 1337)
   )
 )
 module loaded from binary form:


### PR DESCRIPTION
`return` statements in particular were not handled properly without this.