### PR TITLE
Handle param overloading in asm2wasm ffis

### DIFF
--- a/test/unit.asm.js
+++ b/test/unit.asm.js
@@ -194,6 +194,8 @@ function asm(global, env, buffer) {
     abort();
     abort(55);
     abort();
+    abort(12.34);
+    abort(Math_fround(56.78));
   }
   function continues() {
     while (1) {

--- a/test/unit.fromasm
+++ b/test/unit.fromasm
@@ -5,7 +5,8 @@
   (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
   (type $FUNCSIG$vf (func (param f32)))
   (type $FUNCSIG$vi (func (param i32)))
-  (import $abort "env" "abort" (param i32))
+  (type $FUNCSIG$vd (func (param f64)))
+  (import $abort "env" "abort" (param f64))
   (import $print "env" "print" (param i32))
   (import $h "env" "h" (param i32))
   (import $f64-to-int "asm2wasm" "f64-to-int" (param f64) (result i32))
@@ -303,13 +304,23 @@
   )
   (func $aborts
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
     )
     (call_import $abort
-      (i32.const 55)
+      (f64.convert_s/i32
+        (i32.const 55)
+      )
     )
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
+    )
+    (call_import $abort
+      (f64.const 12.34)
+    )
+    (call_import $abort
+      (f64.promote/f32
+        (f32.const 56.779998779296875)
+      )
     )
   )
   (func $continues

--- a/test/unit.fromasm.imprecise
+++ b/test/unit.fromasm.imprecise
@@ -4,7 +4,8 @@
   (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
   (type $FUNCSIG$vf (func (param f32)))
   (type $FUNCSIG$vi (func (param i32)))
-  (import $abort "env" "abort" (param i32))
+  (type $FUNCSIG$vd (func (param f64)))
+  (import $abort "env" "abort" (param f64))
   (import $print "env" "print" (param i32))
   (import $h "env" "h" (param i32))
   (import $f64-rem "asm2wasm" "f64-rem" (param f64 f64) (result f64))
@@ -295,13 +296,23 @@
   )
   (func $aborts
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
     )
     (call_import $abort
-      (i32.const 55)
+      (f64.convert_s/i32
+        (i32.const 55)
+      )
     )
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
+    )
+    (call_import $abort
+      (f64.const 12.34)
+    )
+    (call_import $abort
+      (f64.promote/f32
+        (f32.const 56.779998779296875)
+      )
     )
   )
   (func $continues

--- a/test/unit.fromasm.imprecise.no-opts
+++ b/test/unit.fromasm.imprecise.no-opts
@@ -4,7 +4,8 @@
   (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
   (type $FUNCSIG$vf (func (param f32)))
   (type $FUNCSIG$vi (func (param i32)))
-  (import $abort "env" "abort" (param i32))
+  (type $FUNCSIG$vd (func (param f64)))
+  (import $abort "env" "abort" (param f64))
   (import $print "env" "print" (param i32))
   (import $h "env" "h" (param i32))
   (import $f64-rem "asm2wasm" "f64-rem" (param f64 f64) (result f64))
@@ -515,13 +516,23 @@
   )
   (func $aborts
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
     )
     (call_import $abort
-      (i32.const 55)
+      (f64.convert_s/i32
+        (i32.const 55)
+      )
     )
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
+    )
+    (call_import $abort
+      (f64.const 12.34)
+    )
+    (call_import $abort
+      (f64.promote/f32
+        (f32.const 56.779998779296875)
+      )
     )
   )
   (func $continues

--- a/test/unit.fromasm.no-opts
+++ b/test/unit.fromasm.no-opts
@@ -5,7 +5,8 @@
   (type $FUNCSIG$ddd (func (param f64 f64) (result f64)))
   (type $FUNCSIG$vf (func (param f32)))
   (type $FUNCSIG$vi (func (param i32)))
-  (import $abort "env" "abort" (param i32))
+  (type $FUNCSIG$vd (func (param f64)))
+  (import $abort "env" "abort" (param f64))
   (import $print "env" "print" (param i32))
   (import $h "env" "h" (param i32))
   (import $f64-to-int "asm2wasm" "f64-to-int" (param f64) (result i32))
@@ -519,13 +520,23 @@
   )
   (func $aborts
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
     )
     (call_import $abort
-      (i32.const 55)
+      (f64.convert_s/i32
+        (i32.const 55)
+      )
     )
     (call_import $abort
-      (i32.const 0)
+      (f64.const 0)
+    )
+    (call_import $abort
+      (f64.const 12.34)
+    )
+    (call_import $abort
+      (f64.promote/f32
+        (f32.const 56.779998779296875)
+      )
     )
   )
   (func $continues


### PR DESCRIPTION
We handled missing params, but fastcomp output can also overload them, in the case of `abort()` calls that represent a function call that was to an absolute address (in which case we keep the params as is). Upgrading everything to a double is ok in this case.