### PR TITLE
Spec test update

### DIFF
--- a/check.py
+++ b/check.py
@@ -453,7 +453,7 @@ for t in spec_tests:
 
     # check binary format. here we can verify execution of the final result, no need for an output verification
     split_num = 0
-    if os.path.basename(wast) not in ['has_feature.wast']: # avoid some tests with things still in spec tests, but likely to be taken out soon
+    if os.path.basename(wast) not in ['call_indirect.wast']: # avoid some tests with things still being sorted out in the spec https://github.com/WebAssembly/spec/pull/301
       actual = ''
       for module, asserts in split_wast(wast):
         print '    testing split module', split_num

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -127,7 +127,7 @@ inline Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allo
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str);
-        int32_t temp;
+        uint32_t temp;
         istr >> temp;
         ret->value = Literal(temp);
       }
@@ -143,7 +143,7 @@ inline Expression* parseConst(cashew::IString s, WasmType type, MixedArena& allo
         ret->value = Literal(negative ? -temp : temp);
       } else {
         std::istringstream istr(str);
-        int64_t temp;
+        uint64_t temp;
         istr >> temp;
         ret->value = Literal(temp);
       }

--- a/src/tools/binaryen-shell.cpp
+++ b/src/tools/binaryen-shell.cpp
@@ -105,7 +105,10 @@ static void run_asserts(size_t* i, bool* checked, Module* wasm,
     Colors::green(std::cerr);
     std::cerr << " CHECKING: ";
     Colors::normal(std::cerr);
-    std::cerr << curr << '\n';
+    std::cerr << curr;
+    Colors::green(std::cerr);
+    std::cerr << " [line: " << curr.line << "]\n";
+    Colors::normal(std::cerr);
     if (id == ASSERT_INVALID) {
       // a module invalidity test
       Module wasm;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -469,6 +469,7 @@ class WasmBinaryWriter : public Visitor<WasmBinaryWriter, void> {
       if (func->type.isNull()) {
         func->type = ensureFunctionType(getSig(func.get()), wasm)->name;
       }
+      // TODO: depending on upstream flux https://github.com/WebAssembly/spec/pull/301 might want this: assert(!func->type.isNull());
     }
   }
 

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -498,6 +498,14 @@ private:
       body = allocator.alloc<Nop>();
     }
     if (currFunction->result != result) throw ParseException("bad func declaration", s.line, s.col);
+    /* TODO: spec in flux, https://github.com/WebAssembly/spec/pull/301
+    if (type.isNull()) {
+      // if no function type provided, generate a private one for this function
+      auto* functionType = sigToFunctionType(getSig(currFunction.get()));
+      wasm.addFunctionType(functionType);
+      type = functionType->name;
+    }
+    */
     currFunction->body = body;
     currFunction->type = type;
     wasm.addFunction(currFunction.release());


### PR DESCRIPTION
Minor fixes and improvements for latest test updates.

This temporarily disables `call_import.wast` from binary format tests since there is some uncertainty and flux around it, https://github.com/WebAssembly/spec/pull/301