### PR TITLE
Optimize to remove as many copies as possible in coalesce-locals

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -408,7 +408,7 @@ void CoalesceLocals::pickIndicesFromOrder(std::vector<Index>& order, std::vector
     assert(order[i] == i); // order must leave the params in place
     indices[i] = i;
     types[i] = getFunction()->getLocalType(i);
-    for (Index j = 0; j < numLocals; j++) {
+    for (Index j = numParams; j < numLocals; j++) {
       newInterferences[numLocals * i + j] = interferes(i, j);
       newCopies[numLocals * i + j] = getCopies(i, j);
     }
@@ -434,7 +434,8 @@ void CoalesceLocals::pickIndicesFromOrder(std::vector<Index>& order, std::vector
       nextFree++;
     }
     // merge new interferences and copies for the new index
-    for (Index j = 0; j < numLocals; j++) {
+    for (Index k = i + 1; k < numLocals; k++) {
+      auto j = order[k]; // go in the order, we only need to update for those we will see later
       newInterferences[found * numLocals + j] = newInterferences[found * numLocals + j] | interferes(actual, j);
       newCopies[found * numLocals + j] += getCopies(actual, j);
     }

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -108,12 +108,12 @@
             (i32.and
               (set_local $2
                 (i32.shr_u
-                  (set_local $5
+                  (set_local $7
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (set_local $4
+                  (set_local $5
                     (i32.shr_u
                       (set_local $0
                         (select
@@ -141,11 +141,11 @@
             (block
               (set_local $2
                 (i32.load
-                  (set_local $9
+                  (set_local $8
                     (i32.add
-                      (set_local $4
+                      (set_local $5
                         (i32.load
-                          (set_local $6
+                          (set_local $4
                             (i32.add
                               (set_local $1
                                 (i32.add
@@ -161,7 +161,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $4)
+                                          (get_local $5)
                                         )
                                       )
                                       (i32.const 1)
@@ -198,22 +198,22 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $8
+                        (set_local $9
                           (i32.add
                             (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
-                        (get_local $8)
+                        (get_local $9)
                         (get_local $1)
                       )
                       (i32.store
-                        (get_local $6)
+                        (get_local $4)
                         (get_local $2)
                       )
                     )
@@ -223,7 +223,7 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $5)
+                    (get_local $7)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -235,7 +235,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $5)
                 (i32.or
                   (set_local $2
                     (i32.shl
@@ -247,10 +247,10 @@
                 )
               )
               (i32.store
-                (set_local $6
+                (set_local $4
                   (i32.add
                     (i32.add
-                      (get_local $4)
+                      (get_local $5)
                       (get_local $2)
                     )
                     (i32.const 4)
@@ -258,20 +258,20 @@
                 )
                 (i32.or
                   (i32.load
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (i32.const 1)
                 )
               )
               (return
-                (get_local $9)
+                (get_local $8)
               )
             )
           )
           (if
             (i32.gt_u
               (get_local $0)
-              (set_local $6
+              (set_local $4
                 (i32.load
                   (i32.const 184)
                 )
@@ -291,13 +291,13 @@
                                 (i32.and
                                   (i32.shl
                                     (get_local $2)
-                                    (get_local $4)
+                                    (get_local $5)
                                   )
                                   (i32.or
                                     (set_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $4)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.sub
@@ -322,9 +322,9 @@
                   )
                   (set_local $1
                     (i32.load
-                      (set_local $8
+                      (set_local $9
                         (i32.add
-                          (set_local $15
+                          (set_local $16
                             (i32.load
                               (set_local $18
                                 (i32.add
@@ -342,7 +342,7 @@
                                                       (set_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $8
+                                                            (set_local $9
                                                               (i32.shr_u
                                                                 (get_local $2)
                                                                 (get_local $1)
@@ -355,12 +355,12 @@
                                                       )
                                                       (get_local $1)
                                                     )
-                                                    (set_local $8
+                                                    (set_local $9
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $15
+                                                          (set_local $16
                                                             (i32.shr_u
-                                                              (get_local $8)
+                                                              (get_local $9)
                                                               (get_local $2)
                                                             )
                                                           )
@@ -370,13 +370,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $15
+                                                  (set_local $16
                                                     (i32.and
                                                       (i32.shr_u
                                                         (set_local $10
                                                           (i32.shr_u
-                                                            (get_local $15)
-                                                            (get_local $8)
+                                                            (get_local $16)
+                                                            (get_local $9)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -391,7 +391,7 @@
                                                       (set_local $18
                                                         (i32.shr_u
                                                           (get_local $10)
-                                                          (get_local $15)
+                                                          (get_local $16)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -447,7 +447,7 @@
                               )
                             )
                           )
-                          (get_local $15)
+                          (get_local $16)
                         )
                         (block
                           (i32.store
@@ -458,7 +458,7 @@
                             (get_local $18)
                             (get_local $1)
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.load
                               (i32.const 184)
                             )
@@ -471,7 +471,7 @@
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $5)
+                          (get_local $7)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
@@ -481,27 +481,27 @@
                           )
                         )
                       )
-                      (set_local $9
-                        (get_local $6)
+                      (set_local $8
+                        (get_local $4)
                       )
                     )
                   )
                   (i32.store offset=4
-                    (get_local $15)
+                    (get_local $16)
                     (i32.or
                       (get_local $0)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $5
+                    (set_local $7
                       (i32.add
-                        (get_local $15)
+                        (get_local $16)
                         (get_local $0)
                       )
                     )
                     (i32.or
-                      (set_local $6
+                      (set_local $4
                         (i32.sub
                           (i32.shl
                             (get_local $19)
@@ -515,13 +515,13 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $5)
-                      (get_local $6)
+                      (get_local $7)
+                      (get_local $4)
                     )
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (if
-                    (get_local $9)
+                    (get_local $8)
                     (block
                       (set_local $1
                         (i32.load
@@ -535,7 +535,7 @@
                             (i32.shl
                               (set_local $18
                                 (i32.shr_u
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 3)
                                 )
                               )
@@ -547,7 +547,7 @@
                       )
                       (if
                         (i32.and
-                          (set_local $4
+                          (set_local $5
                             (i32.load
                               (i32.const 176)
                             )
@@ -561,7 +561,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (set_local $9
+                            (set_local $8
                               (i32.load
                                 (set_local $18
                                   (i32.add
@@ -581,7 +581,7 @@
                               (get_local $18)
                             )
                             (set_local $31
-                              (get_local $9)
+                              (get_local $8)
                             )
                           )
                         )
@@ -589,7 +589,7 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $4)
+                              (get_local $5)
                               (get_local $2)
                             )
                           )
@@ -624,34 +624,34 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $5)
+                    (get_local $7)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $9)
                   )
                 )
               )
               (if
-                (set_local $5
+                (set_local $7
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (block
-                  (set_local $5
+                  (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (i32.and
-                              (get_local $5)
+                              (get_local $7)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $5)
+                                (get_local $7)
                               )
                             )
                             (i32.const -1)
@@ -666,7 +666,7 @@
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $9
+                          (set_local $8
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -674,13 +674,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $6
+                                          (set_local $4
                                             (i32.and
                                               (i32.shr_u
                                                 (set_local $10
                                                   (i32.shr_u
-                                                    (get_local $6)
-                                                    (get_local $5)
+                                                    (get_local $4)
+                                                    (get_local $7)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -688,7 +688,7 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $5)
+                                          (get_local $7)
                                         )
                                         (set_local $10
                                           (i32.and
@@ -696,7 +696,7 @@
                                               (set_local $1
                                                 (i32.shr_u
                                                   (get_local $10)
-                                                  (get_local $6)
+                                                  (get_local $4)
                                                 )
                                               )
                                               (i32.const 2)
@@ -723,7 +723,7 @@
                                     (set_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $4
+                                          (set_local $5
                                             (i32.shr_u
                                               (get_local $2)
                                               (get_local $1)
@@ -736,7 +736,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $2)
                                   )
                                 )
@@ -750,36 +750,36 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $4
-                    (get_local $9)
+                  (set_local $5
+                    (get_local $8)
                   )
                   (set_local $1
-                    (get_local $9)
+                    (get_local $8)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $9
+                      (set_local $8
                         (i32.load offset=16
-                          (get_local $4)
+                          (get_local $5)
                         )
                       )
-                      (set_local $5
-                        (get_local $9)
+                      (set_local $7
+                        (get_local $8)
                       )
                       (if
                         (set_local $10
                           (i32.load offset=20
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
-                        (set_local $5
+                        (set_local $7
                           (get_local $10)
                         )
                         (block
-                          (set_local $5
+                          (set_local $7
                             (get_local $2)
                           )
-                          (set_local $6
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-out$6)
@@ -788,11 +788,11 @@
                     )
                     (set_local $10
                       (i32.lt_u
-                        (set_local $9
+                        (set_local $8
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $5)
+                                (get_local $7)
                               )
                               (i32.const -8)
                             )
@@ -804,17 +804,17 @@
                     )
                     (set_local $2
                       (select
-                        (get_local $9)
+                        (get_local $8)
                         (get_local $2)
                         (get_local $10)
                       )
                     )
-                    (set_local $4
-                      (get_local $5)
+                    (set_local $5
+                      (get_local $7)
                     )
                     (set_local $1
                       (select
-                        (get_local $5)
+                        (get_local $7)
                         (get_local $1)
                         (get_local $10)
                       )
@@ -823,7 +823,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $4)
                       (set_local $1
                         (i32.load
                           (i32.const 192)
@@ -834,10 +834,10 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $6)
-                      (set_local $4
+                      (get_local $4)
+                      (set_local $5
                         (i32.add
-                          (get_local $6)
+                          (get_local $4)
                           (get_local $0)
                         )
                       )
@@ -846,52 +846,51 @@
                   )
                   (set_local $2
                     (i32.load offset=24
-                      (get_local $6)
+                      (get_local $4)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $8
+                        (set_local $9
                           (i32.load offset=12
-                            (get_local $6)
+                            (get_local $4)
                           )
                         )
-                        (get_local $6)
+                        (get_local $4)
                       )
                       (block
                         (if
                           (set_local $19
                             (i32.load
-                              (set_local $15
+                              (set_local $16
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $4)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $9
+                            (set_local $8
                               (get_local $19)
                             )
-                            (set_local $8
-                              (get_local $15)
+                            (set_local $10
+                              (get_local $16)
                             )
                           )
                           (if
-                            (set_local $9
-                              (i32.load
-                                (set_local $10
-                                  (i32.add
-                                    (get_local $6)
-                                    (i32.const 16)
+                            (i32.eqz
+                              (set_local $8
+                                (i32.load
+                                  (set_local $10
+                                    (i32.add
+                                      (get_local $4)
+                                      (i32.const 16)
+                                    )
                                   )
                                 )
                               )
-                            )
-                            (set_local $8
-                              (get_local $10)
                             )
                             (block
                               (set_local $18
@@ -905,20 +904,20 @@
                           (if
                             (set_local $19
                               (i32.load
-                                (set_local $15
+                                (set_local $16
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $9
+                              (set_local $8
                                 (get_local $19)
                               )
-                              (set_local $8
-                                (get_local $15)
+                              (set_local $10
+                                (get_local $16)
                               )
                               (br $while-in$11)
                             )
@@ -926,20 +925,20 @@
                           (if
                             (set_local $19
                               (i32.load
-                                (set_local $15
+                                (set_local $16
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $9
+                              (set_local $8
                                 (get_local $19)
                               )
-                              (set_local $8
-                                (get_local $15)
+                              (set_local $10
+                                (get_local $16)
                               )
                             )
                             (br $while-out$10)
@@ -948,17 +947,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $8)
+                            (get_local $10)
                             (get_local $1)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $8)
+                              (get_local $10)
                               (i32.const 0)
                             )
                             (set_local $18
-                              (get_local $9)
+                              (get_local $8)
                             )
                           )
                         )
@@ -966,9 +965,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $15
+                            (set_local $16
                               (i32.load offset=8
-                                (get_local $6)
+                                (get_local $4)
                               )
                             )
                             (get_local $1)
@@ -980,12 +979,12 @@
                             (i32.load
                               (set_local $19
                                 (i32.add
-                                  (get_local $15)
+                                  (get_local $16)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $4)
                           )
                           (call_import $_abort)
                         )
@@ -994,24 +993,24 @@
                             (i32.load
                               (set_local $10
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $9)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $4)
                           )
                           (block
                             (i32.store
                               (get_local $19)
-                              (get_local $8)
+                              (get_local $9)
                             )
                             (i32.store
                               (get_local $10)
-                              (get_local $15)
+                              (get_local $16)
                             )
                             (set_local $18
-                              (get_local $8)
+                              (get_local $9)
                             )
                           )
                           (call_import $_abort)
@@ -1025,15 +1024,15 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $6)
+                            (get_local $4)
                             (i32.load
                               (set_local $1
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (set_local $8
+                                    (set_local $9
                                       (i32.load offset=28
-                                        (get_local $6)
+                                        (get_local $4)
                                       )
                                     )
                                     (i32.const 2)
@@ -1061,7 +1060,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $9)
                                       )
                                       (i32.const -1)
                                     )
@@ -1084,17 +1083,17 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store
-                                (get_local $8)
+                                (get_local $9)
                                 (get_local $18)
                               )
                               (i32.store offset=20
@@ -1112,7 +1111,7 @@
                         (if
                           (i32.lt_u
                             (get_local $18)
-                            (set_local $8
+                            (set_local $9
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1127,13 +1126,13 @@
                         (if
                           (set_local $1
                             (i32.load offset=16
-                              (get_local $6)
+                              (get_local $4)
                             )
                           )
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $9)
                             )
                             (call_import $_abort)
                             (block
@@ -1151,7 +1150,7 @@
                         (if
                           (set_local $1
                             (i32.load offset=20
-                              (get_local $6)
+                              (get_local $4)
                             )
                           )
                           (if
@@ -1179,16 +1178,16 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $4)
                         (i32.or
                           (set_local $2
                             (i32.add
-                              (get_local $5)
+                              (get_local $7)
                               (get_local $0)
                             )
                           )
@@ -1199,7 +1198,7 @@
                         (set_local $1
                           (i32.add
                             (i32.add
-                              (get_local $6)
+                              (get_local $4)
                               (get_local $2)
                             )
                             (i32.const 4)
@@ -1215,25 +1214,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $4)
                         (i32.or
                           (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $4)
+                        (get_local $5)
                         (i32.or
-                          (get_local $5)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $4)
                           (get_local $5)
+                          (get_local $7)
                         )
-                        (get_local $5)
+                        (get_local $7)
                       )
                       (if
                         (set_local $1
@@ -1252,7 +1251,7 @@
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1266,7 +1265,7 @@
                           )
                           (if
                             (i32.and
-                              (set_local $15
+                              (set_local $16
                                 (i32.load
                                   (i32.const 176)
                                 )
@@ -1274,7 +1273,7 @@
                               (set_local $10
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -1282,7 +1281,7 @@
                               (i32.lt_u
                                 (set_local $19
                                   (i32.load
-                                    (set_local $8
+                                    (set_local $9
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1297,7 +1296,7 @@
                               (call_import $_abort)
                               (block
                                 (set_local $40
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                                 (set_local $32
                                   (get_local $19)
@@ -1308,7 +1307,7 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $15)
+                                  (get_local $16)
                                   (get_local $10)
                                 )
                               )
@@ -1343,17 +1342,17 @@
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $5)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $6)
+                      (get_local $4)
                       (i32.const 8)
                     )
                   )
@@ -1388,7 +1387,7 @@
                 )
               )
               (block
-                (set_local $15
+                (set_local $16
                   (i32.sub
                     (i32.const 0)
                     (get_local $2)
@@ -1396,7 +1395,7 @@
                 )
                 (block $label$break$L123
                   (if
-                    (set_local $5
+                    (set_local $7
                       (i32.load offset=480
                         (i32.shl
                           (set_local $0
@@ -1418,7 +1417,7 @@
                                     (i32.shr_u
                                       (get_local $2)
                                       (i32.add
-                                        (set_local $5
+                                        (set_local $7
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
@@ -1428,7 +1427,7 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $8
+                                                          (set_local $9
                                                             (i32.shl
                                                               (get_local $19)
                                                               (set_local $1
@@ -1454,13 +1453,13 @@
                                                   )
                                                   (get_local $1)
                                                 )
-                                                (set_local $8
+                                                (set_local $9
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $9
+                                                        (set_local $8
                                                           (i32.shl
-                                                            (get_local $8)
+                                                            (get_local $9)
                                                             (get_local $19)
                                                           )
                                                         )
@@ -1475,8 +1474,8 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $9)
                                                 (get_local $8)
+                                                (get_local $9)
                                               )
                                               (i32.const 15)
                                             )
@@ -1488,7 +1487,7 @@
                                     (i32.const 1)
                                   )
                                   (i32.shl
-                                    (get_local $5)
+                                    (get_local $7)
                                     (i32.const 1)
                                   )
                                 )
@@ -1501,10 +1500,10 @@
                       )
                     )
                     (block
-                      (set_local $8
-                        (get_local $15)
-                      )
                       (set_local $9
+                        (get_local $16)
+                      )
+                      (set_local $8
                         (i32.const 0)
                       )
                       (set_local $1
@@ -1527,15 +1526,15 @@
                         )
                       )
                       (set_local $19
-                        (get_local $5)
+                        (get_local $7)
                       )
-                      (set_local $6
+                      (set_local $4
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $4
+                            (set_local $5
                               (i32.sub
                                 (set_local $18
                                   (i32.and
@@ -1548,7 +1547,7 @@
                                 (get_local $2)
                               )
                             )
-                            (get_local $8)
+                            (get_local $9)
                           )
                           (if
                             (i32.eq
@@ -1557,7 +1556,7 @@
                             )
                             (block
                               (set_local $27
-                                (get_local $4)
+                                (get_local $5)
                               )
                               (set_local $25
                                 (get_local $19)
@@ -1565,39 +1564,36 @@
                               (set_local $29
                                 (get_local $19)
                               )
-                              (set_local $8
+                              (set_local $9
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $5
-                                (get_local $4)
+                              (set_local $9
+                                (get_local $5)
                               )
-                              (set_local $6
+                              (set_local $4
                                 (get_local $19)
                               )
                             )
                           )
-                          (set_local $5
-                            (get_local $8)
-                          )
                         )
                         (set_local $18
                           (select
-                            (get_local $9)
-                            (set_local $4
+                            (get_local $8)
+                            (set_local $5
                               (i32.load offset=20
                                 (get_local $19)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $4)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $4)
+                                (get_local $5)
                                 (set_local $19
                                   (i32.load
                                     (i32.add
@@ -1620,7 +1616,7 @@
                           )
                         )
                         (if
-                          (set_local $4
+                          (set_local $5
                             (i32.eq
                               (get_local $19)
                               (i32.const 0)
@@ -1628,24 +1624,21 @@
                           )
                           (block
                             (set_local $33
-                              (get_local $5)
+                              (get_local $9)
                             )
                             (set_local $34
                               (get_local $18)
                             )
                             (set_local $30
-                              (get_local $6)
+                              (get_local $4)
                             )
-                            (set_local $8
+                            (set_local $9
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
                             (set_local $8
-                              (get_local $5)
-                            )
-                            (set_local $9
                               (get_local $18)
                             )
                             (set_local $1
@@ -1653,7 +1646,7 @@
                                 (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $4)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1667,7 +1660,7 @@
                     )
                     (block
                       (set_local $33
-                        (get_local $15)
+                        (get_local $16)
                       )
                       (set_local $34
                         (i32.const 0)
@@ -1675,7 +1668,7 @@
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $9
                         (i32.const 86)
                       )
                     )
@@ -1683,7 +1676,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $9)
                     (i32.const 86)
                   )
                   (if
@@ -1702,11 +1695,11 @@
                         (block
                           (if
                             (i32.eqz
-                              (set_local $15
+                              (set_local $16
                                 (i32.and
                                   (get_local $10)
                                   (i32.or
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $0)
@@ -1714,7 +1707,7 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $5)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -1727,16 +1720,16 @@
                               (br $do-once$0)
                             )
                           )
-                          (set_local $15
+                          (set_local $16
                             (i32.and
                               (i32.shr_u
-                                (set_local $5
+                                (set_local $7
                                   (i32.add
                                     (i32.and
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $15)
+                                        (get_local $16)
                                       )
                                     )
                                     (i32.const -1)
@@ -1754,13 +1747,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (set_local $5
+                                        (set_local $7
                                           (i32.and
                                             (i32.shr_u
                                               (set_local $0
                                                 (i32.shr_u
-                                                  (get_local $5)
-                                                  (get_local $15)
+                                                  (get_local $7)
+                                                  (get_local $16)
                                                 )
                                               )
                                               (i32.const 5)
@@ -1768,15 +1761,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $15)
+                                        (get_local $16)
                                       )
                                       (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $4
+                                            (set_local $5
                                               (i32.shr_u
                                                 (get_local $0)
-                                                (get_local $5)
+                                                (get_local $7)
                                               )
                                             )
                                             (i32.const 2)
@@ -1785,12 +1778,12 @@
                                         )
                                       )
                                     )
-                                    (set_local $4
+                                    (set_local $5
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $6
+                                          (set_local $4
                                             (i32.shr_u
-                                              (get_local $4)
+                                              (get_local $5)
                                               (get_local $0)
                                             )
                                           )
@@ -1800,13 +1793,13 @@
                                       )
                                     )
                                   )
-                                  (set_local $6
+                                  (set_local $4
                                     (i32.and
                                       (i32.shr_u
                                         (set_local $1
                                           (i32.shr_u
-                                            (get_local $6)
                                             (get_local $4)
+                                            (get_local $5)
                                           )
                                         )
                                         (i32.const 1)
@@ -1817,7 +1810,7 @@
                                 )
                                 (i32.shr_u
                                   (get_local $1)
-                                  (get_local $6)
+                                  (get_local $4)
                                 )
                               )
                               (i32.const 2)
@@ -1837,12 +1830,12 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $8
+                      (set_local $9
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (get_local $33)
                       )
                       (set_local $12
@@ -1853,16 +1846,16 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $9)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $8
+                    (set_local $9
                       (i32.const 0)
                     )
                     (set_local $1
                       (i32.lt_u
-                        (set_local $6
+                        (set_local $4
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
@@ -1876,14 +1869,14 @@
                         (get_local $27)
                       )
                     )
-                    (set_local $4
+                    (set_local $5
                       (select
-                        (get_local $6)
+                        (get_local $4)
                         (get_local $27)
                         (get_local $1)
                       )
                     )
-                    (set_local $6
+                    (set_local $4
                       (select
                         (get_local $25)
                         (get_local $29)
@@ -1898,13 +1891,13 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $25
                           (get_local $1)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $4)
                         )
                         (br $while-in$20)
                       )
@@ -1917,18 +1910,18 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $4)
                         )
                       )
                       (block
-                        (set_local $7
-                          (get_local $4)
+                        (set_local $6
+                          (get_local $5)
                         )
                         (set_local $12
-                          (get_local $6)
+                          (get_local $4)
                         )
                         (br $while-out$19)
                       )
@@ -1939,7 +1932,7 @@
                 (if
                   (select
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $6)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
@@ -1968,7 +1961,7 @@
                     (if
                       (i32.ge_u
                         (get_local $12)
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (get_local $12)
                             (get_local $2)
@@ -1977,7 +1970,7 @@
                       )
                       (call_import $_abort)
                     )
-                    (set_local $4
+                    (set_local $5
                       (i32.load offset=24
                         (get_local $12)
                       )
@@ -1994,7 +1987,7 @@
                         )
                         (block
                           (if
-                            (set_local $15
+                            (set_local $16
                               (i32.load
                                 (set_local $0
                                   (i32.add
@@ -2005,26 +1998,25 @@
                               )
                             )
                             (block
-                              (set_local $1
-                                (get_local $15)
+                              (set_local $8
+                                (get_local $16)
                               )
-                              (set_local $5
+                              (set_local $7
                                 (get_local $0)
                               )
                             )
                             (if
-                              (set_local $9
-                                (i32.load
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $12)
-                                      (i32.const 16)
+                              (i32.eqz
+                                (set_local $8
+                                  (i32.load
+                                    (set_local $7
+                                      (i32.add
+                                        (get_local $12)
+                                        (i32.const 16)
+                                      )
                                     )
                                   )
                                 )
-                              )
-                              (set_local $1
-                                (get_local $9)
                               )
                               (block
                                 (set_local $11
@@ -2036,67 +2028,62 @@
                           )
                           (loop $while-out$23 $while-in$24
                             (if
-                              (set_local $15
+                              (set_local $16
                                 (i32.load
                                   (set_local $0
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $8)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $1
-                                  (get_local $15)
+                                (set_local $8
+                                  (get_local $16)
                                 )
-                                (set_local $5
+                                (set_local $7
                                   (get_local $0)
                                 )
                                 (br $while-in$24)
                               )
                             )
                             (if
-                              (set_local $15
+                              (set_local $16
                                 (i32.load
                                   (set_local $0
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $8)
                                       (i32.const 16)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $1
-                                  (get_local $15)
+                                (set_local $8
+                                  (get_local $16)
                                 )
-                                (set_local $5
+                                (set_local $7
                                   (get_local $0)
                                 )
                               )
-                              (block
-                                (set_local $0
-                                  (get_local $1)
-                                )
-                                (br $while-out$23)
-                              )
+                              (br $while-out$23)
                             )
                             (br $while-in$24)
                           )
                           (if
                             (i32.lt_u
-                              (get_local $5)
+                              (get_local $7)
                               (get_local $10)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store
-                                (get_local $5)
+                                (get_local $7)
                                 (i32.const 0)
                               )
                               (set_local $11
-                                (get_local $0)
+                                (get_local $8)
                               )
                             )
                           )
@@ -2116,7 +2103,7 @@
                           (if
                             (i32.ne
                               (i32.load
-                                (set_local $15
+                                (set_local $16
                                   (i32.add
                                     (get_local $0)
                                     (i32.const 12)
@@ -2130,7 +2117,7 @@
                           (if
                             (i32.eq
                               (i32.load
-                                (set_local $5
+                                (set_local $7
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 8)
@@ -2141,11 +2128,11 @@
                             )
                             (block
                               (i32.store
-                                (get_local $15)
+                                (get_local $16)
                                 (get_local $1)
                               )
                               (i32.store
-                                (get_local $5)
+                                (get_local $7)
                                 (get_local $0)
                               )
                               (set_local $11
@@ -2159,7 +2146,7 @@
                     )
                     (block $do-once$25
                       (if
-                        (get_local $4)
+                        (get_local $5)
                         (block
                           (if
                             (i32.eq
@@ -2212,7 +2199,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $4)
+                                  (get_local $5)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2224,7 +2211,7 @@
                                   (i32.load
                                     (set_local $1
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $5)
                                         (i32.const 16)
                                       )
                                     )
@@ -2236,7 +2223,7 @@
                                   (get_local $11)
                                 )
                                 (i32.store offset=20
-                                  (get_local $4)
+                                  (get_local $5)
                                   (get_local $11)
                                 )
                               )
@@ -2260,7 +2247,7 @@
                           )
                           (i32.store offset=24
                             (get_local $11)
-                            (get_local $4)
+                            (get_local $5)
                           )
                           (if
                             (set_local $10
@@ -2318,7 +2305,7 @@
                     (block $do-once$29
                       (if
                         (i32.ge_u
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 16)
                         )
                         (block
@@ -2330,28 +2317,28 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $6)
+                            (get_local $4)
                             (i32.or
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
+                              (get_local $4)
                               (get_local $6)
-                              (get_local $7)
                             )
-                            (get_local $7)
+                            (get_local $6)
                           )
-                          (set_local $4
+                          (set_local $5
                             (i32.shr_u
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 256)
                             )
                             (block
@@ -2360,7 +2347,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $4)
+                                      (get_local $5)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2377,15 +2364,15 @@
                                   (set_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.lt_u
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.load
-                                        (set_local $4
+                                        (set_local $5
                                           (i32.add
                                             (get_local $10)
                                             (i32.const 8)
@@ -2400,10 +2387,10 @@
                                   (call_import $_abort)
                                   (block
                                     (set_local $14
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                     (set_local $26
-                                      (get_local $5)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -2428,47 +2415,47 @@
                               )
                               (i32.store
                                 (get_local $14)
-                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store offset=12
                                 (get_local $26)
-                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $6)
+                                (get_local $4)
                                 (get_local $26)
                               )
                               (i32.store offset=12
-                                (get_local $6)
+                                (get_local $4)
                                 (get_local $10)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $4
+                          (set_local $5
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $9
+                                (set_local $8
                                   (if
                                     (set_local $10
                                       (i32.shr_u
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
                                     (if
                                       (i32.gt_u
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 16777215)
                                       )
                                       (i32.const 31)
                                       (i32.or
                                         (i32.and
                                           (i32.shr_u
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.add
-                                              (set_local $4
+                                              (set_local $5
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2508,7 +2495,7 @@
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $5
+                                                              (set_local $7
                                                                 (i32.shl
                                                                   (get_local $1)
                                                                   (get_local $10)
@@ -2525,7 +2512,7 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $5)
+                                                      (get_local $7)
                                                       (get_local $1)
                                                     )
                                                     (i32.const 15)
@@ -2538,7 +2525,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $4)
+                                          (get_local $5)
                                           (i32.const 1)
                                         )
                                       )
@@ -2551,13 +2538,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $6)
-                            (get_local $9)
+                            (get_local $4)
+                            (get_local $8)
                           )
                           (i32.store offset=4
                             (set_local $1
                               (i32.add
-                                (get_local $6)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
@@ -2575,10 +2562,10 @@
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $5
+                                (set_local $7
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -2588,42 +2575,42 @@
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $1)
-                                  (get_local $5)
+                                  (get_local $7)
                                 )
                               )
                               (i32.store
+                                (get_local $5)
                                 (get_local $4)
-                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $6)
                                 (get_local $4)
+                                (get_local $5)
                               )
                               (i32.store offset=12
-                                (get_local $6)
-                                (get_local $6)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $6)
-                                (get_local $6)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $5
+                          (set_local $7
                             (i32.shl
-                              (get_local $7)
+                              (get_local $6)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 31)
                                 )
                               )
@@ -2631,7 +2618,7 @@
                           )
                           (set_local $1
                             (i32.load
-                              (get_local $4)
+                              (get_local $5)
                             )
                           )
                           (loop $while-out$31 $while-in$32
@@ -2643,13 +2630,13 @@
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (block
-                                (set_local $16
+                                (set_local $15
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 148)
                                 )
                                 (br $while-out$31)
@@ -2658,7 +2645,7 @@
                             (if
                               (set_local $0
                                 (i32.load
-                                  (set_local $4
+                                  (set_local $5
                                     (i32.add
                                       (i32.add
                                         (get_local $1)
@@ -2666,7 +2653,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $5)
+                                          (get_local $7)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -2676,9 +2663,9 @@
                                 )
                               )
                               (block
-                                (set_local $5
+                                (set_local $7
                                   (i32.shl
-                                    (get_local $5)
+                                    (get_local $7)
                                     (i32.const 1)
                                   )
                                 )
@@ -2688,12 +2675,12 @@
                               )
                               (block
                                 (set_local $23
-                                  (get_local $4)
+                                  (get_local $5)
                                 )
                                 (set_local $21
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 145)
                                 )
                                 (br $while-out$31)
@@ -2703,7 +2690,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 145)
                             )
                             (if
@@ -2717,35 +2704,35 @@
                               (block
                                 (i32.store
                                   (get_local $23)
-                                  (get_local $6)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=24
-                                  (get_local $6)
+                                  (get_local $4)
                                   (get_local $21)
                                 )
                                 (i32.store offset=12
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=8
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $9)
                                 (i32.const 148)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.load
                                         (set_local $1
                                           (i32.add
-                                            (get_local $16)
+                                            (get_local $15)
                                             (i32.const 8)
                                           )
                                         )
@@ -2758,29 +2745,29 @@
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $16)
+                                    (get_local $15)
                                     (get_local $0)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $5)
-                                    (get_local $6)
+                                    (get_local $7)
+                                    (get_local $4)
                                   )
                                   (i32.store
                                     (get_local $1)
-                                    (get_local $6)
+                                    (get_local $4)
                                   )
                                   (i32.store offset=8
-                                    (get_local $6)
-                                    (get_local $5)
+                                    (get_local $4)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=12
-                                    (get_local $6)
-                                    (get_local $16)
+                                    (get_local $4)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=24
-                                    (get_local $6)
+                                    (get_local $4)
                                     (i32.const 0)
                                   )
                                 )
@@ -2793,9 +2780,9 @@
                           (i32.store offset=4
                             (get_local $12)
                             (i32.or
-                              (set_local $5
+                              (set_local $7
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (get_local $2)
                                 )
                               )
@@ -2807,7 +2794,7 @@
                               (i32.add
                                 (i32.add
                                   (get_local $12)
-                                  (get_local $5)
+                                  (get_local $7)
                                 )
                                 (i32.const 4)
                               )
@@ -2855,14 +2842,14 @@
         (get_local $0)
       )
       (block
-        (set_local $16
+        (set_local $15
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (set_local $7
+            (set_local $6
               (i32.sub
                 (get_local $12)
                 (get_local $0)
@@ -2875,31 +2862,31 @@
               (i32.const 196)
               (set_local $21
                 (i32.add
-                  (get_local $16)
+                  (get_local $15)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $7)
+              (get_local $6)
             )
             (i32.store offset=4
               (get_local $21)
               (i32.or
-                (get_local $7)
+                (get_local $6)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $21)
-                (get_local $7)
+                (get_local $6)
               )
-              (get_local $7)
+              (get_local $6)
             )
             (i32.store offset=4
-              (get_local $16)
+              (get_local $15)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -2916,17 +2903,17 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $16)
+              (get_local $15)
               (i32.or
                 (get_local $12)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $7
+              (set_local $6
                 (i32.add
                   (i32.add
-                    (get_local $16)
+                    (get_local $15)
                     (get_local $12)
                   )
                   (i32.const 4)
@@ -2934,7 +2921,7 @@
               )
               (i32.or
                 (i32.load
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (i32.const 1)
               )
@@ -2943,7 +2930,7 @@
         )
         (return
           (i32.add
-            (get_local $16)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -2951,7 +2938,7 @@
     )
     (if
       (i32.gt_u
-        (set_local $16
+        (set_local $15
           (i32.load
             (i32.const 188)
           )
@@ -2961,9 +2948,9 @@
       (block
         (i32.store
           (i32.const 188)
-          (set_local $7
+          (set_local $6
             (i32.sub
-              (get_local $16)
+              (get_local $15)
               (get_local $0)
             )
           )
@@ -2972,7 +2959,7 @@
           (i32.const 200)
           (set_local $12
             (i32.add
-              (set_local $16
+              (set_local $15
                 (i32.load
                   (i32.const 200)
                 )
@@ -2984,12 +2971,12 @@
         (i32.store offset=4
           (get_local $12)
           (i32.or
-            (get_local $7)
+            (get_local $6)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $16)
+          (get_local $15)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -2997,7 +2984,7 @@
         )
         (return
           (i32.add
-            (get_local $16)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3012,24 +2999,24 @@
       (if
         (i32.and
           (i32.add
-            (set_local $16
+            (set_local $15
               (call_import $_sysconf
                 (i32.const 30)
               )
             )
             (i32.const -1)
           )
-          (get_local $16)
+          (get_local $15)
         )
         (call_import $_abort)
         (block
           (i32.store
             (i32.const 656)
-            (get_local $16)
+            (get_local $15)
           )
           (i32.store
             (i32.const 652)
-            (get_local $16)
+            (get_local $15)
           )
           (i32.store
             (i32.const 660)
@@ -3062,7 +3049,7 @@
         )
       )
     )
-    (set_local $16
+    (set_local $15
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -3070,11 +3057,11 @@
     )
     (if
       (i32.le_u
-        (set_local $7
+        (set_local $6
           (i32.and
             (set_local $21
               (i32.add
-                (set_local $7
+                (set_local $6
                   (i32.load
                     (i32.const 656)
                   )
@@ -3090,7 +3077,7 @@
             (set_local $23
               (i32.sub
                 (i32.const 0)
-                (get_local $7)
+                (get_local $6)
               )
             )
           )
@@ -3104,7 +3091,7 @@
     (if
       (if
         (i32.ne
-          (set_local $9
+          (set_local $8
             (i32.load
               (i32.const 616)
             )
@@ -3120,14 +3107,14 @@
                     (i32.const 608)
                   )
                 )
-                (get_local $7)
+                (get_local $6)
               )
             )
             (get_local $26)
           )
           (i32.gt_u
             (get_local $14)
-            (get_local $9)
+            (get_local $8)
           )
         )
         (i32.const 0)
@@ -3141,12 +3128,12 @@
         (if
           (select
             (i32.lt_u
-              (get_local $7)
+              (get_local $6)
               (i32.const 2147483647)
             )
             (i32.const 0)
             (i32.eq
-              (set_local $8
+              (set_local $9
                 (block $label$break$L257
                   (if
                     (i32.and
@@ -3159,7 +3146,7 @@
                     (block
                       (block $label$break$L259
                         (if
-                          (set_local $9
+                          (set_local $8
                             (i32.load
                               (i32.const 200)
                             )
@@ -3177,7 +3164,7 @@
                                         (get_local $14)
                                       )
                                     )
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (i32.gt_u
                                     (i32.add
@@ -3191,15 +3178,15 @@
                                         )
                                       )
                                     )
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $4
+                                  (set_local $5
                                     (get_local $14)
                                   )
-                                  (set_local $5
+                                  (set_local $7
                                     (get_local $11)
                                   )
                                   (br $while-out$37)
@@ -3214,7 +3201,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.const 173)
                                   )
                                   (br $label$break$L259)
@@ -3246,10 +3233,10 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                     (i32.load
-                                      (get_local $5)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -3277,14 +3264,14 @@
                                   (set_local $17
                                     (get_local $14)
                                   )
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $8
+                          (set_local $9
                             (i32.const 173)
                           )
                         )
@@ -3293,11 +3280,11 @@
                         (if
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 173)
                             )
                             (i32.ne
-                              (set_local $9
+                              (set_local $8
                                 (call_import $_sbrk
                                   (i32.const 0)
                                 )
@@ -3321,12 +3308,12 @@
                                     )
                                   )
                                   (set_local $2
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                 )
                                 (i32.add
                                   (i32.sub
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $2)
                                   )
                                   (i32.and
@@ -3340,7 +3327,7 @@
                                     )
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (set_local $2
@@ -3395,11 +3382,11 @@
                                         (get_local $1)
                                       )
                                     )
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (block
                                     (set_local $20
-                                      (get_local $9)
+                                      (get_local $8)
                                     )
                                     (set_local $22
                                       (get_local $1)
@@ -3415,7 +3402,7 @@
                                     (set_local $17
                                       (get_local $1)
                                     )
-                                    (set_local $8
+                                    (set_local $9
                                       (i32.const 183)
                                     )
                                   )
@@ -3428,7 +3415,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $8)
+                            (get_local $9)
                             (i32.const 183)
                           )
                           (block
@@ -3442,7 +3429,7 @@
                               (if
                                 (i32.and
                                   (i32.gt_u
-                                    (get_local $16)
+                                    (get_local $15)
                                     (get_local $17)
                                   )
                                   (i32.and
@@ -3464,7 +3451,7 @@
                                           (get_local $12)
                                           (get_local $17)
                                         )
-                                        (set_local $9
+                                        (set_local $8
                                           (i32.load
                                             (i32.const 656)
                                           )
@@ -3472,7 +3459,7 @@
                                       )
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $9)
+                                        (get_local $8)
                                       )
                                     )
                                   )
@@ -3545,10 +3532,10 @@
             (i32.lt_u
               (set_local $3
                 (call_import $_sbrk
-                  (get_local $7)
+                  (get_local $6)
                 )
               )
-              (set_local $7
+              (set_local $6
                 (call_import $_sbrk
                   (i32.const 0)
                 )
@@ -3560,7 +3547,7 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $7)
+                (get_local $6)
                 (i32.const -1)
               )
             )
@@ -3570,7 +3557,7 @@
         (i32.gt_u
           (set_local $13
             (i32.sub
-              (get_local $7)
+              (get_local $6)
               (get_local $3)
             )
           )
@@ -3588,14 +3575,14 @@
         (set_local $22
           (get_local $13)
         )
-        (set_local $8
+        (set_local $9
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $9)
         (i32.const 193)
       )
       (block
@@ -3638,7 +3625,7 @@
                   (i32.eq
                     (get_local $20)
                     (i32.add
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (get_local $3)
                         )
@@ -3657,7 +3644,7 @@
                   )
                   (block
                     (set_local $47
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (set_local $48
                       (get_local $17)
@@ -3668,7 +3655,7 @@
                     (set_local $50
                       (get_local $3)
                     )
-                    (set_local $8
+                    (set_local $9
                       (i32.const 203)
                     )
                     (br $do-out$46)
@@ -3710,7 +3697,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 203)
                     )
                   )
@@ -3794,7 +3781,7 @@
                   (br $do-once$44)
                 )
               )
-              (set_local $6
+              (set_local $4
                 (if
                   (i32.lt_u
                     (get_local $20)
@@ -3838,7 +3825,7 @@
                     (set_local $41
                       (get_local $3)
                     )
-                    (set_local $8
+                    (set_local $9
                       (i32.const 211)
                     )
                     (br $while-out$48)
@@ -3863,7 +3850,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $9)
                   (i32.const 211)
                 )
                 (if
@@ -3922,7 +3909,7 @@
                         )
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (i32.add
                         (get_local $17)
                         (select
@@ -3955,10 +3942,10 @@
                         (get_local $0)
                       )
                     )
-                    (set_local $16
+                    (set_local $15
                       (i32.sub
                         (i32.sub
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $12)
                         )
                         (get_local $0)
@@ -3974,13 +3961,13 @@
                     (block $do-once$50
                       (if
                         (i32.ne
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $13)
                         )
                         (block
                           (if
                             (i32.eq
-                              (get_local $7)
+                              (get_local $6)
                               (i32.load
                                 (i32.const 196)
                               )
@@ -3993,7 +3980,7 @@
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $16)
+                                    (get_local $15)
                                   )
                                 )
                               )
@@ -4019,14 +4006,14 @@
                             )
                           )
                           (i32.store
-                            (set_local $4
+                            (set_local $5
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
                                       (set_local $1
                                         (i32.load offset=4
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 3)
@@ -4034,13 +4021,13 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.and
                                         (get_local $1)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $4
+                                    (set_local $5
                                       (i32.shr_u
                                         (get_local $1)
                                         (i32.const 3)
@@ -4055,7 +4042,7 @@
                                         (block
                                           (set_local $23
                                             (i32.load offset=24
-                                              (get_local $7)
+                                              (get_local $6)
                                             )
                                           )
                                           (block $do-once$53
@@ -4063,20 +4050,20 @@
                                               (i32.eq
                                                 (set_local $21
                                                   (i32.load offset=12
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $9
+                                                  (set_local $8
                                                     (i32.load
                                                       (set_local $2
                                                         (i32.add
                                                           (set_local $11
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4086,25 +4073,19 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $0
-                                                      (get_local $9)
+                                                    (set_local $14
+                                                      (get_local $8)
                                                     )
-                                                    (set_local $4
+                                                    (set_local $11
                                                       (get_local $2)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $14
-                                                      (i32.load
-                                                        (get_local $11)
-                                                      )
-                                                    )
-                                                    (block
-                                                      (set_local $0
-                                                        (get_local $14)
-                                                      )
-                                                      (set_local $4
-                                                        (get_local $11)
+                                                    (i32.eqz
+                                                      (set_local $14
+                                                        (i32.load
+                                                          (get_local $11)
+                                                        )
                                                       )
                                                     )
                                                     (block
@@ -4117,42 +4098,42 @@
                                                 )
                                                 (loop $while-out$55 $while-in$56
                                                   (if
-                                                    (set_local $9
+                                                    (set_local $8
                                                       (i32.load
                                                         (set_local $2
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $14)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $9)
+                                                      (set_local $14
+                                                        (get_local $8)
                                                       )
-                                                      (set_local $4
+                                                      (set_local $11
                                                         (get_local $2)
                                                       )
                                                       (br $while-in$56)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $9
+                                                    (set_local $8
                                                       (i32.load
                                                         (set_local $2
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $14)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $9)
+                                                      (set_local $14
+                                                        (get_local $8)
                                                       )
-                                                      (set_local $4
+                                                      (set_local $11
                                                         (get_local $2)
                                                       )
                                                     )
@@ -4162,17 +4143,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
+                                                    (get_local $11)
                                                     (get_local $4)
-                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                   (block
                                                     (i32.store
-                                                      (get_local $4)
+                                                      (get_local $11)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $14)
                                                     )
                                                   )
                                                 )
@@ -4182,24 +4163,24 @@
                                                   (i32.lt_u
                                                     (set_local $2
                                                       (i32.load offset=8
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $9
+                                                      (set_local $8
                                                         (i32.add
                                                           (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
@@ -4213,11 +4194,11 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $9)
+                                                      (get_local $8)
                                                       (get_local $21)
                                                     )
                                                     (i32.store
@@ -4241,7 +4222,7 @@
                                           (block $do-once$57
                                             (if
                                               (i32.ne
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.load
                                                   (set_local $2
                                                     (i32.add
@@ -4249,7 +4230,7 @@
                                                       (i32.shl
                                                         (set_local $21
                                                           (i32.load offset=28
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4278,7 +4259,7 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.store
                                                     (get_local $11)
@@ -4342,7 +4323,7 @@
                                               (i32.load
                                                 (set_local $2
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4398,7 +4379,7 @@
                                         (block
                                           (set_local $21
                                             (i32.load offset=12
-                                              (get_local $7)
+                                              (get_local $6)
                                             )
                                           )
                                           (block $do-once$61
@@ -4406,7 +4387,7 @@
                                               (i32.ne
                                                 (set_local $11
                                                   (i32.load offset=8
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                                 (set_local $23
@@ -4414,7 +4395,7 @@
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $4)
+                                                        (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4426,7 +4407,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $11)
-                                                    (get_local $6)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $_abort)
                                                 )
@@ -4435,7 +4416,7 @@
                                                     (i32.load offset=12
                                                       (get_local $11)
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                                 (call_import $_abort)
@@ -4457,7 +4438,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $4)
+                                                      (get_local $5)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4482,7 +4463,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $6)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $_abort)
                                                 )
@@ -4496,7 +4477,7 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (block
                                                     (set_local $42
@@ -4520,30 +4501,25 @@
                                         )
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $15
                                       (i32.add
-                                        (get_local $5)
-                                        (get_local $16)
+                                        (get_local $7)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.add
+                                      (get_local $6)
                                       (get_local $7)
-                                      (get_local $5)
                                     )
                                   )
-                                  (block
-                                    (set_local $0
-                                      (get_local $16)
-                                    )
-                                    (get_local $7)
-                                  )
+                                  (get_local $6)
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.and
                               (i32.load
-                                (get_local $4)
+                                (get_local $5)
                               )
                               (i32.const -2)
                             )
@@ -4551,26 +4527,26 @@
                           (i32.store offset=4
                             (get_local $3)
                             (i32.or
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
                               (get_local $3)
-                              (get_local $0)
+                              (get_local $15)
                             )
-                            (get_local $0)
+                            (get_local $15)
                           )
-                          (set_local $4
+                          (set_local $5
                             (i32.shr_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 256)
                             )
                             (block
@@ -4579,7 +4555,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $4)
+                                      (get_local $5)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4597,16 +4573,16 @@
                                     (set_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $4)
+                                        (get_local $5)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $9
+                                        (set_local $8
                                           (i32.load
-                                            (set_local $4
+                                            (set_local $5
                                               (i32.add
                                                 (get_local $1)
                                                 (i32.const 8)
@@ -4620,10 +4596,10 @@
                                       )
                                       (block
                                         (set_local $43
-                                          (get_local $4)
+                                          (get_local $5)
                                         )
                                         (set_local $35
-                                          (get_local $9)
+                                          (get_local $8)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4673,12 +4649,12 @@
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $4
+                                (set_local $0
                                   (block $do-once$67
                                     (if
                                       (set_local $2
                                         (i32.shr_u
-                                          (get_local $0)
+                                          (get_local $15)
                                           (i32.const 8)
                                         )
                                       )
@@ -4686,14 +4662,14 @@
                                         (br_if $do-once$67
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $0)
+                                            (get_local $15)
                                             (i32.const 16777215)
                                           )
                                         )
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $0)
+                                              (get_local $15)
                                               (i32.add
                                                 (set_local $14
                                                   (i32.add
@@ -4701,11 +4677,11 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $9
+                                                          (set_local $8
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $5
+                                                                  (set_local $7
                                                                     (i32.shl
                                                                       (get_local $2)
                                                                       (set_local $23
@@ -4731,14 +4707,14 @@
                                                           )
                                                           (get_local $23)
                                                         )
-                                                        (set_local $5
+                                                        (set_local $7
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $4
+                                                                (set_local $5
                                                                   (i32.shl
-                                                                    (get_local $5)
-                                                                    (get_local $9)
+                                                                    (get_local $7)
+                                                                    (get_local $8)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4752,8 +4728,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $4)
                                                         (get_local $5)
+                                                        (get_local $7)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4780,7 +4756,7 @@
                           )
                           (i32.store offset=28
                             (get_local $3)
-                            (get_local $4)
+                            (get_local $0)
                           )
                           (i32.store offset=4
                             (set_local $1
@@ -4806,7 +4782,7 @@
                                 (set_local $14
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $4)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -4840,18 +4816,18 @@
                           )
                           (set_local $14
                             (i32.shl
-                              (get_local $0)
+                              (get_local $15)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $4)
+                                  (get_local $0)
                                   (i32.const 31)
                                 )
                               )
@@ -4871,20 +4847,20 @@
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $0)
+                                (get_local $15)
                               )
                               (block
                                 (set_local $36
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 281)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $5
+                              (set_local $7
                                 (i32.load
                                   (set_local $2
                                     (i32.add
@@ -4911,7 +4887,7 @@
                                   )
                                 )
                                 (set_local $1
-                                  (get_local $5)
+                                  (get_local $7)
                                 )
                               )
                               (block
@@ -4921,7 +4897,7 @@
                                 (set_local $52
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 278)
                                 )
                                 (br $while-out$69)
@@ -4931,7 +4907,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 278)
                             )
                             (if
@@ -4963,7 +4939,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $9)
                                 (i32.const 281)
                               )
                               (if
@@ -4979,7 +4955,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -4987,7 +4963,7 @@
                                   )
                                   (i32.ge_u
                                     (get_local $36)
-                                    (get_local $5)
+                                    (get_local $7)
                                   )
                                 )
                                 (block
@@ -5025,7 +5001,7 @@
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $16)
+                                (get_local $15)
                               )
                             )
                           )
@@ -5064,7 +5040,7 @@
                       (get_local $13)
                     )
                     (i32.gt_u
-                      (set_local $16
+                      (set_local $15
                         (i32.add
                           (get_local $3)
                           (i32.load offset=4
@@ -5077,8 +5053,8 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $4
-                      (get_local $16)
+                    (set_local $5
+                      (get_local $15)
                     )
                     (br $while-out$71)
                   )
@@ -5090,11 +5066,11 @@
                 )
                 (br $while-in$72)
               )
-              (set_local $16
+              (set_local $15
                 (i32.add
                   (set_local $12
                     (i32.add
-                      (get_local $4)
+                      (get_local $5)
                       (i32.const -47)
                     )
                   )
@@ -5114,13 +5090,13 @@
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $16)
+                                (get_local $15)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $16)
+                                (get_local $15)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5130,7 +5106,7 @@
                       )
                       (i32.lt_u
                         (get_local $3)
-                        (set_local $16
+                        (set_local $15
                           (i32.add
                             (get_local $13)
                             (i32.const 16)
@@ -5144,7 +5120,7 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $7
+                (set_local $6
                   (i32.add
                     (get_local $20)
                     (set_local $17
@@ -5153,7 +5129,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $7
+                            (set_local $6
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5164,7 +5140,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $7)
+                            (get_local $6)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5187,7 +5163,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $7)
+                (get_local $6)
                 (i32.or
                   (get_local $14)
                   (i32.const 1)
@@ -5195,7 +5171,7 @@
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $7)
+                  (get_local $6)
                   (get_local $14)
                 )
                 (i32.const 40)
@@ -5277,7 +5253,7 @@
                       (get_local $3)
                       (i32.const 4)
                     )
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
               )
@@ -5312,7 +5288,7 @@
                     (get_local $12)
                     (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.shr_u
                       (get_local $3)
                       (i32.const 3)
@@ -5329,7 +5305,7 @@
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5343,10 +5319,10 @@
                               (i32.const 176)
                             )
                           )
-                          (set_local $5
+                          (set_local $7
                             (i32.shl
                               (i32.const 1)
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                         )
@@ -5354,7 +5330,7 @@
                           (i32.lt_u
                             (set_local $2
                               (i32.load
-                                (set_local $7
+                                (set_local $6
                                   (i32.add
                                     (get_local $17)
                                     (i32.const 8)
@@ -5369,7 +5345,7 @@
                           (call_import $_abort)
                           (block
                             (set_local $45
-                              (get_local $7)
+                              (get_local $6)
                             )
                             (set_local $37
                               (get_local $2)
@@ -5381,7 +5357,7 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $1)
-                              (get_local $5)
+                              (get_local $7)
                             )
                           )
                           (set_local $45
@@ -5414,11 +5390,11 @@
                       (br $do-once$44)
                     )
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (set_local $4
+                        (set_local $5
                           (if
                             (set_local $17
                               (i32.shr_u
@@ -5437,7 +5413,7 @@
                                   (i32.shr_u
                                     (get_local $3)
                                     (i32.add
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
@@ -5450,7 +5426,7 @@
                                                         (set_local $1
                                                           (i32.shl
                                                             (get_local $17)
-                                                            (set_local $5
+                                                            (set_local $7
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5471,7 +5447,7 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $5)
+                                                (get_local $7)
                                               )
                                               (set_local $1
                                                 (i32.and
@@ -5507,7 +5483,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
@@ -5521,14 +5497,14 @@
                   )
                   (i32.store offset=28
                     (get_local $13)
-                    (get_local $4)
+                    (get_local $5)
                   )
                   (i32.store offset=20
                     (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $16)
+                    (get_local $15)
                     (i32.const 0)
                   )
                   (if
@@ -5542,7 +5518,7 @@
                         (set_local $2
                           (i32.shl
                             (i32.const 1)
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
                       )
@@ -5556,12 +5532,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $13)
                       )
                       (i32.store offset=24
                         (get_local $13)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store offset=12
                         (get_local $13)
@@ -5582,12 +5558,12 @@
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $4)
+                          (get_local $5)
                           (i32.const 31)
                         )
                       )
@@ -5595,7 +5571,7 @@
                   )
                   (set_local $1
                     (i32.load
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5613,16 +5589,16 @@
                         (set_local $38
                           (get_local $1)
                         )
-                        (set_local $8
+                        (set_local $9
                           (i32.const 307)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $5
+                      (set_local $7
                         (i32.load
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.add
                                 (get_local $1)
@@ -5647,17 +5623,17 @@
                           )
                         )
                         (set_local $1
-                          (get_local $5)
+                          (get_local $7)
                         )
                       )
                       (block
                         (set_local $46
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (set_local $53
                           (get_local $1)
                         )
-                        (set_local $8
+                        (set_local $9
                           (i32.const 304)
                         )
                         (br $while-out$75)
@@ -5667,7 +5643,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 304)
                     )
                     (if
@@ -5699,7 +5675,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $9)
                         (i32.const 307)
                       )
                       (if
@@ -5996,7 +5972,7 @@
             (i32.const -8)
           )
         )
-        (set_local $12
+        (set_local $14
           (i32.load
             (i32.const 192)
           )
@@ -6077,7 +6053,7 @@
                   )
                 )
               )
-              (get_local $12)
+              (get_local $14)
             )
             (call_import $_abort)
           )
@@ -6185,7 +6161,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (get_local $12)
+                      (get_local $14)
                     )
                     (call_import $_abort)
                   )
@@ -6239,7 +6215,7 @@
                   (if
                     (i32.lt_u
                       (get_local $1)
-                      (get_local $12)
+                      (get_local $14)
                     )
                     (call_import $_abort)
                   )
@@ -6397,7 +6373,7 @@
                 (if
                   (i32.lt_u
                     (get_local $10)
-                    (get_local $12)
+                    (get_local $14)
                   )
                   (call_import $_abort)
                   (block
@@ -6419,7 +6395,7 @@
                         (get_local $0)
                       )
                     )
-                    (get_local $12)
+                    (get_local $14)
                   )
                   (call_import $_abort)
                 )
@@ -6824,7 +6800,7 @@
             (get_local $7)
           )
         )
-        (set_local $12
+        (set_local $14
           (i32.shr_u
             (get_local $1)
             (i32.const 3)
@@ -6873,21 +6849,20 @@
                         (set_local $0
                           (get_local $11)
                         )
-                        (set_local $12
+                        (set_local $6
                           (get_local $1)
                         )
                       )
                       (if
-                        (set_local $0
-                          (i32.load
-                            (get_local $6)
+                        (i32.eqz
+                          (set_local $0
+                            (i32.load
+                              (get_local $6)
+                            )
                           )
                         )
-                        (set_local $12
-                          (get_local $6)
-                        )
                         (block
-                          (set_local $13
+                          (set_local $12
                             (i32.const 0)
                           )
                           (br $do-once$10)
@@ -6910,7 +6885,7 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $12
+                          (set_local $6
                             (get_local $1)
                           )
                           (br $while-in$13)
@@ -6931,22 +6906,17 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $12
+                          (set_local $6
                             (get_local $1)
                           )
                         )
-                        (block
-                          (set_local $1
-                            (get_local $12)
-                          )
-                          (br $while-out$12)
-                        )
+                        (br $while-out$12)
                       )
                       (br $while-in$13)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $6)
                         (i32.load
                           (i32.const 192)
                         )
@@ -6954,10 +6924,10 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $6)
                           (i32.const 0)
                         )
-                        (set_local $13
+                        (set_local $12
                           (get_local $0)
                         )
                       )
@@ -7012,7 +6982,7 @@
                           (get_local $6)
                           (get_local $1)
                         )
-                        (set_local $13
+                        (set_local $12
                           (get_local $10)
                         )
                       )
@@ -7046,11 +7016,11 @@
                     (block
                       (i32.store
                         (get_local $3)
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (if
                         (i32.eqz
-                          (get_local $13)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
@@ -7096,23 +7066,23 @@
                         )
                         (i32.store
                           (get_local $10)
-                          (get_local $13)
+                          (get_local $12)
                         )
                         (i32.store offset=20
                           (get_local $5)
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eqz
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $13)
+                      (get_local $12)
                       (set_local $10
                         (i32.load
                           (i32.const 192)
@@ -7122,7 +7092,7 @@
                     (call_import $_abort)
                   )
                   (i32.store offset=24
-                    (get_local $13)
+                    (get_local $12)
                     (get_local $5)
                   )
                   (if
@@ -7144,12 +7114,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=16
-                          (get_local $13)
+                          (get_local $12)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7170,12 +7140,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=20
-                          (get_local $13)
+                          (get_local $12)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7201,7 +7171,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $12)
+                          (get_local $14)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -7245,7 +7215,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $12)
+                          (get_local $14)
                         )
                         (i32.const -1)
                       )
@@ -7398,7 +7368,7 @@
               (set_local $15
                 (get_local $7)
               )
-              (set_local $14
+              (set_local $13
                 (get_local $16)
               )
             )
@@ -7417,7 +7387,7 @@
                 (i32.const 8)
               )
             )
-            (set_local $14
+            (set_local $13
               (get_local $1)
             )
           )
@@ -7427,12 +7397,12 @@
           (get_local $2)
         )
         (i32.store offset=12
-          (get_local $14)
+          (get_local $13)
           (get_local $2)
         )
         (i32.store offset=8
           (get_local $2)
-          (get_local $14)
+          (get_local $13)
         )
         (i32.store offset=12
           (get_local $2)
@@ -7477,7 +7447,7 @@
                                           (set_local $15
                                             (i32.shl
                                               (get_local $1)
-                                              (set_local $14
+                                              (set_local $13
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -7498,7 +7468,7 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $14)
+                                  (get_local $13)
                                 )
                                 (set_local $15
                                   (i32.and
@@ -7573,7 +7543,7 @@
         )
       )
       (block
-        (set_local $14
+        (set_local $13
           (i32.shl
             (get_local $0)
             (select
@@ -7629,7 +7599,7 @@
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $14)
+                        (get_local $13)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7639,9 +7609,9 @@
               )
             )
             (block
-              (set_local $14
+              (set_local $13
                 (i32.shl
-                  (get_local $14)
+                  (get_local $13)
                   (i32.const 1)
                 )
               )
@@ -7704,7 +7674,7 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $14
+                  (set_local $13
                     (i32.load
                       (set_local $1
                         (i32.add
@@ -7727,7 +7697,7 @@
               )
               (block
                 (i32.store offset=12
-                  (get_local $14)
+                  (get_local $13)
                   (get_local $2)
                 )
                 (i32.store
@@ -7736,7 +7706,7 @@
                 )
                 (i32.store offset=8
                   (get_local $2)
-                  (get_local $14)
+                  (get_local $13)
                 )
                 (i32.store offset=12
                   (get_local $2)
@@ -8219,7 +8189,7 @@
     (local $6 i32)
     (local $7 i32)
     (if
-      (set_local $6
+      (set_local $5
         (i32.load
           (set_local $3
             (i32.add
@@ -8230,10 +8200,10 @@
         )
       )
       (block
-        (set_local $5
-          (get_local $6)
+        (set_local $7
+          (get_local $5)
         )
-        (set_local $4
+        (set_local $6
           (i32.const 5)
         )
       )
@@ -8241,16 +8211,16 @@
         (call $___towrite
           (get_local $2)
         )
-        (set_local $7
+        (set_local $4
           (i32.const 0)
         )
         (block
-          (set_local $5
+          (set_local $7
             (i32.load
               (get_local $3)
             )
           )
-          (set_local $4
+          (set_local $6
             (i32.const 5)
           )
         )
@@ -8259,14 +8229,14 @@
     (block $label$break$L5
       (if
         (i32.eq
-          (get_local $4)
+          (get_local $6)
           (i32.const 5)
         )
         (block
-          (set_local $4
+          (set_local $6
             (set_local $3
               (i32.load
-                (set_local $6
+                (set_local $5
                   (i32.add
                     (get_local $2)
                     (i32.const 20)
@@ -8278,13 +8248,13 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $5)
+                (get_local $7)
                 (get_local $3)
               )
               (get_local $1)
             )
             (block
-              (set_local $7
+              (set_local $4
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
@@ -8326,9 +8296,6 @@
                           (get_local $0)
                         )
                         (set_local $3
-                          (get_local $4)
-                        )
-                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$L10
@@ -8341,7 +8308,7 @@
                         (i32.load8_s
                           (i32.add
                             (get_local $0)
-                            (set_local $5
+                            (set_local $7
                               (i32.add
                                 (get_local $3)
                                 (i32.const -1)
@@ -8358,7 +8325,7 @@
                         (br $while-out$2)
                       )
                       (set_local $3
-                        (get_local $5)
+                        (get_local $7)
                       )
                     )
                     (br $while-in$3)
@@ -8381,12 +8348,7 @@
                       )
                       (get_local $4)
                     )
-                    (block
-                      (set_local $7
-                        (get_local $4)
-                      )
-                      (br $label$break$L5)
-                    )
+                    (br $label$break$L5)
                   )
                   (set_local $2
                     (i32.add
@@ -8394,12 +8356,12 @@
                       (get_local $4)
                     )
                   )
-                  (set_local $3
+                  (set_local $6
                     (i32.load
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
-                  (set_local $5
+                  (set_local $3
                     (get_local $4)
                   )
                   (i32.sub
@@ -8412,9 +8374,6 @@
                     (get_local $0)
                   )
                   (set_local $3
-                    (get_local $4)
-                  )
-                  (set_local $5
                     (i32.const 0)
                   )
                   (get_local $1)
@@ -8423,29 +8382,29 @@
             )
           )
           (call $_memcpy
-            (get_local $3)
+            (get_local $6)
             (get_local $2)
             (get_local $0)
           )
           (i32.store
-            (get_local $6)
+            (get_local $5)
             (i32.add
               (i32.load
-                (get_local $6)
+                (get_local $5)
               )
               (get_local $0)
             )
           )
-          (set_local $7
+          (set_local $4
             (i32.add
-              (get_local $5)
+              (get_local $3)
               (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $7)
+    (get_local $4)
   )
   (func $_fflush (param $0 i32) (result i32)
     (local $1 i32)
@@ -8634,10 +8593,10 @@
               )
               (get_local $0)
               (block
-                (set_local $1
+                (set_local $2
                   (get_local $0)
                 )
-                (set_local $2
+                (set_local $1
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8647,10 +8606,10 @@
           )
         )
         (block
-          (set_local $1
+          (set_local $2
             (get_local $0)
           )
-          (set_local $2
+          (set_local $1
             (i32.const 4)
           )
         )
@@ -8658,21 +8617,21 @@
     )
     (if
       (i32.eq
-        (get_local $2)
+        (get_local $1)
         (i32.const 4)
       )
       (block
-        (set_local $2
-          (get_local $1)
+        (set_local $1
+          (get_local $2)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $1
+                  (set_local $2
                     (i32.load
-                      (get_local $2)
+                      (get_local $1)
                     )
                   )
                   (i32.const -2139062144)
@@ -8680,22 +8639,14 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $1)
+                (get_local $2)
                 (i32.const -16843009)
               )
             )
-            (block
-              (set_local $0
-                (get_local $1)
-              )
-              (set_local $1
-                (get_local $2)
-              )
-              (br $while-out$3)
-            )
-            (set_local $2
+            (br $while-out$3)
+            (set_local $1
               (i32.add
-                (get_local $2)
+                (get_local $1)
                 (i32.const 4)
               )
             )
@@ -8706,7 +8657,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $0)
+                (get_local $2)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8714,7 +8665,7 @@
             (i32.const 24)
           )
           (block
-            (set_local $0
+            (set_local $2
               (get_local $1)
             )
             (loop $while-out$5 $while-in$6
@@ -8722,30 +8673,23 @@
                 (i32.load8_s
                   (set_local $1
                     (i32.add
-                      (get_local $0)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $0
+                (set_local $2
                   (get_local $1)
                 )
-                (block
-                  (set_local $0
-                    (get_local $1)
-                  )
-                  (br $while-out$5)
-                )
+                (br $while-out$5)
               )
               (br $while-in$6)
             )
           )
-          (set_local $0
-            (get_local $1)
-          )
+          (get_local $1)
         )
         (set_local $5
-          (get_local $0)
+          (get_local $1)
         )
       )
     )

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -107,12 +107,12 @@
             (i32.and
               (set_local $2
                 (i32.shr_u
-                  (set_local $5
+                  (set_local $7
                     (i32.load
                       (i32.const 176)
                     )
                   )
-                  (set_local $4
+                  (set_local $5
                     (i32.shr_u
                       (set_local $0
                         (select
@@ -140,11 +140,11 @@
             (block
               (set_local $2
                 (i32.load
-                  (set_local $9
+                  (set_local $8
                     (i32.add
-                      (set_local $4
+                      (set_local $5
                         (i32.load
-                          (set_local $6
+                          (set_local $4
                             (i32.add
                               (set_local $1
                                 (i32.add
@@ -160,7 +160,7 @@
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $4)
+                                          (get_local $5)
                                         )
                                       )
                                       (i32.const 1)
@@ -197,22 +197,22 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $8
+                        (set_local $9
                           (i32.add
                             (get_local $2)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
-                        (get_local $8)
+                        (get_local $9)
                         (get_local $1)
                       )
                       (i32.store
-                        (get_local $6)
+                        (get_local $4)
                         (get_local $2)
                       )
                     )
@@ -222,7 +222,7 @@
                 (i32.store
                   (i32.const 176)
                   (i32.and
-                    (get_local $5)
+                    (get_local $7)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -234,7 +234,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $5)
                 (i32.or
                   (set_local $2
                     (i32.shl
@@ -246,10 +246,10 @@
                 )
               )
               (i32.store
-                (set_local $6
+                (set_local $4
                   (i32.add
                     (i32.add
-                      (get_local $4)
+                      (get_local $5)
                       (get_local $2)
                     )
                     (i32.const 4)
@@ -257,20 +257,20 @@
                 )
                 (i32.or
                   (i32.load
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (i32.const 1)
                 )
               )
               (return
-                (get_local $9)
+                (get_local $8)
               )
             )
           )
           (if
             (i32.gt_u
               (get_local $0)
-              (set_local $6
+              (set_local $4
                 (i32.load
                   (i32.const 184)
                 )
@@ -290,13 +290,13 @@
                                 (i32.and
                                   (i32.shl
                                     (get_local $2)
-                                    (get_local $4)
+                                    (get_local $5)
                                   )
                                   (i32.or
                                     (set_local $2
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $4)
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.sub
@@ -321,9 +321,9 @@
                   )
                   (set_local $1
                     (i32.load
-                      (set_local $8
+                      (set_local $9
                         (i32.add
-                          (set_local $15
+                          (set_local $16
                             (i32.load
                               (set_local $18
                                 (i32.add
@@ -341,7 +341,7 @@
                                                       (set_local $2
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $8
+                                                            (set_local $9
                                                               (i32.shr_u
                                                                 (get_local $2)
                                                                 (get_local $1)
@@ -354,12 +354,12 @@
                                                       )
                                                       (get_local $1)
                                                     )
-                                                    (set_local $8
+                                                    (set_local $9
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $15
+                                                          (set_local $16
                                                             (i32.shr_u
-                                                              (get_local $8)
+                                                              (get_local $9)
                                                               (get_local $2)
                                                             )
                                                           )
@@ -369,13 +369,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $15
+                                                  (set_local $16
                                                     (i32.and
                                                       (i32.shr_u
                                                         (set_local $10
                                                           (i32.shr_u
-                                                            (get_local $15)
-                                                            (get_local $8)
+                                                            (get_local $16)
+                                                            (get_local $9)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -390,7 +390,7 @@
                                                       (set_local $18
                                                         (i32.shr_u
                                                           (get_local $10)
-                                                          (get_local $15)
+                                                          (get_local $16)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -446,7 +446,7 @@
                               )
                             )
                           )
-                          (get_local $15)
+                          (get_local $16)
                         )
                         (block
                           (i32.store
@@ -457,7 +457,7 @@
                             (get_local $18)
                             (get_local $1)
                           )
-                          (set_local $9
+                          (set_local $8
                             (i32.load
                               (i32.const 184)
                             )
@@ -470,7 +470,7 @@
                       (i32.store
                         (i32.const 176)
                         (i32.and
-                          (get_local $5)
+                          (get_local $7)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
@@ -480,27 +480,27 @@
                           )
                         )
                       )
-                      (set_local $9
-                        (get_local $6)
+                      (set_local $8
+                        (get_local $4)
                       )
                     )
                   )
                   (i32.store offset=4
-                    (get_local $15)
+                    (get_local $16)
                     (i32.or
                       (get_local $0)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $5
+                    (set_local $7
                       (i32.add
-                        (get_local $15)
+                        (get_local $16)
                         (get_local $0)
                       )
                     )
                     (i32.or
-                      (set_local $6
+                      (set_local $4
                         (i32.sub
                           (i32.shl
                             (get_local $19)
@@ -514,13 +514,13 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $5)
-                      (get_local $6)
+                      (get_local $7)
+                      (get_local $4)
                     )
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (if
-                    (get_local $9)
+                    (get_local $8)
                     (block
                       (set_local $1
                         (i32.load
@@ -534,7 +534,7 @@
                             (i32.shl
                               (set_local $18
                                 (i32.shr_u
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 3)
                                 )
                               )
@@ -546,7 +546,7 @@
                       )
                       (if
                         (i32.and
-                          (set_local $4
+                          (set_local $5
                             (i32.load
                               (i32.const 176)
                             )
@@ -560,7 +560,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (set_local $9
+                            (set_local $8
                               (i32.load
                                 (set_local $18
                                   (i32.add
@@ -580,7 +580,7 @@
                               (get_local $18)
                             )
                             (set_local $31
-                              (get_local $9)
+                              (get_local $8)
                             )
                           )
                         )
@@ -588,7 +588,7 @@
                           (i32.store
                             (i32.const 176)
                             (i32.or
-                              (get_local $4)
+                              (get_local $5)
                               (get_local $2)
                             )
                           )
@@ -623,34 +623,34 @@
                   )
                   (i32.store
                     (i32.const 184)
-                    (get_local $6)
+                    (get_local $4)
                   )
                   (i32.store
                     (i32.const 196)
-                    (get_local $5)
+                    (get_local $7)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $9)
                   )
                 )
               )
               (if
-                (set_local $5
+                (set_local $7
                   (i32.load
                     (i32.const 180)
                   )
                 )
                 (block
-                  (set_local $5
+                  (set_local $7
                     (i32.and
                       (i32.shr_u
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (i32.and
-                              (get_local $5)
+                              (get_local $7)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $5)
+                                (get_local $7)
                               )
                             )
                             (i32.const -1)
@@ -665,7 +665,7 @@
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $9
+                          (set_local $8
                             (i32.load offset=480
                               (i32.shl
                                 (i32.add
@@ -673,13 +673,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $6
+                                          (set_local $4
                                             (i32.and
                                               (i32.shr_u
                                                 (set_local $10
                                                   (i32.shr_u
-                                                    (get_local $6)
-                                                    (get_local $5)
+                                                    (get_local $4)
+                                                    (get_local $7)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -687,7 +687,7 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $5)
+                                          (get_local $7)
                                         )
                                         (set_local $10
                                           (i32.and
@@ -695,7 +695,7 @@
                                               (set_local $1
                                                 (i32.shr_u
                                                   (get_local $10)
-                                                  (get_local $6)
+                                                  (get_local $4)
                                                 )
                                               )
                                               (i32.const 2)
@@ -722,7 +722,7 @@
                                     (set_local $2
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $4
+                                          (set_local $5
                                             (i32.shr_u
                                               (get_local $2)
                                               (get_local $1)
@@ -735,7 +735,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $5)
                                     (get_local $2)
                                   )
                                 )
@@ -749,36 +749,36 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $4
-                    (get_local $9)
+                  (set_local $5
+                    (get_local $8)
                   )
                   (set_local $1
-                    (get_local $9)
+                    (get_local $8)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $9
+                      (set_local $8
                         (i32.load offset=16
-                          (get_local $4)
+                          (get_local $5)
                         )
                       )
-                      (set_local $5
-                        (get_local $9)
+                      (set_local $7
+                        (get_local $8)
                       )
                       (if
                         (set_local $10
                           (i32.load offset=20
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
-                        (set_local $5
+                        (set_local $7
                           (get_local $10)
                         )
                         (block
-                          (set_local $5
+                          (set_local $7
                             (get_local $2)
                           )
-                          (set_local $6
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-out$6)
@@ -787,11 +787,11 @@
                     )
                     (set_local $10
                       (i32.lt_u
-                        (set_local $9
+                        (set_local $8
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $5)
+                                (get_local $7)
                               )
                               (i32.const -8)
                             )
@@ -803,17 +803,17 @@
                     )
                     (set_local $2
                       (select
-                        (get_local $9)
+                        (get_local $8)
                         (get_local $2)
                         (get_local $10)
                       )
                     )
-                    (set_local $4
-                      (get_local $5)
+                    (set_local $5
+                      (get_local $7)
                     )
                     (set_local $1
                       (select
-                        (get_local $5)
+                        (get_local $7)
                         (get_local $1)
                         (get_local $10)
                       )
@@ -822,7 +822,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $4)
                       (set_local $1
                         (i32.load
                           (i32.const 192)
@@ -833,10 +833,10 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $6)
-                      (set_local $4
+                      (get_local $4)
+                      (set_local $5
                         (i32.add
-                          (get_local $6)
+                          (get_local $4)
                           (get_local $0)
                         )
                       )
@@ -845,52 +845,51 @@
                   )
                   (set_local $2
                     (i32.load offset=24
-                      (get_local $6)
+                      (get_local $4)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $8
+                        (set_local $9
                           (i32.load offset=12
-                            (get_local $6)
+                            (get_local $4)
                           )
                         )
-                        (get_local $6)
+                        (get_local $4)
                       )
                       (block
                         (if
                           (set_local $19
                             (i32.load
-                              (set_local $15
+                              (set_local $16
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $4)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $9
+                            (set_local $8
                               (get_local $19)
                             )
-                            (set_local $8
-                              (get_local $15)
+                            (set_local $10
+                              (get_local $16)
                             )
                           )
                           (if
-                            (set_local $9
-                              (i32.load
-                                (set_local $10
-                                  (i32.add
-                                    (get_local $6)
-                                    (i32.const 16)
+                            (i32.eqz
+                              (set_local $8
+                                (i32.load
+                                  (set_local $10
+                                    (i32.add
+                                      (get_local $4)
+                                      (i32.const 16)
+                                    )
                                   )
                                 )
                               )
-                            )
-                            (set_local $8
-                              (get_local $10)
                             )
                             (block
                               (set_local $18
@@ -904,20 +903,20 @@
                           (if
                             (set_local $19
                               (i32.load
-                                (set_local $15
+                                (set_local $16
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $9
+                              (set_local $8
                                 (get_local $19)
                               )
-                              (set_local $8
-                                (get_local $15)
+                              (set_local $10
+                                (get_local $16)
                               )
                               (br $while-in$11)
                             )
@@ -925,20 +924,20 @@
                           (if
                             (set_local $19
                               (i32.load
-                                (set_local $15
+                                (set_local $16
                                   (i32.add
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $9
+                              (set_local $8
                                 (get_local $19)
                               )
-                              (set_local $8
-                                (get_local $15)
+                              (set_local $10
+                                (get_local $16)
                               )
                             )
                             (br $while-out$10)
@@ -947,17 +946,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $8)
+                            (get_local $10)
                             (get_local $1)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $8)
+                              (get_local $10)
                               (i32.const 0)
                             )
                             (set_local $18
-                              (get_local $9)
+                              (get_local $8)
                             )
                           )
                         )
@@ -965,9 +964,9 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $15
+                            (set_local $16
                               (i32.load offset=8
-                                (get_local $6)
+                                (get_local $4)
                               )
                             )
                             (get_local $1)
@@ -979,12 +978,12 @@
                             (i32.load
                               (set_local $19
                                 (i32.add
-                                  (get_local $15)
+                                  (get_local $16)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $4)
                           )
                           (call_import $_abort)
                         )
@@ -993,24 +992,24 @@
                             (i32.load
                               (set_local $10
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $9)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $6)
+                            (get_local $4)
                           )
                           (block
                             (i32.store
                               (get_local $19)
-                              (get_local $8)
+                              (get_local $9)
                             )
                             (i32.store
                               (get_local $10)
-                              (get_local $15)
+                              (get_local $16)
                             )
                             (set_local $18
-                              (get_local $8)
+                              (get_local $9)
                             )
                           )
                           (call_import $_abort)
@@ -1024,15 +1023,15 @@
                       (block
                         (if
                           (i32.eq
-                            (get_local $6)
+                            (get_local $4)
                             (i32.load
                               (set_local $1
                                 (i32.add
                                   (i32.const 480)
                                   (i32.shl
-                                    (set_local $8
+                                    (set_local $9
                                       (i32.load offset=28
-                                        (get_local $6)
+                                        (get_local $4)
                                       )
                                     )
                                     (i32.const 2)
@@ -1060,7 +1059,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $9)
                                       )
                                       (i32.const -1)
                                     )
@@ -1083,17 +1082,17 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.add
                                       (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store
-                                (get_local $8)
+                                (get_local $9)
                                 (get_local $18)
                               )
                               (i32.store offset=20
@@ -1111,7 +1110,7 @@
                         (if
                           (i32.lt_u
                             (get_local $18)
-                            (set_local $8
+                            (set_local $9
                               (i32.load
                                 (i32.const 192)
                               )
@@ -1126,13 +1125,13 @@
                         (if
                           (set_local $1
                             (i32.load offset=16
-                              (get_local $6)
+                              (get_local $4)
                             )
                           )
                           (if
                             (i32.lt_u
                               (get_local $1)
-                              (get_local $8)
+                              (get_local $9)
                             )
                             (call_import $_abort)
                             (block
@@ -1150,7 +1149,7 @@
                         (if
                           (set_local $1
                             (i32.load offset=20
-                              (get_local $6)
+                              (get_local $4)
                             )
                           )
                           (if
@@ -1178,16 +1177,16 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $4)
                         (i32.or
                           (set_local $2
                             (i32.add
-                              (get_local $5)
+                              (get_local $7)
                               (get_local $0)
                             )
                           )
@@ -1198,7 +1197,7 @@
                         (set_local $1
                           (i32.add
                             (i32.add
-                              (get_local $6)
+                              (get_local $4)
                               (get_local $2)
                             )
                             (i32.const 4)
@@ -1214,25 +1213,25 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $4)
                         (i32.or
                           (get_local $0)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $4)
+                        (get_local $5)
                         (i32.or
-                          (get_local $5)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $4)
                           (get_local $5)
+                          (get_local $7)
                         )
-                        (get_local $5)
+                        (get_local $7)
                       )
                       (if
                         (set_local $1
@@ -1251,7 +1250,7 @@
                               (i32.const 216)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.shr_u
                                       (get_local $1)
                                       (i32.const 3)
@@ -1265,7 +1264,7 @@
                           )
                           (if
                             (i32.and
-                              (set_local $15
+                              (set_local $16
                                 (i32.load
                                   (i32.const 176)
                                 )
@@ -1273,7 +1272,7 @@
                               (set_local $10
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                               )
                             )
@@ -1281,7 +1280,7 @@
                               (i32.lt_u
                                 (set_local $19
                                   (i32.load
-                                    (set_local $8
+                                    (set_local $9
                                       (i32.add
                                         (get_local $1)
                                         (i32.const 8)
@@ -1296,7 +1295,7 @@
                               (call_import $_abort)
                               (block
                                 (set_local $40
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                                 (set_local $32
                                   (get_local $19)
@@ -1307,7 +1306,7 @@
                               (i32.store
                                 (i32.const 176)
                                 (i32.or
-                                  (get_local $15)
+                                  (get_local $16)
                                   (get_local $10)
                                 )
                               )
@@ -1342,17 +1341,17 @@
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $5)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 196)
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                   )
                   (return
                     (i32.add
-                      (get_local $6)
+                      (get_local $4)
                       (i32.const 8)
                     )
                   )
@@ -1387,7 +1386,7 @@
                 )
               )
               (block
-                (set_local $15
+                (set_local $16
                   (i32.sub
                     (i32.const 0)
                     (get_local $2)
@@ -1395,7 +1394,7 @@
                 )
                 (block $label$break$L123
                   (if
-                    (set_local $5
+                    (set_local $7
                       (i32.load offset=480
                         (i32.shl
                           (set_local $0
@@ -1417,7 +1416,7 @@
                                     (i32.shr_u
                                       (get_local $2)
                                       (i32.add
-                                        (set_local $5
+                                        (set_local $7
                                           (i32.add
                                             (i32.sub
                                               (i32.const 14)
@@ -1427,7 +1426,7 @@
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $8
+                                                          (set_local $9
                                                             (i32.shl
                                                               (get_local $19)
                                                               (set_local $1
@@ -1453,13 +1452,13 @@
                                                   )
                                                   (get_local $1)
                                                 )
-                                                (set_local $8
+                                                (set_local $9
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $9
+                                                        (set_local $8
                                                           (i32.shl
-                                                            (get_local $8)
+                                                            (get_local $9)
                                                             (get_local $19)
                                                           )
                                                         )
@@ -1474,8 +1473,8 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $9)
                                                 (get_local $8)
+                                                (get_local $9)
                                               )
                                               (i32.const 15)
                                             )
@@ -1487,7 +1486,7 @@
                                     (i32.const 1)
                                   )
                                   (i32.shl
-                                    (get_local $5)
+                                    (get_local $7)
                                     (i32.const 1)
                                   )
                                 )
@@ -1500,10 +1499,10 @@
                       )
                     )
                     (block
-                      (set_local $8
-                        (get_local $15)
-                      )
                       (set_local $9
+                        (get_local $16)
+                      )
+                      (set_local $8
                         (i32.const 0)
                       )
                       (set_local $1
@@ -1526,15 +1525,15 @@
                         )
                       )
                       (set_local $19
-                        (get_local $5)
+                        (get_local $7)
                       )
-                      (set_local $6
+                      (set_local $4
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $4
+                            (set_local $5
                               (i32.sub
                                 (set_local $18
                                   (i32.and
@@ -1547,7 +1546,7 @@
                                 (get_local $2)
                               )
                             )
-                            (get_local $8)
+                            (get_local $9)
                           )
                           (if
                             (i32.eq
@@ -1556,7 +1555,7 @@
                             )
                             (block
                               (set_local $27
-                                (get_local $4)
+                                (get_local $5)
                               )
                               (set_local $25
                                 (get_local $19)
@@ -1564,39 +1563,36 @@
                               (set_local $29
                                 (get_local $19)
                               )
-                              (set_local $8
+                              (set_local $9
                                 (i32.const 90)
                               )
                               (br $label$break$L123)
                             )
                             (block
-                              (set_local $5
-                                (get_local $4)
+                              (set_local $9
+                                (get_local $5)
                               )
-                              (set_local $6
+                              (set_local $4
                                 (get_local $19)
                               )
                             )
                           )
-                          (set_local $5
-                            (get_local $8)
-                          )
                         )
                         (set_local $18
                           (select
-                            (get_local $9)
-                            (set_local $4
+                            (get_local $8)
+                            (set_local $5
                               (i32.load offset=20
                                 (get_local $19)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $4)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $4)
+                                (get_local $5)
                                 (set_local $19
                                   (i32.load
                                     (i32.add
@@ -1619,7 +1615,7 @@
                           )
                         )
                         (if
-                          (set_local $4
+                          (set_local $5
                             (i32.eq
                               (get_local $19)
                               (i32.const 0)
@@ -1627,24 +1623,21 @@
                           )
                           (block
                             (set_local $33
-                              (get_local $5)
+                              (get_local $9)
                             )
                             (set_local $34
                               (get_local $18)
                             )
                             (set_local $30
-                              (get_local $6)
+                              (get_local $4)
                             )
-                            (set_local $8
+                            (set_local $9
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
                             (set_local $8
-                              (get_local $5)
-                            )
-                            (set_local $9
                               (get_local $18)
                             )
                             (set_local $1
@@ -1652,7 +1645,7 @@
                                 (get_local $1)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $4)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1666,7 +1659,7 @@
                     )
                     (block
                       (set_local $33
-                        (get_local $15)
+                        (get_local $16)
                       )
                       (set_local $34
                         (i32.const 0)
@@ -1674,7 +1667,7 @@
                       (set_local $30
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $9
                         (i32.const 86)
                       )
                     )
@@ -1682,7 +1675,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $9)
                     (i32.const 86)
                   )
                   (if
@@ -1701,11 +1694,11 @@
                         (block
                           (if
                             (i32.eqz
-                              (set_local $15
+                              (set_local $16
                                 (i32.and
                                   (get_local $10)
                                   (i32.or
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $0)
@@ -1713,7 +1706,7 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $5)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -1726,16 +1719,16 @@
                               (br $do-once$0)
                             )
                           )
-                          (set_local $15
+                          (set_local $16
                             (i32.and
                               (i32.shr_u
-                                (set_local $5
+                                (set_local $7
                                   (i32.add
                                     (i32.and
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $15)
+                                        (get_local $16)
                                       )
                                     )
                                     (i32.const -1)
@@ -1753,13 +1746,13 @@
                                   (i32.or
                                     (i32.or
                                       (i32.or
-                                        (set_local $5
+                                        (set_local $7
                                           (i32.and
                                             (i32.shr_u
                                               (set_local $0
                                                 (i32.shr_u
-                                                  (get_local $5)
-                                                  (get_local $15)
+                                                  (get_local $7)
+                                                  (get_local $16)
                                                 )
                                               )
                                               (i32.const 5)
@@ -1767,15 +1760,15 @@
                                             (i32.const 8)
                                           )
                                         )
-                                        (get_local $15)
+                                        (get_local $16)
                                       )
                                       (set_local $0
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $4
+                                            (set_local $5
                                               (i32.shr_u
                                                 (get_local $0)
-                                                (get_local $5)
+                                                (get_local $7)
                                               )
                                             )
                                             (i32.const 2)
@@ -1784,12 +1777,12 @@
                                         )
                                       )
                                     )
-                                    (set_local $4
+                                    (set_local $5
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $6
+                                          (set_local $4
                                             (i32.shr_u
-                                              (get_local $4)
+                                              (get_local $5)
                                               (get_local $0)
                                             )
                                           )
@@ -1799,13 +1792,13 @@
                                       )
                                     )
                                   )
-                                  (set_local $6
+                                  (set_local $4
                                     (i32.and
                                       (i32.shr_u
                                         (set_local $1
                                           (i32.shr_u
-                                            (get_local $6)
                                             (get_local $4)
+                                            (get_local $5)
                                           )
                                         )
                                         (i32.const 1)
@@ -1816,7 +1809,7 @@
                                 )
                                 (i32.shr_u
                                   (get_local $1)
-                                  (get_local $6)
+                                  (get_local $4)
                                 )
                               )
                               (i32.const 2)
@@ -1836,12 +1829,12 @@
                       (set_local $29
                         (get_local $30)
                       )
-                      (set_local $8
+                      (set_local $9
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (get_local $33)
                       )
                       (set_local $12
@@ -1852,16 +1845,16 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $9)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $8
+                    (set_local $9
                       (i32.const 0)
                     )
                     (set_local $1
                       (i32.lt_u
-                        (set_local $6
+                        (set_local $4
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
@@ -1875,14 +1868,14 @@
                         (get_local $27)
                       )
                     )
-                    (set_local $4
+                    (set_local $5
                       (select
-                        (get_local $6)
+                        (get_local $4)
                         (get_local $27)
                         (get_local $1)
                       )
                     )
-                    (set_local $6
+                    (set_local $4
                       (select
                         (get_local $25)
                         (get_local $29)
@@ -1897,13 +1890,13 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $25
                           (get_local $1)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $4)
                         )
                         (br $while-in$20)
                       )
@@ -1916,18 +1909,18 @@
                       )
                       (block
                         (set_local $27
-                          (get_local $4)
+                          (get_local $5)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $4)
                         )
                       )
                       (block
-                        (set_local $7
-                          (get_local $4)
+                        (set_local $6
+                          (get_local $5)
                         )
                         (set_local $12
-                          (get_local $6)
+                          (get_local $4)
                         )
                         (br $while-out$19)
                       )
@@ -1938,7 +1931,7 @@
                 (if
                   (select
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $6)
                       (i32.sub
                         (i32.load
                           (i32.const 184)
@@ -1967,7 +1960,7 @@
                     (if
                       (i32.ge_u
                         (get_local $12)
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (get_local $12)
                             (get_local $2)
@@ -1976,7 +1969,7 @@
                       )
                       (call_import $_abort)
                     )
-                    (set_local $4
+                    (set_local $5
                       (i32.load offset=24
                         (get_local $12)
                       )
@@ -1993,7 +1986,7 @@
                         )
                         (block
                           (if
-                            (set_local $15
+                            (set_local $16
                               (i32.load
                                 (set_local $0
                                   (i32.add
@@ -2004,26 +1997,25 @@
                               )
                             )
                             (block
-                              (set_local $1
-                                (get_local $15)
+                              (set_local $8
+                                (get_local $16)
                               )
-                              (set_local $5
+                              (set_local $7
                                 (get_local $0)
                               )
                             )
                             (if
-                              (set_local $9
-                                (i32.load
-                                  (set_local $5
-                                    (i32.add
-                                      (get_local $12)
-                                      (i32.const 16)
+                              (i32.eqz
+                                (set_local $8
+                                  (i32.load
+                                    (set_local $7
+                                      (i32.add
+                                        (get_local $12)
+                                        (i32.const 16)
+                                      )
                                     )
                                   )
                                 )
-                              )
-                              (set_local $1
-                                (get_local $9)
                               )
                               (block
                                 (set_local $11
@@ -2035,67 +2027,62 @@
                           )
                           (loop $while-out$23 $while-in$24
                             (if
-                              (set_local $15
+                              (set_local $16
                                 (i32.load
                                   (set_local $0
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $8)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $1
-                                  (get_local $15)
+                                (set_local $8
+                                  (get_local $16)
                                 )
-                                (set_local $5
+                                (set_local $7
                                   (get_local $0)
                                 )
                                 (br $while-in$24)
                               )
                             )
                             (if
-                              (set_local $15
+                              (set_local $16
                                 (i32.load
                                   (set_local $0
                                     (i32.add
-                                      (get_local $1)
+                                      (get_local $8)
                                       (i32.const 16)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $1
-                                  (get_local $15)
+                                (set_local $8
+                                  (get_local $16)
                                 )
-                                (set_local $5
+                                (set_local $7
                                   (get_local $0)
                                 )
                               )
-                              (block
-                                (set_local $0
-                                  (get_local $1)
-                                )
-                                (br $while-out$23)
-                              )
+                              (br $while-out$23)
                             )
                             (br $while-in$24)
                           )
                           (if
                             (i32.lt_u
-                              (get_local $5)
+                              (get_local $7)
                               (get_local $10)
                             )
                             (call_import $_abort)
                             (block
                               (i32.store
-                                (get_local $5)
+                                (get_local $7)
                                 (i32.const 0)
                               )
                               (set_local $11
-                                (get_local $0)
+                                (get_local $8)
                               )
                             )
                           )
@@ -2115,7 +2102,7 @@
                           (if
                             (i32.ne
                               (i32.load
-                                (set_local $15
+                                (set_local $16
                                   (i32.add
                                     (get_local $0)
                                     (i32.const 12)
@@ -2129,7 +2116,7 @@
                           (if
                             (i32.eq
                               (i32.load
-                                (set_local $5
+                                (set_local $7
                                   (i32.add
                                     (get_local $1)
                                     (i32.const 8)
@@ -2140,11 +2127,11 @@
                             )
                             (block
                               (i32.store
-                                (get_local $15)
+                                (get_local $16)
                                 (get_local $1)
                               )
                               (i32.store
-                                (get_local $5)
+                                (get_local $7)
                                 (get_local $0)
                               )
                               (set_local $11
@@ -2158,7 +2145,7 @@
                     )
                     (block $do-once$25
                       (if
-                        (get_local $4)
+                        (get_local $5)
                         (block
                           (if
                             (i32.eq
@@ -2211,7 +2198,7 @@
                             (block
                               (if
                                 (i32.lt_u
-                                  (get_local $4)
+                                  (get_local $5)
                                   (i32.load
                                     (i32.const 192)
                                   )
@@ -2223,7 +2210,7 @@
                                   (i32.load
                                     (set_local $1
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $5)
                                         (i32.const 16)
                                       )
                                     )
@@ -2235,7 +2222,7 @@
                                   (get_local $11)
                                 )
                                 (i32.store offset=20
-                                  (get_local $4)
+                                  (get_local $5)
                                   (get_local $11)
                                 )
                               )
@@ -2259,7 +2246,7 @@
                           )
                           (i32.store offset=24
                             (get_local $11)
-                            (get_local $4)
+                            (get_local $5)
                           )
                           (if
                             (set_local $10
@@ -2317,7 +2304,7 @@
                     (block $do-once$29
                       (if
                         (i32.ge_u
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const 16)
                         )
                         (block
@@ -2329,28 +2316,28 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $6)
+                            (get_local $4)
                             (i32.or
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
+                              (get_local $4)
                               (get_local $6)
-                              (get_local $7)
                             )
-                            (get_local $7)
+                            (get_local $6)
                           )
-                          (set_local $4
+                          (set_local $5
                             (i32.shr_u
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 256)
                             )
                             (block
@@ -2359,7 +2346,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $4)
+                                      (get_local $5)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -2376,15 +2363,15 @@
                                   (set_local $0
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                   )
                                 )
                                 (if
                                   (i32.lt_u
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.load
-                                        (set_local $4
+                                        (set_local $5
                                           (i32.add
                                             (get_local $10)
                                             (i32.const 8)
@@ -2399,10 +2386,10 @@
                                   (call_import $_abort)
                                   (block
                                     (set_local $14
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                     (set_local $26
-                                      (get_local $5)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -2427,47 +2414,47 @@
                               )
                               (i32.store
                                 (get_local $14)
-                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store offset=12
                                 (get_local $26)
-                                (get_local $6)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $6)
+                                (get_local $4)
                                 (get_local $26)
                               )
                               (i32.store offset=12
-                                (get_local $6)
+                                (get_local $4)
                                 (get_local $10)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $4
+                          (set_local $5
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $9
+                                (set_local $8
                                   (if
                                     (set_local $10
                                       (i32.shr_u
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
                                     (if
                                       (i32.gt_u
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 16777215)
                                       )
                                       (i32.const 31)
                                       (i32.or
                                         (i32.and
                                           (i32.shr_u
-                                            (get_local $7)
+                                            (get_local $6)
                                             (i32.add
-                                              (set_local $4
+                                              (set_local $5
                                                 (i32.add
                                                   (i32.sub
                                                     (i32.const 14)
@@ -2507,7 +2494,7 @@
                                                         (i32.and
                                                           (i32.shr_u
                                                             (i32.add
-                                                              (set_local $5
+                                                              (set_local $7
                                                                 (i32.shl
                                                                   (get_local $1)
                                                                   (get_local $10)
@@ -2524,7 +2511,7 @@
                                                   )
                                                   (i32.shr_u
                                                     (i32.shl
-                                                      (get_local $5)
+                                                      (get_local $7)
                                                       (get_local $1)
                                                     )
                                                     (i32.const 15)
@@ -2537,7 +2524,7 @@
                                           (i32.const 1)
                                         )
                                         (i32.shl
-                                          (get_local $4)
+                                          (get_local $5)
                                           (i32.const 1)
                                         )
                                       )
@@ -2550,13 +2537,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $6)
-                            (get_local $9)
+                            (get_local $4)
+                            (get_local $8)
                           )
                           (i32.store offset=4
                             (set_local $1
                               (i32.add
-                                (get_local $6)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
@@ -2574,10 +2561,10 @@
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $5
+                                (set_local $7
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                 )
                               )
@@ -2587,42 +2574,42 @@
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $1)
-                                  (get_local $5)
+                                  (get_local $7)
                                 )
                               )
                               (i32.store
+                                (get_local $5)
                                 (get_local $4)
-                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $6)
                                 (get_local $4)
+                                (get_local $5)
                               )
                               (i32.store offset=12
-                                (get_local $6)
-                                (get_local $6)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $6)
-                                (get_local $6)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (br $do-once$29)
                             )
                           )
-                          (set_local $5
+                          (set_local $7
                             (i32.shl
-                              (get_local $7)
+                              (get_local $6)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $9)
+                                    (get_local $8)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 31)
                                 )
                               )
@@ -2630,7 +2617,7 @@
                           )
                           (set_local $1
                             (i32.load
-                              (get_local $4)
+                              (get_local $5)
                             )
                           )
                           (loop $while-out$31 $while-in$32
@@ -2642,13 +2629,13 @@
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (block
-                                (set_local $16
+                                (set_local $15
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 148)
                                 )
                                 (br $while-out$31)
@@ -2657,7 +2644,7 @@
                             (if
                               (set_local $0
                                 (i32.load
-                                  (set_local $4
+                                  (set_local $5
                                     (i32.add
                                       (i32.add
                                         (get_local $1)
@@ -2665,7 +2652,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $5)
+                                          (get_local $7)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -2675,9 +2662,9 @@
                                 )
                               )
                               (block
-                                (set_local $5
+                                (set_local $7
                                   (i32.shl
-                                    (get_local $5)
+                                    (get_local $7)
                                     (i32.const 1)
                                   )
                                 )
@@ -2687,12 +2674,12 @@
                               )
                               (block
                                 (set_local $23
-                                  (get_local $4)
+                                  (get_local $5)
                                 )
                                 (set_local $21
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 145)
                                 )
                                 (br $while-out$31)
@@ -2702,7 +2689,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 145)
                             )
                             (if
@@ -2716,35 +2703,35 @@
                               (block
                                 (i32.store
                                   (get_local $23)
-                                  (get_local $6)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=24
-                                  (get_local $6)
+                                  (get_local $4)
                                   (get_local $21)
                                 )
                                 (i32.store offset=12
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=8
-                                  (get_local $6)
-                                  (get_local $6)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $9)
                                 (i32.const 148)
                               )
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.load
                                         (set_local $1
                                           (i32.add
-                                            (get_local $16)
+                                            (get_local $15)
                                             (i32.const 8)
                                           )
                                         )
@@ -2757,29 +2744,29 @@
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $16)
+                                    (get_local $15)
                                     (get_local $0)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $5)
-                                    (get_local $6)
+                                    (get_local $7)
+                                    (get_local $4)
                                   )
                                   (i32.store
                                     (get_local $1)
-                                    (get_local $6)
+                                    (get_local $4)
                                   )
                                   (i32.store offset=8
-                                    (get_local $6)
-                                    (get_local $5)
+                                    (get_local $4)
+                                    (get_local $7)
                                   )
                                   (i32.store offset=12
-                                    (get_local $6)
-                                    (get_local $16)
+                                    (get_local $4)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=24
-                                    (get_local $6)
+                                    (get_local $4)
                                     (i32.const 0)
                                   )
                                 )
@@ -2792,9 +2779,9 @@
                           (i32.store offset=4
                             (get_local $12)
                             (i32.or
-                              (set_local $5
+                              (set_local $7
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (get_local $2)
                                 )
                               )
@@ -2806,7 +2793,7 @@
                               (i32.add
                                 (i32.add
                                   (get_local $12)
-                                  (get_local $5)
+                                  (get_local $7)
                                 )
                                 (i32.const 4)
                               )
@@ -2854,14 +2841,14 @@
         (get_local $0)
       )
       (block
-        (set_local $16
+        (set_local $15
           (i32.load
             (i32.const 196)
           )
         )
         (if
           (i32.gt_u
-            (set_local $7
+            (set_local $6
               (i32.sub
                 (get_local $12)
                 (get_local $0)
@@ -2874,31 +2861,31 @@
               (i32.const 196)
               (set_local $21
                 (i32.add
-                  (get_local $16)
+                  (get_local $15)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 184)
-              (get_local $7)
+              (get_local $6)
             )
             (i32.store offset=4
               (get_local $21)
               (i32.or
-                (get_local $7)
+                (get_local $6)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
                 (get_local $21)
-                (get_local $7)
+                (get_local $6)
               )
-              (get_local $7)
+              (get_local $6)
             )
             (i32.store offset=4
-              (get_local $16)
+              (get_local $15)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -2915,17 +2902,17 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $16)
+              (get_local $15)
               (i32.or
                 (get_local $12)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $7
+              (set_local $6
                 (i32.add
                   (i32.add
-                    (get_local $16)
+                    (get_local $15)
                     (get_local $12)
                   )
                   (i32.const 4)
@@ -2933,7 +2920,7 @@
               )
               (i32.or
                 (i32.load
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (i32.const 1)
               )
@@ -2942,7 +2929,7 @@
         )
         (return
           (i32.add
-            (get_local $16)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -2950,7 +2937,7 @@
     )
     (if
       (i32.gt_u
-        (set_local $16
+        (set_local $15
           (i32.load
             (i32.const 188)
           )
@@ -2960,9 +2947,9 @@
       (block
         (i32.store
           (i32.const 188)
-          (set_local $7
+          (set_local $6
             (i32.sub
-              (get_local $16)
+              (get_local $15)
               (get_local $0)
             )
           )
@@ -2971,7 +2958,7 @@
           (i32.const 200)
           (set_local $12
             (i32.add
-              (set_local $16
+              (set_local $15
                 (i32.load
                   (i32.const 200)
                 )
@@ -2983,12 +2970,12 @@
         (i32.store offset=4
           (get_local $12)
           (i32.or
-            (get_local $7)
+            (get_local $6)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $16)
+          (get_local $15)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -2996,7 +2983,7 @@
         )
         (return
           (i32.add
-            (get_local $16)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3011,24 +2998,24 @@
       (if
         (i32.and
           (i32.add
-            (set_local $16
+            (set_local $15
               (call_import $_sysconf
                 (i32.const 30)
               )
             )
             (i32.const -1)
           )
-          (get_local $16)
+          (get_local $15)
         )
         (call_import $_abort)
         (block
           (i32.store
             (i32.const 656)
-            (get_local $16)
+            (get_local $15)
           )
           (i32.store
             (i32.const 652)
-            (get_local $16)
+            (get_local $15)
           )
           (i32.store
             (i32.const 660)
@@ -3061,7 +3048,7 @@
         )
       )
     )
-    (set_local $16
+    (set_local $15
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -3069,11 +3056,11 @@
     )
     (if
       (i32.le_u
-        (set_local $7
+        (set_local $6
           (i32.and
             (set_local $21
               (i32.add
-                (set_local $7
+                (set_local $6
                   (i32.load
                     (i32.const 656)
                   )
@@ -3089,7 +3076,7 @@
             (set_local $23
               (i32.sub
                 (i32.const 0)
-                (get_local $7)
+                (get_local $6)
               )
             )
           )
@@ -3103,7 +3090,7 @@
     (if
       (if
         (i32.ne
-          (set_local $9
+          (set_local $8
             (i32.load
               (i32.const 616)
             )
@@ -3119,14 +3106,14 @@
                     (i32.const 608)
                   )
                 )
-                (get_local $7)
+                (get_local $6)
               )
             )
             (get_local $26)
           )
           (i32.gt_u
             (get_local $14)
-            (get_local $9)
+            (get_local $8)
           )
         )
         (i32.const 0)
@@ -3140,12 +3127,12 @@
         (if
           (select
             (i32.lt_u
-              (get_local $7)
+              (get_local $6)
               (i32.const 2147483647)
             )
             (i32.const 0)
             (i32.eq
-              (set_local $8
+              (set_local $9
                 (block $label$break$L257
                   (if
                     (i32.and
@@ -3158,7 +3145,7 @@
                     (block
                       (block $label$break$L259
                         (if
-                          (set_local $9
+                          (set_local $8
                             (i32.load
                               (i32.const 200)
                             )
@@ -3176,7 +3163,7 @@
                                         (get_local $14)
                                       )
                                     )
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (i32.gt_u
                                     (i32.add
@@ -3190,15 +3177,15 @@
                                         )
                                       )
                                     )
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $4
+                                  (set_local $5
                                     (get_local $14)
                                   )
-                                  (set_local $5
+                                  (set_local $7
                                     (get_local $11)
                                   )
                                   (br $while-out$37)
@@ -3213,7 +3200,7 @@
                                   )
                                 )
                                 (block
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.const 173)
                                   )
                                   (br $label$break$L259)
@@ -3245,10 +3232,10 @@
                                   )
                                   (i32.add
                                     (i32.load
-                                      (get_local $4)
+                                      (get_local $5)
                                     )
                                     (i32.load
-                                      (get_local $5)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -3276,14 +3263,14 @@
                                   (set_local $17
                                     (get_local $14)
                                   )
-                                  (set_local $8
+                                  (set_local $9
                                     (i32.const 183)
                                   )
                                 )
                               )
                             )
                           )
-                          (set_local $8
+                          (set_local $9
                             (i32.const 173)
                           )
                         )
@@ -3292,11 +3279,11 @@
                         (if
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 173)
                             )
                             (i32.ne
-                              (set_local $9
+                              (set_local $8
                                 (call_import $_sbrk
                                   (i32.const 0)
                                 )
@@ -3320,12 +3307,12 @@
                                     )
                                   )
                                   (set_local $2
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                 )
                                 (i32.add
                                   (i32.sub
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $2)
                                   )
                                   (i32.and
@@ -3339,7 +3326,7 @@
                                     )
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                             (set_local $2
@@ -3394,11 +3381,11 @@
                                         (get_local $1)
                                       )
                                     )
-                                    (get_local $9)
+                                    (get_local $8)
                                   )
                                   (block
                                     (set_local $20
-                                      (get_local $9)
+                                      (get_local $8)
                                     )
                                     (set_local $22
                                       (get_local $1)
@@ -3414,7 +3401,7 @@
                                     (set_local $17
                                       (get_local $1)
                                     )
-                                    (set_local $8
+                                    (set_local $9
                                       (i32.const 183)
                                     )
                                   )
@@ -3427,7 +3414,7 @@
                       (block $label$break$L279
                         (if
                           (i32.eq
-                            (get_local $8)
+                            (get_local $9)
                             (i32.const 183)
                           )
                           (block
@@ -3441,7 +3428,7 @@
                               (if
                                 (i32.and
                                   (i32.gt_u
-                                    (get_local $16)
+                                    (get_local $15)
                                     (get_local $17)
                                   )
                                   (i32.and
@@ -3463,7 +3450,7 @@
                                           (get_local $12)
                                           (get_local $17)
                                         )
-                                        (set_local $9
+                                        (set_local $8
                                           (i32.load
                                             (i32.const 656)
                                           )
@@ -3471,7 +3458,7 @@
                                       )
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $9)
+                                        (get_local $8)
                                       )
                                     )
                                   )
@@ -3544,10 +3531,10 @@
             (i32.lt_u
               (set_local $3
                 (call_import $_sbrk
-                  (get_local $7)
+                  (get_local $6)
                 )
               )
-              (set_local $7
+              (set_local $6
                 (call_import $_sbrk
                   (i32.const 0)
                 )
@@ -3559,7 +3546,7 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $7)
+                (get_local $6)
                 (i32.const -1)
               )
             )
@@ -3569,7 +3556,7 @@
         (i32.gt_u
           (set_local $13
             (i32.sub
-              (get_local $7)
+              (get_local $6)
               (get_local $3)
             )
           )
@@ -3587,14 +3574,14 @@
         (set_local $22
           (get_local $13)
         )
-        (set_local $8
+        (set_local $9
           (i32.const 193)
         )
       )
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $9)
         (i32.const 193)
       )
       (block
@@ -3637,7 +3624,7 @@
                   (i32.eq
                     (get_local $20)
                     (i32.add
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (get_local $3)
                         )
@@ -3656,7 +3643,7 @@
                   )
                   (block
                     (set_local $47
-                      (get_local $7)
+                      (get_local $6)
                     )
                     (set_local $48
                       (get_local $17)
@@ -3667,7 +3654,7 @@
                     (set_local $50
                       (get_local $3)
                     )
-                    (set_local $8
+                    (set_local $9
                       (i32.const 203)
                     )
                     (br $do-out$46)
@@ -3709,7 +3696,7 @@
                     )
                     (i32.const 0)
                     (i32.eq
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 203)
                     )
                   )
@@ -3793,7 +3780,7 @@
                   (br $do-once$44)
                 )
               )
-              (set_local $6
+              (set_local $4
                 (if
                   (i32.lt_u
                     (get_local $20)
@@ -3837,7 +3824,7 @@
                     (set_local $41
                       (get_local $3)
                     )
-                    (set_local $8
+                    (set_local $9
                       (i32.const 211)
                     )
                     (br $while-out$48)
@@ -3862,7 +3849,7 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $9)
                   (i32.const 211)
                 )
                 (if
@@ -3921,7 +3908,7 @@
                         )
                       )
                     )
-                    (set_local $7
+                    (set_local $6
                       (i32.add
                         (get_local $17)
                         (select
@@ -3954,10 +3941,10 @@
                         (get_local $0)
                       )
                     )
-                    (set_local $16
+                    (set_local $15
                       (i32.sub
                         (i32.sub
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $12)
                         )
                         (get_local $0)
@@ -3973,13 +3960,13 @@
                     (block $do-once$50
                       (if
                         (i32.ne
-                          (get_local $7)
+                          (get_local $6)
                           (get_local $13)
                         )
                         (block
                           (if
                             (i32.eq
-                              (get_local $7)
+                              (get_local $6)
                               (i32.load
                                 (i32.const 196)
                               )
@@ -3992,7 +3979,7 @@
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $16)
+                                    (get_local $15)
                                   )
                                 )
                               )
@@ -4018,14 +4005,14 @@
                             )
                           )
                           (i32.store
-                            (set_local $4
+                            (set_local $5
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
                                       (set_local $1
                                         (i32.load offset=4
-                                          (get_local $7)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 3)
@@ -4033,13 +4020,13 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.and
                                         (get_local $1)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $4
+                                    (set_local $5
                                       (i32.shr_u
                                         (get_local $1)
                                         (i32.const 3)
@@ -4054,7 +4041,7 @@
                                         (block
                                           (set_local $23
                                             (i32.load offset=24
-                                              (get_local $7)
+                                              (get_local $6)
                                             )
                                           )
                                           (block $do-once$53
@@ -4062,20 +4049,20 @@
                                               (i32.eq
                                                 (set_local $21
                                                   (i32.load offset=12
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $9
+                                                  (set_local $8
                                                     (i32.load
                                                       (set_local $2
                                                         (i32.add
                                                           (set_local $11
                                                             (i32.add
-                                                              (get_local $7)
+                                                              (get_local $6)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4085,25 +4072,19 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $0
-                                                      (get_local $9)
+                                                    (set_local $14
+                                                      (get_local $8)
                                                     )
-                                                    (set_local $4
+                                                    (set_local $11
                                                       (get_local $2)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $14
-                                                      (i32.load
-                                                        (get_local $11)
-                                                      )
-                                                    )
-                                                    (block
-                                                      (set_local $0
-                                                        (get_local $14)
-                                                      )
-                                                      (set_local $4
-                                                        (get_local $11)
+                                                    (i32.eqz
+                                                      (set_local $14
+                                                        (i32.load
+                                                          (get_local $11)
+                                                        )
                                                       )
                                                     )
                                                     (block
@@ -4116,42 +4097,42 @@
                                                 )
                                                 (loop $while-out$55 $while-in$56
                                                   (if
-                                                    (set_local $9
+                                                    (set_local $8
                                                       (i32.load
                                                         (set_local $2
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $14)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $9)
+                                                      (set_local $14
+                                                        (get_local $8)
                                                       )
-                                                      (set_local $4
+                                                      (set_local $11
                                                         (get_local $2)
                                                       )
                                                       (br $while-in$56)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $9
+                                                    (set_local $8
                                                       (i32.load
                                                         (set_local $2
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $14)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
-                                                        (get_local $9)
+                                                      (set_local $14
+                                                        (get_local $8)
                                                       )
-                                                      (set_local $4
+                                                      (set_local $11
                                                         (get_local $2)
                                                       )
                                                     )
@@ -4161,17 +4142,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
+                                                    (get_local $11)
                                                     (get_local $4)
-                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                   (block
                                                     (i32.store
-                                                      (get_local $4)
+                                                      (get_local $11)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $14)
                                                     )
                                                   )
                                                 )
@@ -4181,24 +4162,24 @@
                                                   (i32.lt_u
                                                     (set_local $2
                                                       (i32.load offset=8
-                                                        (get_local $7)
+                                                        (get_local $6)
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $_abort)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $9
+                                                      (set_local $8
                                                         (i32.add
                                                           (get_local $2)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (call_import $_abort)
                                                 )
@@ -4212,11 +4193,11 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (block
                                                     (i32.store
-                                                      (get_local $9)
+                                                      (get_local $8)
                                                       (get_local $21)
                                                     )
                                                     (i32.store
@@ -4240,7 +4221,7 @@
                                           (block $do-once$57
                                             (if
                                               (i32.ne
-                                                (get_local $7)
+                                                (get_local $6)
                                                 (i32.load
                                                   (set_local $2
                                                     (i32.add
@@ -4248,7 +4229,7 @@
                                                       (i32.shl
                                                         (set_local $21
                                                           (i32.load offset=28
-                                                            (get_local $7)
+                                                            (get_local $6)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4277,7 +4258,7 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (i32.store
                                                     (get_local $11)
@@ -4341,7 +4322,7 @@
                                               (i32.load
                                                 (set_local $2
                                                   (i32.add
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4397,7 +4378,7 @@
                                         (block
                                           (set_local $21
                                             (i32.load offset=12
-                                              (get_local $7)
+                                              (get_local $6)
                                             )
                                           )
                                           (block $do-once$61
@@ -4405,7 +4386,7 @@
                                               (i32.ne
                                                 (set_local $11
                                                   (i32.load offset=8
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                                 (set_local $23
@@ -4413,7 +4394,7 @@
                                                     (i32.const 216)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $4)
+                                                        (get_local $5)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4425,7 +4406,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $11)
-                                                    (get_local $6)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $_abort)
                                                 )
@@ -4434,7 +4415,7 @@
                                                     (i32.load offset=12
                                                       (get_local $11)
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                 )
                                                 (call_import $_abort)
@@ -4456,7 +4437,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $4)
+                                                      (get_local $5)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4481,7 +4462,7 @@
                                                 (if
                                                   (i32.lt_u
                                                     (get_local $21)
-                                                    (get_local $6)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $_abort)
                                                 )
@@ -4495,7 +4476,7 @@
                                                         )
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
                                                   (block
                                                     (set_local $42
@@ -4519,30 +4500,25 @@
                                         )
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $15
                                       (i32.add
-                                        (get_local $5)
-                                        (get_local $16)
+                                        (get_local $7)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.add
+                                      (get_local $6)
                                       (get_local $7)
-                                      (get_local $5)
                                     )
                                   )
-                                  (block
-                                    (set_local $0
-                                      (get_local $16)
-                                    )
-                                    (get_local $7)
-                                  )
+                                  (get_local $6)
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.and
                               (i32.load
-                                (get_local $4)
+                                (get_local $5)
                               )
                               (i32.const -2)
                             )
@@ -4550,26 +4526,26 @@
                           (i32.store offset=4
                             (get_local $3)
                             (i32.or
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
                               (get_local $3)
-                              (get_local $0)
+                              (get_local $15)
                             )
-                            (get_local $0)
+                            (get_local $15)
                           )
-                          (set_local $4
+                          (set_local $5
                             (i32.shr_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 256)
                             )
                             (block
@@ -4578,7 +4554,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $4)
+                                      (get_local $5)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4596,16 +4572,16 @@
                                     (set_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $4)
+                                        (get_local $5)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $9
+                                        (set_local $8
                                           (i32.load
-                                            (set_local $4
+                                            (set_local $5
                                               (i32.add
                                                 (get_local $1)
                                                 (i32.const 8)
@@ -4619,10 +4595,10 @@
                                       )
                                       (block
                                         (set_local $43
-                                          (get_local $4)
+                                          (get_local $5)
                                         )
                                         (set_local $35
-                                          (get_local $9)
+                                          (get_local $8)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4672,12 +4648,12 @@
                             (i32.add
                               (i32.const 480)
                               (i32.shl
-                                (set_local $4
+                                (set_local $0
                                   (block $do-once$67
                                     (if
                                       (set_local $2
                                         (i32.shr_u
-                                          (get_local $0)
+                                          (get_local $15)
                                           (i32.const 8)
                                         )
                                       )
@@ -4685,14 +4661,14 @@
                                         (br_if $do-once$67
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $0)
+                                            (get_local $15)
                                             (i32.const 16777215)
                                           )
                                         )
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $0)
+                                              (get_local $15)
                                               (i32.add
                                                 (set_local $14
                                                   (i32.add
@@ -4700,11 +4676,11 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $9
+                                                          (set_local $8
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $5
+                                                                  (set_local $7
                                                                     (i32.shl
                                                                       (get_local $2)
                                                                       (set_local $23
@@ -4730,14 +4706,14 @@
                                                           )
                                                           (get_local $23)
                                                         )
-                                                        (set_local $5
+                                                        (set_local $7
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $4
+                                                                (set_local $5
                                                                   (i32.shl
-                                                                    (get_local $5)
-                                                                    (get_local $9)
+                                                                    (get_local $7)
+                                                                    (get_local $8)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4751,8 +4727,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $4)
                                                         (get_local $5)
+                                                        (get_local $7)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4779,7 +4755,7 @@
                           )
                           (i32.store offset=28
                             (get_local $3)
-                            (get_local $4)
+                            (get_local $0)
                           )
                           (i32.store offset=4
                             (set_local $1
@@ -4805,7 +4781,7 @@
                                 (set_local $14
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $4)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -4839,18 +4815,18 @@
                           )
                           (set_local $14
                             (i32.shl
-                              (get_local $0)
+                              (get_local $15)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $4)
+                                  (get_local $0)
                                   (i32.const 31)
                                 )
                               )
@@ -4870,20 +4846,20 @@
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $0)
+                                (get_local $15)
                               )
                               (block
                                 (set_local $36
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 281)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $5
+                              (set_local $7
                                 (i32.load
                                   (set_local $2
                                     (i32.add
@@ -4910,7 +4886,7 @@
                                   )
                                 )
                                 (set_local $1
-                                  (get_local $5)
+                                  (get_local $7)
                                 )
                               )
                               (block
@@ -4920,7 +4896,7 @@
                                 (set_local $52
                                   (get_local $1)
                                 )
-                                (set_local $8
+                                (set_local $9
                                   (i32.const 278)
                                 )
                                 (br $while-out$69)
@@ -4930,7 +4906,7 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 278)
                             )
                             (if
@@ -4962,7 +4938,7 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $9)
                                 (i32.const 281)
                               )
                               (if
@@ -4978,7 +4954,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $5
+                                    (set_local $7
                                       (i32.load
                                         (i32.const 192)
                                       )
@@ -4986,7 +4962,7 @@
                                   )
                                   (i32.ge_u
                                     (get_local $36)
-                                    (get_local $5)
+                                    (get_local $7)
                                   )
                                 )
                                 (block
@@ -5024,7 +5000,7 @@
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $16)
+                                (get_local $15)
                               )
                             )
                           )
@@ -5063,7 +5039,7 @@
                       (get_local $13)
                     )
                     (i32.gt_u
-                      (set_local $16
+                      (set_local $15
                         (i32.add
                           (get_local $3)
                           (i32.load offset=4
@@ -5076,8 +5052,8 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $4
-                      (get_local $16)
+                    (set_local $5
+                      (get_local $15)
                     )
                     (br $while-out$71)
                   )
@@ -5089,11 +5065,11 @@
                 )
                 (br $while-in$72)
               )
-              (set_local $16
+              (set_local $15
                 (i32.add
                   (set_local $12
                     (i32.add
-                      (get_local $4)
+                      (get_local $5)
                       (i32.const -47)
                     )
                   )
@@ -5113,13 +5089,13 @@
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $16)
+                                (get_local $15)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $16)
+                                (get_local $15)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5129,7 +5105,7 @@
                       )
                       (i32.lt_u
                         (get_local $3)
-                        (set_local $16
+                        (set_local $15
                           (i32.add
                             (get_local $13)
                             (i32.const 16)
@@ -5143,7 +5119,7 @@
               )
               (i32.store
                 (i32.const 200)
-                (set_local $7
+                (set_local $6
                   (i32.add
                     (get_local $20)
                     (set_local $17
@@ -5152,7 +5128,7 @@
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $7
+                            (set_local $6
                               (i32.add
                                 (get_local $20)
                                 (i32.const 8)
@@ -5163,7 +5139,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $7)
+                            (get_local $6)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5186,7 +5162,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $7)
+                (get_local $6)
                 (i32.or
                   (get_local $14)
                   (i32.const 1)
@@ -5194,7 +5170,7 @@
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $7)
+                  (get_local $6)
                   (get_local $14)
                 )
                 (i32.const 40)
@@ -5276,7 +5252,7 @@
                       (get_local $3)
                       (i32.const 4)
                     )
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
               )
@@ -5311,7 +5287,7 @@
                     (get_local $12)
                     (get_local $3)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.shr_u
                       (get_local $3)
                       (i32.const 3)
@@ -5328,7 +5304,7 @@
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
-                              (get_local $7)
+                              (get_local $6)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5342,10 +5318,10 @@
                               (i32.const 176)
                             )
                           )
-                          (set_local $5
+                          (set_local $7
                             (i32.shl
                               (i32.const 1)
-                              (get_local $7)
+                              (get_local $6)
                             )
                           )
                         )
@@ -5353,7 +5329,7 @@
                           (i32.lt_u
                             (set_local $2
                               (i32.load
-                                (set_local $7
+                                (set_local $6
                                   (i32.add
                                     (get_local $17)
                                     (i32.const 8)
@@ -5368,7 +5344,7 @@
                           (call_import $_abort)
                           (block
                             (set_local $45
-                              (get_local $7)
+                              (get_local $6)
                             )
                             (set_local $37
                               (get_local $2)
@@ -5380,7 +5356,7 @@
                             (i32.const 176)
                             (i32.or
                               (get_local $1)
-                              (get_local $5)
+                              (get_local $7)
                             )
                           )
                           (set_local $45
@@ -5413,11 +5389,11 @@
                       (br $do-once$44)
                     )
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.add
                       (i32.const 480)
                       (i32.shl
-                        (set_local $4
+                        (set_local $5
                           (if
                             (set_local $17
                               (i32.shr_u
@@ -5436,7 +5412,7 @@
                                   (i32.shr_u
                                     (get_local $3)
                                     (i32.add
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
@@ -5449,7 +5425,7 @@
                                                         (set_local $1
                                                           (i32.shl
                                                             (get_local $17)
-                                                            (set_local $5
+                                                            (set_local $7
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
@@ -5470,7 +5446,7 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $5)
+                                                (get_local $7)
                                               )
                                               (set_local $1
                                                 (i32.and
@@ -5506,7 +5482,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
@@ -5520,14 +5496,14 @@
                   )
                   (i32.store offset=28
                     (get_local $13)
-                    (get_local $4)
+                    (get_local $5)
                   )
                   (i32.store offset=20
                     (get_local $13)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $16)
+                    (get_local $15)
                     (i32.const 0)
                   )
                   (if
@@ -5541,7 +5517,7 @@
                         (set_local $2
                           (i32.shl
                             (i32.const 1)
-                            (get_local $4)
+                            (get_local $5)
                           )
                         )
                       )
@@ -5555,12 +5531,12 @@
                         )
                       )
                       (i32.store
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $13)
                       )
                       (i32.store offset=24
                         (get_local $13)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store offset=12
                         (get_local $13)
@@ -5581,12 +5557,12 @@
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $4)
+                            (get_local $5)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $4)
+                          (get_local $5)
                           (i32.const 31)
                         )
                       )
@@ -5594,7 +5570,7 @@
                   )
                   (set_local $1
                     (i32.load
-                      (get_local $7)
+                      (get_local $6)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5612,16 +5588,16 @@
                         (set_local $38
                           (get_local $1)
                         )
-                        (set_local $8
+                        (set_local $9
                           (i32.const 307)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $5
+                      (set_local $7
                         (i32.load
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.add
                                 (get_local $1)
@@ -5646,17 +5622,17 @@
                           )
                         )
                         (set_local $1
-                          (get_local $5)
+                          (get_local $7)
                         )
                       )
                       (block
                         (set_local $46
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (set_local $53
                           (get_local $1)
                         )
-                        (set_local $8
+                        (set_local $9
                           (i32.const 304)
                         )
                         (br $while-out$75)
@@ -5666,7 +5642,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 304)
                     )
                     (if
@@ -5698,7 +5674,7 @@
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $9)
                         (i32.const 307)
                       )
                       (if
@@ -5995,7 +5971,7 @@
             (i32.const -8)
           )
         )
-        (set_local $12
+        (set_local $14
           (i32.load
             (i32.const 192)
           )
@@ -6076,7 +6052,7 @@
                   )
                 )
               )
-              (get_local $12)
+              (get_local $14)
             )
             (call_import $_abort)
           )
@@ -6184,7 +6160,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (get_local $12)
+                      (get_local $14)
                     )
                     (call_import $_abort)
                   )
@@ -6238,7 +6214,7 @@
                   (if
                     (i32.lt_u
                       (get_local $1)
-                      (get_local $12)
+                      (get_local $14)
                     )
                     (call_import $_abort)
                   )
@@ -6396,7 +6372,7 @@
                 (if
                   (i32.lt_u
                     (get_local $10)
-                    (get_local $12)
+                    (get_local $14)
                   )
                   (call_import $_abort)
                   (block
@@ -6418,7 +6394,7 @@
                         (get_local $0)
                       )
                     )
-                    (get_local $12)
+                    (get_local $14)
                   )
                   (call_import $_abort)
                 )
@@ -6823,7 +6799,7 @@
             (get_local $7)
           )
         )
-        (set_local $12
+        (set_local $14
           (i32.shr_u
             (get_local $1)
             (i32.const 3)
@@ -6872,21 +6848,20 @@
                         (set_local $0
                           (get_local $11)
                         )
-                        (set_local $12
+                        (set_local $6
                           (get_local $1)
                         )
                       )
                       (if
-                        (set_local $0
-                          (i32.load
-                            (get_local $6)
+                        (i32.eqz
+                          (set_local $0
+                            (i32.load
+                              (get_local $6)
+                            )
                           )
                         )
-                        (set_local $12
-                          (get_local $6)
-                        )
                         (block
-                          (set_local $13
+                          (set_local $12
                             (i32.const 0)
                           )
                           (br $do-once$10)
@@ -6909,7 +6884,7 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $12
+                          (set_local $6
                             (get_local $1)
                           )
                           (br $while-in$13)
@@ -6930,22 +6905,17 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $12
+                          (set_local $6
                             (get_local $1)
                           )
                         )
-                        (block
-                          (set_local $1
-                            (get_local $12)
-                          )
-                          (br $while-out$12)
-                        )
+                        (br $while-out$12)
                       )
                       (br $while-in$13)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $6)
                         (i32.load
                           (i32.const 192)
                         )
@@ -6953,10 +6923,10 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $6)
                           (i32.const 0)
                         )
-                        (set_local $13
+                        (set_local $12
                           (get_local $0)
                         )
                       )
@@ -7011,7 +6981,7 @@
                           (get_local $6)
                           (get_local $1)
                         )
-                        (set_local $13
+                        (set_local $12
                           (get_local $10)
                         )
                       )
@@ -7045,11 +7015,11 @@
                     (block
                       (i32.store
                         (get_local $3)
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (if
                         (i32.eqz
-                          (get_local $13)
+                          (get_local $12)
                         )
                         (block
                           (i32.store
@@ -7095,23 +7065,23 @@
                         )
                         (i32.store
                           (get_local $10)
-                          (get_local $13)
+                          (get_local $12)
                         )
                         (i32.store offset=20
                           (get_local $5)
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                       (br_if $do-once$8
                         (i32.eqz
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $13)
+                      (get_local $12)
                       (set_local $10
                         (i32.load
                           (i32.const 192)
@@ -7121,7 +7091,7 @@
                     (call_import $_abort)
                   )
                   (i32.store offset=24
-                    (get_local $13)
+                    (get_local $12)
                     (get_local $5)
                   )
                   (if
@@ -7143,12 +7113,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=16
-                          (get_local $13)
+                          (get_local $12)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7169,12 +7139,12 @@
                       (call_import $_abort)
                       (block
                         (i32.store offset=20
-                          (get_local $13)
+                          (get_local $12)
                           (get_local $0)
                         )
                         (i32.store offset=24
                           (get_local $0)
-                          (get_local $13)
+                          (get_local $12)
                         )
                       )
                     )
@@ -7200,7 +7170,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $12)
+                          (get_local $14)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -7244,7 +7214,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $12)
+                          (get_local $14)
                         )
                         (i32.const -1)
                       )
@@ -7397,7 +7367,7 @@
               (set_local $15
                 (get_local $7)
               )
-              (set_local $14
+              (set_local $13
                 (get_local $16)
               )
             )
@@ -7416,7 +7386,7 @@
                 (i32.const 8)
               )
             )
-            (set_local $14
+            (set_local $13
               (get_local $1)
             )
           )
@@ -7426,12 +7396,12 @@
           (get_local $2)
         )
         (i32.store offset=12
-          (get_local $14)
+          (get_local $13)
           (get_local $2)
         )
         (i32.store offset=8
           (get_local $2)
-          (get_local $14)
+          (get_local $13)
         )
         (i32.store offset=12
           (get_local $2)
@@ -7476,7 +7446,7 @@
                                           (set_local $15
                                             (i32.shl
                                               (get_local $1)
-                                              (set_local $14
+                                              (set_local $13
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -7497,7 +7467,7 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $14)
+                                  (get_local $13)
                                 )
                                 (set_local $15
                                   (i32.and
@@ -7572,7 +7542,7 @@
         )
       )
       (block
-        (set_local $14
+        (set_local $13
           (i32.shl
             (get_local $0)
             (select
@@ -7628,7 +7598,7 @@
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $14)
+                        (get_local $13)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7638,9 +7608,9 @@
               )
             )
             (block
-              (set_local $14
+              (set_local $13
                 (i32.shl
-                  (get_local $14)
+                  (get_local $13)
                   (i32.const 1)
                 )
               )
@@ -7703,7 +7673,7 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $14
+                  (set_local $13
                     (i32.load
                       (set_local $1
                         (i32.add
@@ -7726,7 +7696,7 @@
               )
               (block
                 (i32.store offset=12
-                  (get_local $14)
+                  (get_local $13)
                   (get_local $2)
                 )
                 (i32.store
@@ -7735,7 +7705,7 @@
                 )
                 (i32.store offset=8
                   (get_local $2)
-                  (get_local $14)
+                  (get_local $13)
                 )
                 (i32.store offset=12
                   (get_local $2)
@@ -8218,7 +8188,7 @@
     (local $6 i32)
     (local $7 i32)
     (if
-      (set_local $6
+      (set_local $5
         (i32.load
           (set_local $3
             (i32.add
@@ -8229,10 +8199,10 @@
         )
       )
       (block
-        (set_local $5
-          (get_local $6)
+        (set_local $7
+          (get_local $5)
         )
-        (set_local $4
+        (set_local $6
           (i32.const 5)
         )
       )
@@ -8240,16 +8210,16 @@
         (call $___towrite
           (get_local $2)
         )
-        (set_local $7
+        (set_local $4
           (i32.const 0)
         )
         (block
-          (set_local $5
+          (set_local $7
             (i32.load
               (get_local $3)
             )
           )
-          (set_local $4
+          (set_local $6
             (i32.const 5)
           )
         )
@@ -8258,14 +8228,14 @@
     (block $label$break$L5
       (if
         (i32.eq
-          (get_local $4)
+          (get_local $6)
           (i32.const 5)
         )
         (block
-          (set_local $4
+          (set_local $6
             (set_local $3
               (i32.load
-                (set_local $6
+                (set_local $5
                   (i32.add
                     (get_local $2)
                     (i32.const 20)
@@ -8277,13 +8247,13 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $5)
+                (get_local $7)
                 (get_local $3)
               )
               (get_local $1)
             )
             (block
-              (set_local $7
+              (set_local $4
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
@@ -8325,9 +8295,6 @@
                           (get_local $0)
                         )
                         (set_local $3
-                          (get_local $4)
-                        )
-                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$L10
@@ -8340,7 +8307,7 @@
                         (i32.load8_s
                           (i32.add
                             (get_local $0)
-                            (set_local $5
+                            (set_local $7
                               (i32.add
                                 (get_local $3)
                                 (i32.const -1)
@@ -8357,7 +8324,7 @@
                         (br $while-out$2)
                       )
                       (set_local $3
-                        (get_local $5)
+                        (get_local $7)
                       )
                     )
                     (br $while-in$3)
@@ -8380,12 +8347,7 @@
                       )
                       (get_local $4)
                     )
-                    (block
-                      (set_local $7
-                        (get_local $4)
-                      )
-                      (br $label$break$L5)
-                    )
+                    (br $label$break$L5)
                   )
                   (set_local $2
                     (i32.add
@@ -8393,12 +8355,12 @@
                       (get_local $4)
                     )
                   )
-                  (set_local $3
+                  (set_local $6
                     (i32.load
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
-                  (set_local $5
+                  (set_local $3
                     (get_local $4)
                   )
                   (i32.sub
@@ -8411,9 +8373,6 @@
                     (get_local $0)
                   )
                   (set_local $3
-                    (get_local $4)
-                  )
-                  (set_local $5
                     (i32.const 0)
                   )
                   (get_local $1)
@@ -8422,29 +8381,29 @@
             )
           )
           (call $_memcpy
-            (get_local $3)
+            (get_local $6)
             (get_local $2)
             (get_local $0)
           )
           (i32.store
-            (get_local $6)
+            (get_local $5)
             (i32.add
               (i32.load
-                (get_local $6)
+                (get_local $5)
               )
               (get_local $0)
             )
           )
-          (set_local $7
+          (set_local $4
             (i32.add
-              (get_local $5)
+              (get_local $3)
               (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $7)
+    (get_local $4)
   )
   (func $_fflush (param $0 i32) (result i32)
     (local $1 i32)
@@ -8633,10 +8592,10 @@
               )
               (get_local $0)
               (block
-                (set_local $1
+                (set_local $2
                   (get_local $0)
                 )
-                (set_local $2
+                (set_local $1
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8646,10 +8605,10 @@
           )
         )
         (block
-          (set_local $1
+          (set_local $2
             (get_local $0)
           )
-          (set_local $2
+          (set_local $1
             (i32.const 4)
           )
         )
@@ -8657,21 +8616,21 @@
     )
     (if
       (i32.eq
-        (get_local $2)
+        (get_local $1)
         (i32.const 4)
       )
       (block
-        (set_local $2
-          (get_local $1)
+        (set_local $1
+          (get_local $2)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $1
+                  (set_local $2
                     (i32.load
-                      (get_local $2)
+                      (get_local $1)
                     )
                   )
                   (i32.const -2139062144)
@@ -8679,22 +8638,14 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $1)
+                (get_local $2)
                 (i32.const -16843009)
               )
             )
-            (block
-              (set_local $0
-                (get_local $1)
-              )
-              (set_local $1
-                (get_local $2)
-              )
-              (br $while-out$3)
-            )
-            (set_local $2
+            (br $while-out$3)
+            (set_local $1
               (i32.add
-                (get_local $2)
+                (get_local $1)
                 (i32.const 4)
               )
             )
@@ -8705,7 +8656,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $0)
+                (get_local $2)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8713,7 +8664,7 @@
             (i32.const 24)
           )
           (block
-            (set_local $0
+            (set_local $2
               (get_local $1)
             )
             (loop $while-out$5 $while-in$6
@@ -8721,30 +8672,23 @@
                 (i32.load8_s
                   (set_local $1
                     (i32.add
-                      (get_local $0)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $0
+                (set_local $2
                   (get_local $1)
                 )
-                (block
-                  (set_local $0
-                    (get_local $1)
-                  )
-                  (br $while-out$5)
-                )
+                (br $while-out$5)
               )
               (br $while-in$6)
             )
           )
-          (set_local $0
-            (get_local $1)
-          )
+          (get_local $1)
         )
         (set_local $5
-          (get_local $0)
+          (get_local $1)
         )
       )
     )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -459,10 +459,10 @@
           (i32.const 87)
         )
         (block
-          (set_local $2
+          (set_local $3
             (i32.const 87)
           )
-          (set_local $3
+          (set_local $2
             (i32.const 775)
           )
           (set_local $0
@@ -488,10 +488,10 @@
           (i32.const 775)
         )
         (block
-          (set_local $2
+          (set_local $3
             (get_local $4)
           )
-          (set_local $3
+          (set_local $2
             (i32.const 775)
           )
           (set_local $0
@@ -506,13 +506,10 @@
         (i32.const 5)
       )
       (loop $while-out$2 $while-in$3
-        (set_local $1
-          (get_local $3)
-        )
         (loop $while-out$4 $while-in$5
           (set_local $0
             (i32.add
-              (get_local $1)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -521,7 +518,7 @@
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $1)
+                    (get_local $2)
                   )
                   (i32.const 24)
                 )
@@ -535,7 +532,7 @@
               )
               (br $while-out$4)
             )
-            (set_local $1
+            (set_local $2
               (get_local $0)
             )
           )
@@ -545,7 +542,7 @@
           (i32.eq
             (set_local $0
               (i32.add
-                (get_local $2)
+                (get_local $3)
                 (i32.const -1)
               )
             )
@@ -558,10 +555,10 @@
             (br $while-out$2)
           )
           (block
-            (set_local $2
+            (set_local $3
               (get_local $0)
             )
-            (set_local $3
+            (set_local $2
               (get_local $1)
             )
           )
@@ -1086,13 +1083,13 @@
       (get_local $8)
     )
     (i32.store
-      (set_local $3
+      (set_local $4
         (i32.add
           (get_local $8)
           (i32.const 32)
         )
       )
-      (set_local $4
+      (set_local $3
         (i32.load
           (set_local $7
             (i32.add
@@ -1104,8 +1101,8 @@
       )
     )
     (i32.store offset=4
-      (get_local $3)
-      (set_local $4
+      (get_local $4)
+      (set_local $3
         (i32.sub
           (i32.load
             (set_local $11
@@ -1115,16 +1112,16 @@
               )
             )
           )
-          (get_local $4)
+          (get_local $3)
         )
       )
     )
     (i32.store offset=8
-      (get_local $3)
+      (get_local $4)
       (get_local $1)
     )
     (i32.store offset=12
-      (get_local $3)
+      (get_local $4)
       (get_local $2)
     )
     (set_local $12
@@ -1139,23 +1136,20 @@
         (i32.const 44)
       )
     )
-    (set_local $5
-      (get_local $3)
-    )
     (set_local $6
       (i32.const 2)
     )
-    (set_local $4
+    (set_local $3
       (i32.add
-        (get_local $4)
+        (get_local $3)
         (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
       (if
         (i32.eq
-          (get_local $4)
-          (set_local $3
+          (get_local $3)
+          (set_local $5
             (if
               (i32.eq
                 (i32.load
@@ -1172,7 +1166,7 @@
                 )
                 (i32.store offset=4
                   (get_local $9)
-                  (get_local $5)
+                  (get_local $4)
                 )
                 (i32.store offset=8
                   (get_local $9)
@@ -1198,7 +1192,7 @@
                 )
                 (i32.store offset=4
                   (get_local $10)
-                  (get_local $5)
+                  (get_local $4)
                 )
                 (i32.store offset=8
                   (get_local $10)
@@ -1229,12 +1223,12 @@
       )
       (if
         (i32.lt_s
-          (get_local $3)
+          (get_local $5)
           (i32.const 0)
         )
         (block
           (set_local $15
-            (get_local $5)
+            (get_local $4)
           )
           (set_local $16
             (get_local $6)
@@ -1247,24 +1241,24 @@
       )
       (set_local $17
         (i32.sub
-          (get_local $4)
           (get_local $3)
+          (get_local $5)
         )
       )
       (set_local $1
         (if
           (i32.gt_u
-            (get_local $3)
+            (get_local $5)
             (set_local $1
               (i32.load offset=4
-                (get_local $5)
+                (get_local $4)
               )
             )
           )
           (block
             (i32.store
               (get_local $7)
-              (set_local $4
+              (set_local $3
                 (i32.load
                   (get_local $13)
                 )
@@ -1272,17 +1266,17 @@
             )
             (i32.store
               (get_local $11)
-              (get_local $4)
+              (get_local $3)
             )
-            (set_local $4
+            (set_local $5
               (i32.sub
-                (get_local $3)
+                (get_local $5)
                 (get_local $1)
               )
             )
             (set_local $3
               (i32.add
-                (get_local $5)
+                (get_local $4)
                 (i32.const 8)
               )
             )
@@ -1293,7 +1287,7 @@
               )
             )
             (i32.load offset=12
-              (get_local $5)
+              (get_local $4)
             )
           )
           (if
@@ -1308,14 +1302,11 @@
                   (i32.load
                     (get_local $7)
                   )
-                  (get_local $3)
+                  (get_local $5)
                 )
               )
-              (set_local $4
-                (get_local $3)
-              )
               (set_local $3
-                (get_local $5)
+                (get_local $4)
               )
               (set_local $6
                 (i32.const 2)
@@ -1323,11 +1314,8 @@
               (get_local $1)
             )
             (block
-              (set_local $4
-                (get_local $3)
-              )
               (set_local $3
-                (get_local $5)
+                (get_local $4)
               )
               (get_local $1)
             )
@@ -1340,20 +1328,20 @@
           (i32.load
             (get_local $3)
           )
-          (get_local $4)
+          (get_local $5)
         )
       )
       (i32.store offset=4
         (get_local $3)
         (i32.sub
           (get_local $1)
-          (get_local $4)
+          (get_local $5)
         )
       )
-      (set_local $5
+      (set_local $4
         (get_local $3)
       )
-      (set_local $4
+      (set_local $3
         (get_local $17)
       )
       (br $while-in$1)
@@ -1379,13 +1367,11 @@
         )
         (i32.store
           (get_local $7)
-          (set_local $0
-            (get_local $1)
-          )
+          (get_local $1)
         )
         (i32.store
           (get_local $11)
-          (get_local $0)
+          (get_local $1)
         )
         (set_local $14
           (get_local $2)
@@ -1778,9 +1764,9 @@
     )
     (if
       (i32.eq
-        (set_local $3
+        (set_local $6
           (i32.load
-            (set_local $6
+            (set_local $5
               (i32.add
                 (get_local $2)
                 (i32.const 16)
@@ -1798,22 +1784,22 @@
           (i32.const 0)
         )
         (block
-          (set_local $4
+          (set_local $3
             (i32.load
-              (get_local $6)
+              (get_local $5)
             )
           )
           (set_local $7
             (i32.const 5)
           )
         )
-        (set_local $5
+        (set_local $4
           (i32.const 0)
         )
       )
       (block
-        (set_local $4
-          (get_local $3)
+        (set_local $3
+          (get_local $6)
         )
         (set_local $7
           (i32.const 5)
@@ -1827,13 +1813,13 @@
           (i32.const 5)
         )
         (block
-          (set_local $4
+          (set_local $3
             (i32.lt_u
               (i32.sub
-                (get_local $4)
-                (set_local $3
+                (get_local $3)
+                (set_local $6
                   (i32.load
-                    (set_local $6
+                    (set_local $5
                       (i32.add
                         (get_local $2)
                         (i32.const 20)
@@ -1846,9 +1832,9 @@
             )
           )
           (if
-            (get_local $4)
+            (get_local $3)
             (block
-              (set_local $5
+              (set_local $4
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
@@ -1883,13 +1869,13 @@
                   (i32.const -1)
                 )
                 (block
-                  (set_local $4
+                  (set_local $3
                     (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eq
-                        (get_local $4)
+                        (get_local $3)
                         (i32.const 0)
                       )
                       (block
@@ -1897,7 +1883,7 @@
                           (i32.const 0)
                         )
                         (br $label$break$L10
-                          (get_local $3)
+                          (get_local $6)
                         )
                       )
                     )
@@ -1908,9 +1894,9 @@
                             (i32.load8_s
                               (i32.add
                                 (get_local $0)
-                                (set_local $5
+                                (set_local $4
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $3)
                                     (i32.const -1)
                                   )
                                 )
@@ -1922,14 +1908,9 @@
                         )
                         (i32.const 10)
                       )
-                      (block
-                        (set_local $3
-                          (get_local $4)
-                        )
-                        (br $while-out$2)
-                      )
-                      (set_local $4
-                        (get_local $5)
+                      (br $while-out$2)
+                      (set_local $3
+                        (get_local $4)
                       )
                     )
                     (br $while-in$3)
@@ -1953,7 +1934,7 @@
                       (get_local $3)
                     )
                     (block
-                      (set_local $5
+                      (set_local $4
                         (get_local $3)
                       )
                       (br $label$break$L5)
@@ -1975,14 +1956,14 @@
                     )
                   )
                   (i32.load
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
                 (block
                   (set_local $2
                     (i32.const 0)
                   )
-                  (get_local $3)
+                  (get_local $6)
                 )
               )
             )
@@ -1990,15 +1971,15 @@
             (get_local $1)
           )
           (i32.store
-            (get_local $6)
+            (get_local $5)
             (i32.add
               (i32.load
-                (get_local $6)
+                (get_local $5)
               )
               (get_local $1)
             )
           )
-          (set_local $5
+          (set_local $4
             (i32.add
               (get_local $2)
               (get_local $1)
@@ -2007,7 +1988,7 @@
         )
       )
     )
-    (get_local $5)
+    (get_local $4)
   )
   (func $___towrite (param $0 i32) (result i32)
     (local $1 i32)
@@ -2347,7 +2328,7 @@
     (i32.load
       (i32.const 8)
     )
-    (set_local $5
+    (set_local $16
       (i32.and
         (get_local $1)
         (i32.const 255)
@@ -2356,7 +2337,7 @@
     (block $label$break$L1
       (if
         (i32.and
-          (set_local $4
+          (set_local $6
             (i32.ne
               (get_local $2)
               (i32.const 0)
@@ -2371,7 +2352,7 @@
           )
         )
         (block
-          (set_local $4
+          (set_local $6
             (i32.and
               (get_local $1)
               (i32.const 255)
@@ -2397,17 +2378,17 @@
                 )
                 (i32.shr_s
                   (i32.shl
-                    (get_local $4)
+                    (get_local $6)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
               (block
-                (set_local $6
+                (set_local $4
                   (get_local $3)
                 )
-                (set_local $7
+                (set_local $5
                   (get_local $2)
                 )
                 (set_local $3
@@ -2446,13 +2427,13 @@
                 (get_local $0)
               )
               (block
-                (set_local $11
+                (set_local $14
                   (get_local $0)
                 )
-                (set_local $13
+                (set_local $11
                   (get_local $2)
                 )
-                (set_local $16
+                (set_local $15
                   (get_local $3)
                 )
                 (set_local $3
@@ -2465,14 +2446,14 @@
           )
         )
         (block
-          (set_local $11
+          (set_local $14
             (get_local $2)
           )
-          (set_local $13
+          (set_local $11
             (get_local $0)
           )
-          (set_local $16
-            (get_local $4)
+          (set_local $15
+            (get_local $6)
           )
           (set_local $3
             (i32.const 5)
@@ -2486,24 +2467,24 @@
         (i32.const 5)
       )
       (if
-        (get_local $16)
+        (get_local $15)
         (block
-          (set_local $6
-            (get_local $11)
+          (set_local $4
+            (get_local $14)
           )
-          (set_local $7
-            (get_local $13)
+          (set_local $5
+            (get_local $11)
           )
           (set_local $3
             (i32.const 6)
           )
         )
         (block
-          (set_local $8
+          (set_local $7
             (i32.const 0)
           )
-          (set_local $9
-            (get_local $13)
+          (set_local $8
+            (get_local $11)
           )
         )
       )
@@ -2519,7 +2500,7 @@
             (i32.shr_s
               (i32.shl
                 (i32.load8_s
-                  (get_local $7)
+                  (get_local $5)
                 )
                 (i32.const 24)
               )
@@ -2539,37 +2520,31 @@
             )
           )
           (block
-            (set_local $8
-              (get_local $6)
+            (set_local $7
+              (get_local $4)
             )
-            (set_local $9
-              (get_local $7)
+            (set_local $8
+              (get_local $5)
             )
           )
           (block
             (set_local $2
               (i32.mul
-                (get_local $5)
+                (get_local $16)
                 (i32.const 16843009)
               )
             )
             (block $label$break$L11
               (if
                 (i32.gt_u
-                  (get_local $6)
+                  (get_local $4)
                   (i32.const 3)
                 )
                 (block
-                  (set_local $4
-                    (get_local $6)
-                  )
-                  (set_local $5
-                    (get_local $7)
-                  )
                   (loop $while-out$5 $while-in$6
                     (set_local $1
                       (i32.add
-                        (set_local $11
+                        (set_local $6
                           (i32.xor
                             (i32.load
                               (get_local $5)
@@ -2585,7 +2560,7 @@
                         (i32.and
                           (i32.xor
                             (i32.and
-                              (get_local $11)
+                              (get_local $6)
                               (i32.const -2139062144)
                             )
                             (i32.const -2139062144)
@@ -2594,15 +2569,7 @@
                         )
                         (i32.const 0)
                       )
-                      (block
-                        (set_local $1
-                          (get_local $4)
-                        )
-                        (set_local $2
-                          (get_local $5)
-                        )
-                        (br $while-out$5)
-                      )
+                      (br $while-out$5)
                     )
                     (set_local $1
                       (i32.add
@@ -2624,10 +2591,10 @@
                         (get_local $1)
                       )
                       (block
-                        (set_local $14
+                        (set_local $12
                           (get_local $4)
                         )
-                        (set_local $15
+                        (set_local $13
                           (get_local $1)
                         )
                         (set_local $3
@@ -2638,19 +2605,19 @@
                     )
                     (br $while-in$6)
                   )
-                  (set_local $12
-                    (get_local $1)
-                  )
                   (set_local $10
-                    (get_local $2)
+                    (get_local $4)
+                  )
+                  (set_local $9
+                    (get_local $5)
                   )
                 )
                 (block
-                  (set_local $14
-                    (get_local $6)
+                  (set_local $12
+                    (get_local $4)
                   )
-                  (set_local $15
-                    (get_local $7)
+                  (set_local $13
+                    (get_local $5)
                   )
                   (set_local $3
                     (i32.const 11)
@@ -2665,24 +2632,24 @@
               )
               (if
                 (i32.eq
-                  (get_local $14)
+                  (get_local $12)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $8
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $9
-                    (get_local $15)
+                  (set_local $8
+                    (get_local $13)
                   )
                   (br $label$break$L8)
                 )
                 (block
-                  (set_local $12
-                    (get_local $14)
-                  )
                   (set_local $10
-                    (get_local $15)
+                    (get_local $12)
+                  )
+                  (set_local $9
+                    (get_local $13)
                   )
                 )
               )
@@ -2693,7 +2660,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s
-                        (get_local $10)
+                        (get_local $9)
                       )
                       (i32.const 24)
                     )
@@ -2708,18 +2675,18 @@
                   )
                 )
                 (block
-                  (set_local $8
-                    (get_local $12)
-                  )
-                  (set_local $9
+                  (set_local $7
                     (get_local $10)
+                  )
+                  (set_local $8
+                    (get_local $9)
                   )
                   (br $label$break$L8)
                 )
               )
               (set_local $2
                 (i32.add
-                  (get_local $10)
+                  (get_local $9)
                   (i32.const 1)
                 )
               )
@@ -2727,26 +2694,26 @@
                 (i32.eq
                   (set_local $1
                     (i32.add
-                      (get_local $12)
+                      (get_local $10)
                       (i32.const -1)
                     )
                   )
                   (i32.const 0)
                 )
                 (block
-                  (set_local $8
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $9
+                  (set_local $8
                     (get_local $2)
                   )
                   (br $while-out$7)
                 )
                 (block
-                  (set_local $12
+                  (set_local $10
                     (get_local $1)
                   )
-                  (set_local $10
+                  (set_local $9
                     (get_local $2)
                   )
                 )
@@ -2758,10 +2725,10 @@
       )
     )
     (select
-      (get_local $9)
+      (get_local $8)
       (i32.const 0)
       (i32.ne
-        (get_local $8)
+        (get_local $7)
         (i32.const 0)
       )
     )
@@ -2951,8 +2918,8 @@
     (local $11 i32)
     (local $12 i32)
     (local $13 i32)
-    (local $14 f64)
-    (local $15 i32)
+    (local $14 i32)
+    (local $15 f64)
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
@@ -2966,8 +2933,8 @@
     (local $26 i32)
     (local $27 i32)
     (local $28 i32)
-    (local $29 f64)
-    (local $30 i32)
+    (local $29 i32)
+    (local $30 f64)
     (local $31 i32)
     (local $32 i32)
     (local $33 i32)
@@ -3052,7 +3019,7 @@
         (i32.const 16)
       )
     )
-    (set_local $18
+    (set_local $19
       (get_local $31)
     )
     (set_local $63
@@ -3061,14 +3028,14 @@
         (i32.const 528)
       )
     )
-    (set_local $45
+    (set_local $44
       (i32.ne
         (get_local $0)
         (i32.const 0)
       )
     )
     (set_local $71
-      (set_local $27
+      (set_local $28
         (i32.add
           (set_local $5
             (i32.add
@@ -3097,7 +3064,7 @@
         (i32.const 4)
       )
     )
-    (set_local $54
+    (set_local $52
       (i32.add
         (set_local $5
           (i32.add
@@ -3116,11 +3083,11 @@
     )
     (set_local $77
       (i32.sub
-        (set_local $41
-          (get_local $54)
+        (set_local $40
+          (get_local $52)
         )
         (set_local $64
-          (set_local $28
+          (set_local $29
             (i32.add
               (get_local $31)
               (i32.const 588)
@@ -3137,7 +3104,7 @@
     )
     (set_local $79
       (i32.add
-        (get_local $41)
+        (get_local $40)
         (i32.const 2)
       )
     )
@@ -3153,20 +3120,20 @@
       )
     )
     (set_local $75
-      (set_local $46
+      (set_local $45
         (i32.add
-          (get_local $28)
+          (get_local $29)
           (i32.const 9)
         )
       )
     )
-    (set_local $55
+    (set_local $53
       (i32.add
-        (get_local $28)
+        (get_local $29)
         (i32.const 8)
       )
     )
-    (set_local $19
+    (set_local $22
       (i32.const 0)
     )
     (set_local $20
@@ -3175,14 +3142,14 @@
     (set_local $1
       (i32.const 0)
     )
-    (set_local $11
+    (set_local $8
       (i32.const 0)
     )
     (loop $label$break$L1 $label$continue$L1
-      (set_local $8
+      (set_local $22
         (if
           (i32.gt_s
-            (get_local $19)
+            (get_local $22)
             (i32.const -1)
           )
           (if
@@ -3190,7 +3157,7 @@
               (get_local $1)
               (i32.sub
                 (i32.const 2147483647)
-                (get_local $19)
+                (get_local $22)
               )
             )
             (block
@@ -3202,10 +3169,10 @@
             )
             (i32.add
               (get_local $1)
-              (get_local $19)
+              (get_local $22)
             )
           )
-          (get_local $19)
+          (get_local $22)
         )
       )
       (if
@@ -3225,10 +3192,10 @@
         )
         (block
           (set_local $82
-            (get_local $8)
+            (get_local $22)
           )
           (set_local $83
-            (get_local $11)
+            (get_local $8)
           )
           (set_local $12
             (i32.const 242)
@@ -3257,7 +3224,7 @@
                   )
                 )
               )
-              (set_local $56
+              (set_local $54
                 (get_local $5)
               )
               (set_local $65
@@ -3268,10 +3235,10 @@
               )
               (br $label$break$L9)
             )
-            (set_local $42
+            (set_local $41
               (get_local $5)
             )
-            (set_local $57
+            (set_local $55
               (get_local $5)
             )
             (br $label$break$L9)
@@ -3304,7 +3271,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s offset=1
-                      (get_local $56)
+                      (get_local $54)
                     )
                     (i32.const 24)
                   )
@@ -3313,10 +3280,10 @@
                 (i32.const 37)
               )
               (block
-                (set_local $42
-                  (get_local $56)
+                (set_local $41
+                  (get_local $54)
                 )
-                (set_local $57
+                (set_local $55
                   (get_local $65)
                 )
                 (br $label$break$L12)
@@ -3335,7 +3302,7 @@
                     (i32.load8_s
                       (set_local $1
                         (i32.add
-                          (get_local $56)
+                          (get_local $54)
                           (i32.const 2)
                         )
                       )
@@ -3347,7 +3314,7 @@
                 (i32.const 37)
               )
               (block
-                (set_local $56
+                (set_local $54
                   (get_local $1)
                 )
                 (set_local $65
@@ -3355,10 +3322,10 @@
                 )
               )
               (block
-                (set_local $42
+                (set_local $41
                   (get_local $1)
                 )
-                (set_local $57
+                (set_local $55
                   (get_local $5)
                 )
                 (br $while-out$7)
@@ -3368,14 +3335,14 @@
           )
         )
       )
-      (set_local $16
+      (set_local $17
         (i32.sub
-          (get_local $57)
+          (get_local $55)
           (get_local $20)
         )
       )
       (if
-        (get_local $45)
+        (get_local $44)
         (if
           (i32.eq
             (i32.and
@@ -3388,33 +3355,30 @@
           )
           (call $___fwritex
             (get_local $20)
-            (get_local $16)
+            (get_local $17)
             (get_local $0)
           )
         )
       )
       (if
         (i32.ne
-          (get_local $57)
+          (get_local $55)
           (get_local $20)
         )
         (block
-          (set_local $19
-            (get_local $8)
-          )
           (set_local $20
-            (get_local $42)
+            (get_local $41)
           )
           (set_local $1
-            (get_local $16)
+            (get_local $17)
           )
           (br $label$continue$L1)
         )
       )
-      (set_local $6
+      (set_local $7
         (if
           (i32.lt_u
-            (set_local $7
+            (set_local $6
               (i32.add
                 (i32.shr_s
                   (i32.shl
@@ -3422,7 +3386,7 @@
                       (i32.load8_s
                         (set_local $5
                           (i32.add
-                            (get_local $42)
+                            (get_local $41)
                             (i32.const 1)
                           )
                         )
@@ -3443,16 +3407,16 @@
                 (set_local $5
                   (select
                     (i32.add
-                      (get_local $42)
+                      (get_local $41)
                       (i32.const 3)
                     )
                     (get_local $5)
-                    (set_local $6
+                    (set_local $7
                       (i32.eq
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s offset=2
-                              (get_local $42)
+                              (get_local $41)
                             )
                             (i32.const 24)
                           )
@@ -3465,25 +3429,25 @@
                 )
               )
             )
-            (set_local $13
+            (set_local $11
               (select
                 (i32.const 1)
-                (get_local $11)
-                (get_local $6)
+                (get_local $8)
+                (get_local $7)
               )
             )
             (set_local $9
               (get_local $5)
             )
             (select
-              (get_local $7)
-              (i32.const -1)
               (get_local $6)
+              (i32.const -1)
+              (get_local $7)
             )
           )
           (block
-            (set_local $13
-              (get_local $11)
+            (set_local $11
+              (get_local $8)
             )
             (set_local $9
               (get_local $5)
@@ -3510,7 +3474,7 @@
             (i32.const 32)
           )
           (block
-            (set_local $7
+            (set_local $8
               (i32.const 0)
             )
             (loop $while-out$10 $while-in$11
@@ -3528,14 +3492,9 @@
                   )
                   (i32.const 0)
                 )
-                (block
-                  (set_local $11
-                    (get_local $7)
-                  )
-                  (br $label$break$L25)
-                )
+                (br $label$break$L25)
               )
-              (set_local $7
+              (set_local $8
                 (i32.or
                   (i32.shl
                     (i32.const 1)
@@ -3550,18 +3509,18 @@
                       (i32.const -32)
                     )
                   )
-                  (get_local $7)
+                  (get_local $8)
                 )
               )
               (if
-                (i32.ne
+                (i32.eq
                   (i32.and
                     (set_local $5
                       (i32.shr_s
                         (i32.shl
                           (set_local $1
                             (i32.load8_s
-                              (set_local $9
+                              (set_local $6
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 1)
@@ -3578,9 +3537,12 @@
                   )
                   (i32.const 32)
                 )
+                (set_local $9
+                  (get_local $6)
+                )
                 (block
-                  (set_local $11
-                    (get_local $7)
+                  (set_local $9
+                    (get_local $6)
                   )
                   (br $while-out$10)
                 )
@@ -3588,7 +3550,7 @@
               (br $while-in$11)
             )
           )
-          (set_local $11
+          (set_local $8
             (i32.const 0)
           )
         )
@@ -3613,7 +3575,7 @@
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (get_local $9)
                               (i32.const 1)
@@ -3663,7 +3625,7 @@
                               (i32.shr_s
                                 (i32.shl
                                   (i32.load8_s
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.const 24)
                                 )
@@ -3689,7 +3651,7 @@
                       (i32.const 3)
                     )
                   )
-                  (set_local $58
+                  (set_local $56
                     (get_local $5)
                   )
                 )
@@ -3712,11 +3674,11 @@
                 )
                 (if
                   (i32.ne
-                    (get_local $13)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (block
-                    (set_local $23
+                    (set_local $24
                       (i32.const -1)
                     )
                     (br $label$break$L1)
@@ -3724,16 +3686,16 @@
                 )
                 (if
                   (i32.eqz
-                    (get_local $45)
+                    (get_local $44)
                   )
                   (block
                     (set_local $9
-                      (get_local $7)
+                      (get_local $6)
                     )
-                    (set_local $22
+                    (set_local $21
                       (i32.const 0)
                     )
-                    (set_local $15
+                    (set_local $16
                       (i32.const 0)
                     )
                     (br $do-once$12)
@@ -3765,34 +3727,34 @@
                   (i32.const 0)
                 )
                 (set_local $67
-                  (get_local $7)
+                  (get_local $6)
                 )
-                (set_local $58
+                (set_local $56
                   (get_local $5)
                 )
               )
             )
-            (set_local $11
+            (set_local $8
               (if
                 (i32.lt_s
-                  (get_local $58)
+                  (get_local $56)
                   (i32.const 0)
                 )
                 (block
                   (set_local $9
                     (get_local $67)
                   )
-                  (set_local $22
+                  (set_local $21
                     (get_local $66)
                   )
-                  (set_local $15
+                  (set_local $16
                     (i32.sub
                       (i32.const 0)
-                      (get_local $58)
+                      (get_local $56)
                     )
                   )
                   (i32.or
-                    (get_local $11)
+                    (get_local $8)
                     (i32.const 8192)
                   )
                 )
@@ -3800,20 +3762,20 @@
                   (set_local $9
                     (get_local $67)
                   )
-                  (set_local $22
+                  (set_local $21
                     (get_local $66)
                   )
-                  (set_local $15
-                    (get_local $58)
+                  (set_local $16
+                    (get_local $56)
                   )
-                  (get_local $11)
+                  (get_local $8)
                 )
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $7
+              (set_local $6
                 (i32.add
                   (i32.shr_s
                     (i32.shl
@@ -3841,17 +3803,17 @@
                       (get_local $5)
                       (i32.const 10)
                     )
-                    (get_local $7)
+                    (get_local $6)
                   )
                 )
                 (if
-                  (i32.lt_u
-                    (set_local $9
+                  (i32.ge_u
+                    (set_local $6
                       (i32.add
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s
-                              (set_local $7
+                              (set_local $1
                                 (i32.add
                                   (get_local $1)
                                   (i32.const 1)
@@ -3867,62 +3829,46 @@
                     )
                     (i32.const 10)
                   )
-                  (block
-                    (set_local $1
-                      (get_local $7)
-                    )
-                    (set_local $7
-                      (get_local $9)
-                    )
-                  )
-                  (block
-                    (set_local $1
-                      (get_local $5)
-                    )
-                    (set_local $5
-                      (get_local $7)
-                    )
-                    (br $while-out$14)
-                  )
+                  (br $while-out$14)
                 )
                 (br $while-in$15)
               )
               (if
                 (i32.lt_s
-                  (get_local $1)
+                  (get_local $5)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $23
+                  (set_local $24
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
                 (block
                   (set_local $9
-                    (get_local $5)
-                  )
-                  (set_local $22
-                    (get_local $13)
-                  )
-                  (set_local $15
                     (get_local $1)
+                  )
+                  (set_local $21
+                    (get_local $11)
+                  )
+                  (set_local $16
+                    (get_local $5)
                   )
                 )
               )
             )
             (block
-              (set_local $22
-                (get_local $13)
+              (set_local $21
+                (get_local $11)
               )
-              (set_local $15
+              (set_local $16
                 (i32.const 0)
               )
             )
           )
         )
       )
-      (set_local $13
+      (set_local $11
         (block $label$break$L46
           (if
             (i32.eq
@@ -3961,7 +3907,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (set_local $7
+                      (set_local $6
                         (i32.add
                           (i32.shr_s
                             (i32.shl
@@ -3999,12 +3945,12 @@
                           (get_local $5)
                           (i32.const 10)
                         )
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                     (if
                       (i32.ge_u
-                        (set_local $7
+                        (set_local $6
                           (i32.add
                             (i32.shr_s
                               (i32.shl
@@ -4045,7 +3991,7 @@
                       (i32.shr_s
                         (i32.shl
                           (i32.load8_s
-                            (set_local $7
+                            (set_local $6
                               (i32.add
                                 (get_local $9)
                                 (i32.const 2)
@@ -4095,7 +4041,7 @@
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.load8_s
-                                      (get_local $7)
+                                      (get_local $6)
                                     )
                                     (i32.const 24)
                                   )
@@ -4126,18 +4072,18 @@
               )
               (if
                 (i32.ne
-                  (get_local $22)
+                  (get_local $21)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $23
+                  (set_local $24
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
               )
               (if
-                (get_local $45)
+                (get_local $44)
                 (block
                   (set_local $5
                     (i32.load
@@ -4164,13 +4110,13 @@
                   (set_local $10
                     (get_local $5)
                   )
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (block
                   (set_local $10
                     (i32.const 0)
                   )
-                  (get_local $7)
+                  (get_local $6)
                 )
               )
             )
@@ -4183,7 +4129,7 @@
           )
         )
       )
-      (set_local $19
+      (set_local $13
         (i32.const 0)
       )
       (loop $while-out$19 $while-in$20
@@ -4194,7 +4140,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $13)
+                      (get_local $11)
                     )
                     (i32.const 24)
                   )
@@ -4206,7 +4152,7 @@
             (i32.const 57)
           )
           (block
-            (set_local $23
+            (set_local $24
               (i32.const -1)
             )
             (br $label$break$L1)
@@ -4214,7 +4160,7 @@
         )
         (set_local $9
           (i32.add
-            (get_local $13)
+            (get_local $11)
             (i32.const 1)
           )
         )
@@ -4229,7 +4175,7 @@
                         (i32.add
                           (i32.const 3611)
                           (i32.mul
-                            (get_local $19)
+                            (get_local $13)
                             (i32.const 58)
                           )
                         )
@@ -4245,15 +4191,15 @@
             (i32.const 8)
           )
           (block
-            (set_local $13
+            (set_local $11
               (get_local $9)
             )
-            (set_local $19
+            (set_local $13
               (get_local $5)
             )
           )
           (block
-            (set_local $7
+            (set_local $6
               (get_local $5)
             )
             (br $while-out$19)
@@ -4273,7 +4219,7 @@
           (i32.const 0)
         )
         (block
-          (set_local $23
+          (set_local $24
             (i32.const -1)
           )
           (br $label$break$L1)
@@ -4281,7 +4227,7 @@
       )
       (set_local $5
         (i32.gt_s
-          (get_local $6)
+          (get_local $7)
           (i32.const -1)
         )
       )
@@ -4300,7 +4246,7 @@
           (if
             (get_local $5)
             (block
-              (set_local $23
+              (set_local $24
                 (i32.const -1)
               )
               (br $label$break$L1)
@@ -4317,11 +4263,11 @@
                   (i32.add
                     (get_local $4)
                     (i32.shl
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 2)
                     )
                   )
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (set_local $5
                   (i32.load
@@ -4329,7 +4275,7 @@
                       (i32.add
                         (get_local $3)
                         (i32.shl
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 3)
                         )
                       )
@@ -4342,13 +4288,13 @@
                   )
                 )
                 (i32.store
-                  (set_local $6
-                    (get_local $18)
+                  (set_local $7
+                    (get_local $19)
                   )
                   (get_local $5)
                 )
                 (i32.store offset=4
-                  (get_local $6)
+                  (get_local $7)
                   (get_local $1)
                 )
                 (set_local $12
@@ -4359,18 +4305,18 @@
             )
             (if
               (i32.eqz
-                (get_local $45)
+                (get_local $44)
               )
               (block
-                (set_local $23
+                (set_local $24
                   (i32.const 0)
                 )
                 (br $label$break$L1)
               )
             )
             (call $_pop_arg_336
-              (get_local $18)
-              (get_local $7)
+              (get_local $19)
+              (get_local $6)
               (get_local $2)
             )
           )
@@ -4387,20 +4333,17 @@
           )
           (if
             (i32.eqz
-              (get_local $45)
+              (get_local $44)
             )
             (block
-              (set_local $19
-                (get_local $8)
-              )
               (set_local $20
                 (get_local $9)
               )
               (set_local $1
-                (get_local $16)
+                (get_local $17)
               )
-              (set_local $11
-                (get_local $22)
+              (set_local $8
+                (get_local $21)
               )
               (br $label$continue$L1)
             )
@@ -4410,7 +4353,7 @@
       (set_local $5
         (i32.and
           (i32.ne
-            (get_local $19)
+            (get_local $13)
             (i32.const 0)
           )
           (i32.eq
@@ -4419,7 +4362,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $13)
+                      (get_local $11)
                     )
                     (i32.const 24)
                   )
@@ -4432,18 +4375,18 @@
           )
         )
       )
-      (set_local $17
+      (set_local $18
         (select
-          (get_local $11)
+          (get_local $8)
           (set_local $7
             (i32.and
-              (get_local $11)
+              (get_local $8)
               (i32.const -65537)
             )
           )
           (i32.eq
             (i32.and
-              (get_local $11)
+              (get_local $8)
               (i32.const 8192)
             )
             (i32.const 0)
@@ -4477,7 +4420,7 @@
                                                       (block $switch-case$34
                                                         (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
                                                           (i32.sub
-                                                            (set_local $33
+                                                            (set_local $26
                                                               (select
                                                                 (i32.and
                                                                   (get_local $1)
@@ -4502,65 +4445,59 @@
                                                                       (block $switch-case$26
                                                                         (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
                                                                           (i32.sub
-                                                                            (get_local $19)
+                                                                            (get_local $13)
                                                                             (i32.const 0)
                                                                           )
                                                                         )
                                                                       )
                                                                       (i32.store
                                                                         (i32.load
-                                                                          (get_local $18)
+                                                                          (get_local $19)
                                                                         )
-                                                                        (get_local $8)
-                                                                      )
-                                                                      (set_local $19
-                                                                        (get_local $8)
+                                                                        (get_local $22)
                                                                       )
                                                                       (set_local $20
                                                                         (get_local $9)
                                                                       )
                                                                       (set_local $1
-                                                                        (get_local $16)
+                                                                        (get_local $17)
                                                                       )
-                                                                      (set_local $11
-                                                                        (get_local $22)
+                                                                      (set_local $8
+                                                                        (get_local $21)
                                                                       )
                                                                       (br $label$continue$L1)
                                                                     )
                                                                     (i32.store
                                                                       (i32.load
-                                                                        (get_local $18)
+                                                                        (get_local $19)
                                                                       )
-                                                                      (get_local $8)
-                                                                    )
-                                                                    (set_local $19
-                                                                      (get_local $8)
+                                                                      (get_local $22)
                                                                     )
                                                                     (set_local $20
                                                                       (get_local $9)
                                                                     )
                                                                     (set_local $1
-                                                                      (get_local $16)
+                                                                      (get_local $17)
                                                                     )
-                                                                    (set_local $11
-                                                                      (get_local $22)
+                                                                    (set_local $8
+                                                                      (get_local $21)
                                                                     )
                                                                     (br $label$continue$L1)
                                                                   )
                                                                   (i32.store
                                                                     (set_local $1
                                                                       (i32.load
-                                                                        (get_local $18)
+                                                                        (get_local $19)
                                                                       )
                                                                     )
-                                                                    (get_local $8)
+                                                                    (get_local $22)
                                                                   )
                                                                   (i32.store offset=4
                                                                     (get_local $1)
                                                                     (i32.shr_s
                                                                       (i32.shl
                                                                         (i32.lt_s
-                                                                          (get_local $8)
+                                                                          (get_local $22)
                                                                           (i32.const 0)
                                                                         )
                                                                         (i32.const 31)
@@ -4568,100 +4505,88 @@
                                                                       (i32.const 31)
                                                                     )
                                                                   )
-                                                                  (set_local $19
-                                                                    (get_local $8)
-                                                                  )
                                                                   (set_local $20
                                                                     (get_local $9)
                                                                   )
                                                                   (set_local $1
-                                                                    (get_local $16)
+                                                                    (get_local $17)
                                                                   )
-                                                                  (set_local $11
-                                                                    (get_local $22)
+                                                                  (set_local $8
+                                                                    (get_local $21)
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
                                                                 (i32.store16
                                                                   (i32.load
-                                                                    (get_local $18)
+                                                                    (get_local $19)
                                                                   )
                                                                   (i32.and
-                                                                    (get_local $8)
+                                                                    (get_local $22)
                                                                     (i32.const 65535)
                                                                   )
-                                                                )
-                                                                (set_local $19
-                                                                  (get_local $8)
                                                                 )
                                                                 (set_local $20
                                                                   (get_local $9)
                                                                 )
                                                                 (set_local $1
-                                                                  (get_local $16)
+                                                                  (get_local $17)
                                                                 )
-                                                                (set_local $11
-                                                                  (get_local $22)
+                                                                (set_local $8
+                                                                  (get_local $21)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
                                                               (i32.store8
                                                                 (i32.load
-                                                                  (get_local $18)
+                                                                  (get_local $19)
                                                                 )
                                                                 (i32.and
-                                                                  (get_local $8)
+                                                                  (get_local $22)
                                                                   (i32.const 255)
                                                                 )
-                                                              )
-                                                              (set_local $19
-                                                                (get_local $8)
                                                               )
                                                               (set_local $20
                                                                 (get_local $9)
                                                               )
                                                               (set_local $1
-                                                                (get_local $16)
+                                                                (get_local $17)
                                                               )
-                                                              (set_local $11
-                                                                (get_local $22)
+                                                              (set_local $8
+                                                                (get_local $21)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
                                                             (i32.store
                                                               (i32.load
-                                                                (get_local $18)
+                                                                (get_local $19)
                                                               )
-                                                              (get_local $8)
-                                                            )
-                                                            (set_local $19
-                                                              (get_local $8)
+                                                              (get_local $22)
                                                             )
                                                             (set_local $20
                                                               (get_local $9)
                                                             )
                                                             (set_local $1
-                                                              (get_local $16)
+                                                              (get_local $17)
                                                             )
-                                                            (set_local $11
-                                                              (get_local $22)
+                                                            (set_local $8
+                                                              (get_local $21)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
                                                           (i32.store
                                                             (set_local $1
                                                               (i32.load
-                                                                (get_local $18)
+                                                                (get_local $19)
                                                               )
                                                             )
-                                                            (get_local $8)
+                                                            (get_local $22)
                                                           )
                                                           (i32.store offset=4
                                                             (get_local $1)
                                                             (i32.shr_s
                                                               (i32.shl
                                                                 (i32.lt_s
-                                                                  (get_local $8)
+                                                                  (get_local $22)
                                                                   (i32.const 0)
                                                                 )
                                                                 (i32.const 31)
@@ -4669,42 +4594,36 @@
                                                               (i32.const 31)
                                                             )
                                                           )
-                                                          (set_local $19
-                                                            (get_local $8)
-                                                          )
                                                           (set_local $20
                                                             (get_local $9)
                                                           )
                                                           (set_local $1
-                                                            (get_local $16)
+                                                            (get_local $17)
                                                           )
-                                                          (set_local $11
-                                                            (get_local $22)
+                                                          (set_local $8
+                                                            (get_local $21)
                                                           )
                                                           (br $label$continue$L1)
-                                                        )
-                                                        (set_local $19
-                                                          (get_local $8)
                                                         )
                                                         (set_local $20
                                                           (get_local $9)
                                                         )
                                                         (set_local $1
-                                                          (get_local $16)
+                                                          (get_local $17)
                                                         )
-                                                        (set_local $11
-                                                          (get_local $22)
+                                                        (set_local $8
+                                                          (get_local $21)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
                                                     )
-                                                    (set_local $47
+                                                    (set_local $46
                                                       (i32.or
-                                                        (get_local $17)
+                                                        (get_local $18)
                                                         (i32.const 8)
                                                       )
                                                     )
-                                                    (set_local $59
+                                                    (set_local $57
                                                       (select
                                                         (get_local $10)
                                                         (i32.const 8)
@@ -4723,14 +4642,14 @@
                                                     (br $switch$24)
                                                   )
                                                 )
-                                                (set_local $47
-                                                  (get_local $17)
+                                                (set_local $46
+                                                  (get_local $18)
                                                 )
-                                                (set_local $59
+                                                (set_local $57
                                                   (get_local $10)
                                                 )
                                                 (set_local $68
-                                                  (get_local $33)
+                                                  (get_local $26)
                                                 )
                                                 (set_local $12
                                                   (i32.const 64)
@@ -4743,7 +4662,7 @@
                                                     (set_local $5
                                                       (i32.load
                                                         (set_local $1
-                                                          (get_local $18)
+                                                          (get_local $19)
                                                         )
                                                       )
                                                     )
@@ -4759,15 +4678,15 @@
                                                   )
                                                 )
                                                 (set_local $6
-                                                  (get_local $27)
+                                                  (get_local $28)
                                                 )
                                                 (block
                                                   (set_local $6
-                                                    (get_local $27)
+                                                    (get_local $28)
                                                   )
                                                   (loop $while-out$38 $while-in$39
                                                     (i32.store8
-                                                      (set_local $34
+                                                      (set_local $6
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const -1)
@@ -4787,7 +4706,7 @@
                                                     (if
                                                       (i32.and
                                                         (i32.eq
-                                                          (set_local $1
+                                                          (set_local $5
                                                             (call $_bitshift64Lshr
                                                               (get_local $5)
                                                               (get_local $1)
@@ -4797,7 +4716,7 @@
                                                           (i32.const 0)
                                                         )
                                                         (i32.eq
-                                                          (set_local $6
+                                                          (set_local $1
                                                             (i32.load
                                                               (i32.const 168)
                                                             )
@@ -4805,48 +4724,32 @@
                                                           (i32.const 0)
                                                         )
                                                       )
-                                                      (block
-                                                        (set_local $6
-                                                          (get_local $34)
-                                                        )
-                                                        (br $while-out$38)
-                                                      )
-                                                      (block
-                                                        (set_local $5
-                                                          (get_local $1)
-                                                        )
-                                                        (set_local $1
-                                                          (get_local $6)
-                                                        )
-                                                        (set_local $6
-                                                          (get_local $34)
-                                                        )
-                                                      )
+                                                      (br $while-out$38)
                                                     )
                                                     (br $while-in$39)
                                                   )
                                                 )
                                               )
-                                              (set_local $34
+                                              (set_local $58
                                                 (if
                                                   (i32.eq
                                                     (i32.and
-                                                      (get_local $17)
+                                                      (get_local $18)
                                                       (i32.const 8)
                                                     )
                                                     (i32.const 0)
                                                   )
                                                   (block
-                                                    (set_local $35
-                                                      (get_local $17)
+                                                    (set_local $34
+                                                      (get_local $18)
                                                     )
                                                     (set_local $32
                                                       (get_local $10)
                                                     )
-                                                    (set_local $36
+                                                    (set_local $35
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $37
+                                                    (set_local $36
                                                       (i32.const 4091)
                                                     )
                                                     (set_local $12
@@ -4869,8 +4772,8 @@
                                                         )
                                                       )
                                                     )
-                                                    (set_local $35
-                                                      (get_local $17)
+                                                    (set_local $34
+                                                      (get_local $18)
                                                     )
                                                     (set_local $32
                                                       (select
@@ -4879,10 +4782,10 @@
                                                         (get_local $5)
                                                       )
                                                     )
-                                                    (set_local $36
+                                                    (set_local $35
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $37
+                                                    (set_local $36
                                                       (i32.const 4091)
                                                     )
                                                     (set_local $12
@@ -4898,13 +4801,13 @@
                                           (set_local $5
                                             (i32.load
                                               (set_local $1
-                                                (get_local $18)
+                                                (get_local $19)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (set_local $6
+                                              (set_local $33
                                                 (i32.load offset=4
                                                   (get_local $1)
                                                 )
@@ -4917,7 +4820,7 @@
                                                   (i32.const 0)
                                                   (i32.const 0)
                                                   (get_local $5)
-                                                  (get_local $6)
+                                                  (get_local $33)
                                                 )
                                               )
                                               (set_local $5
@@ -4926,25 +4829,25 @@
                                                 )
                                               )
                                               (i32.store
-                                                (set_local $6
-                                                  (get_local $18)
+                                                (set_local $33
+                                                  (get_local $19)
                                                 )
                                                 (get_local $1)
                                               )
                                               (i32.store offset=4
-                                                (get_local $6)
+                                                (get_local $33)
                                                 (get_local $5)
                                               )
-                                              (set_local $48
+                                              (set_local $33
                                                 (get_local $1)
                                               )
-                                              (set_local $60
+                                              (set_local $59
                                                 (get_local $5)
                                               )
-                                              (set_local $61
+                                              (set_local $60
                                                 (i32.const 1)
                                               )
-                                              (set_local $62
+                                              (set_local $61
                                                 (i32.const 4091)
                                               )
                                               (set_local $12
@@ -4953,11 +4856,11 @@
                                               (br $label$break$L75)
                                             )
                                           )
-                                          (set_local $48
+                                          (set_local $33
                                             (if
                                               (i32.eq
                                                 (i32.and
-                                                  (get_local $17)
+                                                  (get_local $18)
                                                   (i32.const 2048)
                                                 )
                                                 (i32.const 0)
@@ -4968,9 +4871,9 @@
                                                     (i32.const 4091)
                                                     (i32.const 4093)
                                                     (i32.eq
-                                                      (set_local $48
+                                                      (set_local $6
                                                         (i32.and
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -4978,13 +4881,13 @@
                                                     )
                                                   )
                                                 )
+                                                (set_local $59
+                                                  (get_local $33)
+                                                )
                                                 (set_local $60
                                                   (get_local $6)
                                                 )
                                                 (set_local $61
-                                                  (get_local $48)
-                                                )
-                                                (set_local $62
                                                   (get_local $1)
                                                 )
                                                 (set_local $12
@@ -4993,13 +4896,13 @@
                                                 (get_local $5)
                                               )
                                               (block
-                                                (set_local $60
-                                                  (get_local $6)
+                                                (set_local $59
+                                                  (get_local $33)
                                                 )
-                                                (set_local $61
+                                                (set_local $60
                                                   (i32.const 1)
                                                 )
-                                                (set_local $62
+                                                (set_local $61
                                                   (i32.const 4092)
                                                 )
                                                 (set_local $12
@@ -5011,22 +4914,22 @@
                                           )
                                           (br $switch$24)
                                         )
-                                        (set_local $48
+                                        (set_local $33
                                           (i32.load
                                             (set_local $1
-                                              (get_local $18)
+                                              (get_local $19)
                                             )
                                           )
                                         )
-                                        (set_local $60
+                                        (set_local $59
                                           (i32.load offset=4
                                             (get_local $1)
                                           )
                                         )
-                                        (set_local $61
+                                        (set_local $60
                                           (i32.const 0)
                                         )
-                                        (set_local $62
+                                        (set_local $61
                                           (i32.const 4091)
                                         )
                                         (set_local $12
@@ -5037,7 +4940,7 @@
                                       (set_local $5
                                         (i32.load
                                           (set_local $1
-                                            (get_local $18)
+                                            (get_local $19)
                                           )
                                         )
                                       )
@@ -5051,27 +4954,27 @@
                                           (i32.const 255)
                                         )
                                       )
-                                      (set_local $49
+                                      (set_local $47
                                         (get_local $72)
                                       )
-                                      (set_local $38
+                                      (set_local $37
                                         (get_local $7)
                                       )
-                                      (set_local $43
+                                      (set_local $42
                                         (i32.const 1)
                                       )
-                                      (set_local $44
+                                      (set_local $43
                                         (i32.const 0)
                                       )
-                                      (set_local $50
+                                      (set_local $48
                                         (i32.const 4091)
                                       )
-                                      (set_local $51
-                                        (get_local $27)
+                                      (set_local $49
+                                        (get_local $28)
                                       )
                                       (br $switch$24)
                                     )
-                                    (set_local $52
+                                    (set_local $50
                                       (call $_strerror
                                         (i32.load
                                           (call $___errno_location)
@@ -5087,13 +4990,13 @@
                                     (i32.ne
                                       (set_local $1
                                         (i32.load
-                                          (get_local $18)
+                                          (get_local $19)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $52
+                                  (set_local $50
                                     (select
                                       (get_local $1)
                                       (i32.const 4101)
@@ -5108,7 +5011,7 @@
                                 (set_local $5
                                   (i32.load
                                     (set_local $1
-                                      (get_local $18)
+                                      (get_local $19)
                                     )
                                   )
                                 )
@@ -5124,7 +5027,7 @@
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $18)
+                                  (get_local $19)
                                   (get_local $73)
                                 )
                                 (set_local $69
@@ -5145,11 +5048,11 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.const 0)
-                                      (get_local $17)
+                                      (get_local $18)
                                     )
-                                    (set_local $39
+                                    (set_local $38
                                       (i32.const 0)
                                     )
                                     (i32.const 98)
@@ -5171,9 +5074,9 @@
                   )
                 )
               )
-              (set_local $14
+              (set_local $15
                 (f64.load
-                  (get_local $18)
+                  (get_local $19)
                 )
               )
               (i32.store
@@ -5184,14 +5087,14 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $14)
+                (get_local $15)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
               )
-              (set_local $53
+              (set_local $51
                 (if
                   (i32.lt_s
                     (i32.load offset=4
@@ -5202,12 +5105,12 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $40
+                    (set_local $39
                       (i32.const 4108)
                     )
-                    (set_local $14
+                    (set_local $15
                       (f64.neg
-                        (get_local $14)
+                        (get_local $15)
                       )
                     )
                     (i32.const 1)
@@ -5215,20 +5118,20 @@
                   (if
                     (i32.eq
                       (i32.and
-                        (get_local $17)
+                        (get_local $18)
                         (i32.const 2048)
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $40
+                      (set_local $39
                         (select
                           (i32.const 4109)
                           (i32.const 4114)
                           (i32.eq
                             (set_local $1
                               (i32.and
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 1)
                               )
                             )
@@ -5239,7 +5142,7 @@
                       (get_local $1)
                     )
                     (block
-                      (set_local $40
+                      (set_local $39
                         (i32.const 4111)
                       )
                       (i32.const 1)
@@ -5251,15 +5154,12 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $14)
+                (get_local $15)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
-              )
-              (set_local $19
-                (get_local $8)
               )
               (set_local $20
                 (get_local $9)
@@ -5293,10 +5193,10 @@
                       (if
                         (set_local $5
                           (f64.ne
-                            (set_local $14
+                            (set_local $15
                               (f64.mul
                                 (call $_frexpl
-                                  (get_local $14)
+                                  (get_local $15)
                                   (get_local $25)
                                 )
                                 (f64.const 2)
@@ -5317,26 +5217,26 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $21
+                          (set_local $14
                             (i32.or
-                              (get_local $33)
+                              (get_local $26)
                               (i32.const 32)
                             )
                           )
                           (i32.const 97)
                         )
                         (block
-                          (set_local $11
+                          (set_local $9
                             (select
-                              (get_local $40)
+                              (get_local $39)
                               (i32.add
-                                (get_local $40)
+                                (get_local $39)
                                 (i32.const 9)
                               )
                               (i32.eq
-                                (set_local $7
+                                (set_local $6
                                   (i32.and
-                                    (get_local $33)
+                                    (get_local $26)
                                     (i32.const 32)
                                   )
                                 )
@@ -5344,13 +5244,13 @@
                               )
                             )
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.or
-                              (get_local $53)
+                              (get_local $51)
                               (i32.const 2)
                             )
                           )
-                          (set_local $14
+                          (set_local $15
                             (if
                               (i32.or
                                 (i32.gt_u
@@ -5367,15 +5267,15 @@
                                   (i32.const 0)
                                 )
                               )
-                              (get_local $14)
+                              (get_local $15)
                               (block
-                                (set_local $29
+                                (set_local $30
                                   (f64.const 8)
                                 )
                                 (loop $while-out$60 $while-in$61
-                                  (set_local $29
+                                  (set_local $30
                                     (f64.mul
-                                      (get_local $29)
+                                      (get_local $30)
                                       (f64.const 16)
                                     )
                                   )
@@ -5396,27 +5296,27 @@
                                 (select
                                   (f64.neg
                                     (f64.add
-                                      (get_local $29)
+                                      (get_local $30)
                                       (f64.sub
                                         (f64.neg
-                                          (get_local $14)
+                                          (get_local $15)
                                         )
-                                        (get_local $29)
+                                        (get_local $30)
                                       )
                                     )
                                   )
                                   (f64.sub
                                     (f64.add
-                                      (get_local $14)
-                                      (get_local $29)
+                                      (get_local $15)
+                                      (get_local $30)
                                     )
-                                    (get_local $29)
+                                    (get_local $30)
                                   )
                                   (i32.eq
                                     (i32.shr_s
                                       (i32.shl
                                         (i32.load8_s
-                                          (get_local $11)
+                                          (get_local $9)
                                         )
                                         (i32.const 24)
                                       )
@@ -5468,10 +5368,10 @@
                                       (call $_fmt_u
                                         (get_local $8)
                                         (get_local $5)
-                                        (get_local $54)
+                                        (get_local $52)
                                       )
                                     )
-                                    (get_local $54)
+                                    (get_local $52)
                                   )
                                   (block
                                     (i32.store8
@@ -5508,7 +5408,7 @@
                             )
                             (i32.and
                               (i32.add
-                                (get_local $33)
+                                (get_local $26)
                                 (i32.const 15)
                               )
                               (i32.const 255)
@@ -5523,18 +5423,18 @@
                           (set_local $13
                             (i32.eq
                               (i32.and
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 8)
                               )
                               (i32.const 0)
                             )
                           )
-                          (set_local $9
-                            (get_local $28)
+                          (set_local $11
+                            (get_local $29)
                           )
                           (loop $while-out$62 $while-in$63
                             (i32.store8
-                              (get_local $9)
+                              (get_local $11)
                               (i32.and
                                 (i32.or
                                   (i32.and
@@ -5542,7 +5442,7 @@
                                       (i32.add
                                         (set_local $1
                                           (call_import $f64-to-int
-                                            (get_local $14)
+                                            (get_local $15)
                                           )
                                         )
                                         (i32.const 4075)
@@ -5550,15 +5450,15 @@
                                     )
                                     (i32.const 255)
                                   )
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.const 255)
                               )
                             )
-                            (set_local $14
+                            (set_local $15
                               (f64.mul
                                 (f64.sub
-                                  (get_local $14)
+                                  (get_local $15)
                                   (f64.convert_s/i32
                                     (get_local $1)
                                   )
@@ -5566,14 +5466,14 @@
                                 (f64.const 16)
                               )
                             )
-                            (set_local $1
+                            (set_local $11
                               (block $do-once$64
                                 (if
                                   (i32.eq
                                     (i32.sub
                                       (set_local $1
                                         (i32.add
-                                          (get_local $9)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
@@ -5589,7 +5489,7 @@
                                         (i32.and
                                           (get_local $5)
                                           (f64.eq
-                                            (get_local $14)
+                                            (get_local $15)
                                             (f64.const 0)
                                           )
                                         )
@@ -5600,7 +5500,7 @@
                                       (i32.const 46)
                                     )
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $11)
                                       (i32.const 2)
                                     )
                                   )
@@ -5609,14 +5509,16 @@
                               )
                             )
                             (if
-                              (f64.ne
-                                (get_local $14)
+                              (f64.eq
+                                (get_local $15)
                                 (f64.const 0)
                               )
-                              (set_local $9
-                                (get_local $1)
+                              (block
+                                (set_local $1
+                                  (get_local $11)
+                                )
+                                (br $while-out$62)
                               )
-                              (br $while-out$62)
                             )
                             (br $while-in$63)
                           )
@@ -5638,10 +5540,10 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $15)
+                            (get_local $16)
                             (set_local $5
                               (i32.add
-                                (set_local $7
+                                (set_local $6
                                   (select
                                     (i32.sub
                                       (i32.add
@@ -5660,10 +5562,10 @@
                                     (get_local $5)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
-                            (get_local $17)
+                            (get_local $18)
                           )
                           (if
                             (i32.eq
@@ -5676,18 +5578,18 @@
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $11)
-                              (get_local $6)
+                              (get_local $9)
+                              (get_local $7)
                               (get_local $0)
                             )
                           )
                           (call $_pad
                             (get_local $0)
                             (i32.const 48)
-                            (get_local $15)
+                            (get_local $16)
                             (get_local $5)
                             (i32.xor
-                              (get_local $17)
+                              (get_local $18)
                               (i32.const 65536)
                             )
                           )
@@ -5708,7 +5610,7 @@
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $28)
+                              (get_local $29)
                               (get_local $1)
                               (get_local $0)
                             )
@@ -5717,12 +5619,12 @@
                             (get_local $0)
                             (i32.const 48)
                             (i32.sub
-                              (get_local $7)
+                              (get_local $6)
                               (i32.add
                                 (get_local $1)
                                 (set_local $1
                                   (i32.sub
-                                    (get_local $41)
+                                    (get_local $40)
                                     (get_local $8)
                                   )
                                 )
@@ -5750,20 +5652,20 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $15)
+                            (get_local $16)
                             (get_local $5)
                             (i32.xor
-                              (get_local $17)
+                              (get_local $18)
                               (i32.const 8192)
                             )
                           )
                           (br $do-once$56
                             (select
-                              (get_local $15)
+                              (get_local $16)
                               (get_local $5)
                               (i32.lt_s
                                 (get_local $5)
-                                (get_local $15)
+                                (get_local $16)
                               )
                             )
                           )
@@ -5779,8 +5681,8 @@
                           )
                         )
                       )
-                      (set_local $30
-                        (set_local $11
+                      (set_local $62
+                        (set_local $9
                           (select
                             (get_local $80)
                             (get_local $81)
@@ -5799,9 +5701,9 @@
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $15
                                     (f64.mul
-                                      (get_local $14)
+                                      (get_local $15)
                                       (f64.const 268435456)
                                     )
                                   )
@@ -5816,30 +5718,30 @@
                           )
                         )
                       )
-                      (set_local $6
-                        (get_local $11)
+                      (set_local $7
+                        (get_local $9)
                       )
                       (loop $while-out$66 $while-in$67
                         (i32.store
-                          (get_local $6)
+                          (get_local $7)
                           (set_local $5
                             (call_import $f64-to-int
-                              (get_local $14)
+                              (get_local $15)
                             )
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $6)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (if
                           (f64.eq
-                            (set_local $14
+                            (set_local $15
                               (f64.mul
                                 (f64.sub
-                                  (get_local $14)
+                                  (get_local $15)
                                   (f64.convert_u/i32
                                     (get_local $5)
                                   )
@@ -5850,8 +5752,8 @@
                             (f64.const 0)
                           )
                           (block
-                            (set_local $7
-                              (get_local $6)
+                            (set_local $6
+                              (get_local $7)
                             )
                             (br $while-out$66)
                           )
@@ -5869,13 +5771,13 @@
                         )
                         (block
                           (set_local $8
-                            (get_local $11)
+                            (get_local $9)
                           )
-                          (set_local $10
-                            (get_local $7)
+                          (set_local $13
+                            (get_local $6)
                           )
                           (loop $while-out$68 $while-in$69
-                            (set_local $9
+                            (set_local $11
                               (select
                                 (i32.const 29)
                                 (get_local $5)
@@ -5885,13 +5787,13 @@
                                 )
                               )
                             )
-                            (set_local $6
+                            (set_local $7
                               (block $do-once$70
                                 (if
                                   (i32.lt_u
-                                    (set_local $6
+                                    (set_local $7
                                       (i32.add
-                                        (get_local $10)
+                                        (get_local $13)
                                         (i32.const -4)
                                       )
                                     )
@@ -5902,20 +5804,20 @@
                                     (set_local $5
                                       (i32.const 0)
                                     )
-                                    (set_local $13
-                                      (get_local $6)
+                                    (set_local $10
+                                      (get_local $7)
                                     )
                                     (loop $while-out$72 $while-in$73
-                                      (set_local $7
+                                      (set_local $6
                                         (call $___uremdi3
                                           (set_local $5
                                             (call $_i64Add
                                               (call $_bitshift64Shl
                                                 (i32.load
-                                                  (get_local $13)
+                                                  (get_local $10)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $9)
+                                                (get_local $11)
                                               )
                                               (i32.load
                                                 (i32.const 168)
@@ -5924,7 +5826,7 @@
                                               (i32.const 0)
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.load
                                               (i32.const 168)
                                             )
@@ -5937,13 +5839,13 @@
                                         (i32.const 168)
                                       )
                                       (i32.store
-                                        (get_local $13)
-                                        (get_local $7)
+                                        (get_local $10)
+                                        (get_local $6)
                                       )
                                       (set_local $5
                                         (call $___udivdi3
                                           (get_local $5)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 1000000000)
                                           (i32.const 0)
                                         )
@@ -5953,17 +5855,17 @@
                                       )
                                       (if
                                         (i32.lt_u
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.add
-                                              (get_local $13)
+                                              (get_local $10)
                                               (i32.const -4)
                                             )
                                           )
                                           (get_local $8)
                                         )
                                         (br $while-out$72)
-                                        (set_local $13
-                                          (get_local $6)
+                                        (set_local $10
+                                          (get_local $7)
                                         )
                                       )
                                       (br $while-in$73)
@@ -5976,7 +5878,7 @@
                                       )
                                     )
                                     (i32.store
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
                                           (get_local $8)
                                           (i32.const -4)
@@ -5984,19 +5886,16 @@
                                       )
                                       (get_local $5)
                                     )
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                 )
                               )
                             )
-                            (set_local $7
-                              (get_local $10)
-                            )
                             (loop $while-out$74 $while-in$75
                               (if
                                 (i32.le_u
+                                  (get_local $13)
                                   (get_local $7)
-                                  (get_local $6)
                                 )
                                 (br $while-out$74)
                               )
@@ -6005,14 +5904,14 @@
                                   (i32.load
                                     (set_local $5
                                       (i32.add
-                                        (get_local $7)
+                                        (get_local $13)
                                         (i32.const -4)
                                       )
                                     )
                                   )
                                   (i32.const 0)
                                 )
-                                (set_local $7
+                                (set_local $13
                                   (get_local $5)
                                 )
                                 (br $while-out$74)
@@ -6026,7 +5925,7 @@
                                   (i32.load
                                     (get_local $25)
                                   )
-                                  (get_local $9)
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -6035,21 +5934,21 @@
                                 (get_local $5)
                                 (i32.const 0)
                               )
-                              (block
-                                (set_local $8
-                                  (get_local $6)
-                                )
-                                (set_local $10
-                                  (get_local $7)
-                                )
+                              (set_local $8
+                                (get_local $7)
                               )
-                              (br $while-out$68)
+                              (block
+                                (set_local $6
+                                  (get_local $13)
+                                )
+                                (br $while-out$68)
+                              )
                             )
                             (br $while-in$69)
                           )
                         )
-                        (set_local $6
-                          (get_local $11)
+                        (set_local $7
+                          (get_local $9)
                         )
                       )
                       (if
@@ -6073,19 +5972,19 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $13
+                          (set_local $10
                             (i32.eq
-                              (get_local $21)
+                              (get_local $14)
                               (i32.const 102)
                             )
                           )
-                          (set_local $24
-                            (get_local $7)
+                          (set_local $23
+                            (get_local $6)
                           )
                           (loop $while-out$76 $while-in$77
                             (set_local $5
                               (i32.gt_s
-                                (set_local $7
+                                (set_local $6
                                   (i32.sub
                                     (i32.const 0)
                                     (get_local $5)
@@ -6094,86 +5993,78 @@
                                 (i32.const 9)
                               )
                             )
-                            (set_local $10
+                            (set_local $13
                               (select
                                 (i32.const 9)
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $5)
                               )
                             )
-                            (set_local $9
+                            (set_local $11
                               (block $do-once$78
                                 (if
                                   (i32.lt_u
-                                    (get_local $6)
-                                    (get_local $24)
+                                    (get_local $7)
+                                    (get_local $23)
                                   )
                                   (block
                                     (set_local $70
                                       (i32.add
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $10)
+                                          (get_local $13)
                                         )
                                         (i32.const -1)
                                       )
                                     )
-                                    (set_local $26
+                                    (set_local $27
                                       (i32.shr_u
                                         (i32.const 1000000000)
-                                        (get_local $10)
+                                        (get_local $13)
                                       )
                                     )
-                                    (set_local $9
+                                    (set_local $11
                                       (i32.const 0)
                                     )
-                                    (set_local $16
-                                      (get_local $6)
+                                    (set_local $17
+                                      (get_local $7)
                                     )
                                     (loop $while-out$80 $while-in$81
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.and
                                           (set_local $5
                                             (i32.load
-                                              (get_local $16)
+                                              (get_local $17)
                                             )
                                           )
                                           (get_local $70)
                                         )
                                       )
                                       (i32.store
-                                        (get_local $16)
+                                        (get_local $17)
                                         (i32.add
                                           (i32.shr_u
                                             (get_local $5)
-                                            (get_local $10)
+                                            (get_local $13)
                                           )
-                                          (get_local $9)
+                                          (get_local $11)
                                         )
                                       )
-                                      (set_local $7
+                                      (set_local $11
                                         (i32.mul
-                                          (get_local $7)
-                                          (get_local $26)
+                                          (get_local $6)
+                                          (get_local $27)
                                         )
                                       )
                                       (if
-                                        (i32.lt_u
-                                          (set_local $5
+                                        (i32.ge_u
+                                          (set_local $17
                                             (i32.add
-                                              (get_local $16)
+                                              (get_local $17)
                                               (i32.const 4)
                                             )
                                           )
-                                          (get_local $24)
-                                        )
-                                        (block
-                                          (set_local $9
-                                            (get_local $7)
-                                          )
-                                          (set_local $16
-                                            (get_local $5)
-                                          )
+                                          (get_local $23)
                                         )
                                         (br $while-out$80)
                                       )
@@ -6182,13 +6073,13 @@
                                     (set_local $5
                                       (select
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 4)
                                         )
-                                        (get_local $6)
+                                        (get_local $7)
                                         (i32.eq
                                           (i32.load
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                           (i32.const 0)
                                         )
@@ -6196,46 +6087,36 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (get_local $7)
+                                        (get_local $11)
                                         (i32.const 0)
                                       )
-                                      (block
-                                        (set_local $7
-                                          (get_local $24)
-                                        )
-                                        (br $do-once$78
-                                          (get_local $5)
-                                        )
+                                      (br $do-once$78
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.store
-                                      (get_local $24)
-                                      (get_local $7)
+                                      (get_local $23)
+                                      (get_local $11)
                                     )
-                                    (set_local $7
+                                    (set_local $23
                                       (i32.add
-                                        (get_local $24)
+                                        (get_local $23)
                                         (i32.const 4)
                                       )
                                     )
                                     (get_local $5)
                                   )
-                                  (block
-                                    (set_local $7
-                                      (get_local $24)
+                                  (select
+                                    (i32.add
+                                      (get_local $7)
+                                      (i32.const 4)
                                     )
-                                    (select
-                                      (i32.add
-                                        (get_local $6)
-                                        (i32.const 4)
+                                    (get_local $7)
+                                    (i32.eq
+                                      (i32.load
+                                        (get_local $7)
                                       )
-                                      (get_local $6)
-                                      (i32.eq
-                                        (i32.load
-                                          (get_local $6)
-                                        )
-                                        (i32.const 0)
-                                      )
+                                      (i32.const 0)
                                     )
                                   )
                                 )
@@ -6245,12 +6126,12 @@
                               (i32.gt_s
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $7)
-                                    (set_local $6
+                                    (get_local $23)
+                                    (set_local $7
                                       (select
-                                        (get_local $11)
                                         (get_local $9)
-                                        (get_local $13)
+                                        (get_local $11)
+                                        (get_local $10)
                                       )
                                     )
                                   )
@@ -6259,16 +6140,16 @@
                                 (get_local $8)
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (select
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $7)
                                   (i32.shl
                                     (get_local $8)
                                     (i32.const 2)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $23)
                                 (get_local $5)
                               )
                             )
@@ -6279,7 +6160,7 @@
                                   (i32.load
                                     (get_local $25)
                                   )
-                                  (get_local $10)
+                                  (get_local $13)
                                 )
                               )
                             )
@@ -6289,19 +6170,19 @@
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $6
-                                  (get_local $9)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $24
-                                  (get_local $7)
+                                (set_local $23
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $6
-                                  (get_local $9)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $26
-                                  (get_local $7)
+                                (set_local $27
+                                  (get_local $6)
                                 )
                                 (br $while-out$76)
                               )
@@ -6309,23 +6190,23 @@
                             (br $while-in$77)
                           )
                         )
-                        (set_local $26
-                          (get_local $7)
+                        (set_local $27
+                          (get_local $6)
                         )
                       )
                       (block $do-once$82
                         (if
                           (i32.lt_u
-                            (get_local $6)
-                            (get_local $26)
+                            (get_local $7)
+                            (get_local $27)
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $30)
-                                    (get_local $6)
+                                    (get_local $62)
+                                    (get_local $7)
                                   )
                                   (i32.const 2)
                                 )
@@ -6336,14 +6217,14 @@
                               (i32.lt_u
                                 (set_local $5
                                   (i32.load
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 10)
                               )
                               (block
-                                (set_local $10
-                                  (get_local $7)
+                                (set_local $13
+                                  (get_local $6)
                                 )
                                 (br $do-once$82)
                               )
@@ -6352,9 +6233,9 @@
                               )
                             )
                             (loop $while-out$84 $while-in$85
-                              (set_local $7
+                              (set_local $6
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
@@ -6369,8 +6250,8 @@
                                   )
                                 )
                                 (block
-                                  (set_local $10
-                                    (get_local $7)
+                                  (set_local $13
+                                    (get_local $6)
                                   )
                                   (br $while-out$84)
                                 )
@@ -6378,12 +6259,12 @@
                               (br $while-in$85)
                             )
                           )
-                          (set_local $10
+                          (set_local $13
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (if
                           (i32.lt_s
                             (set_local $5
@@ -6391,10 +6272,10 @@
                                 (i32.sub
                                   (get_local $1)
                                   (select
-                                    (get_local $10)
+                                    (get_local $13)
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $21)
+                                      (get_local $14)
                                       (i32.const 102)
                                     )
                                   )
@@ -6410,7 +6291,7 @@
                                       )
                                       (set_local $8
                                         (i32.eq
-                                          (get_local $21)
+                                          (get_local $14)
                                           (i32.const 103)
                                         )
                                       )
@@ -6425,8 +6306,8 @@
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $26)
-                                    (get_local $30)
+                                    (get_local $27)
+                                    (get_local $62)
                                   )
                                   (i32.const 2)
                                 )
@@ -6436,10 +6317,10 @@
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (i32.add
                                 (i32.add
-                                  (get_local $11)
+                                  (get_local $9)
                                   (i32.const 4)
                                 )
                                 (i32.shl
@@ -6464,7 +6345,7 @@
                             )
                             (if
                               (i32.lt_s
-                                (set_local $9
+                                (set_local $11
                                   (i32.add
                                     (i32.and
                                       (call_import $i32s-rem
@@ -6491,16 +6372,16 @@
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $9
+                                      (set_local $11
                                         (i32.add
-                                          (get_local $9)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
                                       (i32.const 9)
                                     )
                                     (block
-                                      (set_local $16
+                                      (set_local $17
                                         (get_local $5)
                                       )
                                       (br $while-out$86)
@@ -6509,52 +6390,43 @@
                                   (br $while-in$87)
                                 )
                               )
-                              (set_local $16
+                              (set_local $17
                                 (i32.const 10)
                               )
                             )
                             (block $do-once$88
                               (if
-                                (i32.and
-                                  (set_local $9
-                                    (i32.eq
-                                      (i32.add
-                                        (get_local $7)
-                                        (i32.const 4)
-                                      )
-                                      (get_local $26)
-                                    )
-                                  )
-                                  (i32.eq
-                                    (set_local $21
-                                      (i32.and
-                                        (call_import $i32u-rem
-                                          (set_local $5
-                                            (i32.load
-                                              (get_local $7)
-                                            )
-                                          )
-                                          (get_local $16)
+                                (i32.eqz
+                                  (i32.and
+                                    (set_local $11
+                                      (i32.eq
+                                        (i32.add
+                                          (get_local $6)
+                                          (i32.const 4)
                                         )
-                                        (i32.const -1)
+                                        (get_local $27)
                                       )
                                     )
-                                    (i32.const 0)
+                                    (i32.eq
+                                      (set_local $14
+                                        (i32.and
+                                          (call_import $i32u-rem
+                                            (set_local $5
+                                              (i32.load
+                                                (get_local $6)
+                                              )
+                                            )
+                                            (get_local $17)
+                                          )
+                                          (i32.const -1)
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
                                   )
                                 )
                                 (block
-                                  (set_local $5
-                                    (get_local $6)
-                                  )
-                                  (set_local $6
-                                    (get_local $7)
-                                  )
-                                  (set_local $9
-                                    (get_local $10)
-                                  )
-                                )
-                                (block
-                                  (set_local $14
+                                  (set_local $15
                                     (select
                                       (f64.const 9007199254740992)
                                       (f64.const 9007199254740994)
@@ -6563,7 +6435,7 @@
                                           (i32.and
                                             (call_import $i32u-div
                                               (get_local $5)
-                                              (get_local $16)
+                                              (get_local $17)
                                             )
                                             (i32.const -1)
                                           )
@@ -6573,14 +6445,14 @@
                                       )
                                     )
                                   )
-                                  (set_local $29
+                                  (set_local $30
                                     (if
                                       (i32.lt_u
-                                        (get_local $21)
-                                        (set_local $13
+                                        (get_local $14)
+                                        (set_local $10
                                           (i32.and
                                             (call_import $i32s-div
-                                              (get_local $16)
+                                              (get_local $17)
                                               (i32.const 2)
                                             )
                                             (i32.const -1)
@@ -6592,30 +6464,30 @@
                                         (f64.const 1)
                                         (f64.const 1.5)
                                         (i32.and
-                                          (get_local $9)
+                                          (get_local $11)
                                           (i32.eq
-                                            (get_local $21)
-                                            (get_local $13)
+                                            (get_local $14)
+                                            (get_local $10)
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $15
                                     (block $do-once$90
                                       (if
                                         (i32.eq
-                                          (get_local $53)
+                                          (get_local $51)
                                           (i32.const 0)
                                         )
-                                        (get_local $14)
+                                        (get_local $15)
                                         (block
                                           (if
                                             (i32.ne
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.load8_s
-                                                    (get_local $40)
+                                                    (get_local $39)
                                                   )
                                                   (i32.const 24)
                                                 )
@@ -6624,57 +6496,46 @@
                                               (i32.const 45)
                                             )
                                             (br $do-once$90
-                                              (get_local $14)
+                                              (get_local $15)
                                             )
                                           )
-                                          (set_local $29
+                                          (set_local $30
                                             (f64.neg
-                                              (get_local $29)
+                                              (get_local $30)
                                             )
                                           )
                                           (f64.neg
-                                            (get_local $14)
+                                            (get_local $15)
                                           )
                                         )
                                       )
                                     )
                                   )
                                   (i32.store
-                                    (get_local $7)
+                                    (get_local $6)
                                     (set_local $5
                                       (i32.sub
                                         (get_local $5)
-                                        (get_local $21)
+                                        (get_local $14)
                                       )
                                     )
                                   )
                                   (if
                                     (f64.eq
                                       (f64.add
-                                        (get_local $14)
-                                        (get_local $29)
+                                        (get_local $15)
+                                        (get_local $30)
                                       )
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
-                                    (block
-                                      (set_local $5
-                                        (get_local $6)
-                                      )
-                                      (set_local $6
-                                        (get_local $7)
-                                      )
-                                      (set_local $9
-                                        (get_local $10)
-                                      )
-                                      (br $do-once$88)
-                                    )
+                                    (br $do-once$88)
                                   )
                                   (i32.store
-                                    (get_local $7)
+                                    (get_local $6)
                                     (set_local $5
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $16)
+                                        (get_local $17)
                                       )
                                     )
                                   )
@@ -6683,80 +6544,64 @@
                                       (get_local $5)
                                       (i32.const 999999999)
                                     )
-                                    (block
-                                      (set_local $5
+                                    (loop $while-out$92 $while-in$93
+                                      (i32.store
                                         (get_local $6)
+                                        (i32.const 0)
                                       )
-                                      (set_local $6
-                                        (get_local $7)
-                                      )
-                                      (loop $while-out$92 $while-in$93
-                                        (i32.store
-                                          (get_local $6)
-                                          (i32.const 0)
-                                        )
-                                        (set_local $5
-                                          (if
-                                            (i32.lt_u
-                                              (set_local $7
-                                                (i32.add
-                                                  (get_local $6)
-                                                  (i32.const -4)
-                                                )
-                                              )
-                                              (get_local $5)
-                                            )
-                                            (block
-                                              (i32.store
-                                                (set_local $5
-                                                  (i32.add
-                                                    (get_local $5)
-                                                    (i32.const -4)
-                                                  )
-                                                )
-                                                (i32.const 0)
-                                              )
-                                              (get_local $5)
-                                            )
-                                            (get_local $5)
-                                          )
-                                        )
-                                        (i32.store
-                                          (get_local $7)
-                                          (set_local $6
-                                            (i32.add
-                                              (i32.load
-                                                (get_local $7)
-                                              )
-                                              (i32.const 1)
-                                            )
-                                          )
-                                        )
+                                      (set_local $7
                                         (if
-                                          (i32.gt_u
-                                            (get_local $6)
-                                            (i32.const 999999999)
-                                          )
-                                          (set_local $6
+                                          (i32.lt_u
+                                            (set_local $6
+                                              (i32.add
+                                                (get_local $6)
+                                                (i32.const -4)
+                                              )
+                                            )
                                             (get_local $7)
                                           )
                                           (block
-                                            (set_local $6
-                                              (get_local $5)
+                                            (i32.store
+                                              (set_local $5
+                                                (i32.add
+                                                  (get_local $7)
+                                                  (i32.const -4)
+                                                )
+                                              )
+                                              (i32.const 0)
                                             )
-                                            (br $while-out$92)
+                                            (get_local $5)
+                                          )
+                                          (get_local $7)
+                                        )
+                                      )
+                                      (i32.store
+                                        (get_local $6)
+                                        (set_local $5
+                                          (i32.add
+                                            (i32.load
+                                              (get_local $6)
+                                            )
+                                            (i32.const 1)
                                           )
                                         )
-                                        (br $while-in$93)
                                       )
+                                      (if
+                                        (i32.le_u
+                                          (get_local $5)
+                                          (i32.const 999999999)
+                                        )
+                                        (br $while-out$92)
+                                      )
+                                      (br $while-in$93)
                                     )
                                   )
-                                  (set_local $9
+                                  (set_local $11
                                     (i32.mul
                                       (i32.shr_s
                                         (i32.sub
-                                          (get_local $30)
-                                          (get_local $6)
+                                          (get_local $62)
+                                          (get_local $7)
                                         )
                                         (i32.const 2)
                                       )
@@ -6767,47 +6612,41 @@
                                     (i32.lt_u
                                       (set_local $5
                                         (i32.load
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 10)
                                     )
                                     (block
-                                      (set_local $5
-                                        (get_local $6)
-                                      )
-                                      (set_local $6
-                                        (get_local $7)
+                                      (set_local $13
+                                        (get_local $11)
                                       )
                                       (br $do-once$88)
                                     )
-                                    (set_local $13
+                                    (set_local $10
                                       (i32.const 10)
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
-                                    (set_local $9
+                                    (set_local $11
                                       (i32.add
-                                        (get_local $9)
+                                        (get_local $11)
                                         (i32.const 1)
                                       )
                                     )
                                     (if
                                       (i32.lt_u
                                         (get_local $5)
-                                        (set_local $13
+                                        (set_local $10
                                           (i32.mul
-                                            (get_local $13)
+                                            (get_local $10)
                                             (i32.const 10)
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $5
-                                          (get_local $6)
-                                        )
-                                        (set_local $6
-                                          (get_local $7)
+                                        (set_local $13
+                                          (get_local $11)
                                         )
                                         (br $while-out$94)
                                       )
@@ -6817,10 +6656,10 @@
                                 )
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.gt_u
-                                (get_local $26)
-                                (set_local $6
+                                (get_local $27)
+                                (set_local $5
                                   (i32.add
                                     (get_local $6)
                                     (i32.const 4)
@@ -6828,44 +6667,41 @@
                                 )
                               )
                             )
-                            (set_local $10
-                              (get_local $9)
-                            )
-                            (set_local $7
+                            (set_local $6
                               (select
+                                (get_local $5)
+                                (get_local $27)
                                 (get_local $6)
-                                (get_local $26)
-                                (get_local $7)
                               )
                             )
-                            (get_local $5)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $7
-                              (get_local $26)
+                            (set_local $6
+                              (get_local $27)
                             )
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
-                      (set_local $26
+                      (set_local $27
                         (i32.sub
                           (i32.const 0)
-                          (get_local $10)
+                          (get_local $13)
                         )
                       )
                       (loop $while-out$96 $while-in$97
                         (if
                           (i32.le_u
-                            (get_local $7)
                             (get_local $6)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $9
+                            (set_local $11
                               (i32.const 0)
                             )
-                            (set_local $24
-                              (get_local $7)
+                            (set_local $23
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
@@ -6875,22 +6711,22 @@
                             (i32.load
                               (set_local $5
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const -4)
                                 )
                               )
                             )
                             (i32.const 0)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $5)
                           )
                           (block
-                            (set_local $9
+                            (set_local $11
                               (i32.const 1)
                             )
-                            (set_local $24
-                              (get_local $7)
+                            (set_local $23
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
@@ -6918,17 +6754,17 @@
                                           (get_local $1)
                                         )
                                       )
-                                      (get_local $10)
+                                      (get_local $13)
                                     )
                                     (i32.gt_s
-                                      (get_local $10)
+                                      (get_local $13)
                                       (i32.const -5)
                                     )
                                   )
                                   (block
-                                    (set_local $13
+                                    (set_local $10
                                       (i32.add
-                                        (get_local $33)
+                                        (get_local $26)
                                         (i32.const -1)
                                       )
                                     )
@@ -6937,13 +6773,13 @@
                                         (get_local $1)
                                         (i32.const -1)
                                       )
-                                      (get_local $10)
+                                      (get_local $13)
                                     )
                                   )
                                   (block
-                                    (set_local $13
+                                    (set_local $10
                                       (i32.add
-                                        (get_local $33)
+                                        (get_local $26)
                                         (i32.const -2)
                                       )
                                     )
@@ -6958,18 +6794,18 @@
                                 (i32.ne
                                   (set_local $1
                                     (i32.and
-                                      (get_local $17)
+                                      (get_local $18)
                                       (i32.const 8)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $21
+                                  (set_local $14
                                     (get_local $8)
                                   )
-                                  (set_local $30
-                                    (get_local $13)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                   (br $do-once$98
                                     (get_local $1)
@@ -6978,14 +6814,14 @@
                               )
                               (block $do-once$100
                                 (if
-                                  (get_local $9)
+                                  (get_local $11)
                                   (block
                                     (if
                                       (i32.eq
                                         (set_local $1
                                           (i32.load
                                             (i32.add
-                                              (get_local $24)
+                                              (get_local $23)
                                               (i32.const -4)
                                             )
                                           )
@@ -6993,7 +6829,7 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $1
+                                        (set_local $6
                                           (i32.const 9)
                                         )
                                         (br $do-once$100)
@@ -7014,21 +6850,21 @@
                                         (set_local $5
                                           (i32.const 10)
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                       )
                                       (block
-                                        (set_local $1
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                         (br $do-once$100)
                                       )
                                     )
                                     (loop $while-out$102 $while-in$103
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 1)
                                         )
                                       )
@@ -7048,28 +6884,23 @@
                                           )
                                           (i32.const 0)
                                         )
-                                        (block
-                                          (set_local $1
-                                            (get_local $7)
-                                          )
-                                          (br $while-out$102)
-                                        )
+                                        (br $while-out$102)
                                       )
                                       (br $while-in$103)
                                     )
                                   )
-                                  (set_local $1
+                                  (set_local $6
                                     (i32.const 9)
                                   )
                                 )
                               )
-                              (set_local $5
+                              (set_local $1
                                 (i32.add
                                   (i32.mul
                                     (i32.shr_s
                                       (i32.sub
-                                        (get_local $24)
-                                        (get_local $30)
+                                        (get_local $23)
+                                        (get_local $62)
                                       )
                                       (i32.const 2)
                                     )
@@ -7081,7 +6912,7 @@
                               (if
                                 (i32.eq
                                   (i32.or
-                                    (get_local $13)
+                                    (get_local $10)
                                     (i32.const 32)
                                   )
                                   (i32.const 102)
@@ -7091,8 +6922,8 @@
                                     (i32.lt_s
                                       (set_local $5
                                         (i32.sub
-                                          (get_local $5)
                                           (get_local $1)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 0)
@@ -7110,15 +6941,15 @@
                                       )
                                     )
                                   )
-                                  (set_local $21
+                                  (set_local $14
                                     (select
                                       (get_local $8)
                                       (get_local $1)
                                       (get_local $5)
                                     )
                                   )
-                                  (set_local $30
-                                    (get_local $13)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                   (i32.const 0)
                                 )
@@ -7128,10 +6959,10 @@
                                       (set_local $5
                                         (i32.sub
                                           (i32.add
-                                            (get_local $5)
-                                            (get_local $10)
+                                            (get_local $1)
+                                            (get_local $13)
                                           )
-                                          (get_local $1)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 0)
@@ -7149,41 +6980,38 @@
                                       )
                                     )
                                   )
-                                  (set_local $21
+                                  (set_local $14
                                     (select
                                       (get_local $8)
                                       (get_local $1)
                                       (get_local $5)
                                     )
                                   )
-                                  (set_local $30
-                                    (get_local $13)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                   (i32.const 0)
                                 )
                               )
                             )
                             (block
-                              (set_local $21
+                              (set_local $14
                                 (get_local $1)
                               )
-                              (set_local $30
-                                (get_local $33)
-                              )
                               (i32.and
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 8)
                               )
                             )
                           )
                         )
                       )
-                      (set_local $16
+                      (set_local $17
                         (i32.and
                           (i32.ne
                             (set_local $1
                               (i32.or
-                                (get_local $21)
+                                (get_local $14)
                                 (get_local $8)
                               )
                             )
@@ -7192,24 +7020,24 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $10
+                      (set_local $13
                         (if
-                          (set_local $13
+                          (set_local $10
                             (i32.eq
                               (i32.or
-                                (get_local $30)
+                                (get_local $26)
                                 (i32.const 32)
                               )
                               (i32.const 102)
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (select
-                                (get_local $10)
+                                (get_local $13)
                                 (i32.const 0)
                                 (i32.gt_s
-                                  (get_local $10)
+                                  (get_local $13)
                                   (i32.const 0)
                                 )
                               )
@@ -7221,12 +7049,12 @@
                               (i32.shr_s
                                 (i32.shl
                                   (i32.lt_s
-                                    (set_local $7
+                                    (set_local $6
                                       (select
-                                        (get_local $26)
-                                        (get_local $10)
+                                        (get_local $27)
+                                        (get_local $13)
                                         (i32.lt_s
-                                          (get_local $10)
+                                          (get_local $13)
                                           (i32.const 0)
                                         )
                                       )
@@ -7241,12 +7069,12 @@
                             (if
                               (i32.lt_s
                                 (i32.sub
-                                  (get_local $41)
+                                  (get_local $40)
                                   (set_local $5
                                     (call $_fmt_u
-                                      (get_local $7)
+                                      (get_local $6)
                                       (get_local $5)
-                                      (get_local $54)
+                                      (get_local $52)
                                     )
                                   )
                                 )
@@ -7265,7 +7093,7 @@
                                 (if
                                   (i32.lt_s
                                     (i32.sub
-                                      (get_local $41)
+                                      (get_local $40)
                                       (get_local $5)
                                     )
                                     (i32.const 2)
@@ -7286,7 +7114,7 @@
                                 (i32.add
                                   (i32.and
                                     (i32.shr_s
-                                      (get_local $10)
+                                      (get_local $13)
                                       (i32.const 31)
                                     )
                                     (i32.const 2)
@@ -7304,13 +7132,13 @@
                                 )
                               )
                               (i32.and
-                                (get_local $30)
+                                (get_local $26)
                                 (i32.const 255)
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.sub
-                                (get_local $41)
+                                (get_local $40)
                                 (get_local $5)
                               )
                             )
@@ -7321,23 +7149,23 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
-                        (set_local $7
+                        (get_local $16)
+                        (set_local $6
                           (i32.add
                             (i32.add
                               (i32.add
                                 (i32.add
-                                  (get_local $53)
+                                  (get_local $51)
                                   (i32.const 1)
                                 )
-                                (get_local $21)
+                                (get_local $14)
                               )
-                              (get_local $16)
+                              (get_local $17)
                             )
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
-                        (get_local $17)
+                        (get_local $18)
                       )
                       (if
                         (i32.eq
@@ -7350,33 +7178,33 @@
                           (i32.const 0)
                         )
                         (call $___fwritex
-                          (get_local $40)
-                          (get_local $53)
+                          (get_local $39)
+                          (get_local $51)
                           (get_local $0)
                         )
                       )
                       (call $_pad
                         (get_local $0)
                         (i32.const 48)
-                        (get_local $15)
-                        (get_local $7)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $17)
+                          (get_local $18)
                           (i32.const 65536)
                         )
                       )
                       (block $do-once$106
                         (if
-                          (get_local $13)
+                          (get_local $10)
                           (block
-                            (set_local $6
+                            (set_local $7
                               (set_local $8
                                 (select
-                                  (get_local $11)
-                                  (get_local $6)
+                                  (get_local $9)
+                                  (get_local $7)
                                   (i32.gt_u
-                                    (get_local $6)
-                                    (get_local $11)
+                                    (get_local $7)
+                                    (get_local $9)
                                   )
                                 )
                               )
@@ -7385,39 +7213,39 @@
                               (set_local $5
                                 (call $_fmt_u
                                   (i32.load
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                   (i32.const 0)
-                                  (get_local $46)
+                                  (get_local $45)
                                 )
                               )
                               (block $do-once$110
                                 (if
                                   (i32.eq
-                                    (get_local $6)
+                                    (get_local $7)
                                     (get_local $8)
                                   )
                                   (block
                                     (if
                                       (i32.ne
                                         (get_local $5)
-                                        (get_local $46)
+                                        (get_local $45)
                                       )
                                       (br $do-once$110)
                                     )
                                     (i32.store8
-                                      (get_local $55)
+                                      (get_local $53)
                                       (i32.const 48)
                                     )
                                     (set_local $5
-                                      (get_local $55)
+                                      (get_local $53)
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.gt_u
                                         (get_local $5)
-                                        (get_local $28)
+                                        (get_local $29)
                                       )
                                       (get_local $5)
                                       (br $do-once$110)
@@ -7435,7 +7263,7 @@
                                       (if
                                         (i32.gt_u
                                           (get_local $5)
-                                          (get_local $28)
+                                          (get_local $29)
                                         )
                                         (get_local $5)
                                         (br $while-out$112)
@@ -7466,18 +7294,21 @@
                               )
                               (if
                                 (i32.gt_u
-                                  (set_local $5
+                                  (set_local $7
                                     (i32.add
-                                      (get_local $6)
+                                      (get_local $7)
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
-                                (br $while-out$108)
-                                (set_local $6
-                                  (get_local $5)
+                                (block
+                                  (set_local $5
+                                    (get_local $7)
+                                  )
+                                  (br $while-out$108)
                                 )
+                                (get_local $7)
                               )
                               (br $while-in$109)
                             )
@@ -7510,126 +7341,114 @@
                             (if
                               (i32.and
                                 (i32.gt_s
-                                  (get_local $21)
+                                  (get_local $14)
                                   (i32.const 0)
                                 )
                                 (i32.lt_u
                                   (get_local $5)
-                                  (get_local $24)
+                                  (get_local $23)
                                 )
                               )
-                              (block
-                                (set_local $6
-                                  (get_local $21)
-                                )
-                                (loop $while-out$116 $while-in$117
-                                  (if
-                                    (i32.gt_u
+                              (loop $while-out$116 $while-in$117
+                                (if
+                                  (i32.gt_u
+                                    (set_local $1
+                                      (call $_fmt_u
+                                        (i32.load
+                                          (get_local $5)
+                                        )
+                                        (i32.const 0)
+                                        (get_local $45)
+                                      )
+                                    )
+                                    (get_local $29)
+                                  )
+                                  (loop $while-out$118 $while-in$119
+                                    (i32.store8
                                       (set_local $1
-                                        (call $_fmt_u
-                                          (i32.load
-                                            (get_local $5)
-                                          )
-                                          (i32.const 0)
-                                          (get_local $46)
-                                        )
-                                      )
-                                      (get_local $28)
-                                    )
-                                    (loop $while-out$118 $while-in$119
-                                      (i32.store8
-                                        (set_local $1
-                                          (i32.add
-                                            (get_local $1)
-                                            (i32.const -1)
-                                          )
-                                        )
-                                        (i32.const 48)
-                                      )
-                                      (if
-                                        (i32.gt_u
+                                        (i32.add
                                           (get_local $1)
-                                          (get_local $28)
+                                          (i32.const -1)
                                         )
-                                        (get_local $1)
-                                        (br $while-out$118)
                                       )
-                                      (br $while-in$119)
+                                      (i32.const 48)
                                     )
+                                    (if
+                                      (i32.gt_u
+                                        (get_local $1)
+                                        (get_local $29)
+                                      )
+                                      (get_local $1)
+                                      (br $while-out$118)
+                                    )
+                                    (br $while-in$119)
+                                  )
+                                  (get_local $1)
+                                )
+                                (if
+                                  (i32.eq
+                                    (i32.and
+                                      (i32.load
+                                        (get_local $0)
+                                      )
+                                      (i32.const 32)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (call $___fwritex
+                                    (get_local $1)
+                                    (select
+                                      (i32.const 9)
+                                      (get_local $14)
+                                      (i32.gt_s
+                                        (get_local $14)
+                                        (i32.const 9)
+                                      )
+                                    )
+                                    (get_local $0)
+                                  )
+                                )
+                                (set_local $1
+                                  (i32.add
+                                    (get_local $14)
+                                    (i32.const -9)
+                                  )
+                                )
+                                (if
+                                  (i32.and
+                                    (i32.gt_s
+                                      (get_local $14)
+                                      (i32.const 9)
+                                    )
+                                    (i32.lt_u
+                                      (set_local $5
+                                        (i32.add
+                                          (get_local $5)
+                                          (i32.const 4)
+                                        )
+                                      )
+                                      (get_local $23)
+                                    )
+                                  )
+                                  (set_local $14
                                     (get_local $1)
                                   )
-                                  (if
-                                    (i32.eq
-                                      (i32.and
-                                        (i32.load
-                                          (get_local $0)
-                                        )
-                                        (i32.const 32)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (call $___fwritex
+                                  (block
+                                    (set_local $14
                                       (get_local $1)
-                                      (select
-                                        (i32.const 9)
-                                        (get_local $6)
-                                        (i32.gt_s
-                                          (get_local $6)
-                                          (i32.const 9)
-                                        )
-                                      )
-                                      (get_local $0)
                                     )
+                                    (br $while-out$116)
                                   )
-                                  (set_local $8
-                                    (i32.add
-                                      (get_local $6)
-                                      (i32.const -9)
-                                    )
-                                  )
-                                  (if
-                                    (i32.and
-                                      (i32.gt_s
-                                        (get_local $6)
-                                        (i32.const 9)
-                                      )
-                                      (i32.lt_u
-                                        (set_local $1
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 4)
-                                          )
-                                        )
-                                        (get_local $24)
-                                      )
-                                    )
-                                    (block
-                                      (set_local $5
-                                        (get_local $1)
-                                      )
-                                      (set_local $6
-                                        (get_local $8)
-                                      )
-                                    )
-                                    (block
-                                      (set_local $1
-                                        (get_local $8)
-                                      )
-                                      (br $while-out$116)
-                                    )
-                                  )
-                                  (br $while-in$117)
                                 )
+                                (br $while-in$117)
                               )
-                              (set_local $1
-                                (get_local $21)
-                              )
+                              (get_local $14)
                             )
                             (call $_pad
                               (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $1)
+                                (get_local $14)
                                 (i32.const 9)
                               )
                               (i32.const 9)
@@ -7637,19 +7456,19 @@
                             )
                           )
                           (block
-                            (set_local $13
+                            (set_local $11
                               (select
-                                (get_local $24)
+                                (get_local $23)
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $7)
                                   (i32.const 4)
                                 )
-                                (get_local $9)
+                                (get_local $11)
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $21)
+                                (get_local $14)
                                 (i32.const -1)
                               )
                               (block
@@ -7660,13 +7479,10 @@
                                   )
                                 )
                                 (set_local $5
-                                  (get_local $6)
-                                )
-                                (set_local $8
-                                  (get_local $21)
+                                  (get_local $7)
                                 )
                                 (loop $while-out$120 $while-in$121
-                                  (set_local $11
+                                  (set_local $8
                                     (if
                                       (i32.eq
                                         (set_local $1
@@ -7675,17 +7491,17 @@
                                               (get_local $5)
                                             )
                                             (i32.const 0)
-                                            (get_local $46)
+                                            (get_local $45)
                                           )
                                         )
-                                        (get_local $46)
+                                        (get_local $45)
                                       )
                                       (block
                                         (i32.store8
-                                          (get_local $55)
+                                          (get_local $53)
                                           (i32.const 48)
                                         )
-                                        (get_local $55)
+                                        (get_local $53)
                                       )
                                       (get_local $1)
                                     )
@@ -7694,12 +7510,12 @@
                                     (if
                                       (i32.eq
                                         (get_local $5)
-                                        (get_local $6)
+                                        (get_local $7)
                                       )
                                       (block
                                         (set_local $1
                                           (i32.add
-                                            (get_local $11)
+                                            (get_local $8)
                                             (i32.const 1)
                                           )
                                         )
@@ -7714,7 +7530,7 @@
                                             (i32.const 0)
                                           )
                                           (call $___fwritex
-                                            (get_local $11)
+                                            (get_local $8)
                                             (i32.const 1)
                                             (get_local $0)
                                           )
@@ -7723,7 +7539,7 @@
                                           (i32.and
                                             (get_local $9)
                                             (i32.lt_s
-                                              (get_local $8)
+                                              (get_local $14)
                                               (i32.const 1)
                                             )
                                           )
@@ -7750,15 +7566,15 @@
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $11)
-                                            (get_local $28)
+                                            (get_local $8)
+                                            (get_local $29)
                                           )
                                           (set_local $1
-                                            (get_local $11)
+                                            (get_local $8)
                                           )
                                           (block
                                             (set_local $1
-                                              (get_local $11)
+                                              (get_local $8)
                                             )
                                             (br $do-once$122)
                                           )
@@ -7776,7 +7592,7 @@
                                           (if
                                             (i32.gt_u
                                               (get_local $1)
-                                              (get_local $28)
+                                              (get_local $29)
                                             )
                                             (get_local $1)
                                             (br $while-out$124)
@@ -7786,7 +7602,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $11
+                                  (set_local $8
                                     (i32.sub
                                       (get_local $75)
                                       (get_local $1)
@@ -7805,59 +7621,51 @@
                                     (call $___fwritex
                                       (get_local $1)
                                       (select
-                                        (get_local $11)
                                         (get_local $8)
+                                        (get_local $14)
                                         (i32.gt_s
+                                          (get_local $14)
                                           (get_local $8)
-                                          (get_local $11)
                                         )
                                       )
                                       (get_local $0)
                                     )
                                   )
                                   (if
-                                    (i32.and
-                                      (i32.lt_u
-                                        (set_local $1
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 4)
+                                    (i32.eqz
+                                      (i32.and
+                                        (i32.lt_u
+                                          (set_local $5
+                                            (i32.add
+                                              (get_local $5)
+                                              (i32.const 4)
+                                            )
                                           )
+                                          (get_local $11)
                                         )
-                                        (get_local $13)
-                                      )
-                                      (i32.gt_s
-                                        (set_local $8
-                                          (i32.sub
-                                            (get_local $8)
-                                            (get_local $11)
+                                        (i32.gt_s
+                                          (set_local $14
+                                            (i32.sub
+                                              (get_local $14)
+                                              (get_local $8)
+                                            )
                                           )
+                                          (i32.const -1)
                                         )
-                                        (i32.const -1)
                                       )
                                     )
-                                    (set_local $5
-                                      (get_local $1)
-                                    )
-                                    (block
-                                      (set_local $1
-                                        (get_local $8)
-                                      )
-                                      (br $while-out$120)
-                                    )
+                                    (br $while-out$120)
                                   )
                                   (br $while-in$121)
                                 )
                               )
-                              (set_local $1
-                                (get_local $21)
-                              )
+                              (get_local $14)
                             )
                             (call $_pad
                               (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $1)
+                                (get_local $14)
                                 (i32.const 18)
                               )
                               (i32.const 18)
@@ -7875,10 +7683,10 @@
                               )
                             )
                             (call $___fwritex
-                              (get_local $10)
+                              (get_local $13)
                               (i32.sub
-                                (get_local $41)
-                                (get_local $10)
+                                (get_local $40)
+                                (get_local $13)
                               )
                               (get_local $0)
                             )
@@ -7888,19 +7696,19 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
-                        (get_local $7)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $17)
+                          (get_local $18)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $15)
-                        (get_local $7)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.lt_s
-                          (get_local $7)
-                          (get_local $15)
+                          (get_local $6)
+                          (get_local $16)
                         )
                       )
                     )
@@ -7912,7 +7720,7 @@
                           (set_local $8
                             (i32.ne
                               (i32.and
-                                (get_local $33)
+                                (get_local $26)
                                 (i32.const 32)
                               )
                               (i32.const 0)
@@ -7923,12 +7731,12 @@
                       (set_local $6
                         (select
                           (i32.const 0)
-                          (get_local $53)
+                          (get_local $51)
                           (set_local $1
                             (i32.or
                               (f64.ne
-                                (get_local $14)
-                                (get_local $14)
+                                (get_local $15)
+                                (get_local $15)
                               )
                               (i32.const 0)
                             )
@@ -7949,7 +7757,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
+                        (get_local $16)
                         (set_local $5
                           (i32.add
                             (get_local $6)
@@ -7975,7 +7783,7 @@
                               )
                               (block
                                 (call $___fwritex
-                                  (get_local $40)
+                                  (get_local $39)
                                   (get_local $6)
                                   (get_local $0)
                                 )
@@ -7998,47 +7806,47 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
+                        (get_local $16)
                         (get_local $5)
                         (i32.xor
-                          (get_local $17)
+                          (get_local $18)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $15)
+                        (get_local $16)
                         (get_local $5)
                         (i32.lt_s
                           (get_local $5)
-                          (get_local $15)
+                          (get_local $16)
                         )
                       )
                     )
                   )
                 )
               )
-              (set_local $11
-                (get_local $22)
+              (set_local $8
+                (get_local $21)
               )
               (br $label$continue$L1)
             )
-            (set_local $49
+            (set_local $47
               (get_local $20)
             )
-            (set_local $38
-              (get_local $17)
+            (set_local $37
+              (get_local $18)
             )
-            (set_local $43
+            (set_local $42
               (get_local $10)
             )
-            (set_local $44
+            (set_local $43
               (i32.const 0)
             )
-            (set_local $50
+            (set_local $48
               (i32.const 4091)
             )
-            (set_local $51
-              (get_local $27)
+            (set_local $49
+              (get_local $28)
             )
           )
         )
@@ -8050,20 +7858,20 @@
             (i32.const 64)
           )
           (block
-            (set_local $6
+            (set_local $7
               (i32.and
                 (get_local $68)
                 (i32.const 32)
               )
             )
-            (set_local $34
+            (set_local $58
               (if
                 (i32.and
                   (i32.eq
                     (set_local $5
                       (i32.load
                         (set_local $1
-                          (get_local $18)
+                          (get_local $19)
                         )
                       )
                     )
@@ -8079,32 +7887,32 @@
                   )
                 )
                 (block
-                  (set_local $35
-                    (get_local $47)
+                  (set_local $34
+                    (get_local $46)
                   )
                   (set_local $32
-                    (get_local $59)
+                    (get_local $57)
                   )
-                  (set_local $36
+                  (set_local $35
                     (i32.const 0)
                   )
-                  (set_local $37
+                  (set_local $36
                     (i32.const 4091)
                   )
                   (set_local $12
                     (i32.const 77)
                   )
-                  (get_local $27)
+                  (get_local $28)
                 )
                 (block
-                  (set_local $7
-                    (get_local $27)
+                  (set_local $6
+                    (get_local $28)
                   )
                   (loop $while-out$129 $while-in$130
                     (i32.store8
-                      (set_local $7
+                      (set_local $6
                         (i32.add
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const -1)
                         )
                       )
@@ -8122,7 +7930,7 @@
                             )
                             (i32.const 255)
                           )
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (i32.const 255)
                       )
@@ -8148,12 +7956,7 @@
                           (i32.const 0)
                         )
                       )
-                      (block
-                        (set_local $5
-                          (get_local $7)
-                        )
-                        (br $while-out$129)
-                      )
+                      (br $while-out$129)
                     )
                     (br $while-in$130)
                   )
@@ -8161,7 +7964,7 @@
                     (i32.or
                       (i32.eq
                         (i32.and
-                          (get_local $47)
+                          (get_local $46)
                           (i32.const 8)
                         )
                         (i32.const 0)
@@ -8170,7 +7973,7 @@
                         (i32.eq
                           (i32.load
                             (set_local $1
-                              (get_local $18)
+                              (get_local $19)
                             )
                           )
                           (i32.const 0)
@@ -8184,34 +7987,34 @@
                       )
                     )
                     (block
-                      (set_local $35
-                        (get_local $47)
+                      (set_local $34
+                        (get_local $46)
                       )
                       (set_local $32
-                        (get_local $59)
+                        (get_local $57)
                       )
-                      (set_local $36
+                      (set_local $35
                         (i32.const 0)
                       )
-                      (set_local $37
+                      (set_local $36
                         (i32.const 4091)
                       )
                       (set_local $12
                         (i32.const 77)
                       )
-                      (get_local $5)
+                      (get_local $6)
                     )
                     (block
-                      (set_local $35
-                        (get_local $47)
+                      (set_local $34
+                        (get_local $46)
                       )
                       (set_local $32
-                        (get_local $59)
+                        (get_local $57)
                       )
-                      (set_local $36
+                      (set_local $35
                         (i32.const 2)
                       )
-                      (set_local $37
+                      (set_local $36
                         (i32.add
                           (i32.const 4091)
                           (i32.shr_s
@@ -8223,7 +8026,7 @@
                       (set_local $12
                         (i32.const 77)
                       )
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                 )
@@ -8236,24 +8039,24 @@
               (i32.const 76)
             )
             (block
-              (set_local $34
+              (set_local $58
                 (call $_fmt_u
-                  (get_local $48)
-                  (get_local $60)
-                  (get_local $27)
+                  (get_local $33)
+                  (get_local $59)
+                  (get_local $28)
                 )
               )
-              (set_local $35
-                (get_local $17)
+              (set_local $34
+                (get_local $18)
               )
               (set_local $32
                 (get_local $10)
               )
+              (set_local $35
+                (get_local $60)
+              )
               (set_local $36
                 (get_local $61)
-              )
-              (set_local $37
-                (get_local $62)
               )
               (set_local $12
                 (i32.const 77)
@@ -8272,7 +8075,7 @@
                   (i32.eq
                     (set_local $1
                       (call $_memchr
-                        (get_local $52)
+                        (get_local $50)
                         (i32.const 0)
                         (get_local $10)
                       )
@@ -8280,32 +8083,32 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $49
-                  (get_local $52)
+                (set_local $47
+                  (get_local $50)
                 )
-                (set_local $38
+                (set_local $37
                   (get_local $7)
                 )
-                (set_local $43
+                (set_local $42
                   (select
                     (get_local $10)
                     (i32.sub
                       (get_local $1)
-                      (get_local $52)
+                      (get_local $50)
                     )
                     (get_local $5)
                   )
                 )
-                (set_local $44
+                (set_local $43
                   (i32.const 0)
                 )
-                (set_local $50
+                (set_local $48
                   (i32.const 4091)
                 )
-                (set_local $51
+                (set_local $49
                   (select
                     (i32.add
-                      (get_local $52)
+                      (get_local $50)
                       (get_local $10)
                     )
                     (get_local $1)
@@ -8322,15 +8125,15 @@
                   (set_local $12
                     (i32.const 0)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
                   (set_local $5
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.load
-                      (get_local $18)
+                      (get_local $19)
                     )
                   )
                   (loop $while-out$131 $while-in$132
@@ -8338,17 +8141,12 @@
                       (i32.eq
                         (set_local $1
                           (i32.load
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                         (i32.const 0)
                       )
-                      (block
-                        (set_local $1
-                          (get_local $5)
-                        )
-                        (br $while-out$131)
-                      )
+                      (br $while-out$131)
                     )
                     (if
                       (i32.or
@@ -8365,20 +8163,15 @@
                           (get_local $5)
                           (i32.sub
                             (get_local $69)
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
-                      (block
-                        (set_local $1
-                          (get_local $5)
-                        )
-                        (br $while-out$131)
-                      )
+                      (br $while-out$131)
                     )
-                    (set_local $7
+                    (set_local $6
                       (i32.add
-                        (get_local $7)
+                        (get_local $6)
                         (i32.const 4)
                       )
                     )
@@ -8388,19 +8181,16 @@
                         (set_local $1
                           (i32.add
                             (get_local $5)
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (get_local $1)
                       )
                       (block
-                        (set_local $6
+                        (set_local $7
                           (get_local $1)
-                        )
-                        (set_local $1
-                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
@@ -8409,11 +8199,11 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $1)
+                      (get_local $5)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $23
+                      (set_local $24
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -8422,17 +8212,17 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $15)
-                    (get_local $6)
-                    (get_local $17)
+                    (get_local $16)
+                    (get_local $7)
+                    (get_local $18)
                   )
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $39
+                      (set_local $38
                         (i32.const 0)
                       )
                       (set_local $12
@@ -8440,12 +8230,12 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.load
-                          (get_local $18)
+                          (get_local $19)
                         )
                       )
                       (loop $while-out$133 $while-in$134
@@ -8453,14 +8243,14 @@
                           (i32.eq
                             (set_local $1
                               (i32.load
-                                (get_local $5)
+                                (get_local $8)
                               )
                             )
                             (i32.const 0)
                           )
                           (block
-                            (set_local $39
-                              (get_local $6)
+                            (set_local $38
+                              (get_local $7)
                             )
                             (set_local $12
                               (i32.const 98)
@@ -8468,9 +8258,9 @@
                             (br $label$break$L308)
                           )
                         )
-                        (set_local $11
+                        (set_local $8
                           (i32.add
-                            (get_local $5)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -8484,14 +8274,14 @@
                                     (get_local $1)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $39
-                              (get_local $6)
+                            (set_local $38
+                              (get_local $7)
                             )
                             (set_local $12
                               (i32.const 98)
@@ -8518,19 +8308,14 @@
                         (if
                           (i32.lt_u
                             (get_local $1)
-                            (get_local $6)
+                            (get_local $7)
+                          )
+                          (set_local $6
+                            (get_local $1)
                           )
                           (block
-                            (set_local $7
-                              (get_local $1)
-                            )
-                            (set_local $5
-                              (get_local $11)
-                            )
-                          )
-                          (block
-                            (set_local $39
-                              (get_local $6)
+                            (set_local $38
+                              (get_local $7)
                             )
                             (set_local $12
                               (i32.const 98)
@@ -8560,31 +8345,28 @@
           (call $_pad
             (get_local $0)
             (i32.const 32)
-            (get_local $15)
-            (get_local $39)
+            (get_local $16)
+            (get_local $38)
             (i32.xor
-              (get_local $17)
+              (get_local $18)
               (i32.const 8192)
             )
-          )
-          (set_local $19
-            (get_local $8)
           )
           (set_local $20
             (get_local $9)
           )
           (set_local $1
             (select
-              (get_local $15)
-              (get_local $39)
+              (get_local $16)
+              (get_local $38)
               (i32.gt_s
-                (get_local $15)
-                (get_local $39)
+                (get_local $16)
+                (get_local $38)
               )
             )
           )
-          (set_local $11
-            (get_local $22)
+          (set_local $8
+            (get_local $21)
           )
           (br $label$continue$L1)
         )
@@ -8601,17 +8383,17 @@
           (set_local $5
             (select
               (i32.and
-                (get_local $35)
+                (get_local $34)
                 (i32.const -65537)
               )
-              (get_local $35)
+              (get_local $34)
               (i32.gt_s
                 (get_local $32)
                 (i32.const -1)
               )
             )
           )
-          (set_local $49
+          (set_local $47
             (if
               (i32.or
                 (i32.ne
@@ -8623,7 +8405,7 @@
                     (i32.ne
                       (i32.load
                         (set_local $1
-                          (get_local $18)
+                          (get_local $19)
                         )
                       )
                       (i32.const 0)
@@ -8638,7 +8420,7 @@
                 )
               )
               (block
-                (set_local $6
+                (set_local $7
                   (i32.gt_s
                     (get_local $32)
                     (set_local $1
@@ -8652,50 +8434,50 @@
                         )
                         (i32.sub
                           (get_local $71)
-                          (get_local $34)
+                          (get_local $58)
                         )
                       )
                     )
                   )
                 )
-                (set_local $38
+                (set_local $37
                   (get_local $5)
                 )
-                (set_local $43
+                (set_local $42
                   (select
                     (get_local $32)
                     (get_local $1)
-                    (get_local $6)
+                    (get_local $7)
                   )
                 )
-                (set_local $44
+                (set_local $43
+                  (get_local $35)
+                )
+                (set_local $48
                   (get_local $36)
                 )
-                (set_local $50
-                  (get_local $37)
+                (set_local $49
+                  (get_local $28)
                 )
-                (set_local $51
-                  (get_local $27)
-                )
-                (get_local $34)
+                (get_local $58)
               )
               (block
-                (set_local $38
+                (set_local $37
                   (get_local $5)
                 )
-                (set_local $43
+                (set_local $42
                   (i32.const 0)
                 )
-                (set_local $44
+                (set_local $43
+                  (get_local $35)
+                )
+                (set_local $48
                   (get_local $36)
                 )
-                (set_local $50
-                  (get_local $37)
+                (set_local $49
+                  (get_local $28)
                 )
-                (set_local $51
-                  (get_local $27)
-                )
-                (get_local $27)
+                (get_local $28)
               )
             )
           )
@@ -8703,25 +8485,25 @@
       )
       (set_local $1
         (i32.lt_s
-          (get_local $43)
-          (set_local $6
+          (get_local $42)
+          (set_local $7
             (i32.sub
-              (get_local $51)
               (get_local $49)
+              (get_local $47)
             )
           )
         )
       )
       (set_local $5
         (i32.lt_s
-          (get_local $15)
+          (get_local $16)
           (set_local $1
             (i32.add
-              (get_local $44)
-              (set_local $7
+              (get_local $43)
+              (set_local $6
                 (select
-                  (get_local $6)
-                  (get_local $43)
+                  (get_local $7)
+                  (get_local $42)
                   (get_local $1)
                 )
               )
@@ -8735,12 +8517,12 @@
         (set_local $5
           (select
             (get_local $1)
-            (get_local $15)
+            (get_local $16)
             (get_local $5)
           )
         )
         (get_local $1)
-        (get_local $38)
+        (get_local $37)
       )
       (if
         (i32.eq
@@ -8753,8 +8535,8 @@
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $50)
-          (get_local $44)
+          (get_local $48)
+          (get_local $43)
           (get_local $0)
         )
       )
@@ -8764,15 +8546,15 @@
         (get_local $5)
         (get_local $1)
         (i32.xor
-          (get_local $38)
+          (get_local $37)
           (i32.const 65536)
         )
       )
       (call $_pad
         (get_local $0)
         (i32.const 48)
-        (get_local $7)
         (get_local $6)
+        (get_local $7)
         (i32.const 0)
       )
       (if
@@ -8786,8 +8568,8 @@
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $49)
-          (get_local $6)
+          (get_local $47)
+          (get_local $7)
           (get_local $0)
         )
       )
@@ -8797,12 +8579,9 @@
         (get_local $5)
         (get_local $1)
         (i32.xor
-          (get_local $38)
+          (get_local $37)
           (i32.const 8192)
         )
-      )
-      (set_local $19
-        (get_local $8)
       )
       (set_local $20
         (get_local $9)
@@ -8810,8 +8589,8 @@
       (set_local $1
         (get_local $5)
       )
-      (set_local $11
-        (get_local $22)
+      (set_local $8
+        (get_local $21)
       )
       (br $label$continue$L1)
     )
@@ -8831,7 +8610,7 @@
               (get_local $83)
               (i32.const 0)
             )
-            (set_local $23
+            (set_local $24
               (i32.const 0)
             )
             (block
@@ -8854,12 +8633,7 @@
                     )
                     (i32.const 0)
                   )
-                  (block
-                    (set_local $0
-                      (get_local $1)
-                    )
-                    (br $while-out$136)
-                  )
+                  (br $while-out$136)
                 )
                 (call $_pop_arg_336
                   (i32.add
@@ -8874,7 +8648,7 @@
                 )
                 (if
                   (i32.lt_s
-                    (set_local $0
+                    (set_local $1
                       (i32.add
                         (get_local $1)
                         (i32.const 1)
@@ -8882,11 +8656,9 @@
                     )
                     (i32.const 10)
                   )
-                  (set_local $1
-                    (get_local $0)
-                  )
+                  (get_local $1)
                   (block
-                    (set_local $23
+                    (set_local $24
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -8896,13 +8668,13 @@
               )
               (if
                 (i32.lt_s
-                  (get_local $0)
+                  (get_local $1)
                   (i32.const 10)
                 )
                 (loop $while-out$138 $while-in$139
-                  (set_local $1
+                  (set_local $0
                     (i32.add
-                      (get_local $0)
+                      (get_local $1)
                       (i32.const 1)
                     )
                   )
@@ -8912,7 +8684,7 @@
                         (i32.add
                           (get_local $4)
                           (i32.shl
-                            (get_local $0)
+                            (get_local $1)
                             (i32.const 2)
                           )
                         )
@@ -8920,7 +8692,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $23
+                      (set_local $24
                         (i32.const -1)
                       )
                       (br $label$break$L343)
@@ -8928,14 +8700,14 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $1)
+                      (get_local $0)
                       (i32.const 10)
                     )
-                    (set_local $0
-                      (get_local $1)
+                    (set_local $1
+                      (get_local $0)
                     )
                     (block
-                      (set_local $23
+                      (set_local $24
                         (i32.const 1)
                       )
                       (br $while-out$138)
@@ -8943,13 +8715,13 @@
                   )
                   (br $while-in$139)
                 )
-                (set_local $23
+                (set_local $24
                   (i32.const 1)
                 )
               )
             )
           )
-          (set_local $23
+          (set_local $24
             (get_local $82)
           )
         )
@@ -8959,7 +8731,7 @@
       (i32.const 8)
       (get_local $31)
     )
-    (get_local $23)
+    (get_local $24)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -9403,9 +9175,6 @@
           (set_local $4
             (get_local $1)
           )
-          (set_local $1
-            (get_local $2)
-          )
           (loop $while-out$0 $while-in$1
             (set_local $0
               (call $___uremdi3
@@ -9421,7 +9190,7 @@
             (i32.store8
               (set_local $2
                 (i32.add
-                  (get_local $1)
+                  (get_local $2)
                   (i32.const -1)
                 )
               )
@@ -9470,23 +9239,15 @@
                 (set_local $4
                   (get_local $1)
                 )
-                (set_local $1
-                  (get_local $2)
-                )
               )
-              (block
-                (set_local $1
-                  (get_local $2)
-                )
-                (br $while-out$0)
-              )
+              (br $while-out$0)
             )
             (br $while-in$1)
           )
           (set_local $3
             (get_local $0)
           )
-          (get_local $1)
+          (get_local $2)
         )
         (block
           (set_local $3
@@ -9506,9 +9267,6 @@
         (set_local $1
           (get_local $0)
         )
-        (set_local $2
-          (get_local $3)
-        )
         (loop $while-out$2 $while-in$3
           (i32.store8
             (set_local $1
@@ -9521,7 +9279,7 @@
               (i32.or
                 (i32.and
                   (call_import $i32u-rem
-                    (get_local $2)
+                    (get_local $3)
                     (i32.const 10)
                   )
                   (i32.const -1)
@@ -9534,7 +9292,7 @@
           (set_local $0
             (i32.and
               (call_import $i32u-div
-                (get_local $2)
+                (get_local $3)
                 (i32.const 10)
               )
               (i32.const -1)
@@ -9542,7 +9300,7 @@
           )
           (if
             (i32.lt_u
-              (get_local $2)
+              (get_local $3)
               (i32.const 10)
             )
             (block
@@ -9551,7 +9309,7 @@
               )
               (br $while-out$2)
             )
-            (set_local $2
+            (set_local $3
               (get_local $0)
             )
           )
@@ -9798,7 +9556,7 @@
                     )
                     (set_local $22
                       (i32.shr_u
-                        (set_local $12
+                        (set_local $6
                           (select
                             (i32.const 16)
                             (i32.and
@@ -9837,7 +9595,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $7
+                                      (set_local $8
                                         (i32.add
                                           (i32.xor
                                             (i32.and
@@ -9877,7 +9635,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $7)
+                        (get_local $8)
                       )
                       (i32.const -1)
                     )
@@ -9924,7 +9682,7 @@
                 (i32.or
                   (set_local $0
                     (i32.shl
-                      (get_local $7)
+                      (get_local $8)
                       (i32.const 3)
                     )
                   )
@@ -9958,7 +9716,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $12)
+              (get_local $6)
               (set_local $10
                 (i32.load
                   (i32.const 184)
@@ -10030,7 +9788,7 @@
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $7
+                                          (set_local $8
                                             (i32.add
                                               (i32.or
                                                 (i32.or
@@ -10132,13 +9890,13 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $7)
+                              (get_local $8)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (get_local $10)
                       )
                     )
@@ -10173,7 +9931,7 @@
                             (get_local $1)
                             (get_local $0)
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.load
                               (i32.const 184)
                             )
@@ -10186,7 +9944,7 @@
                   (i32.store offset=4
                     (get_local $2)
                     (i32.or
-                      (get_local $12)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
@@ -10194,17 +9952,17 @@
                     (set_local $4
                       (i32.add
                         (get_local $2)
-                        (get_local $12)
+                        (get_local $6)
                       )
                     )
                     (i32.or
                       (set_local $9
                         (i32.sub
                           (i32.shl
-                            (get_local $7)
+                            (get_local $8)
                             (i32.const 3)
                           )
-                          (get_local $12)
+                          (get_local $6)
                         )
                       )
                       (i32.const 1)
@@ -10219,7 +9977,7 @@
                   )
                   (if
                     (i32.ne
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
@@ -10228,14 +9986,14 @@
                           (i32.const 196)
                         )
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
                               (set_local $2
                                 (i32.shr_u
-                                  (get_local $6)
+                                  (get_local $7)
                                   (i32.const 3)
                                 )
                               )
@@ -10272,12 +10030,12 @@
                           )
                           (set_local $5
                             (i32.add
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 8)
                             )
                           )
-                          (set_local $8
-                            (get_local $7)
+                          (set_local $12
+                            (get_local $8)
                           )
                         )
                         (if
@@ -10286,7 +10044,7 @@
                               (i32.load
                                 (set_local $1
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $8)
                                     (i32.const 8)
                                   )
                                 )
@@ -10301,7 +10059,7 @@
                             (set_local $5
                               (get_local $1)
                             )
-                            (set_local $8
+                            (set_local $12
                               (get_local $2)
                             )
                           )
@@ -10312,16 +10070,16 @@
                         (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $8)
+                        (get_local $12)
                         (get_local $0)
                       )
                       (i32.store offset=8
                         (get_local $0)
-                        (get_local $8)
+                        (get_local $12)
                       )
                       (i32.store offset=12
                         (get_local $0)
-                        (get_local $7)
+                        (get_local $8)
                       )
                     )
                   )
@@ -10347,9 +10105,7 @@
                   )
                   (i32.const 0)
                 )
-                (set_local $8
-                  (get_local $12)
-                )
+                (get_local $6)
                 (block
                   (set_local $0
                     (i32.and
@@ -10456,13 +10212,13 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $12)
+                      (get_local $6)
                     )
                   )
                   (set_local $4
                     (get_local $0)
                   )
-                  (set_local $7
+                  (set_local $8
                     (get_local $0)
                   )
                   (loop $while-out$6 $while-in$7
@@ -10485,11 +10241,11 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $6
+                          (set_local $7
                             (get_local $2)
                           )
                           (set_local $10
-                            (get_local $7)
+                            (get_local $8)
                           )
                           (br $while-out$6)
                         )
@@ -10511,7 +10267,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $12)
+                            (get_local $6)
                           )
                         )
                         (get_local $2)
@@ -10527,10 +10283,10 @@
                     (set_local $4
                       (get_local $1)
                     )
-                    (set_local $7
+                    (set_local $8
                       (select
                         (get_local $1)
-                        (get_local $7)
+                        (get_local $8)
                         (get_local $0)
                       )
                     )
@@ -10553,7 +10309,7 @@
                       (set_local $9
                         (i32.add
                           (get_local $10)
-                          (get_local $12)
+                          (get_local $6)
                         )
                       )
                     )
@@ -10579,7 +10335,7 @@
                           (i32.eq
                             (set_local $2
                               (i32.load
-                                (set_local $7
+                                (set_local $8
                                   (i32.add
                                     (get_local $10)
                                     (i32.const 20)
@@ -10593,7 +10349,7 @@
                             (i32.eq
                               (set_local $2
                                 (i32.load
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 16)
@@ -10604,7 +10360,7 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $14
+                              (set_local $15
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -10636,7 +10392,7 @@
                               (set_local $4
                                 (get_local $2)
                               )
-                              (set_local $7
+                              (set_local $8
                                 (get_local $5)
                               )
                               (br $while-in$11)
@@ -10656,20 +10412,12 @@
                               )
                               (i32.const 0)
                             )
-                            (block
-                              (set_local $2
-                                (get_local $4)
-                              )
-                              (set_local $4
-                                (get_local $7)
-                              )
-                              (br $while-out$10)
-                            )
+                            (br $while-out$10)
                             (block
                               (set_local $4
                                 (get_local $2)
                               )
-                              (set_local $7
+                              (set_local $8
                                 (get_local $5)
                               )
                             )
@@ -10678,17 +10426,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $4)
+                            (get_local $8)
                             (get_local $0)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $4)
+                              (get_local $8)
                               (i32.const 0)
                             )
-                            (set_local $14
-                              (get_local $2)
+                            (set_local $15
+                              (get_local $4)
                             )
                           )
                         )
@@ -10722,7 +10470,7 @@
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $7
+                              (set_local $8
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
@@ -10737,10 +10485,10 @@
                               (get_local $2)
                             )
                             (i32.store
-                              (get_local $7)
+                              (get_local $8)
                               (get_local $4)
                             )
-                            (set_local $14
+                            (set_local $15
                               (get_local $2)
                             )
                           )
@@ -10778,11 +10526,11 @@
                           (block
                             (i32.store
                               (get_local $2)
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (if
                               (i32.eq
-                                (get_local $14)
+                                (get_local $15)
                                 (i32.const 0)
                               )
                               (block
@@ -10829,16 +10577,16 @@
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $14)
+                                (get_local $15)
                               )
                               (i32.store offset=20
                                 (get_local $1)
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eq
-                                (get_local $14)
+                                (get_local $15)
                                 (i32.const 0)
                               )
                             )
@@ -10846,7 +10594,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $14)
+                            (get_local $15)
                             (set_local $0
                               (i32.load
                                 (i32.const 192)
@@ -10856,7 +10604,7 @@
                           (call_import $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $14)
+                          (get_local $15)
                           (get_local $1)
                         )
                         (if
@@ -10876,12 +10624,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $14)
+                                (get_local $15)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                           )
@@ -10905,12 +10653,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $14)
+                                (get_local $15)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                           )
@@ -10920,7 +10668,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
@@ -10929,8 +10677,8 @@
                         (i32.or
                           (set_local $0
                             (i32.add
+                              (get_local $7)
                               (get_local $6)
-                              (get_local $12)
                             )
                           )
                           (i32.const 3)
@@ -10961,23 +10709,23 @@
                       (i32.store offset=4
                         (get_local $10)
                         (i32.or
-                          (get_local $12)
+                          (get_local $6)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
                         (get_local $9)
                         (i32.or
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
                           (get_local $9)
-                          (get_local $6)
+                          (get_local $7)
                         )
-                        (get_local $6)
+                        (get_local $7)
                       )
                       (if
                         (i32.ne
@@ -11042,7 +10790,7 @@
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $13
+                              (set_local $16
                                 (get_local $4)
                               )
                             )
@@ -11067,7 +10815,7 @@
                                 (set_local $3
                                   (get_local $0)
                                 )
-                                (set_local $13
+                                (set_local $16
                                   (get_local $2)
                                 )
                               )
@@ -11078,12 +10826,12 @@
                             (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $13)
+                            (get_local $16)
                             (get_local $1)
                           )
                           (i32.store offset=8
                             (get_local $1)
-                            (get_local $13)
+                            (get_local $16)
                           )
                           (i32.store offset=12
                             (get_local $1)
@@ -11093,7 +10841,7 @@
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $6)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 196)
@@ -11110,9 +10858,7 @@
                 )
               )
             )
-            (set_local $8
-              (get_local $12)
-            )
+            (get_local $6)
           )
         )
         (if
@@ -11120,7 +10866,7 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $8
+          (set_local $6
             (i32.const -1)
           )
           (block
@@ -11144,11 +10890,11 @@
                 )
                 (i32.const 0)
               )
-              (set_local $8
+              (set_local $6
                 (get_local $5)
               )
               (block
-                (set_local $13
+                (set_local $16
                   (i32.sub
                     (i32.const 0)
                     (get_local $5)
@@ -11160,7 +10906,7 @@
                       (set_local $3
                         (i32.load offset=480
                           (i32.shl
-                            (set_local $8
+                            (set_local $12
                               (if
                                 (i32.eq
                                   (set_local $3
@@ -11179,7 +10925,7 @@
                                   )
                                   (i32.const 31)
                                   (block
-                                    (set_local $6
+                                    (set_local $7
                                       (i32.shl
                                         (set_local $3
                                           (i32.add
@@ -11187,11 +10933,11 @@
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $8
+                                                          (set_local $12
                                                             (i32.shl
                                                               (get_local $3)
                                                               (set_local $3
@@ -11221,10 +10967,10 @@
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $6
+                                                        (set_local $7
                                                           (i32.shl
-                                                            (get_local $8)
-                                                            (get_local $6)
+                                                            (get_local $12)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -11238,7 +10984,7 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (get_local $3)
                                               )
                                               (i32.const 15)
@@ -11259,7 +11005,7 @@
                                         )
                                         (i32.const 1)
                                       )
-                                      (get_local $6)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -11273,7 +11019,7 @@
                     )
                     (block
                       (set_local $31
-                        (get_local $13)
+                        (get_local $16)
                       )
                       (set_local $32
                         (i32.const 0)
@@ -11286,10 +11032,10 @@
                       )
                     )
                     (block
-                      (set_local $6
-                        (get_local $13)
+                      (set_local $7
+                        (get_local $16)
                       )
-                      (set_local $14
+                      (set_local $15
                         (i32.const 0)
                       )
                       (set_local $11
@@ -11300,12 +11046,12 @@
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $8)
+                                (get_local $12)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $8)
+                              (get_local $12)
                               (i32.const 31)
                             )
                           )
@@ -11320,7 +11066,7 @@
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $13
+                            (set_local $16
                               (i32.sub
                                 (set_local $3
                                   (i32.and
@@ -11333,7 +11079,7 @@
                                 (get_local $5)
                               )
                             )
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (if
                             (i32.eq
@@ -11342,7 +11088,7 @@
                             )
                             (block
                               (set_local $26
-                                (get_local $13)
+                                (get_local $16)
                               )
                               (set_local $24
                                 (get_local $23)
@@ -11359,11 +11105,11 @@
                               (get_local $23)
                             )
                           )
-                          (set_local $13
-                            (get_local $6)
+                          (set_local $16
+                            (get_local $7)
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.eq
                             (set_local $3
                               (i32.load offset=20
@@ -11373,12 +11119,12 @@
                             (i32.const 0)
                           )
                         )
-                        (set_local $14
+                        (set_local $15
                           (select
-                            (get_local $14)
+                            (get_local $15)
                             (get_local $3)
                             (i32.or
-                              (get_local $6)
+                              (get_local $7)
                               (i32.eq
                                 (get_local $3)
                                 (set_local $3
@@ -11407,7 +11153,7 @@
                             (get_local $11)
                             (i32.xor
                               (i32.and
-                                (set_local $6
+                                (set_local $7
                                   (i32.eq
                                     (get_local $3)
                                     (i32.const 0)
@@ -11420,13 +11166,13 @@
                           )
                         )
                         (if
-                          (get_local $6)
+                          (get_local $7)
                           (block
                             (set_local $31
-                              (get_local $13)
+                              (get_local $16)
                             )
                             (set_local $32
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (set_local $28
                               (get_local $36)
@@ -11437,8 +11183,8 @@
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $6
-                              (get_local $13)
+                            (set_local $7
+                              (get_local $16)
                             )
                             (set_local $23
                               (get_local $3)
@@ -11470,13 +11216,13 @@
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (i32.sub
                                 (i32.const 0)
                                 (set_local $3
                                   (i32.shl
                                     (i32.const 2)
-                                    (get_local $8)
+                                    (get_local $12)
                                   )
                                 )
                               )
@@ -11488,14 +11234,14 @@
                                     (get_local $0)
                                     (i32.or
                                       (get_local $3)
-                                      (get_local $6)
+                                      (get_local $7)
                                     )
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $8
+                                (set_local $6
                                   (get_local $5)
                                 )
                                 (br $do-once$0)
@@ -11531,7 +11277,7 @@
                                           (set_local $3
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.shr_u
                                                     (get_local $3)
                                                     (get_local $0)
@@ -11549,7 +11295,7 @@
                                             (i32.shr_u
                                               (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (get_local $3)
                                                 )
                                               )
@@ -11607,7 +11353,7 @@
                       (set_local $17
                         (get_local $31)
                       )
-                      (set_local $15
+                      (set_local $13
                         (get_local $28)
                       )
                     )
@@ -11652,14 +11398,14 @@
                         (get_local $26)
                       )
                     )
-                    (set_local $3
+                    (set_local $17
                       (select
                         (get_local $3)
                         (get_local $26)
                         (get_local $0)
                       )
                     )
-                    (set_local $6
+                    (set_local $3
                       (select
                         (get_local $24)
                         (get_local $29)
@@ -11677,13 +11423,13 @@
                       )
                       (block
                         (set_local $26
-                          (get_local $3)
+                          (get_local $17)
                         )
                         (set_local $24
                           (get_local $0)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $3)
                         )
                         (br $while-in$20)
                       )
@@ -11698,23 +11444,20 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $17
+                        (set_local $13
                           (get_local $3)
-                        )
-                        (set_local $15
-                          (get_local $6)
                         )
                         (br $while-out$19)
                       )
                       (block
                         (set_local $26
-                          (get_local $3)
+                          (get_local $17)
                         )
                         (set_local $24
                           (get_local $0)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $3)
                         )
                       )
                     )
@@ -11723,10 +11466,10 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $15)
+                    (get_local $13)
                     (i32.const 0)
                   )
-                  (set_local $8
+                  (set_local $6
                     (get_local $5)
                   )
                   (if
@@ -11742,7 +11485,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $15)
+                          (get_local $13)
                           (set_local $0
                             (i32.load
                               (i32.const 192)
@@ -11753,10 +11496,10 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $15)
+                          (get_local $13)
                           (set_local $3
                             (i32.add
-                              (get_local $15)
+                              (get_local $13)
                               (get_local $5)
                             )
                           )
@@ -11765,7 +11508,7 @@
                       )
                       (set_local $1
                         (i32.load offset=24
-                          (get_local $15)
+                          (get_local $13)
                         )
                       )
                       (block $do-once$21
@@ -11773,10 +11516,10 @@
                           (i32.eq
                             (set_local $2
                               (i32.load offset=12
-                                (get_local $15)
+                                (get_local $13)
                               )
                             )
-                            (get_local $15)
+                            (get_local $13)
                           )
                           (block
                             (if
@@ -11785,7 +11528,7 @@
                                   (i32.load
                                     (set_local $9
                                       (i32.add
-                                        (get_local $15)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
@@ -11799,7 +11542,7 @@
                                     (i32.load
                                       (set_local $9
                                         (i32.add
-                                          (get_local $15)
+                                          (get_local $13)
                                           (i32.const 16)
                                         )
                                       )
@@ -11808,16 +11551,16 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $12
+                                  (set_local $6
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (get_local $2)
                                 )
                               )
-                              (set_local $7
+                              (set_local $8
                                 (get_local $2)
                               )
                             )
@@ -11826,9 +11569,9 @@
                                 (i32.ne
                                   (set_local $2
                                     (i32.load
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $8)
                                           (i32.const 20)
                                         )
                                       )
@@ -11837,11 +11580,11 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $7
+                                  (set_local $8
                                     (get_local $2)
                                   )
                                   (set_local $9
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                   (br $while-in$24)
                                 )
@@ -11850,9 +11593,9 @@
                                 (i32.eq
                                   (set_local $2
                                     (i32.load
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $8)
                                           (i32.const 16)
                                         )
                                       )
@@ -11860,21 +11603,13 @@
                                   )
                                   (i32.const 0)
                                 )
+                                (br $while-out$23)
                                 (block
-                                  (set_local $2
-                                    (get_local $7)
-                                  )
-                                  (set_local $7
-                                    (get_local $9)
-                                  )
-                                  (br $while-out$23)
-                                )
-                                (block
-                                  (set_local $7
+                                  (set_local $8
                                     (get_local $2)
                                   )
                                   (set_local $9
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                 )
                               )
@@ -11882,17 +11617,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $7)
+                                (get_local $9)
                                 (get_local $0)
                               )
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $7)
+                                  (get_local $9)
                                   (i32.const 0)
                                 )
-                                (set_local $12
-                                  (get_local $2)
+                                (set_local $6
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -11900,9 +11635,9 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $7
+                                (set_local $8
                                   (i32.load offset=8
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                 )
                                 (get_local $0)
@@ -11914,12 +11649,12 @@
                                 (i32.load
                                   (set_local $0
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $8)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $15)
+                                (get_local $13)
                               )
                               (call_import $_abort)
                             )
@@ -11933,7 +11668,7 @@
                                     )
                                   )
                                 )
-                                (get_local $15)
+                                (get_local $13)
                               )
                               (block
                                 (i32.store
@@ -11942,9 +11677,9 @@
                                 )
                                 (i32.store
                                   (get_local $9)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
-                                (set_local $12
+                                (set_local $6
                                   (get_local $2)
                                 )
                               )
@@ -11962,7 +11697,7 @@
                           (block
                             (if
                               (i32.eq
-                                (get_local $15)
+                                (get_local $13)
                                 (i32.load
                                   (set_local $2
                                     (i32.add
@@ -11970,7 +11705,7 @@
                                       (i32.shl
                                         (set_local $0
                                           (i32.load offset=28
-                                            (get_local $15)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.const 2)
@@ -11982,11 +11717,11 @@
                               (block
                                 (i32.store
                                   (get_local $2)
-                                  (get_local $12)
+                                  (get_local $6)
                                 )
                                 (if
                                   (i32.eq
-                                    (get_local $12)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                   (block
@@ -12029,20 +11764,20 @@
                                         )
                                       )
                                     )
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=20
                                     (get_local $1)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eq
-                                    (get_local $12)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -12050,7 +11785,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $12)
+                                (get_local $6)
                                 (set_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -12060,14 +11795,14 @@
                               (call_import $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $12)
+                              (get_local $6)
                               (get_local $1)
                             )
                             (if
                               (i32.ne
                                 (set_local $1
                                   (i32.load offset=16
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                 )
                                 (i32.const 0)
@@ -12080,12 +11815,12 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $12)
+                                    (get_local $6)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                 )
                               )
@@ -12094,7 +11829,7 @@
                               (i32.ne
                                 (set_local $0
                                   (i32.load offset=20
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                 )
                                 (i32.const 0)
@@ -12109,12 +11844,12 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $12)
+                                    (get_local $6)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                 )
                               )
@@ -12130,7 +11865,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $15)
+                              (get_local $13)
                               (i32.or
                                 (set_local $0
                                   (i32.add
@@ -12147,7 +11882,7 @@
                                   (set_local $0
                                     (i32.add
                                       (i32.add
-                                        (get_local $15)
+                                        (get_local $13)
                                         (get_local $0)
                                       )
                                       (i32.const 4)
@@ -12164,7 +11899,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $15)
+                              (get_local $13)
                               (i32.or
                                 (get_local $5)
                                 (i32.const 3)
@@ -12652,12 +12387,12 @@
                       )
                       (return
                         (i32.add
-                          (get_local $15)
+                          (get_local $13)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $8
+                    (set_local $6
                       (get_local $5)
                     )
                   )
@@ -12675,7 +12410,7 @@
             (i32.const 184)
           )
         )
-        (get_local $8)
+        (get_local $6)
       )
       (block
         (set_local $1
@@ -12688,7 +12423,7 @@
             (set_local $2
               (i32.sub
                 (get_local $0)
-                (get_local $8)
+                (get_local $6)
               )
             )
             (i32.const 15)
@@ -12699,7 +12434,7 @@
               (set_local $0
                 (i32.add
                   (get_local $1)
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
             )
@@ -12724,7 +12459,7 @@
             (i32.store offset=4
               (get_local $1)
               (i32.or
-                (get_local $8)
+                (get_local $6)
                 (i32.const 3)
               )
             )
@@ -12782,7 +12517,7 @@
             (i32.const 188)
           )
         )
-        (get_local $8)
+        (get_local $6)
       )
       (block
         (i32.store
@@ -12790,7 +12525,7 @@
           (set_local $2
             (i32.sub
               (get_local $0)
-              (get_local $8)
+              (get_local $6)
             )
           )
         )
@@ -12803,7 +12538,7 @@
                   (i32.const 200)
                 )
               )
-              (get_local $8)
+              (get_local $6)
             )
           )
         )
@@ -12817,7 +12552,7 @@
         (i32.store offset=4
           (get_local $0)
           (i32.or
-            (get_local $8)
+            (get_local $6)
             (i32.const 3)
           )
         )
@@ -12894,7 +12629,7 @@
     )
     (set_local $5
       (i32.add
-        (get_local $8)
+        (get_local $6)
         (i32.const 48)
       )
     )
@@ -12902,22 +12637,22 @@
       (i32.le_u
         (set_local $10
           (i32.and
-            (set_local $6
+            (set_local $7
               (i32.add
                 (set_local $0
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (set_local $12
+                (set_local $15
                   (i32.add
-                    (get_local $8)
+                    (get_local $6)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $13
+            (set_local $12
               (i32.sub
                 (i32.const 0)
                 (get_local $0)
@@ -12925,7 +12660,7 @@
             )
           )
         )
-        (get_local $8)
+        (get_local $6)
       )
       (return
         (i32.const 0)
@@ -12994,7 +12729,7 @@
                       (i32.const 173)
                     )
                     (block
-                      (set_local $14
+                      (set_local $16
                         (i32.const 624)
                       )
                       (loop $while-out$37 $while-in$38
@@ -13002,7 +12737,7 @@
                           (i32.le_u
                             (set_local $4
                               (i32.load
-                                (get_local $14)
+                                (get_local $16)
                               )
                             )
                             (get_local $0)
@@ -13014,7 +12749,7 @@
                                 (i32.load
                                   (set_local $3
                                     (i32.add
-                                      (get_local $14)
+                                      (get_local $16)
                                       (i32.const 4)
                                     )
                                   )
@@ -13024,9 +12759,9 @@
                             )
                             (block
                               (set_local $4
-                                (get_local $14)
+                                (get_local $16)
                               )
-                              (set_local $14
+                              (set_local $16
                                 (get_local $3)
                               )
                               (br $while-out$37)
@@ -13037,7 +12772,7 @@
                           (i32.eq
                             (set_local $4
                               (i32.load offset=8
-                                (get_local $14)
+                                (get_local $16)
                               )
                             )
                             (i32.const 0)
@@ -13048,7 +12783,7 @@
                             )
                             (br $label$break$L259)
                           )
-                          (set_local $14
+                          (set_local $16
                             (get_local $4)
                           )
                         )
@@ -13059,12 +12794,12 @@
                           (set_local $0
                             (i32.and
                               (i32.sub
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.load
                                   (i32.const 188)
                                 )
                               )
-                              (get_local $13)
+                              (get_local $12)
                             )
                           )
                           (i32.const 2147483647)
@@ -13081,7 +12816,7 @@
                                 (get_local $4)
                               )
                               (i32.load
-                                (get_local $14)
+                                (get_local $16)
                               )
                             )
                           )
@@ -13091,7 +12826,7 @@
                               (i32.const -1)
                             )
                             (block
-                              (set_local $16
+                              (set_local $14
                                 (get_local $3)
                               )
                               (set_local $19
@@ -13106,7 +12841,7 @@
                             (set_local $30
                               (get_local $3)
                             )
-                            (set_local $21
+                            (set_local $20
                               (get_local $0)
                             )
                             (set_local $11
@@ -13126,7 +12861,7 @@
                     )
                     (if
                       (i32.ne
-                        (set_local $6
+                        (set_local $7
                           (call_import $_sbrk
                             (i32.const 0)
                           )
@@ -13141,11 +12876,11 @@
                                 (i32.const 608)
                               )
                             )
-                            (set_local $13
+                            (set_local $12
                               (if
                                 (i32.eq
                                   (i32.and
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.add
                                         (set_local $4
                                           (i32.load
@@ -13156,7 +12891,7 @@
                                       )
                                     )
                                     (set_local $0
-                                      (get_local $6)
+                                      (get_local $7)
                                     )
                                   )
                                   (i32.const 0)
@@ -13169,7 +12904,7 @@
                                   )
                                   (i32.and
                                     (i32.add
-                                      (get_local $13)
+                                      (get_local $12)
                                       (get_local $0)
                                     )
                                     (i32.sub
@@ -13185,11 +12920,11 @@
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $13)
-                              (get_local $8)
+                              (get_local $12)
+                              (get_local $6)
                             )
                             (i32.lt_u
-                              (get_local $13)
+                              (get_local $12)
                               (i32.const 2147483647)
                             )
                           )
@@ -13218,30 +12953,27 @@
                             )
                             (if
                               (i32.eq
-                                (set_local $0
+                                (set_local $30
                                   (call_import $_sbrk
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                               (block
-                                (set_local $16
-                                  (get_local $6)
+                                (set_local $14
+                                  (get_local $7)
                                 )
                                 (set_local $19
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
                                 )
                               )
                               (block
-                                (set_local $30
-                                  (get_local $0)
-                                )
-                                (set_local $21
-                                  (get_local $13)
+                                (set_local $20
+                                  (get_local $12)
                                 )
                                 (set_local $11
                                   (i32.const 183)
@@ -13264,18 +12996,18 @@
                       (set_local $4
                         (i32.sub
                           (i32.const 0)
-                          (get_local $21)
+                          (get_local $20)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
                             (get_local $5)
-                            (get_local $21)
+                            (get_local $20)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $21)
+                              (get_local $20)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -13290,8 +13022,8 @@
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $12)
-                                    (get_local $21)
+                                    (get_local $15)
+                                    (get_local $20)
                                   )
                                   (set_local $0
                                     (i32.load
@@ -13320,20 +13052,16 @@
                               )
                               (br $label$break$L279)
                             )
-                            (set_local $0
+                            (set_local $20
                               (i32.add
                                 (get_local $0)
-                                (get_local $21)
+                                (get_local $20)
                               )
                             )
                           )
-                          (set_local $0
-                            (get_local $21)
-                          )
+                          (get_local $20)
                         )
-                        (set_local $0
-                          (get_local $21)
-                        )
+                        (get_local $20)
                       )
                       (if
                         (i32.ne
@@ -13341,11 +13069,11 @@
                           (i32.const -1)
                         )
                         (block
-                          (set_local $16
+                          (set_local $14
                             (get_local $30)
                           )
                           (set_local $19
-                            (get_local $0)
+                            (get_local $20)
                           )
                           (br $label$break$L257
                             (i32.const 193)
@@ -13415,12 +13143,12 @@
                   )
                 )
                 (i32.add
-                  (get_local $8)
+                  (get_local $6)
                   (i32.const 40)
                 )
               )
               (block
-                (set_local $16
+                (set_local $14
                   (get_local $0)
                 )
                 (set_local $19
@@ -13486,18 +13214,18 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $16)
+                    (get_local $14)
                     (get_local $0)
                   )
                 )
                 (i32.store
                   (i32.const 192)
-                  (get_local $16)
+                  (get_local $14)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $16)
+                (get_local $14)
               )
               (i32.store
                 (i32.const 628)
@@ -13542,7 +13270,7 @@
                 )
                 (if
                   (i32.eq
-                    (set_local $0
+                    (set_local $1
                       (i32.add
                         (get_local $1)
                         (i32.const 1)
@@ -13551,9 +13279,7 @@
                     (i32.const 32)
                   )
                   (br $while-out$46)
-                  (set_local $1
-                    (get_local $0)
-                  )
+                  (get_local $1)
                 )
                 (br $while-in$47)
               )
@@ -13562,7 +13288,7 @@
                   (i32.and
                     (set_local $0
                       (i32.add
-                        (get_local $16)
+                        (get_local $14)
                         (i32.const 8)
                       )
                     )
@@ -13575,7 +13301,7 @@
                 (i32.const 200)
                 (set_local $0
                   (i32.add
-                    (get_local $16)
+                    (get_local $14)
                     (set_local $1
                       (select
                         (i32.const 0)
@@ -13626,24 +13352,24 @@
               )
             )
             (block
-              (set_local $6
+              (set_local $7
                 (i32.const 624)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
-                    (get_local $16)
+                    (get_local $14)
                     (i32.add
                       (set_local $4
                         (i32.load
-                          (get_local $6)
+                          (get_local $7)
                         )
                       )
                       (set_local $3
                         (i32.load
                           (set_local $5
                             (i32.add
-                              (get_local $6)
+                              (get_local $7)
                               (i32.const 4)
                             )
                           )
@@ -13662,7 +13388,7 @@
                       (get_local $5)
                     )
                     (set_local $43
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (set_local $11
                       (i32.const 203)
@@ -13674,13 +13400,13 @@
                   (i32.eq
                     (set_local $4
                       (i32.load offset=8
-                        (get_local $6)
+                        (get_local $7)
                       )
                     )
                     (i32.const 0)
                   )
                   (br $while-out$48)
-                  (set_local $6
+                  (set_local $7
                     (get_local $4)
                   )
                 )
@@ -13705,7 +13431,7 @@
                     (i32.and
                       (i32.lt_u
                         (get_local $0)
-                        (get_local $16)
+                        (get_local $14)
                       )
                       (i32.ge_u
                         (get_local $0)
@@ -13799,7 +13525,7 @@
               (set_local $4
                 (if
                   (i32.lt_u
-                    (get_local $16)
+                    (get_local $14)
                     (set_local $1
                       (i32.load
                         (i32.const 192)
@@ -13809,16 +13535,16 @@
                   (block
                     (i32.store
                       (i32.const 192)
-                      (get_local $16)
+                      (get_local $14)
                     )
-                    (get_local $16)
+                    (get_local $14)
                   )
                   (get_local $1)
                 )
               )
               (set_local $3
                 (i32.add
-                  (get_local $16)
+                  (get_local $14)
                   (get_local $19)
                 )
               )
@@ -13883,7 +13609,7 @@
                   (block
                     (i32.store
                       (get_local $44)
-                      (get_local $16)
+                      (get_local $14)
                     )
                     (set_local $1
                       (i32.add
@@ -13907,7 +13633,7 @@
                         (i32.and
                           (set_local $1
                             (i32.add
-                              (get_local $16)
+                              (get_local $14)
                               (i32.const 8)
                             )
                           )
@@ -13948,9 +13674,9 @@
                             )
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $16)
+                            (get_local $14)
                             (select
                               (i32.const 0)
                               (i32.and
@@ -13968,20 +13694,20 @@
                     )
                     (set_local $5
                       (i32.add
+                        (get_local $7)
                         (get_local $6)
-                        (get_local $8)
                       )
                     )
-                    (set_local $13
+                    (set_local $12
                       (i32.sub
                         (get_local $1)
-                        (get_local $8)
+                        (get_local $6)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $6)
+                      (get_local $7)
                       (i32.or
-                        (get_local $8)
+                        (get_local $6)
                         (i32.const 3)
                       )
                     )
@@ -13999,7 +13725,7 @@
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
                           )
@@ -14031,7 +13757,7 @@
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                 )
                               )
@@ -14238,7 +13964,7 @@
                                                           (i32.load
                                                             (set_local $9
                                                               (i32.add
-                                                                (set_local $20
+                                                                (set_local $21
                                                                   (i32.add
                                                                     (get_local $3)
                                                                     (i32.const 16)
@@ -14255,7 +13981,7 @@
                                                         (i32.eq
                                                           (set_local $1
                                                             (i32.load
-                                                              (get_local $20)
+                                                              (get_local $21)
                                                             )
                                                           )
                                                           (i32.const 0)
@@ -14271,7 +13997,7 @@
                                                             (get_local $1)
                                                           )
                                                           (set_local $9
-                                                            (get_local $20)
+                                                            (get_local $21)
                                                           )
                                                         )
                                                       )
@@ -14284,7 +14010,7 @@
                                                         (i32.ne
                                                           (set_local $1
                                                             (i32.load
-                                                              (set_local $20
+                                                              (set_local $21
                                                                 (i32.add
                                                                   (get_local $2)
                                                                   (i32.const 20)
@@ -14299,7 +14025,7 @@
                                                             (get_local $1)
                                                           )
                                                           (set_local $9
-                                                            (get_local $20)
+                                                            (get_local $21)
                                                           )
                                                           (br $while-in$62)
                                                         )
@@ -14308,7 +14034,7 @@
                                                         (i32.eq
                                                           (set_local $1
                                                             (i32.load
-                                                              (set_local $20
+                                                              (set_local $21
                                                                 (i32.add
                                                                   (get_local $2)
                                                                   (i32.const 16)
@@ -14318,21 +14044,13 @@
                                                           )
                                                           (i32.const 0)
                                                         )
-                                                        (block
-                                                          (set_local $1
-                                                            (get_local $2)
-                                                          )
-                                                          (set_local $2
-                                                            (get_local $9)
-                                                          )
-                                                          (br $while-out$61)
-                                                        )
+                                                        (br $while-out$61)
                                                         (block
                                                           (set_local $2
                                                             (get_local $1)
                                                           )
                                                           (set_local $9
-                                                            (get_local $20)
+                                                            (get_local $21)
                                                           )
                                                         )
                                                       )
@@ -14340,17 +14058,17 @@
                                                     )
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $2)
+                                                        (get_local $9)
                                                         (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                       (block
                                                         (i32.store
-                                                          (get_local $2)
+                                                          (get_local $9)
                                                           (i32.const 0)
                                                         )
                                                         (set_local $18
-                                                          (get_local $1)
+                                                          (get_local $2)
                                                         )
                                                       )
                                                     )
@@ -14587,7 +14305,7 @@
                                         (set_local $4
                                           (i32.add
                                             (get_local $10)
-                                            (get_local $13)
+                                            (get_local $12)
                                           )
                                         )
                                         (i32.add
@@ -14597,7 +14315,7 @@
                                       )
                                       (block
                                         (set_local $4
-                                          (get_local $13)
+                                          (get_local $12)
                                         )
                                         (get_local $3)
                                       )
@@ -14677,7 +14395,7 @@
                                         (get_local $1)
                                       )
                                     )
-                                    (set_local $7
+                                    (set_local $8
                                       (i32.add
                                         (get_local $2)
                                         (i32.const 8)
@@ -14705,7 +14423,7 @@
                                         )
                                       )
                                       (block
-                                        (set_local $7
+                                        (set_local $8
                                           (get_local $0)
                                         )
                                         (set_local $33
@@ -14719,7 +14437,7 @@
                                 )
                               )
                               (i32.store
-                                (get_local $7)
+                                (get_local $8)
                                 (get_local $5)
                               )
                               (i32.store offset=12
@@ -14877,7 +14595,7 @@
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (i32.shl
                                     (i32.const 1)
                                     (get_local $1)
@@ -14891,7 +14609,7 @@
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $0)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                               )
                               (i32.store
@@ -14958,7 +14676,7 @@
                                 (br $while-out$71)
                               )
                             )
-                            (set_local $7
+                            (set_local $8
                               (i32.shl
                                 (get_local $1)
                                 (i32.const 1)
@@ -15001,7 +14719,7 @@
                               )
                               (block
                                 (set_local $1
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (set_local $2
                                   (get_local $0)
@@ -15102,7 +14820,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $6)
+                        (get_local $7)
                         (i32.const 8)
                       )
                     )
@@ -15149,7 +14867,7 @@
                 )
                 (br $while-in$74)
               )
-              (set_local $7
+              (set_local $8
                 (i32.eq
                   (i32.and
                     (set_local $1
@@ -15182,11 +14900,11 @@
                           )
                           (i32.const 7)
                         )
-                        (get_local $7)
+                        (get_local $8)
                       )
                     )
                   )
-                  (set_local $7
+                  (set_local $8
                     (i32.add
                       (get_local $0)
                       (i32.const 16)
@@ -15211,7 +14929,7 @@
                   (i32.and
                     (set_local $1
                       (i32.add
-                        (get_local $16)
+                        (get_local $14)
                         (i32.const 8)
                       )
                     )
@@ -15224,7 +14942,7 @@
                 (i32.const 200)
                 (set_local $1
                   (i32.add
-                    (get_local $16)
+                    (get_local $14)
                     (set_local $3
                       (select
                         (i32.const 0)
@@ -15308,7 +15026,7 @@
               )
               (i32.store
                 (i32.const 624)
-                (get_local $16)
+                (get_local $14)
               )
               (i32.store
                 (i32.const 628)
@@ -15437,7 +15155,7 @@
                               (i32.const 8)
                             )
                           )
-                          (set_local $20
+                          (set_local $21
                             (get_local $4)
                           )
                         )
@@ -15462,7 +15180,7 @@
                             (set_local $9
                               (get_local $1)
                             )
-                            (set_local $20
+                            (set_local $21
                               (get_local $2)
                             )
                           )
@@ -15473,12 +15191,12 @@
                         (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $20)
+                        (get_local $21)
                         (get_local $0)
                       )
                       (i32.store offset=8
                         (get_local $0)
-                        (get_local $20)
+                        (get_local $21)
                       )
                       (i32.store offset=12
                         (get_local $0)
@@ -15609,7 +15327,7 @@
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $7)
+                    (get_local $8)
                     (i32.const 0)
                   )
                   (if
@@ -15620,7 +15338,7 @@
                             (i32.const 180)
                           )
                         )
-                        (set_local $7
+                        (set_local $8
                           (i32.shl
                             (i32.const 1)
                             (get_local $2)
@@ -15634,7 +15352,7 @@
                         (i32.const 180)
                         (i32.or
                           (get_local $1)
-                          (get_local $7)
+                          (get_local $8)
                         )
                       )
                       (i32.store
@@ -15701,7 +15419,7 @@
                         (br $while-out$77)
                       )
                     )
-                    (set_local $7
+                    (set_local $8
                       (i32.shl
                         (get_local $2)
                         (i32.const 1)
@@ -15744,7 +15462,7 @@
                       )
                       (block
                         (set_local $2
-                          (get_local $7)
+                          (get_local $8)
                         )
                         (set_local $4
                           (get_local $1)
@@ -15852,7 +15570,7 @@
                 (i32.const 188)
               )
             )
-            (get_local $8)
+            (get_local $6)
           )
           (block
             (i32.store
@@ -15860,7 +15578,7 @@
               (set_local $2
                 (i32.sub
                   (get_local $0)
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
             )
@@ -15873,7 +15591,7 @@
                       (i32.const 200)
                     )
                   )
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
             )
@@ -15887,7 +15605,7 @@
             (i32.store offset=4
               (get_local $0)
               (i32.or
-                (get_local $8)
+                (get_local $6)
                 (i32.const 3)
               )
             )
@@ -15954,7 +15672,7 @@
     )
     (if
       (i32.eq
-        (set_local $6
+        (set_local $8
           (i32.and
             (set_local $0
               (i32.load
@@ -15971,7 +15689,7 @@
       )
       (call_import $_abort)
     )
-    (set_local $8
+    (set_local $9
       (i32.add
         (get_local $2)
         (set_local $7
@@ -15999,7 +15717,7 @@
           )
           (if
             (i32.eq
-              (get_local $6)
+              (get_local $8)
               (i32.const 0)
             )
             (return)
@@ -16012,7 +15730,7 @@
           )
           (if
             (i32.lt_u
-              (set_local $4
+              (set_local $6
                 (i32.add
                   (get_local $2)
                   (i32.sub
@@ -16027,7 +15745,7 @@
           )
           (if
             (i32.eq
-              (get_local $4)
+              (get_local $6)
               (i32.load
                 (i32.const 196)
               )
@@ -16040,7 +15758,7 @@
                       (i32.load
                         (set_local $1
                           (i32.add
-                            (get_local $8)
+                            (get_local $9)
                             (i32.const 4)
                           )
                         )
@@ -16052,7 +15770,7 @@
                 )
                 (block
                   (set_local $3
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (set_local $10
                     (get_local $12)
@@ -16072,7 +15790,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $6)
                 (i32.or
                   (get_local $12)
                   (i32.const 1)
@@ -16080,7 +15798,7 @@
               )
               (i32.store
                 (i32.add
-                  (get_local $4)
+                  (get_local $6)
                   (get_local $12)
                 )
                 (get_local $12)
@@ -16102,17 +15820,17 @@
             (block
               (set_local $2
                 (i32.load offset=12
-                  (get_local $4)
+                  (get_local $6)
                 )
               )
               (if
                 (i32.ne
                   (set_local $0
                     (i32.load offset=8
-                      (get_local $4)
+                      (get_local $6)
                     )
                   )
-                  (set_local $6
+                  (set_local $8
                     (i32.add
                       (i32.const 216)
                       (i32.shl
@@ -16138,7 +15856,7 @@
                       (i32.load offset=12
                         (get_local $0)
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (call_import $_abort)
                   )
@@ -16166,7 +15884,7 @@
                     )
                   )
                   (set_local $3
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (set_local $10
                     (get_local $12)
@@ -16177,7 +15895,7 @@
               (if
                 (i32.eq
                   (get_local $2)
-                  (get_local $6)
+                  (get_local $8)
                 )
                 (set_local $13
                   (i32.add
@@ -16203,7 +15921,7 @@
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (set_local $13
                       (get_local $1)
@@ -16221,7 +15939,7 @@
                 (get_local $0)
               )
               (set_local $3
-                (get_local $4)
+                (get_local $6)
               )
               (set_local $10
                 (get_local $12)
@@ -16229,9 +15947,9 @@
               (br $do-once$0)
             )
           )
-          (set_local $6
+          (set_local $8
             (i32.load offset=24
-              (get_local $4)
+              (get_local $6)
             )
           )
           (block $do-once$2
@@ -16239,10 +15957,10 @@
               (i32.eq
                 (set_local $0
                   (i32.load offset=12
-                    (get_local $4)
+                    (get_local $6)
                   )
                 )
-                (get_local $4)
+                (get_local $6)
               )
               (block
                 (if
@@ -16253,7 +15971,7 @@
                           (i32.add
                             (set_local $13
                               (i32.add
-                                (get_local $4)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
@@ -16274,7 +15992,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $9
+                      (set_local $4
                         (i32.const 0)
                       )
                       (br $do-once$2)
@@ -16331,15 +16049,7 @@
                       )
                       (i32.const 0)
                     )
-                    (block
-                      (set_local $0
-                        (get_local $2)
-                      )
-                      (set_local $2
-                        (get_local $7)
-                      )
-                      (br $while-out$4)
-                    )
+                    (br $while-out$4)
                     (block
                       (set_local $2
                         (get_local $0)
@@ -16353,17 +16063,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $2)
+                    (get_local $7)
                     (get_local $1)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store
-                      (get_local $2)
+                      (get_local $7)
                       (i32.const 0)
                     )
-                    (set_local $9
-                      (get_local $0)
+                    (set_local $4
+                      (get_local $2)
                     )
                   )
                 )
@@ -16373,7 +16083,7 @@
                   (i32.lt_u
                     (set_local $2
                       (i32.load offset=8
-                        (get_local $4)
+                        (get_local $6)
                       )
                     )
                     (get_local $1)
@@ -16390,7 +16100,7 @@
                         )
                       )
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (call_import $_abort)
                 )
@@ -16404,7 +16114,7 @@
                         )
                       )
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (block
                     (i32.store
@@ -16415,7 +16125,7 @@
                       (get_local $7)
                       (get_local $2)
                     )
-                    (set_local $9
+                    (set_local $4
                       (get_local $0)
                     )
                   )
@@ -16426,12 +16136,12 @@
           )
           (if
             (i32.eq
-              (get_local $6)
+              (get_local $8)
               (i32.const 0)
             )
             (block
               (set_local $3
-                (get_local $4)
+                (get_local $6)
               )
               (set_local $10
                 (get_local $12)
@@ -16440,7 +16150,7 @@
             (block
               (if
                 (i32.eq
-                  (get_local $4)
+                  (get_local $6)
                   (i32.load
                     (set_local $1
                       (i32.add
@@ -16448,7 +16158,7 @@
                         (i32.shl
                           (set_local $0
                             (i32.load offset=28
-                              (get_local $4)
+                              (get_local $6)
                             )
                           )
                           (i32.const 2)
@@ -16460,11 +16170,11 @@
                 (block
                   (i32.store
                     (get_local $1)
-                    (get_local $9)
+                    (get_local $4)
                   )
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $4)
                       (i32.const 0)
                     )
                     (block
@@ -16484,7 +16194,7 @@
                         )
                       )
                       (set_local $3
-                        (get_local $4)
+                        (get_local $6)
                       )
                       (set_local $10
                         (get_local $12)
@@ -16496,7 +16206,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $8)
                       (i32.load
                         (i32.const 192)
                       )
@@ -16508,30 +16218,30 @@
                       (i32.load
                         (set_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.store
                       (get_local $0)
-                      (get_local $9)
+                      (get_local $4)
                     )
                     (i32.store offset=20
-                      (get_local $6)
-                      (get_local $9)
+                      (get_local $8)
+                      (get_local $4)
                     )
                   )
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $4)
                       (i32.const 0)
                     )
                     (block
                       (set_local $3
-                        (get_local $4)
+                        (get_local $6)
                       )
                       (set_local $10
                         (get_local $12)
@@ -16543,7 +16253,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $9)
+                  (get_local $4)
                   (set_local $0
                     (i32.load
                       (i32.const 192)
@@ -16553,8 +16263,8 @@
                 (call_import $_abort)
               )
               (i32.store offset=24
-                (get_local $9)
-                (get_local $6)
+                (get_local $4)
+                (get_local $8)
               )
               (if
                 (i32.ne
@@ -16562,7 +16272,7 @@
                     (i32.load
                       (set_local $2
                         (i32.add
-                          (get_local $4)
+                          (get_local $6)
                           (i32.const 16)
                         )
                       )
@@ -16578,12 +16288,12 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $9)
+                      (get_local $4)
                       (get_local $1)
                     )
                     (i32.store offset=24
                       (get_local $1)
-                      (get_local $9)
+                      (get_local $4)
                     )
                   )
                 )
@@ -16599,7 +16309,7 @@
                 )
                 (block
                   (set_local $3
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (set_local $10
                     (get_local $12)
@@ -16615,15 +16325,15 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $9)
+                      (get_local $4)
                       (get_local $0)
                     )
                     (i32.store offset=24
                       (get_local $0)
-                      (get_local $9)
+                      (get_local $4)
                     )
                     (set_local $3
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (set_local $10
                       (get_local $12)
@@ -16647,7 +16357,7 @@
     (if
       (i32.ge_u
         (get_local $3)
-        (get_local $8)
+        (get_local $9)
       )
       (call_import $_abort)
     )
@@ -16658,7 +16368,7 @@
             (i32.load
               (set_local $1
                 (i32.add
-                  (get_local $8)
+                  (get_local $9)
                   (i32.const 4)
                 )
               )
@@ -16681,7 +16391,7 @@
       (block
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $9)
             (i32.load
               (i32.const 200)
             )
@@ -16731,7 +16441,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $9)
             (i32.load
               (i32.const 196)
             )
@@ -16769,7 +16479,7 @@
             (return)
           )
         )
-        (set_local $9
+        (set_local $4
           (i32.add
             (i32.and
               (get_local $0)
@@ -16778,7 +16488,7 @@
             (get_local $10)
           )
         )
-        (set_local $6
+        (set_local $8
           (i32.shr_u
             (get_local $0)
             (i32.const 3)
@@ -16793,14 +16503,14 @@
             (block
               (set_local $1
                 (i32.load offset=12
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
               (if
                 (i32.ne
                   (set_local $0
                     (i32.load offset=8
-                      (get_local $8)
+                      (get_local $9)
                     )
                   )
                   (set_local $2
@@ -16808,7 +16518,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $6)
+                          (get_local $8)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -16831,7 +16541,7 @@
                       (i32.load offset=12
                         (get_local $0)
                       )
-                      (get_local $8)
+                      (get_local $9)
                     )
                     (call_import $_abort)
                   )
@@ -16852,7 +16562,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.const -1)
                       )
@@ -16892,7 +16602,7 @@
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $9)
                     )
                     (set_local $16
                       (get_local $2)
@@ -16913,7 +16623,7 @@
             (block
               (set_local $0
                 (i32.load offset=24
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
               (block $do-once$10
@@ -16921,21 +16631,21 @@
                   (i32.eq
                     (set_local $1
                       (i32.load offset=12
-                        (get_local $8)
+                        (get_local $9)
                       )
                     )
-                    (get_local $8)
+                    (get_local $9)
                   )
                   (block
                     (if
                       (i32.eq
                         (set_local $1
                           (i32.load
-                            (set_local $6
+                            (set_local $8
                               (i32.add
                                 (set_local $7
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $9)
                                     (i32.const 16)
                                   )
                                 )
@@ -16965,7 +16675,7 @@
                           (set_local $2
                             (get_local $1)
                           )
-                          (set_local $6
+                          (set_local $8
                             (get_local $7)
                           )
                         )
@@ -16993,7 +16703,7 @@
                           (set_local $2
                             (get_local $1)
                           )
-                          (set_local $6
+                          (set_local $8
                             (get_local $7)
                           )
                           (br $while-in$13)
@@ -17013,20 +16723,12 @@
                           )
                           (i32.const 0)
                         )
-                        (block
-                          (set_local $1
-                            (get_local $2)
-                          )
-                          (set_local $2
-                            (get_local $6)
-                          )
-                          (br $while-out$12)
-                        )
+                        (br $while-out$12)
                         (block
                           (set_local $2
                             (get_local $1)
                           )
-                          (set_local $6
+                          (set_local $8
                             (get_local $7)
                           )
                         )
@@ -17035,7 +16737,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $2)
+                        (get_local $8)
                         (i32.load
                           (i32.const 192)
                         )
@@ -17043,11 +16745,11 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $2)
+                          (get_local $8)
                           (i32.const 0)
                         )
                         (set_local $11
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                     )
@@ -17057,7 +16759,7 @@
                       (i32.lt_u
                         (set_local $2
                           (i32.load offset=8
-                            (get_local $8)
+                            (get_local $9)
                           )
                         )
                         (i32.load
@@ -17069,14 +16771,14 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $6
+                          (set_local $8
                             (i32.add
                               (get_local $2)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $9)
                       )
                       (call_import $_abort)
                     )
@@ -17090,11 +16792,11 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $9)
                       )
                       (block
                         (i32.store
-                          (get_local $6)
+                          (get_local $8)
                           (get_local $1)
                         )
                         (i32.store
@@ -17118,7 +16820,7 @@
                 (block
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $9)
                       (i32.load
                         (set_local $2
                           (i32.add
@@ -17126,7 +16828,7 @@
                             (i32.shl
                               (set_local $1
                                 (i32.load offset=28
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                               )
                               (i32.const 2)
@@ -17185,7 +16887,7 @@
                               )
                             )
                           )
-                          (get_local $8)
+                          (get_local $9)
                         )
                         (i32.store
                           (get_local $1)
@@ -17225,7 +16927,7 @@
                         (i32.load
                           (set_local $2
                             (i32.add
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 16)
                             )
                           )
@@ -17288,16 +16990,16 @@
         (i32.store offset=4
           (get_local $3)
           (i32.or
-            (get_local $9)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $3)
-            (get_local $9)
+            (get_local $4)
           )
-          (get_local $9)
+          (get_local $4)
         )
         (if
           (i32.eq
@@ -17309,13 +17011,11 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $9)
+              (get_local $4)
             )
             (return)
           )
-          (set_local $2
-            (get_local $9)
-          )
+          (get_local $4)
         )
       )
       (block
@@ -17340,20 +17040,20 @@
           )
           (get_local $10)
         )
-        (set_local $2
+        (set_local $4
           (get_local $10)
         )
       )
     )
     (set_local $1
       (i32.shr_u
-        (get_local $2)
+        (get_local $4)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $2)
+        (get_local $4)
         (i32.const 256)
       )
       (block
@@ -17459,7 +17159,7 @@
               (i32.eq
                 (set_local $0
                   (i32.shr_u
-                    (get_local $2)
+                    (get_local $4)
                     (i32.const 8)
                   )
                 )
@@ -17468,7 +17168,7 @@
               (i32.const 0)
               (if
                 (i32.gt_u
-                  (get_local $2)
+                  (get_local $4)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
@@ -17545,7 +17245,7 @@
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $2)
+                        (get_local $4)
                         (i32.add
                           (get_local $0)
                           (i32.const 7)
@@ -17583,7 +17283,7 @@
               (i32.const 180)
             )
           )
-          (set_local $6
+          (set_local $2
             (i32.shl
               (i32.const 1)
               (get_local $5)
@@ -17597,7 +17297,7 @@
           (i32.const 180)
           (i32.or
             (get_local $0)
-            (get_local $6)
+            (get_local $2)
           )
         )
         (i32.store
@@ -17620,7 +17320,7 @@
       (block
         (set_local $5
           (i32.shl
-            (get_local $2)
+            (get_local $4)
             (select
               (i32.const 0)
               (i32.sub
@@ -17651,7 +17351,7 @@
                 )
                 (i32.const -8)
               )
-              (get_local $2)
+              (get_local $4)
             )
             (block
               (set_local $15
@@ -17663,7 +17363,7 @@
               (br $while-out$18)
             )
           )
-          (set_local $6
+          (set_local $2
             (i32.shl
               (get_local $5)
               (i32.const 1)
@@ -17706,7 +17406,7 @@
             )
             (block
               (set_local $5
-                (get_local $6)
+                (get_local $2)
               )
               (set_local $1
                 (get_local $0)
@@ -17820,7 +17520,7 @@
         (get_local $0)
         (i32.const 0)
       )
-      (set_local $0
+      (set_local $5
         (i32.const 632)
       )
       (return)
@@ -17830,7 +17530,7 @@
         (i32.eq
           (set_local $5
             (i32.load
-              (get_local $0)
+              (get_local $5)
             )
           )
           (i32.const 0)
@@ -17845,9 +17545,7 @@
       (if
         (get_local $0)
         (br $while-out$20)
-        (set_local $0
-          (get_local $5)
-        )
+        (get_local $5)
       )
       (br $while-in$21)
     )
@@ -18851,14 +18549,14 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $7
+    (set_local $8
       (get_local $0)
     )
     (set_local $5
       (get_local $2)
     )
-    (set_local $8
-      (set_local $11
+    (set_local $7
+      (set_local $14
         (get_local $3)
       )
     )
@@ -18880,7 +18578,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $7)
             (i32.const 0)
           )
           (block
@@ -18890,7 +18588,7 @@
                 (i32.store
                   (get_local $4)
                   (call_import $i32u-rem
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $5)
                   )
                 )
@@ -18902,7 +18600,7 @@
             )
             (set_local $0
               (call_import $i32u-div
-                (get_local $7)
+                (get_local $8)
                 (get_local $5)
               )
             )
@@ -18956,7 +18654,7 @@
     )
     (set_local $10
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 0)
       )
     )
@@ -19006,7 +18704,7 @@
           )
           (if
             (i32.eq
-              (get_local $7)
+              (get_local $8)
               (i32.const 0)
             )
             (block
@@ -19024,7 +18722,7 @@
                     (get_local $4)
                     (call_import $i32u-rem
                       (get_local $6)
-                      (get_local $8)
+                      (get_local $7)
                     )
                   )
                 )
@@ -19032,7 +18730,7 @@
               (set_local $0
                 (call_import $i32u-div
                   (get_local $6)
-                  (get_local $8)
+                  (get_local $7)
                 )
               )
               (i32.store
@@ -19049,11 +18747,11 @@
               (i32.and
                 (set_local $5
                   (i32.sub
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 1)
                   )
                 )
-                (get_local $8)
+                (get_local $7)
               )
               (i32.const 0)
             )
@@ -19097,7 +18795,7 @@
                 (i32.shr_u
                   (get_local $6)
                   (i32.ctz
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -19108,7 +18806,7 @@
               (set_local $5
                 (i32.sub
                   (i32.clz
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (i32.clz
                     (get_local $6)
@@ -19118,7 +18816,7 @@
               (i32.const 30)
             )
             (block
-              (set_local $13
+              (set_local $12
                 (set_local $0
                   (i32.add
                     (get_local $5)
@@ -19126,7 +18824,7 @@
                   )
                 )
               )
-              (set_local $14
+              (set_local $11
                 (i32.or
                   (i32.shl
                     (get_local $6)
@@ -19138,12 +18836,12 @@
                     )
                   )
                   (i32.shr_u
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $0)
                   )
                 )
               )
-              (set_local $12
+              (set_local $13
                 (i32.shr_u
                   (get_local $6)
                   (get_local $0)
@@ -19154,7 +18852,7 @@
               )
               (set_local $0
                 (i32.shl
-                  (get_local $7)
+                  (get_local $8)
                   (get_local $1)
                 )
               )
@@ -19215,7 +18913,7 @@
                   (set_local $5
                     (i32.sub
                       (i32.clz
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (i32.clz
                         (get_local $6)
@@ -19225,7 +18923,7 @@
                   (i32.const 31)
                 )
                 (block
-                  (set_local $13
+                  (set_local $12
                     (set_local $0
                       (i32.add
                         (get_local $5)
@@ -19233,11 +18931,11 @@
                       )
                     )
                   )
-                  (set_local $14
+                  (set_local $11
                     (i32.or
                       (i32.and
                         (i32.shr_u
-                          (get_local $7)
+                          (get_local $8)
                           (get_local $0)
                         )
                         (set_local $9
@@ -19261,7 +18959,7 @@
                       )
                     )
                   )
-                  (set_local $12
+                  (set_local $13
                     (i32.and
                       (i32.shr_u
                         (get_local $6)
@@ -19275,7 +18973,7 @@
                   )
                   (set_local $0
                     (i32.shl
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $1)
                     )
                   )
@@ -19329,7 +19027,7 @@
           (if
             (i32.ne
               (i32.and
-                (set_local $8
+                (set_local $7
                   (i32.sub
                     (get_local $5)
                     (i32.const 1)
@@ -19371,7 +19069,7 @@
               )
               (set_local $10
                 (i32.shr_s
-                  (set_local $8
+                  (set_local $7
                     (i32.sub
                       (get_local $0)
                       (i32.const 32)
@@ -19380,10 +19078,10 @@
                   (i32.const 31)
                 )
               )
-              (set_local $13
+              (set_local $12
                 (get_local $0)
               )
-              (set_local $14
+              (set_local $11
                 (i32.or
                   (i32.and
                     (i32.shr_s
@@ -19395,7 +19093,7 @@
                     )
                     (i32.shr_u
                       (get_local $6)
-                      (get_local $8)
+                      (get_local $7)
                     )
                   )
                   (i32.and
@@ -19405,7 +19103,7 @@
                         (get_local $9)
                       )
                       (i32.shr_u
-                        (get_local $7)
+                        (get_local $8)
                         (get_local $0)
                       )
                     )
@@ -19413,7 +19111,7 @@
                   )
                 )
               )
-              (set_local $12
+              (set_local $13
                 (i32.and
                   (get_local $10)
                   (i32.shr_u
@@ -19425,7 +19123,7 @@
               (set_local $10
                 (i32.and
                   (i32.shl
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $1)
                   )
                   (get_local $5)
@@ -19440,15 +19138,15 @@
                         (get_local $1)
                       )
                       (i32.shr_u
-                        (get_local $7)
                         (get_local $8)
+                        (get_local $7)
                       )
                     )
                     (get_local $5)
                   )
                   (i32.and
                     (i32.shl
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $9)
                     )
                     (i32.shr_s
@@ -19473,8 +19171,8 @@
               (i32.store
                 (get_local $4)
                 (i32.and
-                  (get_local $8)
                   (get_local $7)
+                  (get_local $8)
                 )
               )
               (i32.store offset=4
@@ -19534,7 +19232,7 @@
                     )
                   )
                   (i32.shr_u
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $0)
                   )
                 )
@@ -19547,21 +19245,12 @@
     (set_local $0
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 0)
         )
         (block
-          (set_local $9
+          (set_local $6
             (get_local $0)
-          )
-          (set_local $7
-            (get_local $10)
-          )
-          (set_local $3
-            (get_local $12)
-          )
-          (set_local $2
-            (get_local $14)
           )
           (set_local $1
             (i32.const 0)
@@ -19582,7 +19271,7 @@
               )
               (set_local $2
                 (i32.or
-                  (get_local $11)
+                  (get_local $14)
                   (i32.and
                     (get_local $3)
                     (i32.const 0)
@@ -19593,85 +19282,73 @@
               (i32.const -1)
             )
           )
-          (set_local $7
+          (set_local $8
             (i32.load
               (i32.const 168)
             )
           )
-          (set_local $8
-            (get_local $0)
-          )
-          (set_local $11
-            (get_local $10)
-          )
-          (set_local $5
-            (get_local $12)
-          )
-          (set_local $6
-            (get_local $14)
-          )
           (set_local $9
-            (get_local $13)
+            (get_local $0)
           )
           (set_local $0
             (i32.const 0)
           )
           (loop $while-out$2 $while-in$3
-            (set_local $10
+            (set_local $6
               (i32.or
                 (i32.shr_u
-                  (get_local $11)
+                  (get_local $10)
                   (i32.const 31)
                 )
                 (i32.shl
-                  (get_local $8)
+                  (get_local $9)
                   (i32.const 1)
                 )
               )
             )
-            (set_local $0
+            (set_local $10
               (i32.or
                 (get_local $0)
                 (i32.shl
-                  (get_local $11)
+                  (get_local $10)
                   (i32.const 1)
                 )
               )
             )
             (call $_i64Subtract
               (get_local $3)
-              (get_local $7)
-              (set_local $11
+              (get_local $8)
+              (set_local $0
                 (i32.or
                   (i32.const 0)
                   (i32.or
                     (i32.shl
-                      (get_local $6)
+                      (get_local $11)
                       (i32.const 1)
                     )
                     (i32.shr_u
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 31)
                     )
                   )
                 )
               )
-              (set_local $6
+              (set_local $9
                 (i32.or
                   (i32.shr_u
-                    (get_local $6)
+                    (get_local $11)
                     (i32.const 31)
                   )
                   (i32.shl
-                    (get_local $5)
+                    (get_local $13)
                     (i32.const 1)
                   )
                 )
               )
             )
-            (set_local $12
+            (set_local $7
               (i32.and
-                (set_local $8
+                (set_local $14
                   (i32.or
                     (i32.shr_s
                       (set_local $5
@@ -19697,12 +19374,12 @@
                 (i32.const 1)
               )
             )
-            (set_local $6
+            (set_local $11
               (call $_i64Subtract
-                (get_local $11)
-                (get_local $6)
+                (get_local $0)
+                (get_local $9)
                 (i32.and
-                  (get_local $8)
+                  (get_local $14)
                   (get_local $1)
                 )
                 (i32.and
@@ -19734,16 +19411,16 @@
                 )
               )
             )
-            (set_local $5
+            (set_local $13
               (i32.load
                 (i32.const 168)
               )
             )
             (if
               (i32.eq
-                (set_local $9
+                (set_local $12
                   (i32.sub
-                    (get_local $9)
+                    (get_local $12)
                     (i32.const 1)
                   )
                 )
@@ -19751,42 +19428,27 @@
               )
               (br $while-out$2)
               (block
-                (set_local $8
-                  (get_local $10)
-                )
-                (set_local $11
-                  (get_local $0)
+                (set_local $9
+                  (get_local $6)
                 )
                 (set_local $0
-                  (get_local $12)
+                  (get_local $7)
                 )
               )
             )
             (br $while-in$3)
           )
-          (set_local $9
-            (get_local $10)
-          )
-          (set_local $7
-            (get_local $0)
-          )
-          (set_local $3
-            (get_local $5)
-          )
-          (set_local $2
-            (get_local $6)
-          )
           (set_local $1
             (i32.const 0)
           )
-          (get_local $12)
+          (get_local $7)
         )
       )
     )
-    (set_local $6
+    (set_local $3
       (i32.or
-        (get_local $9)
-        (set_local $9
+        (get_local $6)
+        (set_local $2
           (i32.const 0)
         )
       )
@@ -19801,12 +19463,12 @@
           (get_local $4)
           (i32.or
             (i32.const 0)
-            (get_local $2)
+            (get_local $11)
           )
         )
         (i32.store offset=4
           (get_local $4)
-          (get_local $3)
+          (get_local $13)
         )
       )
     )
@@ -19818,23 +19480,23 @@
             (i32.shr_u
               (i32.or
                 (i32.const 0)
-                (get_local $7)
+                (get_local $10)
               )
               (i32.const 31)
             )
             (i32.shl
-              (get_local $6)
+              (get_local $3)
               (i32.const 1)
             )
           )
           (i32.and
             (i32.or
               (i32.shl
-                (get_local $9)
+                (get_local $2)
                 (i32.const 1)
               )
               (i32.shr_u
-                (get_local $7)
+                (get_local $10)
                 (i32.const 31)
               )
             )
@@ -19848,7 +19510,7 @@
       (i32.and
         (i32.or
           (i32.shl
-            (get_local $7)
+            (get_local $10)
             (i32.const 1)
           )
           (i32.const 0)

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -453,10 +453,10 @@
           (i32.const 87)
         )
         (block
-          (set_local $2
+          (set_local $3
             (i32.const 87)
           )
-          (set_local $3
+          (set_local $2
             (i32.const 775)
           )
           (set_local $0
@@ -482,10 +482,10 @@
           (i32.const 775)
         )
         (block
-          (set_local $2
+          (set_local $3
             (get_local $4)
           )
-          (set_local $3
+          (set_local $2
             (i32.const 775)
           )
           (set_local $0
@@ -500,13 +500,10 @@
         (i32.const 5)
       )
       (loop $while-out$2 $while-in$3
-        (set_local $1
-          (get_local $3)
-        )
         (loop $while-out$4 $while-in$5
           (set_local $0
             (i32.add
-              (get_local $1)
+              (get_local $2)
               (i32.const 1)
             )
           )
@@ -515,7 +512,7 @@
               (i32.shr_s
                 (i32.shl
                   (i32.load8_s
-                    (get_local $1)
+                    (get_local $2)
                   )
                   (i32.const 24)
                 )
@@ -529,7 +526,7 @@
               )
               (br $while-out$4)
             )
-            (set_local $1
+            (set_local $2
               (get_local $0)
             )
           )
@@ -539,7 +536,7 @@
           (i32.eq
             (set_local $0
               (i32.add
-                (get_local $2)
+                (get_local $3)
                 (i32.const -1)
               )
             )
@@ -552,10 +549,10 @@
             (br $while-out$2)
           )
           (block
-            (set_local $2
+            (set_local $3
               (get_local $0)
             )
-            (set_local $3
+            (set_local $2
               (get_local $1)
             )
           )
@@ -1080,13 +1077,13 @@
       (get_local $8)
     )
     (i32.store
-      (set_local $3
+      (set_local $4
         (i32.add
           (get_local $8)
           (i32.const 32)
         )
       )
-      (set_local $4
+      (set_local $3
         (i32.load
           (set_local $7
             (i32.add
@@ -1098,8 +1095,8 @@
       )
     )
     (i32.store offset=4
-      (get_local $3)
-      (set_local $4
+      (get_local $4)
+      (set_local $3
         (i32.sub
           (i32.load
             (set_local $11
@@ -1109,16 +1106,16 @@
               )
             )
           )
-          (get_local $4)
+          (get_local $3)
         )
       )
     )
     (i32.store offset=8
-      (get_local $3)
+      (get_local $4)
       (get_local $1)
     )
     (i32.store offset=12
-      (get_local $3)
+      (get_local $4)
       (get_local $2)
     )
     (set_local $12
@@ -1133,23 +1130,20 @@
         (i32.const 44)
       )
     )
-    (set_local $5
-      (get_local $3)
-    )
     (set_local $6
       (i32.const 2)
     )
-    (set_local $4
+    (set_local $3
       (i32.add
-        (get_local $4)
+        (get_local $3)
         (get_local $2)
       )
     )
     (loop $while-out$0 $while-in$1
       (if
         (i32.eq
-          (get_local $4)
-          (set_local $3
+          (get_local $3)
+          (set_local $5
             (if
               (i32.eq
                 (i32.load
@@ -1166,7 +1160,7 @@
                 )
                 (i32.store offset=4
                   (get_local $9)
-                  (get_local $5)
+                  (get_local $4)
                 )
                 (i32.store offset=8
                   (get_local $9)
@@ -1192,7 +1186,7 @@
                 )
                 (i32.store offset=4
                   (get_local $10)
-                  (get_local $5)
+                  (get_local $4)
                 )
                 (i32.store offset=8
                   (get_local $10)
@@ -1223,12 +1217,12 @@
       )
       (if
         (i32.lt_s
-          (get_local $3)
+          (get_local $5)
           (i32.const 0)
         )
         (block
           (set_local $15
-            (get_local $5)
+            (get_local $4)
           )
           (set_local $16
             (get_local $6)
@@ -1241,24 +1235,24 @@
       )
       (set_local $17
         (i32.sub
-          (get_local $4)
           (get_local $3)
+          (get_local $5)
         )
       )
       (set_local $1
         (if
           (i32.gt_u
-            (get_local $3)
+            (get_local $5)
             (set_local $1
               (i32.load offset=4
-                (get_local $5)
+                (get_local $4)
               )
             )
           )
           (block
             (i32.store
               (get_local $7)
-              (set_local $4
+              (set_local $3
                 (i32.load
                   (get_local $13)
                 )
@@ -1266,17 +1260,17 @@
             )
             (i32.store
               (get_local $11)
-              (get_local $4)
+              (get_local $3)
             )
-            (set_local $4
+            (set_local $5
               (i32.sub
-                (get_local $3)
+                (get_local $5)
                 (get_local $1)
               )
             )
             (set_local $3
               (i32.add
-                (get_local $5)
+                (get_local $4)
                 (i32.const 8)
               )
             )
@@ -1287,7 +1281,7 @@
               )
             )
             (i32.load offset=12
-              (get_local $5)
+              (get_local $4)
             )
           )
           (if
@@ -1302,14 +1296,11 @@
                   (i32.load
                     (get_local $7)
                   )
-                  (get_local $3)
+                  (get_local $5)
                 )
               )
-              (set_local $4
-                (get_local $3)
-              )
               (set_local $3
-                (get_local $5)
+                (get_local $4)
               )
               (set_local $6
                 (i32.const 2)
@@ -1317,11 +1308,8 @@
               (get_local $1)
             )
             (block
-              (set_local $4
-                (get_local $3)
-              )
               (set_local $3
-                (get_local $5)
+                (get_local $4)
               )
               (get_local $1)
             )
@@ -1334,20 +1322,20 @@
           (i32.load
             (get_local $3)
           )
-          (get_local $4)
+          (get_local $5)
         )
       )
       (i32.store offset=4
         (get_local $3)
         (i32.sub
           (get_local $1)
-          (get_local $4)
+          (get_local $5)
         )
       )
-      (set_local $5
+      (set_local $4
         (get_local $3)
       )
-      (set_local $4
+      (set_local $3
         (get_local $17)
       )
       (br $while-in$1)
@@ -1373,13 +1361,11 @@
         )
         (i32.store
           (get_local $7)
-          (set_local $0
-            (get_local $1)
-          )
+          (get_local $1)
         )
         (i32.store
           (get_local $11)
-          (get_local $0)
+          (get_local $1)
         )
         (set_local $14
           (get_local $2)
@@ -1772,9 +1758,9 @@
     )
     (if
       (i32.eq
-        (set_local $3
+        (set_local $6
           (i32.load
-            (set_local $6
+            (set_local $5
               (i32.add
                 (get_local $2)
                 (i32.const 16)
@@ -1792,22 +1778,22 @@
           (i32.const 0)
         )
         (block
-          (set_local $4
+          (set_local $3
             (i32.load
-              (get_local $6)
+              (get_local $5)
             )
           )
           (set_local $7
             (i32.const 5)
           )
         )
-        (set_local $5
+        (set_local $4
           (i32.const 0)
         )
       )
       (block
-        (set_local $4
-          (get_local $3)
+        (set_local $3
+          (get_local $6)
         )
         (set_local $7
           (i32.const 5)
@@ -1821,13 +1807,13 @@
           (i32.const 5)
         )
         (block
-          (set_local $4
+          (set_local $3
             (i32.lt_u
               (i32.sub
-                (get_local $4)
-                (set_local $3
+                (get_local $3)
+                (set_local $6
                   (i32.load
-                    (set_local $6
+                    (set_local $5
                       (i32.add
                         (get_local $2)
                         (i32.const 20)
@@ -1840,9 +1826,9 @@
             )
           )
           (if
-            (get_local $4)
+            (get_local $3)
             (block
-              (set_local $5
+              (set_local $4
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
@@ -1877,13 +1863,13 @@
                   (i32.const -1)
                 )
                 (block
-                  (set_local $4
+                  (set_local $3
                     (get_local $1)
                   )
                   (loop $while-out$2 $while-in$3
                     (if
                       (i32.eq
-                        (get_local $4)
+                        (get_local $3)
                         (i32.const 0)
                       )
                       (block
@@ -1891,7 +1877,7 @@
                           (i32.const 0)
                         )
                         (br $label$break$L10
-                          (get_local $3)
+                          (get_local $6)
                         )
                       )
                     )
@@ -1902,9 +1888,9 @@
                             (i32.load8_s
                               (i32.add
                                 (get_local $0)
-                                (set_local $5
+                                (set_local $4
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $3)
                                     (i32.const -1)
                                   )
                                 )
@@ -1916,14 +1902,9 @@
                         )
                         (i32.const 10)
                       )
-                      (block
-                        (set_local $3
-                          (get_local $4)
-                        )
-                        (br $while-out$2)
-                      )
-                      (set_local $4
-                        (get_local $5)
+                      (br $while-out$2)
+                      (set_local $3
+                        (get_local $4)
                       )
                     )
                     (br $while-in$3)
@@ -1947,7 +1928,7 @@
                       (get_local $3)
                     )
                     (block
-                      (set_local $5
+                      (set_local $4
                         (get_local $3)
                       )
                       (br $label$break$L5)
@@ -1969,14 +1950,14 @@
                     )
                   )
                   (i32.load
-                    (get_local $6)
+                    (get_local $5)
                   )
                 )
                 (block
                   (set_local $2
                     (i32.const 0)
                   )
-                  (get_local $3)
+                  (get_local $6)
                 )
               )
             )
@@ -1984,15 +1965,15 @@
             (get_local $1)
           )
           (i32.store
-            (get_local $6)
+            (get_local $5)
             (i32.add
               (i32.load
-                (get_local $6)
+                (get_local $5)
               )
               (get_local $1)
             )
           )
-          (set_local $5
+          (set_local $4
             (i32.add
               (get_local $2)
               (get_local $1)
@@ -2001,7 +1982,7 @@
         )
       )
     )
-    (get_local $5)
+    (get_local $4)
   )
   (func $___towrite (param $0 i32) (result i32)
     (local $1 i32)
@@ -2341,7 +2322,7 @@
     (i32.load
       (i32.const 8)
     )
-    (set_local $5
+    (set_local $16
       (i32.and
         (get_local $1)
         (i32.const 255)
@@ -2350,7 +2331,7 @@
     (block $label$break$L1
       (if
         (i32.and
-          (set_local $4
+          (set_local $6
             (i32.ne
               (get_local $2)
               (i32.const 0)
@@ -2365,7 +2346,7 @@
           )
         )
         (block
-          (set_local $4
+          (set_local $6
             (i32.and
               (get_local $1)
               (i32.const 255)
@@ -2391,17 +2372,17 @@
                 )
                 (i32.shr_s
                   (i32.shl
-                    (get_local $4)
+                    (get_local $6)
                     (i32.const 24)
                   )
                   (i32.const 24)
                 )
               )
               (block
-                (set_local $6
+                (set_local $4
                   (get_local $3)
                 )
-                (set_local $7
+                (set_local $5
                   (get_local $2)
                 )
                 (set_local $3
@@ -2440,13 +2421,13 @@
                 (get_local $0)
               )
               (block
-                (set_local $11
+                (set_local $14
                   (get_local $0)
                 )
-                (set_local $13
+                (set_local $11
                   (get_local $2)
                 )
-                (set_local $16
+                (set_local $15
                   (get_local $3)
                 )
                 (set_local $3
@@ -2459,14 +2440,14 @@
           )
         )
         (block
-          (set_local $11
+          (set_local $14
             (get_local $2)
           )
-          (set_local $13
+          (set_local $11
             (get_local $0)
           )
-          (set_local $16
-            (get_local $4)
+          (set_local $15
+            (get_local $6)
           )
           (set_local $3
             (i32.const 5)
@@ -2480,24 +2461,24 @@
         (i32.const 5)
       )
       (if
-        (get_local $16)
+        (get_local $15)
         (block
-          (set_local $6
-            (get_local $11)
+          (set_local $4
+            (get_local $14)
           )
-          (set_local $7
-            (get_local $13)
+          (set_local $5
+            (get_local $11)
           )
           (set_local $3
             (i32.const 6)
           )
         )
         (block
-          (set_local $8
+          (set_local $7
             (i32.const 0)
           )
-          (set_local $9
-            (get_local $13)
+          (set_local $8
+            (get_local $11)
           )
         )
       )
@@ -2513,7 +2494,7 @@
             (i32.shr_s
               (i32.shl
                 (i32.load8_s
-                  (get_local $7)
+                  (get_local $5)
                 )
                 (i32.const 24)
               )
@@ -2533,37 +2514,31 @@
             )
           )
           (block
-            (set_local $8
-              (get_local $6)
+            (set_local $7
+              (get_local $4)
             )
-            (set_local $9
-              (get_local $7)
+            (set_local $8
+              (get_local $5)
             )
           )
           (block
             (set_local $2
               (i32.mul
-                (get_local $5)
+                (get_local $16)
                 (i32.const 16843009)
               )
             )
             (block $label$break$L11
               (if
                 (i32.gt_u
-                  (get_local $6)
+                  (get_local $4)
                   (i32.const 3)
                 )
                 (block
-                  (set_local $4
-                    (get_local $6)
-                  )
-                  (set_local $5
-                    (get_local $7)
-                  )
                   (loop $while-out$5 $while-in$6
                     (set_local $1
                       (i32.add
-                        (set_local $11
+                        (set_local $6
                           (i32.xor
                             (i32.load
                               (get_local $5)
@@ -2579,7 +2554,7 @@
                         (i32.and
                           (i32.xor
                             (i32.and
-                              (get_local $11)
+                              (get_local $6)
                               (i32.const -2139062144)
                             )
                             (i32.const -2139062144)
@@ -2588,15 +2563,7 @@
                         )
                         (i32.const 0)
                       )
-                      (block
-                        (set_local $1
-                          (get_local $4)
-                        )
-                        (set_local $2
-                          (get_local $5)
-                        )
-                        (br $while-out$5)
-                      )
+                      (br $while-out$5)
                     )
                     (set_local $1
                       (i32.add
@@ -2618,10 +2585,10 @@
                         (get_local $1)
                       )
                       (block
-                        (set_local $14
+                        (set_local $12
                           (get_local $4)
                         )
-                        (set_local $15
+                        (set_local $13
                           (get_local $1)
                         )
                         (set_local $3
@@ -2632,19 +2599,19 @@
                     )
                     (br $while-in$6)
                   )
-                  (set_local $12
-                    (get_local $1)
-                  )
                   (set_local $10
-                    (get_local $2)
+                    (get_local $4)
+                  )
+                  (set_local $9
+                    (get_local $5)
                   )
                 )
                 (block
-                  (set_local $14
-                    (get_local $6)
+                  (set_local $12
+                    (get_local $4)
                   )
-                  (set_local $15
-                    (get_local $7)
+                  (set_local $13
+                    (get_local $5)
                   )
                   (set_local $3
                     (i32.const 11)
@@ -2659,24 +2626,24 @@
               )
               (if
                 (i32.eq
-                  (get_local $14)
+                  (get_local $12)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $8
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $9
-                    (get_local $15)
+                  (set_local $8
+                    (get_local $13)
                   )
                   (br $label$break$L8)
                 )
                 (block
-                  (set_local $12
-                    (get_local $14)
-                  )
                   (set_local $10
-                    (get_local $15)
+                    (get_local $12)
+                  )
+                  (set_local $9
+                    (get_local $13)
                   )
                 )
               )
@@ -2687,7 +2654,7 @@
                   (i32.shr_s
                     (i32.shl
                       (i32.load8_s
-                        (get_local $10)
+                        (get_local $9)
                       )
                       (i32.const 24)
                     )
@@ -2702,18 +2669,18 @@
                   )
                 )
                 (block
-                  (set_local $8
-                    (get_local $12)
-                  )
-                  (set_local $9
+                  (set_local $7
                     (get_local $10)
+                  )
+                  (set_local $8
+                    (get_local $9)
                   )
                   (br $label$break$L8)
                 )
               )
               (set_local $2
                 (i32.add
-                  (get_local $10)
+                  (get_local $9)
                   (i32.const 1)
                 )
               )
@@ -2721,26 +2688,26 @@
                 (i32.eq
                   (set_local $1
                     (i32.add
-                      (get_local $12)
+                      (get_local $10)
                       (i32.const -1)
                     )
                   )
                   (i32.const 0)
                 )
                 (block
-                  (set_local $8
+                  (set_local $7
                     (i32.const 0)
                   )
-                  (set_local $9
+                  (set_local $8
                     (get_local $2)
                   )
                   (br $while-out$7)
                 )
                 (block
-                  (set_local $12
+                  (set_local $10
                     (get_local $1)
                   )
-                  (set_local $10
+                  (set_local $9
                     (get_local $2)
                   )
                 )
@@ -2752,10 +2719,10 @@
       )
     )
     (select
-      (get_local $9)
+      (get_local $8)
       (i32.const 0)
       (i32.ne
-        (get_local $8)
+        (get_local $7)
         (i32.const 0)
       )
     )
@@ -2945,8 +2912,8 @@
     (local $11 i32)
     (local $12 i32)
     (local $13 i32)
-    (local $14 f64)
-    (local $15 i32)
+    (local $14 i32)
+    (local $15 f64)
     (local $16 i32)
     (local $17 i32)
     (local $18 i32)
@@ -2960,8 +2927,8 @@
     (local $26 i32)
     (local $27 i32)
     (local $28 i32)
-    (local $29 f64)
-    (local $30 i32)
+    (local $29 i32)
+    (local $30 f64)
     (local $31 i32)
     (local $32 i32)
     (local $33 i32)
@@ -3046,7 +3013,7 @@
         (i32.const 16)
       )
     )
-    (set_local $18
+    (set_local $19
       (get_local $31)
     )
     (set_local $63
@@ -3055,14 +3022,14 @@
         (i32.const 528)
       )
     )
-    (set_local $45
+    (set_local $44
       (i32.ne
         (get_local $0)
         (i32.const 0)
       )
     )
     (set_local $71
-      (set_local $27
+      (set_local $28
         (i32.add
           (set_local $5
             (i32.add
@@ -3091,7 +3058,7 @@
         (i32.const 4)
       )
     )
-    (set_local $54
+    (set_local $52
       (i32.add
         (set_local $5
           (i32.add
@@ -3110,11 +3077,11 @@
     )
     (set_local $77
       (i32.sub
-        (set_local $41
-          (get_local $54)
+        (set_local $40
+          (get_local $52)
         )
         (set_local $64
-          (set_local $28
+          (set_local $29
             (i32.add
               (get_local $31)
               (i32.const 588)
@@ -3131,7 +3098,7 @@
     )
     (set_local $79
       (i32.add
-        (get_local $41)
+        (get_local $40)
         (i32.const 2)
       )
     )
@@ -3147,20 +3114,20 @@
       )
     )
     (set_local $75
-      (set_local $46
+      (set_local $45
         (i32.add
-          (get_local $28)
+          (get_local $29)
           (i32.const 9)
         )
       )
     )
-    (set_local $55
+    (set_local $53
       (i32.add
-        (get_local $28)
+        (get_local $29)
         (i32.const 8)
       )
     )
-    (set_local $19
+    (set_local $22
       (i32.const 0)
     )
     (set_local $20
@@ -3169,14 +3136,14 @@
     (set_local $1
       (i32.const 0)
     )
-    (set_local $11
+    (set_local $8
       (i32.const 0)
     )
     (loop $label$break$L1 $label$continue$L1
-      (set_local $8
+      (set_local $22
         (if
           (i32.gt_s
-            (get_local $19)
+            (get_local $22)
             (i32.const -1)
           )
           (if
@@ -3184,7 +3151,7 @@
               (get_local $1)
               (i32.sub
                 (i32.const 2147483647)
-                (get_local $19)
+                (get_local $22)
               )
             )
             (block
@@ -3196,10 +3163,10 @@
             )
             (i32.add
               (get_local $1)
-              (get_local $19)
+              (get_local $22)
             )
           )
-          (get_local $19)
+          (get_local $22)
         )
       )
       (if
@@ -3219,10 +3186,10 @@
         )
         (block
           (set_local $82
-            (get_local $8)
+            (get_local $22)
           )
           (set_local $83
-            (get_local $11)
+            (get_local $8)
           )
           (set_local $12
             (i32.const 242)
@@ -3251,7 +3218,7 @@
                   )
                 )
               )
-              (set_local $56
+              (set_local $54
                 (get_local $5)
               )
               (set_local $65
@@ -3262,10 +3229,10 @@
               )
               (br $label$break$L9)
             )
-            (set_local $42
+            (set_local $41
               (get_local $5)
             )
-            (set_local $57
+            (set_local $55
               (get_local $5)
             )
             (br $label$break$L9)
@@ -3298,7 +3265,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s offset=1
-                      (get_local $56)
+                      (get_local $54)
                     )
                     (i32.const 24)
                   )
@@ -3307,10 +3274,10 @@
                 (i32.const 37)
               )
               (block
-                (set_local $42
-                  (get_local $56)
+                (set_local $41
+                  (get_local $54)
                 )
-                (set_local $57
+                (set_local $55
                   (get_local $65)
                 )
                 (br $label$break$L12)
@@ -3329,7 +3296,7 @@
                     (i32.load8_s
                       (set_local $1
                         (i32.add
-                          (get_local $56)
+                          (get_local $54)
                           (i32.const 2)
                         )
                       )
@@ -3341,7 +3308,7 @@
                 (i32.const 37)
               )
               (block
-                (set_local $56
+                (set_local $54
                   (get_local $1)
                 )
                 (set_local $65
@@ -3349,10 +3316,10 @@
                 )
               )
               (block
-                (set_local $42
+                (set_local $41
                   (get_local $1)
                 )
-                (set_local $57
+                (set_local $55
                   (get_local $5)
                 )
                 (br $while-out$7)
@@ -3362,14 +3329,14 @@
           )
         )
       )
-      (set_local $16
+      (set_local $17
         (i32.sub
-          (get_local $57)
+          (get_local $55)
           (get_local $20)
         )
       )
       (if
-        (get_local $45)
+        (get_local $44)
         (if
           (i32.eq
             (i32.and
@@ -3382,33 +3349,30 @@
           )
           (call $___fwritex
             (get_local $20)
-            (get_local $16)
+            (get_local $17)
             (get_local $0)
           )
         )
       )
       (if
         (i32.ne
-          (get_local $57)
+          (get_local $55)
           (get_local $20)
         )
         (block
-          (set_local $19
-            (get_local $8)
-          )
           (set_local $20
-            (get_local $42)
+            (get_local $41)
           )
           (set_local $1
-            (get_local $16)
+            (get_local $17)
           )
           (br $label$continue$L1)
         )
       )
-      (set_local $6
+      (set_local $7
         (if
           (i32.lt_u
-            (set_local $7
+            (set_local $6
               (i32.add
                 (i32.shr_s
                   (i32.shl
@@ -3416,7 +3380,7 @@
                       (i32.load8_s
                         (set_local $5
                           (i32.add
-                            (get_local $42)
+                            (get_local $41)
                             (i32.const 1)
                           )
                         )
@@ -3437,16 +3401,16 @@
                 (set_local $5
                   (select
                     (i32.add
-                      (get_local $42)
+                      (get_local $41)
                       (i32.const 3)
                     )
                     (get_local $5)
-                    (set_local $6
+                    (set_local $7
                       (i32.eq
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s offset=2
-                              (get_local $42)
+                              (get_local $41)
                             )
                             (i32.const 24)
                           )
@@ -3459,25 +3423,25 @@
                 )
               )
             )
-            (set_local $13
+            (set_local $11
               (select
                 (i32.const 1)
-                (get_local $11)
-                (get_local $6)
+                (get_local $8)
+                (get_local $7)
               )
             )
             (set_local $9
               (get_local $5)
             )
             (select
-              (get_local $7)
-              (i32.const -1)
               (get_local $6)
+              (i32.const -1)
+              (get_local $7)
             )
           )
           (block
-            (set_local $13
-              (get_local $11)
+            (set_local $11
+              (get_local $8)
             )
             (set_local $9
               (get_local $5)
@@ -3504,7 +3468,7 @@
             (i32.const 32)
           )
           (block
-            (set_local $7
+            (set_local $8
               (i32.const 0)
             )
             (loop $while-out$10 $while-in$11
@@ -3522,14 +3486,9 @@
                   )
                   (i32.const 0)
                 )
-                (block
-                  (set_local $11
-                    (get_local $7)
-                  )
-                  (br $label$break$L25)
-                )
+                (br $label$break$L25)
               )
-              (set_local $7
+              (set_local $8
                 (i32.or
                   (i32.shl
                     (i32.const 1)
@@ -3544,18 +3503,18 @@
                       (i32.const -32)
                     )
                   )
-                  (get_local $7)
+                  (get_local $8)
                 )
               )
               (if
-                (i32.ne
+                (i32.eq
                   (i32.and
                     (set_local $5
                       (i32.shr_s
                         (i32.shl
                           (set_local $1
                             (i32.load8_s
-                              (set_local $9
+                              (set_local $6
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 1)
@@ -3572,9 +3531,12 @@
                   )
                   (i32.const 32)
                 )
+                (set_local $9
+                  (get_local $6)
+                )
                 (block
-                  (set_local $11
-                    (get_local $7)
+                  (set_local $9
+                    (get_local $6)
                   )
                   (br $while-out$10)
                 )
@@ -3582,7 +3544,7 @@
               (br $while-in$11)
             )
           )
-          (set_local $11
+          (set_local $8
             (i32.const 0)
           )
         )
@@ -3607,7 +3569,7 @@
                     (i32.shr_s
                       (i32.shl
                         (i32.load8_s
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (get_local $9)
                               (i32.const 1)
@@ -3657,7 +3619,7 @@
                               (i32.shr_s
                                 (i32.shl
                                   (i32.load8_s
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                   (i32.const 24)
                                 )
@@ -3683,7 +3645,7 @@
                       (i32.const 3)
                     )
                   )
-                  (set_local $58
+                  (set_local $56
                     (get_local $5)
                   )
                 )
@@ -3706,11 +3668,11 @@
                 )
                 (if
                   (i32.ne
-                    (get_local $13)
+                    (get_local $11)
                     (i32.const 0)
                   )
                   (block
-                    (set_local $23
+                    (set_local $24
                       (i32.const -1)
                     )
                     (br $label$break$L1)
@@ -3718,16 +3680,16 @@
                 )
                 (if
                   (i32.eqz
-                    (get_local $45)
+                    (get_local $44)
                   )
                   (block
                     (set_local $9
-                      (get_local $7)
+                      (get_local $6)
                     )
-                    (set_local $22
+                    (set_local $21
                       (i32.const 0)
                     )
-                    (set_local $15
+                    (set_local $16
                       (i32.const 0)
                     )
                     (br $do-once$12)
@@ -3759,34 +3721,34 @@
                   (i32.const 0)
                 )
                 (set_local $67
-                  (get_local $7)
+                  (get_local $6)
                 )
-                (set_local $58
+                (set_local $56
                   (get_local $5)
                 )
               )
             )
-            (set_local $11
+            (set_local $8
               (if
                 (i32.lt_s
-                  (get_local $58)
+                  (get_local $56)
                   (i32.const 0)
                 )
                 (block
                   (set_local $9
                     (get_local $67)
                   )
-                  (set_local $22
+                  (set_local $21
                     (get_local $66)
                   )
-                  (set_local $15
+                  (set_local $16
                     (i32.sub
                       (i32.const 0)
-                      (get_local $58)
+                      (get_local $56)
                     )
                   )
                   (i32.or
-                    (get_local $11)
+                    (get_local $8)
                     (i32.const 8192)
                   )
                 )
@@ -3794,20 +3756,20 @@
                   (set_local $9
                     (get_local $67)
                   )
-                  (set_local $22
+                  (set_local $21
                     (get_local $66)
                   )
-                  (set_local $15
-                    (get_local $58)
+                  (set_local $16
+                    (get_local $56)
                   )
-                  (get_local $11)
+                  (get_local $8)
                 )
               )
             )
           )
           (if
             (i32.lt_u
-              (set_local $7
+              (set_local $6
                 (i32.add
                   (i32.shr_s
                     (i32.shl
@@ -3835,17 +3797,17 @@
                       (get_local $5)
                       (i32.const 10)
                     )
-                    (get_local $7)
+                    (get_local $6)
                   )
                 )
                 (if
-                  (i32.lt_u
-                    (set_local $9
+                  (i32.ge_u
+                    (set_local $6
                       (i32.add
                         (i32.shr_s
                           (i32.shl
                             (i32.load8_s
-                              (set_local $7
+                              (set_local $1
                                 (i32.add
                                   (get_local $1)
                                   (i32.const 1)
@@ -3861,62 +3823,46 @@
                     )
                     (i32.const 10)
                   )
-                  (block
-                    (set_local $1
-                      (get_local $7)
-                    )
-                    (set_local $7
-                      (get_local $9)
-                    )
-                  )
-                  (block
-                    (set_local $1
-                      (get_local $5)
-                    )
-                    (set_local $5
-                      (get_local $7)
-                    )
-                    (br $while-out$14)
-                  )
+                  (br $while-out$14)
                 )
                 (br $while-in$15)
               )
               (if
                 (i32.lt_s
-                  (get_local $1)
+                  (get_local $5)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $23
+                  (set_local $24
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
                 (block
                   (set_local $9
-                    (get_local $5)
-                  )
-                  (set_local $22
-                    (get_local $13)
-                  )
-                  (set_local $15
                     (get_local $1)
+                  )
+                  (set_local $21
+                    (get_local $11)
+                  )
+                  (set_local $16
+                    (get_local $5)
                   )
                 )
               )
             )
             (block
-              (set_local $22
-                (get_local $13)
+              (set_local $21
+                (get_local $11)
               )
-              (set_local $15
+              (set_local $16
                 (i32.const 0)
               )
             )
           )
         )
       )
-      (set_local $13
+      (set_local $11
         (block $label$break$L46
           (if
             (i32.eq
@@ -3955,7 +3901,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (set_local $7
+                      (set_local $6
                         (i32.add
                           (i32.shr_s
                             (i32.shl
@@ -3993,12 +3939,12 @@
                           (get_local $5)
                           (i32.const 10)
                         )
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                     (if
                       (i32.ge_u
-                        (set_local $7
+                        (set_local $6
                           (i32.add
                             (i32.shr_s
                               (i32.shl
@@ -4039,7 +3985,7 @@
                       (i32.shr_s
                         (i32.shl
                           (i32.load8_s
-                            (set_local $7
+                            (set_local $6
                               (i32.add
                                 (get_local $9)
                                 (i32.const 2)
@@ -4089,7 +4035,7 @@
                                 (i32.shr_s
                                   (i32.shl
                                     (i32.load8_s
-                                      (get_local $7)
+                                      (get_local $6)
                                     )
                                     (i32.const 24)
                                   )
@@ -4120,18 +4066,18 @@
               )
               (if
                 (i32.ne
-                  (get_local $22)
+                  (get_local $21)
                   (i32.const 0)
                 )
                 (block
-                  (set_local $23
+                  (set_local $24
                     (i32.const -1)
                   )
                   (br $label$break$L1)
                 )
               )
               (if
-                (get_local $45)
+                (get_local $44)
                 (block
                   (set_local $5
                     (i32.load
@@ -4158,13 +4104,13 @@
                   (set_local $10
                     (get_local $5)
                   )
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (block
                   (set_local $10
                     (i32.const 0)
                   )
-                  (get_local $7)
+                  (get_local $6)
                 )
               )
             )
@@ -4177,7 +4123,7 @@
           )
         )
       )
-      (set_local $19
+      (set_local $13
         (i32.const 0)
       )
       (loop $while-out$19 $while-in$20
@@ -4188,7 +4134,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $13)
+                      (get_local $11)
                     )
                     (i32.const 24)
                   )
@@ -4200,7 +4146,7 @@
             (i32.const 57)
           )
           (block
-            (set_local $23
+            (set_local $24
               (i32.const -1)
             )
             (br $label$break$L1)
@@ -4208,7 +4154,7 @@
         )
         (set_local $9
           (i32.add
-            (get_local $13)
+            (get_local $11)
             (i32.const 1)
           )
         )
@@ -4223,7 +4169,7 @@
                         (i32.add
                           (i32.const 3611)
                           (i32.mul
-                            (get_local $19)
+                            (get_local $13)
                             (i32.const 58)
                           )
                         )
@@ -4239,15 +4185,15 @@
             (i32.const 8)
           )
           (block
-            (set_local $13
+            (set_local $11
               (get_local $9)
             )
-            (set_local $19
+            (set_local $13
               (get_local $5)
             )
           )
           (block
-            (set_local $7
+            (set_local $6
               (get_local $5)
             )
             (br $while-out$19)
@@ -4267,7 +4213,7 @@
           (i32.const 0)
         )
         (block
-          (set_local $23
+          (set_local $24
             (i32.const -1)
           )
           (br $label$break$L1)
@@ -4275,7 +4221,7 @@
       )
       (set_local $5
         (i32.gt_s
-          (get_local $6)
+          (get_local $7)
           (i32.const -1)
         )
       )
@@ -4294,7 +4240,7 @@
           (if
             (get_local $5)
             (block
-              (set_local $23
+              (set_local $24
                 (i32.const -1)
               )
               (br $label$break$L1)
@@ -4311,11 +4257,11 @@
                   (i32.add
                     (get_local $4)
                     (i32.shl
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 2)
                     )
                   )
-                  (get_local $7)
+                  (get_local $6)
                 )
                 (set_local $5
                   (i32.load
@@ -4323,7 +4269,7 @@
                       (i32.add
                         (get_local $3)
                         (i32.shl
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 3)
                         )
                       )
@@ -4336,13 +4282,13 @@
                   )
                 )
                 (i32.store
-                  (set_local $6
-                    (get_local $18)
+                  (set_local $7
+                    (get_local $19)
                   )
                   (get_local $5)
                 )
                 (i32.store offset=4
-                  (get_local $6)
+                  (get_local $7)
                   (get_local $1)
                 )
                 (set_local $12
@@ -4353,18 +4299,18 @@
             )
             (if
               (i32.eqz
-                (get_local $45)
+                (get_local $44)
               )
               (block
-                (set_local $23
+                (set_local $24
                   (i32.const 0)
                 )
                 (br $label$break$L1)
               )
             )
             (call $_pop_arg_336
-              (get_local $18)
-              (get_local $7)
+              (get_local $19)
+              (get_local $6)
               (get_local $2)
             )
           )
@@ -4381,20 +4327,17 @@
           )
           (if
             (i32.eqz
-              (get_local $45)
+              (get_local $44)
             )
             (block
-              (set_local $19
-                (get_local $8)
-              )
               (set_local $20
                 (get_local $9)
               )
               (set_local $1
-                (get_local $16)
+                (get_local $17)
               )
-              (set_local $11
-                (get_local $22)
+              (set_local $8
+                (get_local $21)
               )
               (br $label$continue$L1)
             )
@@ -4404,7 +4347,7 @@
       (set_local $5
         (i32.and
           (i32.ne
-            (get_local $19)
+            (get_local $13)
             (i32.const 0)
           )
           (i32.eq
@@ -4413,7 +4356,7 @@
                 (i32.shr_s
                   (i32.shl
                     (i32.load8_s
-                      (get_local $13)
+                      (get_local $11)
                     )
                     (i32.const 24)
                   )
@@ -4426,18 +4369,18 @@
           )
         )
       )
-      (set_local $17
+      (set_local $18
         (select
-          (get_local $11)
+          (get_local $8)
           (set_local $7
             (i32.and
-              (get_local $11)
+              (get_local $8)
               (i32.const -65537)
             )
           )
           (i32.eq
             (i32.and
-              (get_local $11)
+              (get_local $8)
               (i32.const 8192)
             )
             (i32.const 0)
@@ -4471,7 +4414,7 @@
                                                       (block $switch-case$34
                                                         (br_table $switch-case$49 $switch-default$127 $switch-case$47 $switch-default$127 $switch-case$52 $switch-case$51 $switch-case$50 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$48 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$36 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$53 $switch-default$127 $switch-case$44 $switch-case$42 $switch-case$126 $switch-case$55 $switch-case$54 $switch-default$127 $switch-case$41 $switch-default$127 $switch-default$127 $switch-default$127 $switch-case$45 $switch-case$34 $switch-case$40 $switch-case$35 $switch-default$127 $switch-default$127 $switch-case$46 $switch-default$127 $switch-case$43 $switch-default$127 $switch-default$127 $switch-case$37 $switch-default$127
                                                           (i32.sub
-                                                            (set_local $33
+                                                            (set_local $26
                                                               (select
                                                                 (i32.and
                                                                   (get_local $1)
@@ -4496,65 +4439,59 @@
                                                                       (block $switch-case$26
                                                                         (br_table $switch-case$26 $switch-case$27 $switch-case$28 $switch-case$29 $switch-case$30 $switch-default$33 $switch-case$31 $switch-case$32 $switch-default$33
                                                                           (i32.sub
-                                                                            (get_local $19)
+                                                                            (get_local $13)
                                                                             (i32.const 0)
                                                                           )
                                                                         )
                                                                       )
                                                                       (i32.store
                                                                         (i32.load
-                                                                          (get_local $18)
+                                                                          (get_local $19)
                                                                         )
-                                                                        (get_local $8)
-                                                                      )
-                                                                      (set_local $19
-                                                                        (get_local $8)
+                                                                        (get_local $22)
                                                                       )
                                                                       (set_local $20
                                                                         (get_local $9)
                                                                       )
                                                                       (set_local $1
-                                                                        (get_local $16)
+                                                                        (get_local $17)
                                                                       )
-                                                                      (set_local $11
-                                                                        (get_local $22)
+                                                                      (set_local $8
+                                                                        (get_local $21)
                                                                       )
                                                                       (br $label$continue$L1)
                                                                     )
                                                                     (i32.store
                                                                       (i32.load
-                                                                        (get_local $18)
+                                                                        (get_local $19)
                                                                       )
-                                                                      (get_local $8)
-                                                                    )
-                                                                    (set_local $19
-                                                                      (get_local $8)
+                                                                      (get_local $22)
                                                                     )
                                                                     (set_local $20
                                                                       (get_local $9)
                                                                     )
                                                                     (set_local $1
-                                                                      (get_local $16)
+                                                                      (get_local $17)
                                                                     )
-                                                                    (set_local $11
-                                                                      (get_local $22)
+                                                                    (set_local $8
+                                                                      (get_local $21)
                                                                     )
                                                                     (br $label$continue$L1)
                                                                   )
                                                                   (i32.store
                                                                     (set_local $1
                                                                       (i32.load
-                                                                        (get_local $18)
+                                                                        (get_local $19)
                                                                       )
                                                                     )
-                                                                    (get_local $8)
+                                                                    (get_local $22)
                                                                   )
                                                                   (i32.store offset=4
                                                                     (get_local $1)
                                                                     (i32.shr_s
                                                                       (i32.shl
                                                                         (i32.lt_s
-                                                                          (get_local $8)
+                                                                          (get_local $22)
                                                                           (i32.const 0)
                                                                         )
                                                                         (i32.const 31)
@@ -4562,100 +4499,88 @@
                                                                       (i32.const 31)
                                                                     )
                                                                   )
-                                                                  (set_local $19
-                                                                    (get_local $8)
-                                                                  )
                                                                   (set_local $20
                                                                     (get_local $9)
                                                                   )
                                                                   (set_local $1
-                                                                    (get_local $16)
+                                                                    (get_local $17)
                                                                   )
-                                                                  (set_local $11
-                                                                    (get_local $22)
+                                                                  (set_local $8
+                                                                    (get_local $21)
                                                                   )
                                                                   (br $label$continue$L1)
                                                                 )
                                                                 (i32.store16
                                                                   (i32.load
-                                                                    (get_local $18)
+                                                                    (get_local $19)
                                                                   )
                                                                   (i32.and
-                                                                    (get_local $8)
+                                                                    (get_local $22)
                                                                     (i32.const 65535)
                                                                   )
-                                                                )
-                                                                (set_local $19
-                                                                  (get_local $8)
                                                                 )
                                                                 (set_local $20
                                                                   (get_local $9)
                                                                 )
                                                                 (set_local $1
-                                                                  (get_local $16)
+                                                                  (get_local $17)
                                                                 )
-                                                                (set_local $11
-                                                                  (get_local $22)
+                                                                (set_local $8
+                                                                  (get_local $21)
                                                                 )
                                                                 (br $label$continue$L1)
                                                               )
                                                               (i32.store8
                                                                 (i32.load
-                                                                  (get_local $18)
+                                                                  (get_local $19)
                                                                 )
                                                                 (i32.and
-                                                                  (get_local $8)
+                                                                  (get_local $22)
                                                                   (i32.const 255)
                                                                 )
-                                                              )
-                                                              (set_local $19
-                                                                (get_local $8)
                                                               )
                                                               (set_local $20
                                                                 (get_local $9)
                                                               )
                                                               (set_local $1
-                                                                (get_local $16)
+                                                                (get_local $17)
                                                               )
-                                                              (set_local $11
-                                                                (get_local $22)
+                                                              (set_local $8
+                                                                (get_local $21)
                                                               )
                                                               (br $label$continue$L1)
                                                             )
                                                             (i32.store
                                                               (i32.load
-                                                                (get_local $18)
+                                                                (get_local $19)
                                                               )
-                                                              (get_local $8)
-                                                            )
-                                                            (set_local $19
-                                                              (get_local $8)
+                                                              (get_local $22)
                                                             )
                                                             (set_local $20
                                                               (get_local $9)
                                                             )
                                                             (set_local $1
-                                                              (get_local $16)
+                                                              (get_local $17)
                                                             )
-                                                            (set_local $11
-                                                              (get_local $22)
+                                                            (set_local $8
+                                                              (get_local $21)
                                                             )
                                                             (br $label$continue$L1)
                                                           )
                                                           (i32.store
                                                             (set_local $1
                                                               (i32.load
-                                                                (get_local $18)
+                                                                (get_local $19)
                                                               )
                                                             )
-                                                            (get_local $8)
+                                                            (get_local $22)
                                                           )
                                                           (i32.store offset=4
                                                             (get_local $1)
                                                             (i32.shr_s
                                                               (i32.shl
                                                                 (i32.lt_s
-                                                                  (get_local $8)
+                                                                  (get_local $22)
                                                                   (i32.const 0)
                                                                 )
                                                                 (i32.const 31)
@@ -4663,42 +4588,36 @@
                                                               (i32.const 31)
                                                             )
                                                           )
-                                                          (set_local $19
-                                                            (get_local $8)
-                                                          )
                                                           (set_local $20
                                                             (get_local $9)
                                                           )
                                                           (set_local $1
-                                                            (get_local $16)
+                                                            (get_local $17)
                                                           )
-                                                          (set_local $11
-                                                            (get_local $22)
+                                                          (set_local $8
+                                                            (get_local $21)
                                                           )
                                                           (br $label$continue$L1)
-                                                        )
-                                                        (set_local $19
-                                                          (get_local $8)
                                                         )
                                                         (set_local $20
                                                           (get_local $9)
                                                         )
                                                         (set_local $1
-                                                          (get_local $16)
+                                                          (get_local $17)
                                                         )
-                                                        (set_local $11
-                                                          (get_local $22)
+                                                        (set_local $8
+                                                          (get_local $21)
                                                         )
                                                         (br $label$continue$L1)
                                                       )
                                                     )
-                                                    (set_local $47
+                                                    (set_local $46
                                                       (i32.or
-                                                        (get_local $17)
+                                                        (get_local $18)
                                                         (i32.const 8)
                                                       )
                                                     )
-                                                    (set_local $59
+                                                    (set_local $57
                                                       (select
                                                         (get_local $10)
                                                         (i32.const 8)
@@ -4717,14 +4636,14 @@
                                                     (br $switch$24)
                                                   )
                                                 )
-                                                (set_local $47
-                                                  (get_local $17)
+                                                (set_local $46
+                                                  (get_local $18)
                                                 )
-                                                (set_local $59
+                                                (set_local $57
                                                   (get_local $10)
                                                 )
                                                 (set_local $68
-                                                  (get_local $33)
+                                                  (get_local $26)
                                                 )
                                                 (set_local $12
                                                   (i32.const 64)
@@ -4737,7 +4656,7 @@
                                                     (set_local $5
                                                       (i32.load
                                                         (set_local $1
-                                                          (get_local $18)
+                                                          (get_local $19)
                                                         )
                                                       )
                                                     )
@@ -4753,15 +4672,15 @@
                                                   )
                                                 )
                                                 (set_local $6
-                                                  (get_local $27)
+                                                  (get_local $28)
                                                 )
                                                 (block
                                                   (set_local $6
-                                                    (get_local $27)
+                                                    (get_local $28)
                                                   )
                                                   (loop $while-out$38 $while-in$39
                                                     (i32.store8
-                                                      (set_local $34
+                                                      (set_local $6
                                                         (i32.add
                                                           (get_local $6)
                                                           (i32.const -1)
@@ -4781,7 +4700,7 @@
                                                     (if
                                                       (i32.and
                                                         (i32.eq
-                                                          (set_local $1
+                                                          (set_local $5
                                                             (call $_bitshift64Lshr
                                                               (get_local $5)
                                                               (get_local $1)
@@ -4791,7 +4710,7 @@
                                                           (i32.const 0)
                                                         )
                                                         (i32.eq
-                                                          (set_local $6
+                                                          (set_local $1
                                                             (i32.load
                                                               (i32.const 168)
                                                             )
@@ -4799,48 +4718,32 @@
                                                           (i32.const 0)
                                                         )
                                                       )
-                                                      (block
-                                                        (set_local $6
-                                                          (get_local $34)
-                                                        )
-                                                        (br $while-out$38)
-                                                      )
-                                                      (block
-                                                        (set_local $5
-                                                          (get_local $1)
-                                                        )
-                                                        (set_local $1
-                                                          (get_local $6)
-                                                        )
-                                                        (set_local $6
-                                                          (get_local $34)
-                                                        )
-                                                      )
+                                                      (br $while-out$38)
                                                     )
                                                     (br $while-in$39)
                                                   )
                                                 )
                                               )
-                                              (set_local $34
+                                              (set_local $58
                                                 (if
                                                   (i32.eq
                                                     (i32.and
-                                                      (get_local $17)
+                                                      (get_local $18)
                                                       (i32.const 8)
                                                     )
                                                     (i32.const 0)
                                                   )
                                                   (block
-                                                    (set_local $35
-                                                      (get_local $17)
+                                                    (set_local $34
+                                                      (get_local $18)
                                                     )
                                                     (set_local $32
                                                       (get_local $10)
                                                     )
-                                                    (set_local $36
+                                                    (set_local $35
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $37
+                                                    (set_local $36
                                                       (i32.const 4091)
                                                     )
                                                     (set_local $12
@@ -4863,8 +4766,8 @@
                                                         )
                                                       )
                                                     )
-                                                    (set_local $35
-                                                      (get_local $17)
+                                                    (set_local $34
+                                                      (get_local $18)
                                                     )
                                                     (set_local $32
                                                       (select
@@ -4873,10 +4776,10 @@
                                                         (get_local $5)
                                                       )
                                                     )
-                                                    (set_local $36
+                                                    (set_local $35
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $37
+                                                    (set_local $36
                                                       (i32.const 4091)
                                                     )
                                                     (set_local $12
@@ -4892,13 +4795,13 @@
                                           (set_local $5
                                             (i32.load
                                               (set_local $1
-                                                (get_local $18)
+                                                (get_local $19)
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_s
-                                              (set_local $6
+                                              (set_local $33
                                                 (i32.load offset=4
                                                   (get_local $1)
                                                 )
@@ -4911,7 +4814,7 @@
                                                   (i32.const 0)
                                                   (i32.const 0)
                                                   (get_local $5)
-                                                  (get_local $6)
+                                                  (get_local $33)
                                                 )
                                               )
                                               (set_local $5
@@ -4920,25 +4823,25 @@
                                                 )
                                               )
                                               (i32.store
-                                                (set_local $6
-                                                  (get_local $18)
+                                                (set_local $33
+                                                  (get_local $19)
                                                 )
                                                 (get_local $1)
                                               )
                                               (i32.store offset=4
-                                                (get_local $6)
+                                                (get_local $33)
                                                 (get_local $5)
                                               )
-                                              (set_local $48
+                                              (set_local $33
                                                 (get_local $1)
                                               )
-                                              (set_local $60
+                                              (set_local $59
                                                 (get_local $5)
                                               )
-                                              (set_local $61
+                                              (set_local $60
                                                 (i32.const 1)
                                               )
-                                              (set_local $62
+                                              (set_local $61
                                                 (i32.const 4091)
                                               )
                                               (set_local $12
@@ -4947,11 +4850,11 @@
                                               (br $label$break$L75)
                                             )
                                           )
-                                          (set_local $48
+                                          (set_local $33
                                             (if
                                               (i32.eq
                                                 (i32.and
-                                                  (get_local $17)
+                                                  (get_local $18)
                                                   (i32.const 2048)
                                                 )
                                                 (i32.const 0)
@@ -4962,9 +4865,9 @@
                                                     (i32.const 4091)
                                                     (i32.const 4093)
                                                     (i32.eq
-                                                      (set_local $48
+                                                      (set_local $6
                                                         (i32.and
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                           (i32.const 1)
                                                         )
                                                       )
@@ -4972,13 +4875,13 @@
                                                     )
                                                   )
                                                 )
+                                                (set_local $59
+                                                  (get_local $33)
+                                                )
                                                 (set_local $60
                                                   (get_local $6)
                                                 )
                                                 (set_local $61
-                                                  (get_local $48)
-                                                )
-                                                (set_local $62
                                                   (get_local $1)
                                                 )
                                                 (set_local $12
@@ -4987,13 +4890,13 @@
                                                 (get_local $5)
                                               )
                                               (block
-                                                (set_local $60
-                                                  (get_local $6)
+                                                (set_local $59
+                                                  (get_local $33)
                                                 )
-                                                (set_local $61
+                                                (set_local $60
                                                   (i32.const 1)
                                                 )
-                                                (set_local $62
+                                                (set_local $61
                                                   (i32.const 4092)
                                                 )
                                                 (set_local $12
@@ -5005,22 +4908,22 @@
                                           )
                                           (br $switch$24)
                                         )
-                                        (set_local $48
+                                        (set_local $33
                                           (i32.load
                                             (set_local $1
-                                              (get_local $18)
+                                              (get_local $19)
                                             )
                                           )
                                         )
-                                        (set_local $60
+                                        (set_local $59
                                           (i32.load offset=4
                                             (get_local $1)
                                           )
                                         )
-                                        (set_local $61
+                                        (set_local $60
                                           (i32.const 0)
                                         )
-                                        (set_local $62
+                                        (set_local $61
                                           (i32.const 4091)
                                         )
                                         (set_local $12
@@ -5031,7 +4934,7 @@
                                       (set_local $5
                                         (i32.load
                                           (set_local $1
-                                            (get_local $18)
+                                            (get_local $19)
                                           )
                                         )
                                       )
@@ -5045,27 +4948,27 @@
                                           (i32.const 255)
                                         )
                                       )
-                                      (set_local $49
+                                      (set_local $47
                                         (get_local $72)
                                       )
-                                      (set_local $38
+                                      (set_local $37
                                         (get_local $7)
                                       )
-                                      (set_local $43
+                                      (set_local $42
                                         (i32.const 1)
                                       )
-                                      (set_local $44
+                                      (set_local $43
                                         (i32.const 0)
                                       )
-                                      (set_local $50
+                                      (set_local $48
                                         (i32.const 4091)
                                       )
-                                      (set_local $51
-                                        (get_local $27)
+                                      (set_local $49
+                                        (get_local $28)
                                       )
                                       (br $switch$24)
                                     )
-                                    (set_local $52
+                                    (set_local $50
                                       (call $_strerror
                                         (i32.load
                                           (call $___errno_location)
@@ -5081,13 +4984,13 @@
                                     (i32.ne
                                       (set_local $1
                                         (i32.load
-                                          (get_local $18)
+                                          (get_local $19)
                                         )
                                       )
                                       (i32.const 0)
                                     )
                                   )
-                                  (set_local $52
+                                  (set_local $50
                                     (select
                                       (get_local $1)
                                       (i32.const 4101)
@@ -5102,7 +5005,7 @@
                                 (set_local $5
                                   (i32.load
                                     (set_local $1
-                                      (get_local $18)
+                                      (get_local $19)
                                     )
                                   )
                                 )
@@ -5118,7 +5021,7 @@
                                   (i32.const 0)
                                 )
                                 (i32.store
-                                  (get_local $18)
+                                  (get_local $19)
                                   (get_local $73)
                                 )
                                 (set_local $69
@@ -5139,11 +5042,11 @@
                                     (call $_pad
                                       (get_local $0)
                                       (i32.const 32)
-                                      (get_local $15)
+                                      (get_local $16)
                                       (i32.const 0)
-                                      (get_local $17)
+                                      (get_local $18)
                                     )
-                                    (set_local $39
+                                    (set_local $38
                                       (i32.const 0)
                                     )
                                     (i32.const 98)
@@ -5165,9 +5068,9 @@
                   )
                 )
               )
-              (set_local $14
+              (set_local $15
                 (f64.load
-                  (get_local $18)
+                  (get_local $19)
                 )
               )
               (i32.store
@@ -5178,14 +5081,14 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $14)
+                (get_local $15)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
               )
-              (set_local $53
+              (set_local $51
                 (if
                   (i32.lt_s
                     (i32.load offset=4
@@ -5196,12 +5099,12 @@
                     (i32.const 0)
                   )
                   (block
-                    (set_local $40
+                    (set_local $39
                       (i32.const 4108)
                     )
-                    (set_local $14
+                    (set_local $15
                       (f64.neg
-                        (get_local $14)
+                        (get_local $15)
                       )
                     )
                     (i32.const 1)
@@ -5209,20 +5112,20 @@
                   (if
                     (i32.eq
                       (i32.and
-                        (get_local $17)
+                        (get_local $18)
                         (i32.const 2048)
                       )
                       (i32.const 0)
                     )
                     (block
-                      (set_local $40
+                      (set_local $39
                         (select
                           (i32.const 4109)
                           (i32.const 4114)
                           (i32.eq
                             (set_local $1
                               (i32.and
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 1)
                               )
                             )
@@ -5233,7 +5136,7 @@
                       (get_local $1)
                     )
                     (block
-                      (set_local $40
+                      (set_local $39
                         (i32.const 4111)
                       )
                       (i32.const 1)
@@ -5245,15 +5148,12 @@
                 (i32.load
                   (i32.const 24)
                 )
-                (get_local $14)
+                (get_local $15)
               )
               (i32.load
                 (i32.load
                   (i32.const 24)
                 )
-              )
-              (set_local $19
-                (get_local $8)
               )
               (set_local $20
                 (get_local $9)
@@ -5287,10 +5187,10 @@
                       (if
                         (set_local $5
                           (f64.ne
-                            (set_local $14
+                            (set_local $15
                               (f64.mul
                                 (call $_frexpl
-                                  (get_local $14)
+                                  (get_local $15)
                                   (get_local $25)
                                 )
                                 (f64.const 2)
@@ -5311,26 +5211,26 @@
                       )
                       (if
                         (i32.eq
-                          (set_local $21
+                          (set_local $14
                             (i32.or
-                              (get_local $33)
+                              (get_local $26)
                               (i32.const 32)
                             )
                           )
                           (i32.const 97)
                         )
                         (block
-                          (set_local $11
+                          (set_local $9
                             (select
-                              (get_local $40)
+                              (get_local $39)
                               (i32.add
-                                (get_local $40)
+                                (get_local $39)
                                 (i32.const 9)
                               )
                               (i32.eq
-                                (set_local $7
+                                (set_local $6
                                   (i32.and
-                                    (get_local $33)
+                                    (get_local $26)
                                     (i32.const 32)
                                   )
                                 )
@@ -5338,13 +5238,13 @@
                               )
                             )
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.or
-                              (get_local $53)
+                              (get_local $51)
                               (i32.const 2)
                             )
                           )
-                          (set_local $14
+                          (set_local $15
                             (if
                               (i32.or
                                 (i32.gt_u
@@ -5361,15 +5261,15 @@
                                   (i32.const 0)
                                 )
                               )
-                              (get_local $14)
+                              (get_local $15)
                               (block
-                                (set_local $29
+                                (set_local $30
                                   (f64.const 8)
                                 )
                                 (loop $while-out$60 $while-in$61
-                                  (set_local $29
+                                  (set_local $30
                                     (f64.mul
-                                      (get_local $29)
+                                      (get_local $30)
                                       (f64.const 16)
                                     )
                                   )
@@ -5390,27 +5290,27 @@
                                 (select
                                   (f64.neg
                                     (f64.add
-                                      (get_local $29)
+                                      (get_local $30)
                                       (f64.sub
                                         (f64.neg
-                                          (get_local $14)
+                                          (get_local $15)
                                         )
-                                        (get_local $29)
+                                        (get_local $30)
                                       )
                                     )
                                   )
                                   (f64.sub
                                     (f64.add
-                                      (get_local $14)
-                                      (get_local $29)
+                                      (get_local $15)
+                                      (get_local $30)
                                     )
-                                    (get_local $29)
+                                    (get_local $30)
                                   )
                                   (i32.eq
                                     (i32.shr_s
                                       (i32.shl
                                         (i32.load8_s
-                                          (get_local $11)
+                                          (get_local $9)
                                         )
                                         (i32.const 24)
                                       )
@@ -5462,10 +5362,10 @@
                                       (call $_fmt_u
                                         (get_local $8)
                                         (get_local $5)
-                                        (get_local $54)
+                                        (get_local $52)
                                       )
                                     )
-                                    (get_local $54)
+                                    (get_local $52)
                                   )
                                   (block
                                     (i32.store8
@@ -5502,7 +5402,7 @@
                             )
                             (i32.and
                               (i32.add
-                                (get_local $33)
+                                (get_local $26)
                                 (i32.const 15)
                               )
                               (i32.const 255)
@@ -5517,18 +5417,18 @@
                           (set_local $13
                             (i32.eq
                               (i32.and
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 8)
                               )
                               (i32.const 0)
                             )
                           )
-                          (set_local $9
-                            (get_local $28)
+                          (set_local $11
+                            (get_local $29)
                           )
                           (loop $while-out$62 $while-in$63
                             (i32.store8
-                              (get_local $9)
+                              (get_local $11)
                               (i32.and
                                 (i32.or
                                   (i32.and
@@ -5536,7 +5436,7 @@
                                       (i32.add
                                         (set_local $1
                                           (i32.trunc_s/f64
-                                            (get_local $14)
+                                            (get_local $15)
                                           )
                                         )
                                         (i32.const 4075)
@@ -5544,15 +5444,15 @@
                                     )
                                     (i32.const 255)
                                   )
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.const 255)
                               )
                             )
-                            (set_local $14
+                            (set_local $15
                               (f64.mul
                                 (f64.sub
-                                  (get_local $14)
+                                  (get_local $15)
                                   (f64.convert_s/i32
                                     (get_local $1)
                                   )
@@ -5560,14 +5460,14 @@
                                 (f64.const 16)
                               )
                             )
-                            (set_local $1
+                            (set_local $11
                               (block $do-once$64
                                 (if
                                   (i32.eq
                                     (i32.sub
                                       (set_local $1
                                         (i32.add
-                                          (get_local $9)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
@@ -5583,7 +5483,7 @@
                                         (i32.and
                                           (get_local $5)
                                           (f64.eq
-                                            (get_local $14)
+                                            (get_local $15)
                                             (f64.const 0)
                                           )
                                         )
@@ -5594,7 +5494,7 @@
                                       (i32.const 46)
                                     )
                                     (i32.add
-                                      (get_local $9)
+                                      (get_local $11)
                                       (i32.const 2)
                                     )
                                   )
@@ -5603,14 +5503,16 @@
                               )
                             )
                             (if
-                              (f64.ne
-                                (get_local $14)
+                              (f64.eq
+                                (get_local $15)
                                 (f64.const 0)
                               )
-                              (set_local $9
-                                (get_local $1)
+                              (block
+                                (set_local $1
+                                  (get_local $11)
+                                )
+                                (br $while-out$62)
                               )
-                              (br $while-out$62)
                             )
                             (br $while-in$63)
                           )
@@ -5632,10 +5534,10 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $15)
+                            (get_local $16)
                             (set_local $5
                               (i32.add
-                                (set_local $7
+                                (set_local $6
                                   (select
                                     (i32.sub
                                       (i32.add
@@ -5654,10 +5556,10 @@
                                     (get_local $5)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                             )
-                            (get_local $17)
+                            (get_local $18)
                           )
                           (if
                             (i32.eq
@@ -5670,18 +5572,18 @@
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $11)
-                              (get_local $6)
+                              (get_local $9)
+                              (get_local $7)
                               (get_local $0)
                             )
                           )
                           (call $_pad
                             (get_local $0)
                             (i32.const 48)
-                            (get_local $15)
+                            (get_local $16)
                             (get_local $5)
                             (i32.xor
-                              (get_local $17)
+                              (get_local $18)
                               (i32.const 65536)
                             )
                           )
@@ -5702,7 +5604,7 @@
                               (i32.const 0)
                             )
                             (call $___fwritex
-                              (get_local $28)
+                              (get_local $29)
                               (get_local $1)
                               (get_local $0)
                             )
@@ -5711,12 +5613,12 @@
                             (get_local $0)
                             (i32.const 48)
                             (i32.sub
-                              (get_local $7)
+                              (get_local $6)
                               (i32.add
                                 (get_local $1)
                                 (set_local $1
                                   (i32.sub
-                                    (get_local $41)
+                                    (get_local $40)
                                     (get_local $8)
                                   )
                                 )
@@ -5744,20 +5646,20 @@
                           (call $_pad
                             (get_local $0)
                             (i32.const 32)
-                            (get_local $15)
+                            (get_local $16)
                             (get_local $5)
                             (i32.xor
-                              (get_local $17)
+                              (get_local $18)
                               (i32.const 8192)
                             )
                           )
                           (br $do-once$56
                             (select
-                              (get_local $15)
+                              (get_local $16)
                               (get_local $5)
                               (i32.lt_s
                                 (get_local $5)
-                                (get_local $15)
+                                (get_local $16)
                               )
                             )
                           )
@@ -5773,8 +5675,8 @@
                           )
                         )
                       )
-                      (set_local $30
-                        (set_local $11
+                      (set_local $62
+                        (set_local $9
                           (select
                             (get_local $80)
                             (get_local $81)
@@ -5793,9 +5695,9 @@
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $15
                                     (f64.mul
-                                      (get_local $14)
+                                      (get_local $15)
                                       (f64.const 268435456)
                                     )
                                   )
@@ -5810,30 +5712,30 @@
                           )
                         )
                       )
-                      (set_local $6
-                        (get_local $11)
+                      (set_local $7
+                        (get_local $9)
                       )
                       (loop $while-out$66 $while-in$67
                         (i32.store
-                          (get_local $6)
+                          (get_local $7)
                           (set_local $5
                             (i32.trunc_s/f64
-                              (get_local $14)
+                              (get_local $15)
                             )
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $6)
+                            (get_local $7)
                             (i32.const 4)
                           )
                         )
                         (if
                           (f64.eq
-                            (set_local $14
+                            (set_local $15
                               (f64.mul
                                 (f64.sub
-                                  (get_local $14)
+                                  (get_local $15)
                                   (f64.convert_u/i32
                                     (get_local $5)
                                   )
@@ -5844,8 +5746,8 @@
                             (f64.const 0)
                           )
                           (block
-                            (set_local $7
-                              (get_local $6)
+                            (set_local $6
+                              (get_local $7)
                             )
                             (br $while-out$66)
                           )
@@ -5863,13 +5765,13 @@
                         )
                         (block
                           (set_local $8
-                            (get_local $11)
+                            (get_local $9)
                           )
-                          (set_local $10
-                            (get_local $7)
+                          (set_local $13
+                            (get_local $6)
                           )
                           (loop $while-out$68 $while-in$69
-                            (set_local $9
+                            (set_local $11
                               (select
                                 (i32.const 29)
                                 (get_local $5)
@@ -5879,13 +5781,13 @@
                                 )
                               )
                             )
-                            (set_local $6
+                            (set_local $7
                               (block $do-once$70
                                 (if
                                   (i32.lt_u
-                                    (set_local $6
+                                    (set_local $7
                                       (i32.add
-                                        (get_local $10)
+                                        (get_local $13)
                                         (i32.const -4)
                                       )
                                     )
@@ -5896,20 +5798,20 @@
                                     (set_local $5
                                       (i32.const 0)
                                     )
-                                    (set_local $13
-                                      (get_local $6)
+                                    (set_local $10
+                                      (get_local $7)
                                     )
                                     (loop $while-out$72 $while-in$73
-                                      (set_local $7
+                                      (set_local $6
                                         (call $___uremdi3
                                           (set_local $5
                                             (call $_i64Add
                                               (call $_bitshift64Shl
                                                 (i32.load
-                                                  (get_local $13)
+                                                  (get_local $10)
                                                 )
                                                 (i32.const 0)
-                                                (get_local $9)
+                                                (get_local $11)
                                               )
                                               (i32.load
                                                 (i32.const 168)
@@ -5918,7 +5820,7 @@
                                               (i32.const 0)
                                             )
                                           )
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.load
                                               (i32.const 168)
                                             )
@@ -5931,13 +5833,13 @@
                                         (i32.const 168)
                                       )
                                       (i32.store
-                                        (get_local $13)
-                                        (get_local $7)
+                                        (get_local $10)
+                                        (get_local $6)
                                       )
                                       (set_local $5
                                         (call $___udivdi3
                                           (get_local $5)
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 1000000000)
                                           (i32.const 0)
                                         )
@@ -5947,17 +5849,17 @@
                                       )
                                       (if
                                         (i32.lt_u
-                                          (set_local $6
+                                          (set_local $7
                                             (i32.add
-                                              (get_local $13)
+                                              (get_local $10)
                                               (i32.const -4)
                                             )
                                           )
                                           (get_local $8)
                                         )
                                         (br $while-out$72)
-                                        (set_local $13
-                                          (get_local $6)
+                                        (set_local $10
+                                          (get_local $7)
                                         )
                                       )
                                       (br $while-in$73)
@@ -5970,7 +5872,7 @@
                                       )
                                     )
                                     (i32.store
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
                                           (get_local $8)
                                           (i32.const -4)
@@ -5978,19 +5880,16 @@
                                       )
                                       (get_local $5)
                                     )
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                 )
                               )
                             )
-                            (set_local $7
-                              (get_local $10)
-                            )
                             (loop $while-out$74 $while-in$75
                               (if
                                 (i32.le_u
+                                  (get_local $13)
                                   (get_local $7)
-                                  (get_local $6)
                                 )
                                 (br $while-out$74)
                               )
@@ -5999,14 +5898,14 @@
                                   (i32.load
                                     (set_local $5
                                       (i32.add
-                                        (get_local $7)
+                                        (get_local $13)
                                         (i32.const -4)
                                       )
                                     )
                                   )
                                   (i32.const 0)
                                 )
-                                (set_local $7
+                                (set_local $13
                                   (get_local $5)
                                 )
                                 (br $while-out$74)
@@ -6020,7 +5919,7 @@
                                   (i32.load
                                     (get_local $25)
                                   )
-                                  (get_local $9)
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -6029,21 +5928,21 @@
                                 (get_local $5)
                                 (i32.const 0)
                               )
-                              (block
-                                (set_local $8
-                                  (get_local $6)
-                                )
-                                (set_local $10
-                                  (get_local $7)
-                                )
+                              (set_local $8
+                                (get_local $7)
                               )
-                              (br $while-out$68)
+                              (block
+                                (set_local $6
+                                  (get_local $13)
+                                )
+                                (br $while-out$68)
+                              )
                             )
                             (br $while-in$69)
                           )
                         )
-                        (set_local $6
-                          (get_local $11)
+                        (set_local $7
+                          (get_local $9)
                         )
                       )
                       (if
@@ -6067,19 +5966,19 @@
                               (i32.const 1)
                             )
                           )
-                          (set_local $13
+                          (set_local $10
                             (i32.eq
-                              (get_local $21)
+                              (get_local $14)
                               (i32.const 102)
                             )
                           )
-                          (set_local $24
-                            (get_local $7)
+                          (set_local $23
+                            (get_local $6)
                           )
                           (loop $while-out$76 $while-in$77
                             (set_local $5
                               (i32.gt_s
-                                (set_local $7
+                                (set_local $6
                                   (i32.sub
                                     (i32.const 0)
                                     (get_local $5)
@@ -6088,86 +5987,78 @@
                                 (i32.const 9)
                               )
                             )
-                            (set_local $10
+                            (set_local $13
                               (select
                                 (i32.const 9)
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $5)
                               )
                             )
-                            (set_local $9
+                            (set_local $11
                               (block $do-once$78
                                 (if
                                   (i32.lt_u
-                                    (get_local $6)
-                                    (get_local $24)
+                                    (get_local $7)
+                                    (get_local $23)
                                   )
                                   (block
                                     (set_local $70
                                       (i32.add
                                         (i32.shl
                                           (i32.const 1)
-                                          (get_local $10)
+                                          (get_local $13)
                                         )
                                         (i32.const -1)
                                       )
                                     )
-                                    (set_local $26
+                                    (set_local $27
                                       (i32.shr_u
                                         (i32.const 1000000000)
-                                        (get_local $10)
+                                        (get_local $13)
                                       )
                                     )
-                                    (set_local $9
+                                    (set_local $11
                                       (i32.const 0)
                                     )
-                                    (set_local $16
-                                      (get_local $6)
+                                    (set_local $17
+                                      (get_local $7)
                                     )
                                     (loop $while-out$80 $while-in$81
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.and
                                           (set_local $5
                                             (i32.load
-                                              (get_local $16)
+                                              (get_local $17)
                                             )
                                           )
                                           (get_local $70)
                                         )
                                       )
                                       (i32.store
-                                        (get_local $16)
+                                        (get_local $17)
                                         (i32.add
                                           (i32.shr_u
                                             (get_local $5)
-                                            (get_local $10)
+                                            (get_local $13)
                                           )
-                                          (get_local $9)
+                                          (get_local $11)
                                         )
                                       )
-                                      (set_local $7
+                                      (set_local $11
                                         (i32.mul
-                                          (get_local $7)
-                                          (get_local $26)
+                                          (get_local $6)
+                                          (get_local $27)
                                         )
                                       )
                                       (if
-                                        (i32.lt_u
-                                          (set_local $5
+                                        (i32.ge_u
+                                          (set_local $17
                                             (i32.add
-                                              (get_local $16)
+                                              (get_local $17)
                                               (i32.const 4)
                                             )
                                           )
-                                          (get_local $24)
-                                        )
-                                        (block
-                                          (set_local $9
-                                            (get_local $7)
-                                          )
-                                          (set_local $16
-                                            (get_local $5)
-                                          )
+                                          (get_local $23)
                                         )
                                         (br $while-out$80)
                                       )
@@ -6176,13 +6067,13 @@
                                     (set_local $5
                                       (select
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $7)
                                           (i32.const 4)
                                         )
-                                        (get_local $6)
+                                        (get_local $7)
                                         (i32.eq
                                           (i32.load
-                                            (get_local $6)
+                                            (get_local $7)
                                           )
                                           (i32.const 0)
                                         )
@@ -6190,46 +6081,36 @@
                                     )
                                     (if
                                       (i32.eq
-                                        (get_local $7)
+                                        (get_local $11)
                                         (i32.const 0)
                                       )
-                                      (block
-                                        (set_local $7
-                                          (get_local $24)
-                                        )
-                                        (br $do-once$78
-                                          (get_local $5)
-                                        )
+                                      (br $do-once$78
+                                        (get_local $5)
                                       )
                                     )
                                     (i32.store
-                                      (get_local $24)
-                                      (get_local $7)
+                                      (get_local $23)
+                                      (get_local $11)
                                     )
-                                    (set_local $7
+                                    (set_local $23
                                       (i32.add
-                                        (get_local $24)
+                                        (get_local $23)
                                         (i32.const 4)
                                       )
                                     )
                                     (get_local $5)
                                   )
-                                  (block
-                                    (set_local $7
-                                      (get_local $24)
+                                  (select
+                                    (i32.add
+                                      (get_local $7)
+                                      (i32.const 4)
                                     )
-                                    (select
-                                      (i32.add
-                                        (get_local $6)
-                                        (i32.const 4)
+                                    (get_local $7)
+                                    (i32.eq
+                                      (i32.load
+                                        (get_local $7)
                                       )
-                                      (get_local $6)
-                                      (i32.eq
-                                        (i32.load
-                                          (get_local $6)
-                                        )
-                                        (i32.const 0)
-                                      )
+                                      (i32.const 0)
                                     )
                                   )
                                 )
@@ -6239,12 +6120,12 @@
                               (i32.gt_s
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $7)
-                                    (set_local $6
+                                    (get_local $23)
+                                    (set_local $7
                                       (select
-                                        (get_local $11)
                                         (get_local $9)
-                                        (get_local $13)
+                                        (get_local $11)
+                                        (get_local $10)
                                       )
                                     )
                                   )
@@ -6253,16 +6134,16 @@
                                 (get_local $8)
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (select
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $7)
                                   (i32.shl
                                     (get_local $8)
                                     (i32.const 2)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $23)
                                 (get_local $5)
                               )
                             )
@@ -6273,7 +6154,7 @@
                                   (i32.load
                                     (get_local $25)
                                   )
-                                  (get_local $10)
+                                  (get_local $13)
                                 )
                               )
                             )
@@ -6283,19 +6164,19 @@
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $6
-                                  (get_local $9)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $24
-                                  (get_local $7)
+                                (set_local $23
+                                  (get_local $6)
                                 )
                               )
                               (block
-                                (set_local $6
-                                  (get_local $9)
+                                (set_local $7
+                                  (get_local $11)
                                 )
-                                (set_local $26
-                                  (get_local $7)
+                                (set_local $27
+                                  (get_local $6)
                                 )
                                 (br $while-out$76)
                               )
@@ -6303,23 +6184,23 @@
                             (br $while-in$77)
                           )
                         )
-                        (set_local $26
-                          (get_local $7)
+                        (set_local $27
+                          (get_local $6)
                         )
                       )
                       (block $do-once$82
                         (if
                           (i32.lt_u
-                            (get_local $6)
-                            (get_local $26)
+                            (get_local $7)
+                            (get_local $27)
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $30)
-                                    (get_local $6)
+                                    (get_local $62)
+                                    (get_local $7)
                                   )
                                   (i32.const 2)
                                 )
@@ -6330,14 +6211,14 @@
                               (i32.lt_u
                                 (set_local $5
                                   (i32.load
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                 )
                                 (i32.const 10)
                               )
                               (block
-                                (set_local $10
-                                  (get_local $7)
+                                (set_local $13
+                                  (get_local $6)
                                 )
                                 (br $do-once$82)
                               )
@@ -6346,9 +6227,9 @@
                               )
                             )
                             (loop $while-out$84 $while-in$85
-                              (set_local $7
+                              (set_local $6
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
@@ -6363,8 +6244,8 @@
                                   )
                                 )
                                 (block
-                                  (set_local $10
-                                    (get_local $7)
+                                  (set_local $13
+                                    (get_local $6)
                                   )
                                   (br $while-out$84)
                                 )
@@ -6372,12 +6253,12 @@
                               (br $while-in$85)
                             )
                           )
-                          (set_local $10
+                          (set_local $13
                             (i32.const 0)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (if
                           (i32.lt_s
                             (set_local $5
@@ -6385,10 +6266,10 @@
                                 (i32.sub
                                   (get_local $1)
                                   (select
-                                    (get_local $10)
+                                    (get_local $13)
                                     (i32.const 0)
                                     (i32.ne
-                                      (get_local $21)
+                                      (get_local $14)
                                       (i32.const 102)
                                     )
                                   )
@@ -6404,7 +6285,7 @@
                                       )
                                       (set_local $8
                                         (i32.eq
-                                          (get_local $21)
+                                          (get_local $14)
                                           (i32.const 103)
                                         )
                                       )
@@ -6419,8 +6300,8 @@
                               (i32.mul
                                 (i32.shr_s
                                   (i32.sub
-                                    (get_local $26)
-                                    (get_local $30)
+                                    (get_local $27)
+                                    (get_local $62)
                                   )
                                   (i32.const 2)
                                 )
@@ -6430,10 +6311,10 @@
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (i32.add
                                 (i32.add
-                                  (get_local $11)
+                                  (get_local $9)
                                   (i32.const 4)
                                 )
                                 (i32.shl
@@ -6458,7 +6339,7 @@
                             )
                             (if
                               (i32.lt_s
-                                (set_local $9
+                                (set_local $11
                                   (i32.add
                                     (i32.and
                                       (i32.rem_s
@@ -6485,16 +6366,16 @@
                                   )
                                   (if
                                     (i32.eq
-                                      (set_local $9
+                                      (set_local $11
                                         (i32.add
-                                          (get_local $9)
+                                          (get_local $11)
                                           (i32.const 1)
                                         )
                                       )
                                       (i32.const 9)
                                     )
                                     (block
-                                      (set_local $16
+                                      (set_local $17
                                         (get_local $5)
                                       )
                                       (br $while-out$86)
@@ -6503,52 +6384,43 @@
                                   (br $while-in$87)
                                 )
                               )
-                              (set_local $16
+                              (set_local $17
                                 (i32.const 10)
                               )
                             )
                             (block $do-once$88
                               (if
-                                (i32.and
-                                  (set_local $9
-                                    (i32.eq
-                                      (i32.add
-                                        (get_local $7)
-                                        (i32.const 4)
-                                      )
-                                      (get_local $26)
-                                    )
-                                  )
-                                  (i32.eq
-                                    (set_local $21
-                                      (i32.and
-                                        (i32.rem_u
-                                          (set_local $5
-                                            (i32.load
-                                              (get_local $7)
-                                            )
-                                          )
-                                          (get_local $16)
+                                (i32.eqz
+                                  (i32.and
+                                    (set_local $11
+                                      (i32.eq
+                                        (i32.add
+                                          (get_local $6)
+                                          (i32.const 4)
                                         )
-                                        (i32.const -1)
+                                        (get_local $27)
                                       )
                                     )
-                                    (i32.const 0)
+                                    (i32.eq
+                                      (set_local $14
+                                        (i32.and
+                                          (i32.rem_u
+                                            (set_local $5
+                                              (i32.load
+                                                (get_local $6)
+                                              )
+                                            )
+                                            (get_local $17)
+                                          )
+                                          (i32.const -1)
+                                        )
+                                      )
+                                      (i32.const 0)
+                                    )
                                   )
                                 )
                                 (block
-                                  (set_local $5
-                                    (get_local $6)
-                                  )
-                                  (set_local $6
-                                    (get_local $7)
-                                  )
-                                  (set_local $9
-                                    (get_local $10)
-                                  )
-                                )
-                                (block
-                                  (set_local $14
+                                  (set_local $15
                                     (select
                                       (f64.const 9007199254740992)
                                       (f64.const 9007199254740994)
@@ -6557,7 +6429,7 @@
                                           (i32.and
                                             (i32.div_u
                                               (get_local $5)
-                                              (get_local $16)
+                                              (get_local $17)
                                             )
                                             (i32.const -1)
                                           )
@@ -6567,14 +6439,14 @@
                                       )
                                     )
                                   )
-                                  (set_local $29
+                                  (set_local $30
                                     (if
                                       (i32.lt_u
-                                        (get_local $21)
-                                        (set_local $13
+                                        (get_local $14)
+                                        (set_local $10
                                           (i32.and
                                             (i32.div_s
-                                              (get_local $16)
+                                              (get_local $17)
                                               (i32.const 2)
                                             )
                                             (i32.const -1)
@@ -6586,30 +6458,30 @@
                                         (f64.const 1)
                                         (f64.const 1.5)
                                         (i32.and
-                                          (get_local $9)
+                                          (get_local $11)
                                           (i32.eq
-                                            (get_local $21)
-                                            (get_local $13)
+                                            (get_local $14)
+                                            (get_local $10)
                                           )
                                         )
                                       )
                                     )
                                   )
-                                  (set_local $14
+                                  (set_local $15
                                     (block $do-once$90
                                       (if
                                         (i32.eq
-                                          (get_local $53)
+                                          (get_local $51)
                                           (i32.const 0)
                                         )
-                                        (get_local $14)
+                                        (get_local $15)
                                         (block
                                           (if
                                             (i32.ne
                                               (i32.shr_s
                                                 (i32.shl
                                                   (i32.load8_s
-                                                    (get_local $40)
+                                                    (get_local $39)
                                                   )
                                                   (i32.const 24)
                                                 )
@@ -6618,57 +6490,46 @@
                                               (i32.const 45)
                                             )
                                             (br $do-once$90
-                                              (get_local $14)
+                                              (get_local $15)
                                             )
                                           )
-                                          (set_local $29
+                                          (set_local $30
                                             (f64.neg
-                                              (get_local $29)
+                                              (get_local $30)
                                             )
                                           )
                                           (f64.neg
-                                            (get_local $14)
+                                            (get_local $15)
                                           )
                                         )
                                       )
                                     )
                                   )
                                   (i32.store
-                                    (get_local $7)
+                                    (get_local $6)
                                     (set_local $5
                                       (i32.sub
                                         (get_local $5)
-                                        (get_local $21)
+                                        (get_local $14)
                                       )
                                     )
                                   )
                                   (if
                                     (f64.eq
                                       (f64.add
-                                        (get_local $14)
-                                        (get_local $29)
+                                        (get_local $15)
+                                        (get_local $30)
                                       )
-                                      (get_local $14)
+                                      (get_local $15)
                                     )
-                                    (block
-                                      (set_local $5
-                                        (get_local $6)
-                                      )
-                                      (set_local $6
-                                        (get_local $7)
-                                      )
-                                      (set_local $9
-                                        (get_local $10)
-                                      )
-                                      (br $do-once$88)
-                                    )
+                                    (br $do-once$88)
                                   )
                                   (i32.store
-                                    (get_local $7)
+                                    (get_local $6)
                                     (set_local $5
                                       (i32.add
                                         (get_local $5)
-                                        (get_local $16)
+                                        (get_local $17)
                                       )
                                     )
                                   )
@@ -6677,80 +6538,64 @@
                                       (get_local $5)
                                       (i32.const 999999999)
                                     )
-                                    (block
-                                      (set_local $5
+                                    (loop $while-out$92 $while-in$93
+                                      (i32.store
                                         (get_local $6)
+                                        (i32.const 0)
                                       )
-                                      (set_local $6
-                                        (get_local $7)
-                                      )
-                                      (loop $while-out$92 $while-in$93
-                                        (i32.store
-                                          (get_local $6)
-                                          (i32.const 0)
-                                        )
-                                        (set_local $5
-                                          (if
-                                            (i32.lt_u
-                                              (set_local $7
-                                                (i32.add
-                                                  (get_local $6)
-                                                  (i32.const -4)
-                                                )
-                                              )
-                                              (get_local $5)
-                                            )
-                                            (block
-                                              (i32.store
-                                                (set_local $5
-                                                  (i32.add
-                                                    (get_local $5)
-                                                    (i32.const -4)
-                                                  )
-                                                )
-                                                (i32.const 0)
-                                              )
-                                              (get_local $5)
-                                            )
-                                            (get_local $5)
-                                          )
-                                        )
-                                        (i32.store
-                                          (get_local $7)
-                                          (set_local $6
-                                            (i32.add
-                                              (i32.load
-                                                (get_local $7)
-                                              )
-                                              (i32.const 1)
-                                            )
-                                          )
-                                        )
+                                      (set_local $7
                                         (if
-                                          (i32.gt_u
-                                            (get_local $6)
-                                            (i32.const 999999999)
-                                          )
-                                          (set_local $6
+                                          (i32.lt_u
+                                            (set_local $6
+                                              (i32.add
+                                                (get_local $6)
+                                                (i32.const -4)
+                                              )
+                                            )
                                             (get_local $7)
                                           )
                                           (block
-                                            (set_local $6
-                                              (get_local $5)
+                                            (i32.store
+                                              (set_local $5
+                                                (i32.add
+                                                  (get_local $7)
+                                                  (i32.const -4)
+                                                )
+                                              )
+                                              (i32.const 0)
                                             )
-                                            (br $while-out$92)
+                                            (get_local $5)
+                                          )
+                                          (get_local $7)
+                                        )
+                                      )
+                                      (i32.store
+                                        (get_local $6)
+                                        (set_local $5
+                                          (i32.add
+                                            (i32.load
+                                              (get_local $6)
+                                            )
+                                            (i32.const 1)
                                           )
                                         )
-                                        (br $while-in$93)
                                       )
+                                      (if
+                                        (i32.le_u
+                                          (get_local $5)
+                                          (i32.const 999999999)
+                                        )
+                                        (br $while-out$92)
+                                      )
+                                      (br $while-in$93)
                                     )
                                   )
-                                  (set_local $9
+                                  (set_local $11
                                     (i32.mul
                                       (i32.shr_s
                                         (i32.sub
-                                          (get_local $30)
-                                          (get_local $6)
+                                          (get_local $62)
+                                          (get_local $7)
                                         )
                                         (i32.const 2)
                                       )
@@ -6761,47 +6606,41 @@
                                     (i32.lt_u
                                       (set_local $5
                                         (i32.load
-                                          (get_local $6)
+                                          (get_local $7)
                                         )
                                       )
                                       (i32.const 10)
                                     )
                                     (block
-                                      (set_local $5
-                                        (get_local $6)
-                                      )
-                                      (set_local $6
-                                        (get_local $7)
+                                      (set_local $13
+                                        (get_local $11)
                                       )
                                       (br $do-once$88)
                                     )
-                                    (set_local $13
+                                    (set_local $10
                                       (i32.const 10)
                                     )
                                   )
                                   (loop $while-out$94 $while-in$95
-                                    (set_local $9
+                                    (set_local $11
                                       (i32.add
-                                        (get_local $9)
+                                        (get_local $11)
                                         (i32.const 1)
                                       )
                                     )
                                     (if
                                       (i32.lt_u
                                         (get_local $5)
-                                        (set_local $13
+                                        (set_local $10
                                           (i32.mul
-                                            (get_local $13)
+                                            (get_local $10)
                                             (i32.const 10)
                                           )
                                         )
                                       )
                                       (block
-                                        (set_local $5
-                                          (get_local $6)
-                                        )
-                                        (set_local $6
-                                          (get_local $7)
+                                        (set_local $13
+                                          (get_local $11)
                                         )
                                         (br $while-out$94)
                                       )
@@ -6811,10 +6650,10 @@
                                 )
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.gt_u
-                                (get_local $26)
-                                (set_local $6
+                                (get_local $27)
+                                (set_local $5
                                   (i32.add
                                     (get_local $6)
                                     (i32.const 4)
@@ -6822,44 +6661,41 @@
                                 )
                               )
                             )
-                            (set_local $10
-                              (get_local $9)
-                            )
-                            (set_local $7
+                            (set_local $6
                               (select
+                                (get_local $5)
+                                (get_local $27)
                                 (get_local $6)
-                                (get_local $26)
-                                (get_local $7)
                               )
                             )
-                            (get_local $5)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $7
-                              (get_local $26)
+                            (set_local $6
+                              (get_local $27)
                             )
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
-                      (set_local $26
+                      (set_local $27
                         (i32.sub
                           (i32.const 0)
-                          (get_local $10)
+                          (get_local $13)
                         )
                       )
                       (loop $while-out$96 $while-in$97
                         (if
                           (i32.le_u
-                            (get_local $7)
                             (get_local $6)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $9
+                            (set_local $11
                               (i32.const 0)
                             )
-                            (set_local $24
-                              (get_local $7)
+                            (set_local $23
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
@@ -6869,22 +6705,22 @@
                             (i32.load
                               (set_local $5
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const -4)
                                 )
                               )
                             )
                             (i32.const 0)
                           )
-                          (set_local $7
+                          (set_local $6
                             (get_local $5)
                           )
                           (block
-                            (set_local $9
+                            (set_local $11
                               (i32.const 1)
                             )
-                            (set_local $24
-                              (get_local $7)
+                            (set_local $23
+                              (get_local $6)
                             )
                             (br $while-out$96)
                           )
@@ -6912,17 +6748,17 @@
                                           (get_local $1)
                                         )
                                       )
-                                      (get_local $10)
+                                      (get_local $13)
                                     )
                                     (i32.gt_s
-                                      (get_local $10)
+                                      (get_local $13)
                                       (i32.const -5)
                                     )
                                   )
                                   (block
-                                    (set_local $13
+                                    (set_local $10
                                       (i32.add
-                                        (get_local $33)
+                                        (get_local $26)
                                         (i32.const -1)
                                       )
                                     )
@@ -6931,13 +6767,13 @@
                                         (get_local $1)
                                         (i32.const -1)
                                       )
-                                      (get_local $10)
+                                      (get_local $13)
                                     )
                                   )
                                   (block
-                                    (set_local $13
+                                    (set_local $10
                                       (i32.add
-                                        (get_local $33)
+                                        (get_local $26)
                                         (i32.const -2)
                                       )
                                     )
@@ -6952,18 +6788,18 @@
                                 (i32.ne
                                   (set_local $1
                                     (i32.and
-                                      (get_local $17)
+                                      (get_local $18)
                                       (i32.const 8)
                                     )
                                   )
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $21
+                                  (set_local $14
                                     (get_local $8)
                                   )
-                                  (set_local $30
-                                    (get_local $13)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                   (br $do-once$98
                                     (get_local $1)
@@ -6972,14 +6808,14 @@
                               )
                               (block $do-once$100
                                 (if
-                                  (get_local $9)
+                                  (get_local $11)
                                   (block
                                     (if
                                       (i32.eq
                                         (set_local $1
                                           (i32.load
                                             (i32.add
-                                              (get_local $24)
+                                              (get_local $23)
                                               (i32.const -4)
                                             )
                                           )
@@ -6987,7 +6823,7 @@
                                         (i32.const 0)
                                       )
                                       (block
-                                        (set_local $1
+                                        (set_local $6
                                           (i32.const 9)
                                         )
                                         (br $do-once$100)
@@ -7008,21 +6844,21 @@
                                         (set_local $5
                                           (i32.const 10)
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                       )
                                       (block
-                                        (set_local $1
+                                        (set_local $6
                                           (i32.const 0)
                                         )
                                         (br $do-once$100)
                                       )
                                     )
                                     (loop $while-out$102 $while-in$103
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 1)
                                         )
                                       )
@@ -7042,28 +6878,23 @@
                                           )
                                           (i32.const 0)
                                         )
-                                        (block
-                                          (set_local $1
-                                            (get_local $7)
-                                          )
-                                          (br $while-out$102)
-                                        )
+                                        (br $while-out$102)
                                       )
                                       (br $while-in$103)
                                     )
                                   )
-                                  (set_local $1
+                                  (set_local $6
                                     (i32.const 9)
                                   )
                                 )
                               )
-                              (set_local $5
+                              (set_local $1
                                 (i32.add
                                   (i32.mul
                                     (i32.shr_s
                                       (i32.sub
-                                        (get_local $24)
-                                        (get_local $30)
+                                        (get_local $23)
+                                        (get_local $62)
                                       )
                                       (i32.const 2)
                                     )
@@ -7075,7 +6906,7 @@
                               (if
                                 (i32.eq
                                   (i32.or
-                                    (get_local $13)
+                                    (get_local $10)
                                     (i32.const 32)
                                   )
                                   (i32.const 102)
@@ -7085,8 +6916,8 @@
                                     (i32.lt_s
                                       (set_local $5
                                         (i32.sub
-                                          (get_local $5)
                                           (get_local $1)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 0)
@@ -7104,15 +6935,15 @@
                                       )
                                     )
                                   )
-                                  (set_local $21
+                                  (set_local $14
                                     (select
                                       (get_local $8)
                                       (get_local $1)
                                       (get_local $5)
                                     )
                                   )
-                                  (set_local $30
-                                    (get_local $13)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                   (i32.const 0)
                                 )
@@ -7122,10 +6953,10 @@
                                       (set_local $5
                                         (i32.sub
                                           (i32.add
-                                            (get_local $5)
-                                            (get_local $10)
+                                            (get_local $1)
+                                            (get_local $13)
                                           )
-                                          (get_local $1)
+                                          (get_local $6)
                                         )
                                       )
                                       (i32.const 0)
@@ -7143,41 +6974,38 @@
                                       )
                                     )
                                   )
-                                  (set_local $21
+                                  (set_local $14
                                     (select
                                       (get_local $8)
                                       (get_local $1)
                                       (get_local $5)
                                     )
                                   )
-                                  (set_local $30
-                                    (get_local $13)
+                                  (set_local $26
+                                    (get_local $10)
                                   )
                                   (i32.const 0)
                                 )
                               )
                             )
                             (block
-                              (set_local $21
+                              (set_local $14
                                 (get_local $1)
                               )
-                              (set_local $30
-                                (get_local $33)
-                              )
                               (i32.and
-                                (get_local $17)
+                                (get_local $18)
                                 (i32.const 8)
                               )
                             )
                           )
                         )
                       )
-                      (set_local $16
+                      (set_local $17
                         (i32.and
                           (i32.ne
                             (set_local $1
                               (i32.or
-                                (get_local $21)
+                                (get_local $14)
                                 (get_local $8)
                               )
                             )
@@ -7186,24 +7014,24 @@
                           (i32.const 1)
                         )
                       )
-                      (set_local $10
+                      (set_local $13
                         (if
-                          (set_local $13
+                          (set_local $10
                             (i32.eq
                               (i32.or
-                                (get_local $30)
+                                (get_local $26)
                                 (i32.const 32)
                               )
                               (i32.const 102)
                             )
                           )
                           (block
-                            (set_local $7
+                            (set_local $6
                               (select
-                                (get_local $10)
+                                (get_local $13)
                                 (i32.const 0)
                                 (i32.gt_s
-                                  (get_local $10)
+                                  (get_local $13)
                                   (i32.const 0)
                                 )
                               )
@@ -7215,12 +7043,12 @@
                               (i32.shr_s
                                 (i32.shl
                                   (i32.lt_s
-                                    (set_local $7
+                                    (set_local $6
                                       (select
-                                        (get_local $26)
-                                        (get_local $10)
+                                        (get_local $27)
+                                        (get_local $13)
                                         (i32.lt_s
-                                          (get_local $10)
+                                          (get_local $13)
                                           (i32.const 0)
                                         )
                                       )
@@ -7235,12 +7063,12 @@
                             (if
                               (i32.lt_s
                                 (i32.sub
-                                  (get_local $41)
+                                  (get_local $40)
                                   (set_local $5
                                     (call $_fmt_u
-                                      (get_local $7)
+                                      (get_local $6)
                                       (get_local $5)
-                                      (get_local $54)
+                                      (get_local $52)
                                     )
                                   )
                                 )
@@ -7259,7 +7087,7 @@
                                 (if
                                   (i32.lt_s
                                     (i32.sub
-                                      (get_local $41)
+                                      (get_local $40)
                                       (get_local $5)
                                     )
                                     (i32.const 2)
@@ -7280,7 +7108,7 @@
                                 (i32.add
                                   (i32.and
                                     (i32.shr_s
-                                      (get_local $10)
+                                      (get_local $13)
                                       (i32.const 31)
                                     )
                                     (i32.const 2)
@@ -7298,13 +7126,13 @@
                                 )
                               )
                               (i32.and
-                                (get_local $30)
+                                (get_local $26)
                                 (i32.const 255)
                               )
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.sub
-                                (get_local $41)
+                                (get_local $40)
                                 (get_local $5)
                               )
                             )
@@ -7315,23 +7143,23 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
-                        (set_local $7
+                        (get_local $16)
+                        (set_local $6
                           (i32.add
                             (i32.add
                               (i32.add
                                 (i32.add
-                                  (get_local $53)
+                                  (get_local $51)
                                   (i32.const 1)
                                 )
-                                (get_local $21)
+                                (get_local $14)
                               )
-                              (get_local $16)
+                              (get_local $17)
                             )
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
-                        (get_local $17)
+                        (get_local $18)
                       )
                       (if
                         (i32.eq
@@ -7344,33 +7172,33 @@
                           (i32.const 0)
                         )
                         (call $___fwritex
-                          (get_local $40)
-                          (get_local $53)
+                          (get_local $39)
+                          (get_local $51)
                           (get_local $0)
                         )
                       )
                       (call $_pad
                         (get_local $0)
                         (i32.const 48)
-                        (get_local $15)
-                        (get_local $7)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $17)
+                          (get_local $18)
                           (i32.const 65536)
                         )
                       )
                       (block $do-once$106
                         (if
-                          (get_local $13)
+                          (get_local $10)
                           (block
-                            (set_local $6
+                            (set_local $7
                               (set_local $8
                                 (select
-                                  (get_local $11)
-                                  (get_local $6)
+                                  (get_local $9)
+                                  (get_local $7)
                                   (i32.gt_u
-                                    (get_local $6)
-                                    (get_local $11)
+                                    (get_local $7)
+                                    (get_local $9)
                                   )
                                 )
                               )
@@ -7379,39 +7207,39 @@
                               (set_local $5
                                 (call $_fmt_u
                                   (i32.load
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                   (i32.const 0)
-                                  (get_local $46)
+                                  (get_local $45)
                                 )
                               )
                               (block $do-once$110
                                 (if
                                   (i32.eq
-                                    (get_local $6)
+                                    (get_local $7)
                                     (get_local $8)
                                   )
                                   (block
                                     (if
                                       (i32.ne
                                         (get_local $5)
-                                        (get_local $46)
+                                        (get_local $45)
                                       )
                                       (br $do-once$110)
                                     )
                                     (i32.store8
-                                      (get_local $55)
+                                      (get_local $53)
                                       (i32.const 48)
                                     )
                                     (set_local $5
-                                      (get_local $55)
+                                      (get_local $53)
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.gt_u
                                         (get_local $5)
-                                        (get_local $28)
+                                        (get_local $29)
                                       )
                                       (get_local $5)
                                       (br $do-once$110)
@@ -7429,7 +7257,7 @@
                                       (if
                                         (i32.gt_u
                                           (get_local $5)
-                                          (get_local $28)
+                                          (get_local $29)
                                         )
                                         (get_local $5)
                                         (br $while-out$112)
@@ -7460,18 +7288,21 @@
                               )
                               (if
                                 (i32.gt_u
-                                  (set_local $5
+                                  (set_local $7
                                     (i32.add
-                                      (get_local $6)
+                                      (get_local $7)
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $11)
+                                  (get_local $9)
                                 )
-                                (br $while-out$108)
-                                (set_local $6
-                                  (get_local $5)
+                                (block
+                                  (set_local $5
+                                    (get_local $7)
+                                  )
+                                  (br $while-out$108)
                                 )
+                                (get_local $7)
                               )
                               (br $while-in$109)
                             )
@@ -7504,126 +7335,114 @@
                             (if
                               (i32.and
                                 (i32.gt_s
-                                  (get_local $21)
+                                  (get_local $14)
                                   (i32.const 0)
                                 )
                                 (i32.lt_u
                                   (get_local $5)
-                                  (get_local $24)
+                                  (get_local $23)
                                 )
                               )
-                              (block
-                                (set_local $6
-                                  (get_local $21)
-                                )
-                                (loop $while-out$116 $while-in$117
-                                  (if
-                                    (i32.gt_u
+                              (loop $while-out$116 $while-in$117
+                                (if
+                                  (i32.gt_u
+                                    (set_local $1
+                                      (call $_fmt_u
+                                        (i32.load
+                                          (get_local $5)
+                                        )
+                                        (i32.const 0)
+                                        (get_local $45)
+                                      )
+                                    )
+                                    (get_local $29)
+                                  )
+                                  (loop $while-out$118 $while-in$119
+                                    (i32.store8
                                       (set_local $1
-                                        (call $_fmt_u
-                                          (i32.load
-                                            (get_local $5)
-                                          )
-                                          (i32.const 0)
-                                          (get_local $46)
-                                        )
-                                      )
-                                      (get_local $28)
-                                    )
-                                    (loop $while-out$118 $while-in$119
-                                      (i32.store8
-                                        (set_local $1
-                                          (i32.add
-                                            (get_local $1)
-                                            (i32.const -1)
-                                          )
-                                        )
-                                        (i32.const 48)
-                                      )
-                                      (if
-                                        (i32.gt_u
+                                        (i32.add
                                           (get_local $1)
-                                          (get_local $28)
+                                          (i32.const -1)
                                         )
-                                        (get_local $1)
-                                        (br $while-out$118)
                                       )
-                                      (br $while-in$119)
+                                      (i32.const 48)
                                     )
+                                    (if
+                                      (i32.gt_u
+                                        (get_local $1)
+                                        (get_local $29)
+                                      )
+                                      (get_local $1)
+                                      (br $while-out$118)
+                                    )
+                                    (br $while-in$119)
+                                  )
+                                  (get_local $1)
+                                )
+                                (if
+                                  (i32.eq
+                                    (i32.and
+                                      (i32.load
+                                        (get_local $0)
+                                      )
+                                      (i32.const 32)
+                                    )
+                                    (i32.const 0)
+                                  )
+                                  (call $___fwritex
+                                    (get_local $1)
+                                    (select
+                                      (i32.const 9)
+                                      (get_local $14)
+                                      (i32.gt_s
+                                        (get_local $14)
+                                        (i32.const 9)
+                                      )
+                                    )
+                                    (get_local $0)
+                                  )
+                                )
+                                (set_local $1
+                                  (i32.add
+                                    (get_local $14)
+                                    (i32.const -9)
+                                  )
+                                )
+                                (if
+                                  (i32.and
+                                    (i32.gt_s
+                                      (get_local $14)
+                                      (i32.const 9)
+                                    )
+                                    (i32.lt_u
+                                      (set_local $5
+                                        (i32.add
+                                          (get_local $5)
+                                          (i32.const 4)
+                                        )
+                                      )
+                                      (get_local $23)
+                                    )
+                                  )
+                                  (set_local $14
                                     (get_local $1)
                                   )
-                                  (if
-                                    (i32.eq
-                                      (i32.and
-                                        (i32.load
-                                          (get_local $0)
-                                        )
-                                        (i32.const 32)
-                                      )
-                                      (i32.const 0)
-                                    )
-                                    (call $___fwritex
+                                  (block
+                                    (set_local $14
                                       (get_local $1)
-                                      (select
-                                        (i32.const 9)
-                                        (get_local $6)
-                                        (i32.gt_s
-                                          (get_local $6)
-                                          (i32.const 9)
-                                        )
-                                      )
-                                      (get_local $0)
                                     )
+                                    (br $while-out$116)
                                   )
-                                  (set_local $8
-                                    (i32.add
-                                      (get_local $6)
-                                      (i32.const -9)
-                                    )
-                                  )
-                                  (if
-                                    (i32.and
-                                      (i32.gt_s
-                                        (get_local $6)
-                                        (i32.const 9)
-                                      )
-                                      (i32.lt_u
-                                        (set_local $1
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 4)
-                                          )
-                                        )
-                                        (get_local $24)
-                                      )
-                                    )
-                                    (block
-                                      (set_local $5
-                                        (get_local $1)
-                                      )
-                                      (set_local $6
-                                        (get_local $8)
-                                      )
-                                    )
-                                    (block
-                                      (set_local $1
-                                        (get_local $8)
-                                      )
-                                      (br $while-out$116)
-                                    )
-                                  )
-                                  (br $while-in$117)
                                 )
+                                (br $while-in$117)
                               )
-                              (set_local $1
-                                (get_local $21)
-                              )
+                              (get_local $14)
                             )
                             (call $_pad
                               (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $1)
+                                (get_local $14)
                                 (i32.const 9)
                               )
                               (i32.const 9)
@@ -7631,19 +7450,19 @@
                             )
                           )
                           (block
-                            (set_local $13
+                            (set_local $11
                               (select
-                                (get_local $24)
+                                (get_local $23)
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $7)
                                   (i32.const 4)
                                 )
-                                (get_local $9)
+                                (get_local $11)
                               )
                             )
                             (if
                               (i32.gt_s
-                                (get_local $21)
+                                (get_local $14)
                                 (i32.const -1)
                               )
                               (block
@@ -7654,13 +7473,10 @@
                                   )
                                 )
                                 (set_local $5
-                                  (get_local $6)
-                                )
-                                (set_local $8
-                                  (get_local $21)
+                                  (get_local $7)
                                 )
                                 (loop $while-out$120 $while-in$121
-                                  (set_local $11
+                                  (set_local $8
                                     (if
                                       (i32.eq
                                         (set_local $1
@@ -7669,17 +7485,17 @@
                                               (get_local $5)
                                             )
                                             (i32.const 0)
-                                            (get_local $46)
+                                            (get_local $45)
                                           )
                                         )
-                                        (get_local $46)
+                                        (get_local $45)
                                       )
                                       (block
                                         (i32.store8
-                                          (get_local $55)
+                                          (get_local $53)
                                           (i32.const 48)
                                         )
-                                        (get_local $55)
+                                        (get_local $53)
                                       )
                                       (get_local $1)
                                     )
@@ -7688,12 +7504,12 @@
                                     (if
                                       (i32.eq
                                         (get_local $5)
-                                        (get_local $6)
+                                        (get_local $7)
                                       )
                                       (block
                                         (set_local $1
                                           (i32.add
-                                            (get_local $11)
+                                            (get_local $8)
                                             (i32.const 1)
                                           )
                                         )
@@ -7708,7 +7524,7 @@
                                             (i32.const 0)
                                           )
                                           (call $___fwritex
-                                            (get_local $11)
+                                            (get_local $8)
                                             (i32.const 1)
                                             (get_local $0)
                                           )
@@ -7717,7 +7533,7 @@
                                           (i32.and
                                             (get_local $9)
                                             (i32.lt_s
-                                              (get_local $8)
+                                              (get_local $14)
                                               (i32.const 1)
                                             )
                                           )
@@ -7744,15 +7560,15 @@
                                       (block
                                         (if
                                           (i32.gt_u
-                                            (get_local $11)
-                                            (get_local $28)
+                                            (get_local $8)
+                                            (get_local $29)
                                           )
                                           (set_local $1
-                                            (get_local $11)
+                                            (get_local $8)
                                           )
                                           (block
                                             (set_local $1
-                                              (get_local $11)
+                                              (get_local $8)
                                             )
                                             (br $do-once$122)
                                           )
@@ -7770,7 +7586,7 @@
                                           (if
                                             (i32.gt_u
                                               (get_local $1)
-                                              (get_local $28)
+                                              (get_local $29)
                                             )
                                             (get_local $1)
                                             (br $while-out$124)
@@ -7780,7 +7596,7 @@
                                       )
                                     )
                                   )
-                                  (set_local $11
+                                  (set_local $8
                                     (i32.sub
                                       (get_local $75)
                                       (get_local $1)
@@ -7799,59 +7615,51 @@
                                     (call $___fwritex
                                       (get_local $1)
                                       (select
-                                        (get_local $11)
                                         (get_local $8)
+                                        (get_local $14)
                                         (i32.gt_s
+                                          (get_local $14)
                                           (get_local $8)
-                                          (get_local $11)
                                         )
                                       )
                                       (get_local $0)
                                     )
                                   )
                                   (if
-                                    (i32.and
-                                      (i32.lt_u
-                                        (set_local $1
-                                          (i32.add
-                                            (get_local $5)
-                                            (i32.const 4)
+                                    (i32.eqz
+                                      (i32.and
+                                        (i32.lt_u
+                                          (set_local $5
+                                            (i32.add
+                                              (get_local $5)
+                                              (i32.const 4)
+                                            )
                                           )
+                                          (get_local $11)
                                         )
-                                        (get_local $13)
-                                      )
-                                      (i32.gt_s
-                                        (set_local $8
-                                          (i32.sub
-                                            (get_local $8)
-                                            (get_local $11)
+                                        (i32.gt_s
+                                          (set_local $14
+                                            (i32.sub
+                                              (get_local $14)
+                                              (get_local $8)
+                                            )
                                           )
+                                          (i32.const -1)
                                         )
-                                        (i32.const -1)
                                       )
                                     )
-                                    (set_local $5
-                                      (get_local $1)
-                                    )
-                                    (block
-                                      (set_local $1
-                                        (get_local $8)
-                                      )
-                                      (br $while-out$120)
-                                    )
+                                    (br $while-out$120)
                                   )
                                   (br $while-in$121)
                                 )
                               )
-                              (set_local $1
-                                (get_local $21)
-                              )
+                              (get_local $14)
                             )
                             (call $_pad
                               (get_local $0)
                               (i32.const 48)
                               (i32.add
-                                (get_local $1)
+                                (get_local $14)
                                 (i32.const 18)
                               )
                               (i32.const 18)
@@ -7869,10 +7677,10 @@
                               )
                             )
                             (call $___fwritex
-                              (get_local $10)
+                              (get_local $13)
                               (i32.sub
-                                (get_local $41)
-                                (get_local $10)
+                                (get_local $40)
+                                (get_local $13)
                               )
                               (get_local $0)
                             )
@@ -7882,19 +7690,19 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
-                        (get_local $7)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.xor
-                          (get_local $17)
+                          (get_local $18)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $15)
-                        (get_local $7)
+                        (get_local $16)
+                        (get_local $6)
                         (i32.lt_s
-                          (get_local $7)
-                          (get_local $15)
+                          (get_local $6)
+                          (get_local $16)
                         )
                       )
                     )
@@ -7906,7 +7714,7 @@
                           (set_local $8
                             (i32.ne
                               (i32.and
-                                (get_local $33)
+                                (get_local $26)
                                 (i32.const 32)
                               )
                               (i32.const 0)
@@ -7917,12 +7725,12 @@
                       (set_local $6
                         (select
                           (i32.const 0)
-                          (get_local $53)
+                          (get_local $51)
                           (set_local $1
                             (i32.or
                               (f64.ne
-                                (get_local $14)
-                                (get_local $14)
+                                (get_local $15)
+                                (get_local $15)
                               )
                               (i32.const 0)
                             )
@@ -7943,7 +7751,7 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
+                        (get_local $16)
                         (set_local $5
                           (i32.add
                             (get_local $6)
@@ -7969,7 +7777,7 @@
                               )
                               (block
                                 (call $___fwritex
-                                  (get_local $40)
+                                  (get_local $39)
                                   (get_local $6)
                                   (get_local $0)
                                 )
@@ -7992,47 +7800,47 @@
                       (call $_pad
                         (get_local $0)
                         (i32.const 32)
-                        (get_local $15)
+                        (get_local $16)
                         (get_local $5)
                         (i32.xor
-                          (get_local $17)
+                          (get_local $18)
                           (i32.const 8192)
                         )
                       )
                       (select
-                        (get_local $15)
+                        (get_local $16)
                         (get_local $5)
                         (i32.lt_s
                           (get_local $5)
-                          (get_local $15)
+                          (get_local $16)
                         )
                       )
                     )
                   )
                 )
               )
-              (set_local $11
-                (get_local $22)
+              (set_local $8
+                (get_local $21)
               )
               (br $label$continue$L1)
             )
-            (set_local $49
+            (set_local $47
               (get_local $20)
             )
-            (set_local $38
-              (get_local $17)
+            (set_local $37
+              (get_local $18)
             )
-            (set_local $43
+            (set_local $42
               (get_local $10)
             )
-            (set_local $44
+            (set_local $43
               (i32.const 0)
             )
-            (set_local $50
+            (set_local $48
               (i32.const 4091)
             )
-            (set_local $51
-              (get_local $27)
+            (set_local $49
+              (get_local $28)
             )
           )
         )
@@ -8044,20 +7852,20 @@
             (i32.const 64)
           )
           (block
-            (set_local $6
+            (set_local $7
               (i32.and
                 (get_local $68)
                 (i32.const 32)
               )
             )
-            (set_local $34
+            (set_local $58
               (if
                 (i32.and
                   (i32.eq
                     (set_local $5
                       (i32.load
                         (set_local $1
-                          (get_local $18)
+                          (get_local $19)
                         )
                       )
                     )
@@ -8073,32 +7881,32 @@
                   )
                 )
                 (block
-                  (set_local $35
-                    (get_local $47)
+                  (set_local $34
+                    (get_local $46)
                   )
                   (set_local $32
-                    (get_local $59)
+                    (get_local $57)
                   )
-                  (set_local $36
+                  (set_local $35
                     (i32.const 0)
                   )
-                  (set_local $37
+                  (set_local $36
                     (i32.const 4091)
                   )
                   (set_local $12
                     (i32.const 77)
                   )
-                  (get_local $27)
+                  (get_local $28)
                 )
                 (block
-                  (set_local $7
-                    (get_local $27)
+                  (set_local $6
+                    (get_local $28)
                   )
                   (loop $while-out$129 $while-in$130
                     (i32.store8
-                      (set_local $7
+                      (set_local $6
                         (i32.add
-                          (get_local $7)
+                          (get_local $6)
                           (i32.const -1)
                         )
                       )
@@ -8116,7 +7924,7 @@
                             )
                             (i32.const 255)
                           )
-                          (get_local $6)
+                          (get_local $7)
                         )
                         (i32.const 255)
                       )
@@ -8142,12 +7950,7 @@
                           (i32.const 0)
                         )
                       )
-                      (block
-                        (set_local $5
-                          (get_local $7)
-                        )
-                        (br $while-out$129)
-                      )
+                      (br $while-out$129)
                     )
                     (br $while-in$130)
                   )
@@ -8155,7 +7958,7 @@
                     (i32.or
                       (i32.eq
                         (i32.and
-                          (get_local $47)
+                          (get_local $46)
                           (i32.const 8)
                         )
                         (i32.const 0)
@@ -8164,7 +7967,7 @@
                         (i32.eq
                           (i32.load
                             (set_local $1
-                              (get_local $18)
+                              (get_local $19)
                             )
                           )
                           (i32.const 0)
@@ -8178,34 +7981,34 @@
                       )
                     )
                     (block
-                      (set_local $35
-                        (get_local $47)
+                      (set_local $34
+                        (get_local $46)
                       )
                       (set_local $32
-                        (get_local $59)
+                        (get_local $57)
                       )
-                      (set_local $36
+                      (set_local $35
                         (i32.const 0)
                       )
-                      (set_local $37
+                      (set_local $36
                         (i32.const 4091)
                       )
                       (set_local $12
                         (i32.const 77)
                       )
-                      (get_local $5)
+                      (get_local $6)
                     )
                     (block
-                      (set_local $35
-                        (get_local $47)
+                      (set_local $34
+                        (get_local $46)
                       )
                       (set_local $32
-                        (get_local $59)
+                        (get_local $57)
                       )
-                      (set_local $36
+                      (set_local $35
                         (i32.const 2)
                       )
-                      (set_local $37
+                      (set_local $36
                         (i32.add
                           (i32.const 4091)
                           (i32.shr_s
@@ -8217,7 +8020,7 @@
                       (set_local $12
                         (i32.const 77)
                       )
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                 )
@@ -8230,24 +8033,24 @@
               (i32.const 76)
             )
             (block
-              (set_local $34
+              (set_local $58
                 (call $_fmt_u
-                  (get_local $48)
-                  (get_local $60)
-                  (get_local $27)
+                  (get_local $33)
+                  (get_local $59)
+                  (get_local $28)
                 )
               )
-              (set_local $35
-                (get_local $17)
+              (set_local $34
+                (get_local $18)
               )
               (set_local $32
                 (get_local $10)
               )
+              (set_local $35
+                (get_local $60)
+              )
               (set_local $36
                 (get_local $61)
-              )
-              (set_local $37
-                (get_local $62)
               )
               (set_local $12
                 (i32.const 77)
@@ -8266,7 +8069,7 @@
                   (i32.eq
                     (set_local $1
                       (call $_memchr
-                        (get_local $52)
+                        (get_local $50)
                         (i32.const 0)
                         (get_local $10)
                       )
@@ -8274,32 +8077,32 @@
                     (i32.const 0)
                   )
                 )
-                (set_local $49
-                  (get_local $52)
+                (set_local $47
+                  (get_local $50)
                 )
-                (set_local $38
+                (set_local $37
                   (get_local $7)
                 )
-                (set_local $43
+                (set_local $42
                   (select
                     (get_local $10)
                     (i32.sub
                       (get_local $1)
-                      (get_local $52)
+                      (get_local $50)
                     )
                     (get_local $5)
                   )
                 )
-                (set_local $44
+                (set_local $43
                   (i32.const 0)
                 )
-                (set_local $50
+                (set_local $48
                   (i32.const 4091)
                 )
-                (set_local $51
+                (set_local $49
                   (select
                     (i32.add
-                      (get_local $52)
+                      (get_local $50)
                       (get_local $10)
                     )
                     (get_local $1)
@@ -8316,15 +8119,15 @@
                   (set_local $12
                     (i32.const 0)
                   )
-                  (set_local $6
+                  (set_local $7
                     (i32.const 0)
                   )
                   (set_local $5
                     (i32.const 0)
                   )
-                  (set_local $7
+                  (set_local $6
                     (i32.load
-                      (get_local $18)
+                      (get_local $19)
                     )
                   )
                   (loop $while-out$131 $while-in$132
@@ -8332,17 +8135,12 @@
                       (i32.eq
                         (set_local $1
                           (i32.load
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                         (i32.const 0)
                       )
-                      (block
-                        (set_local $1
-                          (get_local $5)
-                        )
-                        (br $while-out$131)
-                      )
+                      (br $while-out$131)
                     )
                     (if
                       (i32.or
@@ -8359,20 +8157,15 @@
                           (get_local $5)
                           (i32.sub
                             (get_local $69)
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
-                      (block
-                        (set_local $1
-                          (get_local $5)
-                        )
-                        (br $while-out$131)
-                      )
+                      (br $while-out$131)
                     )
-                    (set_local $7
+                    (set_local $6
                       (i32.add
-                        (get_local $7)
+                        (get_local $6)
                         (i32.const 4)
                       )
                     )
@@ -8382,19 +8175,16 @@
                         (set_local $1
                           (i32.add
                             (get_local $5)
-                            (get_local $6)
+                            (get_local $7)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (get_local $1)
                       )
                       (block
-                        (set_local $6
+                        (set_local $7
                           (get_local $1)
-                        )
-                        (set_local $1
-                          (get_local $5)
                         )
                         (br $while-out$131)
                       )
@@ -8403,11 +8193,11 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $1)
+                      (get_local $5)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $23
+                      (set_local $24
                         (i32.const -1)
                       )
                       (br $label$break$L1)
@@ -8416,17 +8206,17 @@
                   (call $_pad
                     (get_local $0)
                     (i32.const 32)
-                    (get_local $15)
-                    (get_local $6)
-                    (get_local $17)
+                    (get_local $16)
+                    (get_local $7)
+                    (get_local $18)
                   )
                   (if
                     (i32.eq
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
-                      (set_local $39
+                      (set_local $38
                         (i32.const 0)
                       )
                       (set_local $12
@@ -8434,12 +8224,12 @@
                       )
                     )
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.const 0)
                       )
-                      (set_local $5
+                      (set_local $8
                         (i32.load
-                          (get_local $18)
+                          (get_local $19)
                         )
                       )
                       (loop $while-out$133 $while-in$134
@@ -8447,14 +8237,14 @@
                           (i32.eq
                             (set_local $1
                               (i32.load
-                                (get_local $5)
+                                (get_local $8)
                               )
                             )
                             (i32.const 0)
                           )
                           (block
-                            (set_local $39
-                              (get_local $6)
+                            (set_local $38
+                              (get_local $7)
                             )
                             (set_local $12
                               (i32.const 98)
@@ -8462,9 +8252,9 @@
                             (br $label$break$L308)
                           )
                         )
-                        (set_local $11
+                        (set_local $8
                           (i32.add
-                            (get_local $5)
+                            (get_local $8)
                             (i32.const 4)
                           )
                         )
@@ -8478,14 +8268,14 @@
                                     (get_local $1)
                                   )
                                 )
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (block
-                            (set_local $39
-                              (get_local $6)
+                            (set_local $38
+                              (get_local $7)
                             )
                             (set_local $12
                               (i32.const 98)
@@ -8512,19 +8302,14 @@
                         (if
                           (i32.lt_u
                             (get_local $1)
-                            (get_local $6)
+                            (get_local $7)
+                          )
+                          (set_local $6
+                            (get_local $1)
                           )
                           (block
-                            (set_local $7
-                              (get_local $1)
-                            )
-                            (set_local $5
-                              (get_local $11)
-                            )
-                          )
-                          (block
-                            (set_local $39
-                              (get_local $6)
+                            (set_local $38
+                              (get_local $7)
                             )
                             (set_local $12
                               (i32.const 98)
@@ -8554,31 +8339,28 @@
           (call $_pad
             (get_local $0)
             (i32.const 32)
-            (get_local $15)
-            (get_local $39)
+            (get_local $16)
+            (get_local $38)
             (i32.xor
-              (get_local $17)
+              (get_local $18)
               (i32.const 8192)
             )
-          )
-          (set_local $19
-            (get_local $8)
           )
           (set_local $20
             (get_local $9)
           )
           (set_local $1
             (select
-              (get_local $15)
-              (get_local $39)
+              (get_local $16)
+              (get_local $38)
               (i32.gt_s
-                (get_local $15)
-                (get_local $39)
+                (get_local $16)
+                (get_local $38)
               )
             )
           )
-          (set_local $11
-            (get_local $22)
+          (set_local $8
+            (get_local $21)
           )
           (br $label$continue$L1)
         )
@@ -8595,17 +8377,17 @@
           (set_local $5
             (select
               (i32.and
-                (get_local $35)
+                (get_local $34)
                 (i32.const -65537)
               )
-              (get_local $35)
+              (get_local $34)
               (i32.gt_s
                 (get_local $32)
                 (i32.const -1)
               )
             )
           )
-          (set_local $49
+          (set_local $47
             (if
               (i32.or
                 (i32.ne
@@ -8617,7 +8399,7 @@
                     (i32.ne
                       (i32.load
                         (set_local $1
-                          (get_local $18)
+                          (get_local $19)
                         )
                       )
                       (i32.const 0)
@@ -8632,7 +8414,7 @@
                 )
               )
               (block
-                (set_local $6
+                (set_local $7
                   (i32.gt_s
                     (get_local $32)
                     (set_local $1
@@ -8646,50 +8428,50 @@
                         )
                         (i32.sub
                           (get_local $71)
-                          (get_local $34)
+                          (get_local $58)
                         )
                       )
                     )
                   )
                 )
-                (set_local $38
+                (set_local $37
                   (get_local $5)
                 )
-                (set_local $43
+                (set_local $42
                   (select
                     (get_local $32)
                     (get_local $1)
-                    (get_local $6)
+                    (get_local $7)
                   )
                 )
-                (set_local $44
+                (set_local $43
+                  (get_local $35)
+                )
+                (set_local $48
                   (get_local $36)
                 )
-                (set_local $50
-                  (get_local $37)
+                (set_local $49
+                  (get_local $28)
                 )
-                (set_local $51
-                  (get_local $27)
-                )
-                (get_local $34)
+                (get_local $58)
               )
               (block
-                (set_local $38
+                (set_local $37
                   (get_local $5)
                 )
-                (set_local $43
+                (set_local $42
                   (i32.const 0)
                 )
-                (set_local $44
+                (set_local $43
+                  (get_local $35)
+                )
+                (set_local $48
                   (get_local $36)
                 )
-                (set_local $50
-                  (get_local $37)
+                (set_local $49
+                  (get_local $28)
                 )
-                (set_local $51
-                  (get_local $27)
-                )
-                (get_local $27)
+                (get_local $28)
               )
             )
           )
@@ -8697,25 +8479,25 @@
       )
       (set_local $1
         (i32.lt_s
-          (get_local $43)
-          (set_local $6
+          (get_local $42)
+          (set_local $7
             (i32.sub
-              (get_local $51)
               (get_local $49)
+              (get_local $47)
             )
           )
         )
       )
       (set_local $5
         (i32.lt_s
-          (get_local $15)
+          (get_local $16)
           (set_local $1
             (i32.add
-              (get_local $44)
-              (set_local $7
+              (get_local $43)
+              (set_local $6
                 (select
-                  (get_local $6)
-                  (get_local $43)
+                  (get_local $7)
+                  (get_local $42)
                   (get_local $1)
                 )
               )
@@ -8729,12 +8511,12 @@
         (set_local $5
           (select
             (get_local $1)
-            (get_local $15)
+            (get_local $16)
             (get_local $5)
           )
         )
         (get_local $1)
-        (get_local $38)
+        (get_local $37)
       )
       (if
         (i32.eq
@@ -8747,8 +8529,8 @@
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $50)
-          (get_local $44)
+          (get_local $48)
+          (get_local $43)
           (get_local $0)
         )
       )
@@ -8758,15 +8540,15 @@
         (get_local $5)
         (get_local $1)
         (i32.xor
-          (get_local $38)
+          (get_local $37)
           (i32.const 65536)
         )
       )
       (call $_pad
         (get_local $0)
         (i32.const 48)
-        (get_local $7)
         (get_local $6)
+        (get_local $7)
         (i32.const 0)
       )
       (if
@@ -8780,8 +8562,8 @@
           (i32.const 0)
         )
         (call $___fwritex
-          (get_local $49)
-          (get_local $6)
+          (get_local $47)
+          (get_local $7)
           (get_local $0)
         )
       )
@@ -8791,12 +8573,9 @@
         (get_local $5)
         (get_local $1)
         (i32.xor
-          (get_local $38)
+          (get_local $37)
           (i32.const 8192)
         )
-      )
-      (set_local $19
-        (get_local $8)
       )
       (set_local $20
         (get_local $9)
@@ -8804,8 +8583,8 @@
       (set_local $1
         (get_local $5)
       )
-      (set_local $11
-        (get_local $22)
+      (set_local $8
+        (get_local $21)
       )
       (br $label$continue$L1)
     )
@@ -8825,7 +8604,7 @@
               (get_local $83)
               (i32.const 0)
             )
-            (set_local $23
+            (set_local $24
               (i32.const 0)
             )
             (block
@@ -8848,12 +8627,7 @@
                     )
                     (i32.const 0)
                   )
-                  (block
-                    (set_local $0
-                      (get_local $1)
-                    )
-                    (br $while-out$136)
-                  )
+                  (br $while-out$136)
                 )
                 (call $_pop_arg_336
                   (i32.add
@@ -8868,7 +8642,7 @@
                 )
                 (if
                   (i32.lt_s
-                    (set_local $0
+                    (set_local $1
                       (i32.add
                         (get_local $1)
                         (i32.const 1)
@@ -8876,11 +8650,9 @@
                     )
                     (i32.const 10)
                   )
-                  (set_local $1
-                    (get_local $0)
-                  )
+                  (get_local $1)
                   (block
-                    (set_local $23
+                    (set_local $24
                       (i32.const 1)
                     )
                     (br $label$break$L343)
@@ -8890,13 +8662,13 @@
               )
               (if
                 (i32.lt_s
-                  (get_local $0)
+                  (get_local $1)
                   (i32.const 10)
                 )
                 (loop $while-out$138 $while-in$139
-                  (set_local $1
+                  (set_local $0
                     (i32.add
-                      (get_local $0)
+                      (get_local $1)
                       (i32.const 1)
                     )
                   )
@@ -8906,7 +8678,7 @@
                         (i32.add
                           (get_local $4)
                           (i32.shl
-                            (get_local $0)
+                            (get_local $1)
                             (i32.const 2)
                           )
                         )
@@ -8914,7 +8686,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $23
+                      (set_local $24
                         (i32.const -1)
                       )
                       (br $label$break$L343)
@@ -8922,14 +8694,14 @@
                   )
                   (if
                     (i32.lt_s
-                      (get_local $1)
+                      (get_local $0)
                       (i32.const 10)
                     )
-                    (set_local $0
-                      (get_local $1)
+                    (set_local $1
+                      (get_local $0)
                     )
                     (block
-                      (set_local $23
+                      (set_local $24
                         (i32.const 1)
                       )
                       (br $while-out$138)
@@ -8937,13 +8709,13 @@
                   )
                   (br $while-in$139)
                 )
-                (set_local $23
+                (set_local $24
                   (i32.const 1)
                 )
               )
             )
           )
-          (set_local $23
+          (set_local $24
             (get_local $82)
           )
         )
@@ -8953,7 +8725,7 @@
       (i32.const 8)
       (get_local $31)
     )
-    (get_local $23)
+    (get_local $24)
   )
   (func $_pop_arg_336 (param $0 i32) (param $1 i32) (param $2 i32)
     (local $3 i32)
@@ -9397,9 +9169,6 @@
           (set_local $4
             (get_local $1)
           )
-          (set_local $1
-            (get_local $2)
-          )
           (loop $while-out$0 $while-in$1
             (set_local $0
               (call $___uremdi3
@@ -9415,7 +9184,7 @@
             (i32.store8
               (set_local $2
                 (i32.add
-                  (get_local $1)
+                  (get_local $2)
                   (i32.const -1)
                 )
               )
@@ -9464,23 +9233,15 @@
                 (set_local $4
                   (get_local $1)
                 )
-                (set_local $1
-                  (get_local $2)
-                )
               )
-              (block
-                (set_local $1
-                  (get_local $2)
-                )
-                (br $while-out$0)
-              )
+              (br $while-out$0)
             )
             (br $while-in$1)
           )
           (set_local $3
             (get_local $0)
           )
-          (get_local $1)
+          (get_local $2)
         )
         (block
           (set_local $3
@@ -9500,9 +9261,6 @@
         (set_local $1
           (get_local $0)
         )
-        (set_local $2
-          (get_local $3)
-        )
         (loop $while-out$2 $while-in$3
           (i32.store8
             (set_local $1
@@ -9515,7 +9273,7 @@
               (i32.or
                 (i32.and
                   (i32.rem_u
-                    (get_local $2)
+                    (get_local $3)
                     (i32.const 10)
                   )
                   (i32.const -1)
@@ -9528,7 +9286,7 @@
           (set_local $0
             (i32.and
               (i32.div_u
-                (get_local $2)
+                (get_local $3)
                 (i32.const 10)
               )
               (i32.const -1)
@@ -9536,7 +9294,7 @@
           )
           (if
             (i32.lt_u
-              (get_local $2)
+              (get_local $3)
               (i32.const 10)
             )
             (block
@@ -9545,7 +9303,7 @@
               )
               (br $while-out$2)
             )
-            (set_local $2
+            (set_local $3
               (get_local $0)
             )
           )
@@ -9792,7 +9550,7 @@
                     )
                     (set_local $22
                       (i32.shr_u
-                        (set_local $12
+                        (set_local $6
                           (select
                             (i32.const 16)
                             (i32.and
@@ -9831,7 +9589,7 @@
                                   (i32.const 216)
                                   (i32.shl
                                     (i32.shl
-                                      (set_local $7
+                                      (set_local $8
                                         (i32.add
                                           (i32.xor
                                             (i32.and
@@ -9871,7 +9629,7 @@
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
-                        (get_local $7)
+                        (get_local $8)
                       )
                       (i32.const -1)
                     )
@@ -9918,7 +9676,7 @@
                 (i32.or
                   (set_local $0
                     (i32.shl
-                      (get_local $7)
+                      (get_local $8)
                       (i32.const 3)
                     )
                   )
@@ -9952,7 +9710,7 @@
           )
           (if
             (i32.gt_u
-              (get_local $12)
+              (get_local $6)
               (set_local $10
                 (i32.load
                   (i32.const 184)
@@ -10024,7 +9782,7 @@
                                       (i32.const 216)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $7
+                                          (set_local $8
                                             (i32.add
                                               (i32.or
                                                 (i32.or
@@ -10126,13 +9884,13 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $7)
+                              (get_local $8)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $6
+                      (set_local $7
                         (get_local $10)
                       )
                     )
@@ -10167,7 +9925,7 @@
                             (get_local $1)
                             (get_local $0)
                           )
-                          (set_local $6
+                          (set_local $7
                             (i32.load
                               (i32.const 184)
                             )
@@ -10180,7 +9938,7 @@
                   (i32.store offset=4
                     (get_local $2)
                     (i32.or
-                      (get_local $12)
+                      (get_local $6)
                       (i32.const 3)
                     )
                   )
@@ -10188,17 +9946,17 @@
                     (set_local $4
                       (i32.add
                         (get_local $2)
-                        (get_local $12)
+                        (get_local $6)
                       )
                     )
                     (i32.or
                       (set_local $9
                         (i32.sub
                           (i32.shl
-                            (get_local $7)
+                            (get_local $8)
                             (i32.const 3)
                           )
-                          (get_local $12)
+                          (get_local $6)
                         )
                       )
                       (i32.const 1)
@@ -10213,7 +9971,7 @@
                   )
                   (if
                     (i32.ne
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 0)
                     )
                     (block
@@ -10222,14 +9980,14 @@
                           (i32.const 196)
                         )
                       )
-                      (set_local $7
+                      (set_local $8
                         (i32.add
                           (i32.const 216)
                           (i32.shl
                             (i32.shl
                               (set_local $2
                                 (i32.shr_u
-                                  (get_local $6)
+                                  (get_local $7)
                                   (i32.const 3)
                                 )
                               )
@@ -10266,12 +10024,12 @@
                           )
                           (set_local $5
                             (i32.add
-                              (get_local $7)
+                              (get_local $8)
                               (i32.const 8)
                             )
                           )
-                          (set_local $8
-                            (get_local $7)
+                          (set_local $12
+                            (get_local $8)
                           )
                         )
                         (if
@@ -10280,7 +10038,7 @@
                               (i32.load
                                 (set_local $1
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $8)
                                     (i32.const 8)
                                   )
                                 )
@@ -10295,7 +10053,7 @@
                             (set_local $5
                               (get_local $1)
                             )
-                            (set_local $8
+                            (set_local $12
                               (get_local $2)
                             )
                           )
@@ -10306,16 +10064,16 @@
                         (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $8)
+                        (get_local $12)
                         (get_local $0)
                       )
                       (i32.store offset=8
                         (get_local $0)
-                        (get_local $8)
+                        (get_local $12)
                       )
                       (i32.store offset=12
                         (get_local $0)
-                        (get_local $7)
+                        (get_local $8)
                       )
                     )
                   )
@@ -10341,9 +10099,7 @@
                   )
                   (i32.const 0)
                 )
-                (set_local $8
-                  (get_local $12)
-                )
+                (get_local $6)
                 (block
                   (set_local $0
                     (i32.and
@@ -10450,13 +10206,13 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $12)
+                      (get_local $6)
                     )
                   )
                   (set_local $4
                     (get_local $0)
                   )
-                  (set_local $7
+                  (set_local $8
                     (get_local $0)
                   )
                   (loop $while-out$6 $while-in$7
@@ -10479,11 +10235,11 @@
                           (i32.const 0)
                         )
                         (block
-                          (set_local $6
+                          (set_local $7
                             (get_local $2)
                           )
                           (set_local $10
-                            (get_local $7)
+                            (get_local $8)
                           )
                           (br $while-out$6)
                         )
@@ -10505,7 +10261,7 @@
                               )
                               (i32.const -8)
                             )
-                            (get_local $12)
+                            (get_local $6)
                           )
                         )
                         (get_local $2)
@@ -10521,10 +10277,10 @@
                     (set_local $4
                       (get_local $1)
                     )
-                    (set_local $7
+                    (set_local $8
                       (select
                         (get_local $1)
-                        (get_local $7)
+                        (get_local $8)
                         (get_local $0)
                       )
                     )
@@ -10547,7 +10303,7 @@
                       (set_local $9
                         (i32.add
                           (get_local $10)
-                          (get_local $12)
+                          (get_local $6)
                         )
                       )
                     )
@@ -10573,7 +10329,7 @@
                           (i32.eq
                             (set_local $2
                               (i32.load
-                                (set_local $7
+                                (set_local $8
                                   (i32.add
                                     (get_local $10)
                                     (i32.const 20)
@@ -10587,7 +10343,7 @@
                             (i32.eq
                               (set_local $2
                                 (i32.load
-                                  (set_local $7
+                                  (set_local $8
                                     (i32.add
                                       (get_local $10)
                                       (i32.const 16)
@@ -10598,7 +10354,7 @@
                               (i32.const 0)
                             )
                             (block
-                              (set_local $14
+                              (set_local $15
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -10630,7 +10386,7 @@
                               (set_local $4
                                 (get_local $2)
                               )
-                              (set_local $7
+                              (set_local $8
                                 (get_local $5)
                               )
                               (br $while-in$11)
@@ -10650,20 +10406,12 @@
                               )
                               (i32.const 0)
                             )
-                            (block
-                              (set_local $2
-                                (get_local $4)
-                              )
-                              (set_local $4
-                                (get_local $7)
-                              )
-                              (br $while-out$10)
-                            )
+                            (br $while-out$10)
                             (block
                               (set_local $4
                                 (get_local $2)
                               )
-                              (set_local $7
+                              (set_local $8
                                 (get_local $5)
                               )
                             )
@@ -10672,17 +10420,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $4)
+                            (get_local $8)
                             (get_local $0)
                           )
                           (call_import $_abort)
                           (block
                             (i32.store
-                              (get_local $4)
+                              (get_local $8)
                               (i32.const 0)
                             )
-                            (set_local $14
-                              (get_local $2)
+                            (set_local $15
+                              (get_local $4)
                             )
                           )
                         )
@@ -10716,7 +10464,7 @@
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $7
+                              (set_local $8
                                 (i32.add
                                   (get_local $2)
                                   (i32.const 8)
@@ -10731,10 +10479,10 @@
                               (get_local $2)
                             )
                             (i32.store
-                              (get_local $7)
+                              (get_local $8)
                               (get_local $4)
                             )
-                            (set_local $14
+                            (set_local $15
                               (get_local $2)
                             )
                           )
@@ -10772,11 +10520,11 @@
                           (block
                             (i32.store
                               (get_local $2)
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (if
                               (i32.eq
-                                (get_local $14)
+                                (get_local $15)
                                 (i32.const 0)
                               )
                               (block
@@ -10823,16 +10571,16 @@
                               )
                               (i32.store
                                 (get_local $0)
-                                (get_local $14)
+                                (get_local $15)
                               )
                               (i32.store offset=20
                                 (get_local $1)
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eq
-                                (get_local $14)
+                                (get_local $15)
                                 (i32.const 0)
                               )
                             )
@@ -10840,7 +10588,7 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $14)
+                            (get_local $15)
                             (set_local $0
                               (i32.load
                                 (i32.const 192)
@@ -10850,7 +10598,7 @@
                           (call_import $_abort)
                         )
                         (i32.store offset=24
-                          (get_local $14)
+                          (get_local $15)
                           (get_local $1)
                         )
                         (if
@@ -10870,12 +10618,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=16
-                                (get_local $14)
+                                (get_local $15)
                                 (get_local $1)
                               )
                               (i32.store offset=24
                                 (get_local $1)
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                           )
@@ -10899,12 +10647,12 @@
                             (call_import $_abort)
                             (block
                               (i32.store offset=20
-                                (get_local $14)
+                                (get_local $15)
                                 (get_local $0)
                               )
                               (i32.store offset=24
                                 (get_local $0)
-                                (get_local $14)
+                                (get_local $15)
                               )
                             )
                           )
@@ -10914,7 +10662,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
@@ -10923,8 +10671,8 @@
                         (i32.or
                           (set_local $0
                             (i32.add
+                              (get_local $7)
                               (get_local $6)
-                              (get_local $12)
                             )
                           )
                           (i32.const 3)
@@ -10955,23 +10703,23 @@
                       (i32.store offset=4
                         (get_local $10)
                         (i32.or
-                          (get_local $12)
+                          (get_local $6)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
                         (get_local $9)
                         (i32.or
-                          (get_local $6)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
                           (get_local $9)
-                          (get_local $6)
+                          (get_local $7)
                         )
-                        (get_local $6)
+                        (get_local $7)
                       )
                       (if
                         (i32.ne
@@ -11036,7 +10784,7 @@
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $13
+                              (set_local $16
                                 (get_local $4)
                               )
                             )
@@ -11061,7 +10809,7 @@
                                 (set_local $3
                                   (get_local $0)
                                 )
-                                (set_local $13
+                                (set_local $16
                                   (get_local $2)
                                 )
                               )
@@ -11072,12 +10820,12 @@
                             (get_local $1)
                           )
                           (i32.store offset=12
-                            (get_local $13)
+                            (get_local $16)
                             (get_local $1)
                           )
                           (i32.store offset=8
                             (get_local $1)
-                            (get_local $13)
+                            (get_local $16)
                           )
                           (i32.store offset=12
                             (get_local $1)
@@ -11087,7 +10835,7 @@
                       )
                       (i32.store
                         (i32.const 184)
-                        (get_local $6)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 196)
@@ -11104,9 +10852,7 @@
                 )
               )
             )
-            (set_local $8
-              (get_local $12)
-            )
+            (get_local $6)
           )
         )
         (if
@@ -11114,7 +10860,7 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $8
+          (set_local $6
             (i32.const -1)
           )
           (block
@@ -11138,11 +10884,11 @@
                 )
                 (i32.const 0)
               )
-              (set_local $8
+              (set_local $6
                 (get_local $5)
               )
               (block
-                (set_local $13
+                (set_local $16
                   (i32.sub
                     (i32.const 0)
                     (get_local $5)
@@ -11154,7 +10900,7 @@
                       (set_local $3
                         (i32.load offset=480
                           (i32.shl
-                            (set_local $8
+                            (set_local $12
                               (if
                                 (i32.eq
                                   (set_local $3
@@ -11173,7 +10919,7 @@
                                   )
                                   (i32.const 31)
                                   (block
-                                    (set_local $6
+                                    (set_local $7
                                       (i32.shl
                                         (set_local $3
                                           (i32.add
@@ -11181,11 +10927,11 @@
                                               (i32.const 14)
                                               (i32.or
                                                 (i32.or
-                                                  (set_local $6
+                                                  (set_local $7
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $8
+                                                          (set_local $12
                                                             (i32.shl
                                                               (get_local $3)
                                                               (set_local $3
@@ -11215,10 +10961,10 @@
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $6
+                                                        (set_local $7
                                                           (i32.shl
-                                                            (get_local $8)
-                                                            (get_local $6)
+                                                            (get_local $12)
+                                                            (get_local $7)
                                                           )
                                                         )
                                                         (i32.const 245760)
@@ -11232,7 +10978,7 @@
                                             )
                                             (i32.shr_u
                                               (i32.shl
-                                                (get_local $6)
+                                                (get_local $7)
                                                 (get_local $3)
                                               )
                                               (i32.const 15)
@@ -11253,7 +10999,7 @@
                                         )
                                         (i32.const 1)
                                       )
-                                      (get_local $6)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -11267,7 +11013,7 @@
                     )
                     (block
                       (set_local $31
-                        (get_local $13)
+                        (get_local $16)
                       )
                       (set_local $32
                         (i32.const 0)
@@ -11280,10 +11026,10 @@
                       )
                     )
                     (block
-                      (set_local $6
-                        (get_local $13)
+                      (set_local $7
+                        (get_local $16)
                       )
-                      (set_local $14
+                      (set_local $15
                         (i32.const 0)
                       )
                       (set_local $11
@@ -11294,12 +11040,12 @@
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $8)
+                                (get_local $12)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $8)
+                              (get_local $12)
                               (i32.const 31)
                             )
                           )
@@ -11314,7 +11060,7 @@
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $13
+                            (set_local $16
                               (i32.sub
                                 (set_local $3
                                   (i32.and
@@ -11327,7 +11073,7 @@
                                 (get_local $5)
                               )
                             )
-                            (get_local $6)
+                            (get_local $7)
                           )
                           (if
                             (i32.eq
@@ -11336,7 +11082,7 @@
                             )
                             (block
                               (set_local $26
-                                (get_local $13)
+                                (get_local $16)
                               )
                               (set_local $24
                                 (get_local $23)
@@ -11353,11 +11099,11 @@
                               (get_local $23)
                             )
                           )
-                          (set_local $13
-                            (get_local $6)
+                          (set_local $16
+                            (get_local $7)
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.eq
                             (set_local $3
                               (i32.load offset=20
@@ -11367,12 +11113,12 @@
                             (i32.const 0)
                           )
                         )
-                        (set_local $14
+                        (set_local $15
                           (select
-                            (get_local $14)
+                            (get_local $15)
                             (get_local $3)
                             (i32.or
-                              (get_local $6)
+                              (get_local $7)
                               (i32.eq
                                 (get_local $3)
                                 (set_local $3
@@ -11401,7 +11147,7 @@
                             (get_local $11)
                             (i32.xor
                               (i32.and
-                                (set_local $6
+                                (set_local $7
                                   (i32.eq
                                     (get_local $3)
                                     (i32.const 0)
@@ -11414,13 +11160,13 @@
                           )
                         )
                         (if
-                          (get_local $6)
+                          (get_local $7)
                           (block
                             (set_local $31
-                              (get_local $13)
+                              (get_local $16)
                             )
                             (set_local $32
-                              (get_local $14)
+                              (get_local $15)
                             )
                             (set_local $28
                               (get_local $36)
@@ -11431,8 +11177,8 @@
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $6
-                              (get_local $13)
+                            (set_local $7
+                              (get_local $16)
                             )
                             (set_local $23
                               (get_local $3)
@@ -11464,13 +11210,13 @@
                             )
                           )
                           (block
-                            (set_local $6
+                            (set_local $7
                               (i32.sub
                                 (i32.const 0)
                                 (set_local $3
                                   (i32.shl
                                     (i32.const 2)
-                                    (get_local $8)
+                                    (get_local $12)
                                   )
                                 )
                               )
@@ -11482,14 +11228,14 @@
                                     (get_local $0)
                                     (i32.or
                                       (get_local $3)
-                                      (get_local $6)
+                                      (get_local $7)
                                     )
                                   )
                                 )
                                 (i32.const 0)
                               )
                               (block
-                                (set_local $8
+                                (set_local $6
                                   (get_local $5)
                                 )
                                 (br $do-once$0)
@@ -11525,7 +11271,7 @@
                                           (set_local $3
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $6
+                                                (set_local $7
                                                   (i32.shr_u
                                                     (get_local $3)
                                                     (get_local $0)
@@ -11543,7 +11289,7 @@
                                             (i32.shr_u
                                               (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $6)
+                                                  (get_local $7)
                                                   (get_local $3)
                                                 )
                                               )
@@ -11601,7 +11347,7 @@
                       (set_local $17
                         (get_local $31)
                       )
-                      (set_local $15
+                      (set_local $13
                         (get_local $28)
                       )
                     )
@@ -11646,14 +11392,14 @@
                         (get_local $26)
                       )
                     )
-                    (set_local $3
+                    (set_local $17
                       (select
                         (get_local $3)
                         (get_local $26)
                         (get_local $0)
                       )
                     )
-                    (set_local $6
+                    (set_local $3
                       (select
                         (get_local $24)
                         (get_local $29)
@@ -11671,13 +11417,13 @@
                       )
                       (block
                         (set_local $26
-                          (get_local $3)
+                          (get_local $17)
                         )
                         (set_local $24
                           (get_local $0)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $3)
                         )
                         (br $while-in$20)
                       )
@@ -11692,23 +11438,20 @@
                         (i32.const 0)
                       )
                       (block
-                        (set_local $17
+                        (set_local $13
                           (get_local $3)
-                        )
-                        (set_local $15
-                          (get_local $6)
                         )
                         (br $while-out$19)
                       )
                       (block
                         (set_local $26
-                          (get_local $3)
+                          (get_local $17)
                         )
                         (set_local $24
                           (get_local $0)
                         )
                         (set_local $29
-                          (get_local $6)
+                          (get_local $3)
                         )
                       )
                     )
@@ -11717,10 +11460,10 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $15)
+                    (get_local $13)
                     (i32.const 0)
                   )
-                  (set_local $8
+                  (set_local $6
                     (get_local $5)
                   )
                   (if
@@ -11736,7 +11479,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $15)
+                          (get_local $13)
                           (set_local $0
                             (i32.load
                               (i32.const 192)
@@ -11747,10 +11490,10 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $15)
+                          (get_local $13)
                           (set_local $3
                             (i32.add
-                              (get_local $15)
+                              (get_local $13)
                               (get_local $5)
                             )
                           )
@@ -11759,7 +11502,7 @@
                       )
                       (set_local $1
                         (i32.load offset=24
-                          (get_local $15)
+                          (get_local $13)
                         )
                       )
                       (block $do-once$21
@@ -11767,10 +11510,10 @@
                           (i32.eq
                             (set_local $2
                               (i32.load offset=12
-                                (get_local $15)
+                                (get_local $13)
                               )
                             )
-                            (get_local $15)
+                            (get_local $13)
                           )
                           (block
                             (if
@@ -11779,7 +11522,7 @@
                                   (i32.load
                                     (set_local $9
                                       (i32.add
-                                        (get_local $15)
+                                        (get_local $13)
                                         (i32.const 20)
                                       )
                                     )
@@ -11793,7 +11536,7 @@
                                     (i32.load
                                       (set_local $9
                                         (i32.add
-                                          (get_local $15)
+                                          (get_local $13)
                                           (i32.const 16)
                                         )
                                       )
@@ -11802,16 +11545,16 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $12
+                                  (set_local $6
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (get_local $2)
                                 )
                               )
-                              (set_local $7
+                              (set_local $8
                                 (get_local $2)
                               )
                             )
@@ -11820,9 +11563,9 @@
                                 (i32.ne
                                   (set_local $2
                                     (i32.load
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $8)
                                           (i32.const 20)
                                         )
                                       )
@@ -11831,11 +11574,11 @@
                                   (i32.const 0)
                                 )
                                 (block
-                                  (set_local $7
+                                  (set_local $8
                                     (get_local $2)
                                   )
                                   (set_local $9
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                   (br $while-in$24)
                                 )
@@ -11844,9 +11587,9 @@
                                 (i32.eq
                                   (set_local $2
                                     (i32.load
-                                      (set_local $6
+                                      (set_local $7
                                         (i32.add
-                                          (get_local $7)
+                                          (get_local $8)
                                           (i32.const 16)
                                         )
                                       )
@@ -11854,21 +11597,13 @@
                                   )
                                   (i32.const 0)
                                 )
+                                (br $while-out$23)
                                 (block
-                                  (set_local $2
-                                    (get_local $7)
-                                  )
-                                  (set_local $7
-                                    (get_local $9)
-                                  )
-                                  (br $while-out$23)
-                                )
-                                (block
-                                  (set_local $7
+                                  (set_local $8
                                     (get_local $2)
                                   )
                                   (set_local $9
-                                    (get_local $6)
+                                    (get_local $7)
                                   )
                                 )
                               )
@@ -11876,17 +11611,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $7)
+                                (get_local $9)
                                 (get_local $0)
                               )
                               (call_import $_abort)
                               (block
                                 (i32.store
-                                  (get_local $7)
+                                  (get_local $9)
                                   (i32.const 0)
                                 )
-                                (set_local $12
-                                  (get_local $2)
+                                (set_local $6
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -11894,9 +11629,9 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $7
+                                (set_local $8
                                   (i32.load offset=8
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                 )
                                 (get_local $0)
@@ -11908,12 +11643,12 @@
                                 (i32.load
                                   (set_local $0
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $8)
                                       (i32.const 12)
                                     )
                                   )
                                 )
-                                (get_local $15)
+                                (get_local $13)
                               )
                               (call_import $_abort)
                             )
@@ -11927,7 +11662,7 @@
                                     )
                                   )
                                 )
-                                (get_local $15)
+                                (get_local $13)
                               )
                               (block
                                 (i32.store
@@ -11936,9 +11671,9 @@
                                 )
                                 (i32.store
                                   (get_local $9)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
-                                (set_local $12
+                                (set_local $6
                                   (get_local $2)
                                 )
                               )
@@ -11956,7 +11691,7 @@
                           (block
                             (if
                               (i32.eq
-                                (get_local $15)
+                                (get_local $13)
                                 (i32.load
                                   (set_local $2
                                     (i32.add
@@ -11964,7 +11699,7 @@
                                       (i32.shl
                                         (set_local $0
                                           (i32.load offset=28
-                                            (get_local $15)
+                                            (get_local $13)
                                           )
                                         )
                                         (i32.const 2)
@@ -11976,11 +11711,11 @@
                               (block
                                 (i32.store
                                   (get_local $2)
-                                  (get_local $12)
+                                  (get_local $6)
                                 )
                                 (if
                                   (i32.eq
-                                    (get_local $12)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                   (block
@@ -12023,20 +11758,20 @@
                                         )
                                       )
                                     )
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                   (i32.store
                                     (get_local $0)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                   (i32.store offset=20
                                     (get_local $1)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eq
-                                    (get_local $12)
+                                    (get_local $6)
                                     (i32.const 0)
                                   )
                                 )
@@ -12044,7 +11779,7 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $12)
+                                (get_local $6)
                                 (set_local $0
                                   (i32.load
                                     (i32.const 192)
@@ -12054,14 +11789,14 @@
                               (call_import $_abort)
                             )
                             (i32.store offset=24
-                              (get_local $12)
+                              (get_local $6)
                               (get_local $1)
                             )
                             (if
                               (i32.ne
                                 (set_local $1
                                   (i32.load offset=16
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                 )
                                 (i32.const 0)
@@ -12074,12 +11809,12 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $12)
+                                    (get_local $6)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                 )
                               )
@@ -12088,7 +11823,7 @@
                               (i32.ne
                                 (set_local $0
                                   (i32.load offset=20
-                                    (get_local $15)
+                                    (get_local $13)
                                   )
                                 )
                                 (i32.const 0)
@@ -12103,12 +11838,12 @@
                                 (call_import $_abort)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $12)
+                                    (get_local $6)
                                     (get_local $0)
                                   )
                                   (i32.store offset=24
                                     (get_local $0)
-                                    (get_local $12)
+                                    (get_local $6)
                                   )
                                 )
                               )
@@ -12124,7 +11859,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $15)
+                              (get_local $13)
                               (i32.or
                                 (set_local $0
                                   (i32.add
@@ -12141,7 +11876,7 @@
                                   (set_local $0
                                     (i32.add
                                       (i32.add
-                                        (get_local $15)
+                                        (get_local $13)
                                         (get_local $0)
                                       )
                                       (i32.const 4)
@@ -12158,7 +11893,7 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $15)
+                              (get_local $13)
                               (i32.or
                                 (get_local $5)
                                 (i32.const 3)
@@ -12646,12 +12381,12 @@
                       )
                       (return
                         (i32.add
-                          (get_local $15)
+                          (get_local $13)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $8
+                    (set_local $6
                       (get_local $5)
                     )
                   )
@@ -12669,7 +12404,7 @@
             (i32.const 184)
           )
         )
-        (get_local $8)
+        (get_local $6)
       )
       (block
         (set_local $1
@@ -12682,7 +12417,7 @@
             (set_local $2
               (i32.sub
                 (get_local $0)
-                (get_local $8)
+                (get_local $6)
               )
             )
             (i32.const 15)
@@ -12693,7 +12428,7 @@
               (set_local $0
                 (i32.add
                   (get_local $1)
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
             )
@@ -12718,7 +12453,7 @@
             (i32.store offset=4
               (get_local $1)
               (i32.or
-                (get_local $8)
+                (get_local $6)
                 (i32.const 3)
               )
             )
@@ -12776,7 +12511,7 @@
             (i32.const 188)
           )
         )
-        (get_local $8)
+        (get_local $6)
       )
       (block
         (i32.store
@@ -12784,7 +12519,7 @@
           (set_local $2
             (i32.sub
               (get_local $0)
-              (get_local $8)
+              (get_local $6)
             )
           )
         )
@@ -12797,7 +12532,7 @@
                   (i32.const 200)
                 )
               )
-              (get_local $8)
+              (get_local $6)
             )
           )
         )
@@ -12811,7 +12546,7 @@
         (i32.store offset=4
           (get_local $0)
           (i32.or
-            (get_local $8)
+            (get_local $6)
             (i32.const 3)
           )
         )
@@ -12888,7 +12623,7 @@
     )
     (set_local $5
       (i32.add
-        (get_local $8)
+        (get_local $6)
         (i32.const 48)
       )
     )
@@ -12896,22 +12631,22 @@
       (i32.le_u
         (set_local $10
           (i32.and
-            (set_local $6
+            (set_local $7
               (i32.add
                 (set_local $0
                   (i32.load
                     (i32.const 656)
                   )
                 )
-                (set_local $12
+                (set_local $15
                   (i32.add
-                    (get_local $8)
+                    (get_local $6)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $13
+            (set_local $12
               (i32.sub
                 (i32.const 0)
                 (get_local $0)
@@ -12919,7 +12654,7 @@
             )
           )
         )
-        (get_local $8)
+        (get_local $6)
       )
       (return
         (i32.const 0)
@@ -12988,7 +12723,7 @@
                       (i32.const 173)
                     )
                     (block
-                      (set_local $14
+                      (set_local $16
                         (i32.const 624)
                       )
                       (loop $while-out$37 $while-in$38
@@ -12996,7 +12731,7 @@
                           (i32.le_u
                             (set_local $4
                               (i32.load
-                                (get_local $14)
+                                (get_local $16)
                               )
                             )
                             (get_local $0)
@@ -13008,7 +12743,7 @@
                                 (i32.load
                                   (set_local $3
                                     (i32.add
-                                      (get_local $14)
+                                      (get_local $16)
                                       (i32.const 4)
                                     )
                                   )
@@ -13018,9 +12753,9 @@
                             )
                             (block
                               (set_local $4
-                                (get_local $14)
+                                (get_local $16)
                               )
-                              (set_local $14
+                              (set_local $16
                                 (get_local $3)
                               )
                               (br $while-out$37)
@@ -13031,7 +12766,7 @@
                           (i32.eq
                             (set_local $4
                               (i32.load offset=8
-                                (get_local $14)
+                                (get_local $16)
                               )
                             )
                             (i32.const 0)
@@ -13042,7 +12777,7 @@
                             )
                             (br $label$break$L259)
                           )
-                          (set_local $14
+                          (set_local $16
                             (get_local $4)
                           )
                         )
@@ -13053,12 +12788,12 @@
                           (set_local $0
                             (i32.and
                               (i32.sub
-                                (get_local $6)
+                                (get_local $7)
                                 (i32.load
                                   (i32.const 188)
                                 )
                               )
-                              (get_local $13)
+                              (get_local $12)
                             )
                           )
                           (i32.const 2147483647)
@@ -13075,7 +12810,7 @@
                                 (get_local $4)
                               )
                               (i32.load
-                                (get_local $14)
+                                (get_local $16)
                               )
                             )
                           )
@@ -13085,7 +12820,7 @@
                               (i32.const -1)
                             )
                             (block
-                              (set_local $16
+                              (set_local $14
                                 (get_local $3)
                               )
                               (set_local $19
@@ -13100,7 +12835,7 @@
                             (set_local $30
                               (get_local $3)
                             )
-                            (set_local $21
+                            (set_local $20
                               (get_local $0)
                             )
                             (set_local $11
@@ -13120,7 +12855,7 @@
                     )
                     (if
                       (i32.ne
-                        (set_local $6
+                        (set_local $7
                           (call_import $_sbrk
                             (i32.const 0)
                           )
@@ -13135,11 +12870,11 @@
                                 (i32.const 608)
                               )
                             )
-                            (set_local $13
+                            (set_local $12
                               (if
                                 (i32.eq
                                   (i32.and
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.add
                                         (set_local $4
                                           (i32.load
@@ -13150,7 +12885,7 @@
                                       )
                                     )
                                     (set_local $0
-                                      (get_local $6)
+                                      (get_local $7)
                                     )
                                   )
                                   (i32.const 0)
@@ -13163,7 +12898,7 @@
                                   )
                                   (i32.and
                                     (i32.add
-                                      (get_local $13)
+                                      (get_local $12)
                                       (get_local $0)
                                     )
                                     (i32.sub
@@ -13179,11 +12914,11 @@
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $13)
-                              (get_local $8)
+                              (get_local $12)
+                              (get_local $6)
                             )
                             (i32.lt_u
-                              (get_local $13)
+                              (get_local $12)
                               (i32.const 2147483647)
                             )
                           )
@@ -13212,30 +12947,27 @@
                             )
                             (if
                               (i32.eq
-                                (set_local $0
+                                (set_local $30
                                   (call_import $_sbrk
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                 )
-                                (get_local $6)
+                                (get_local $7)
                               )
                               (block
-                                (set_local $16
-                                  (get_local $6)
+                                (set_local $14
+                                  (get_local $7)
                                 )
                                 (set_local $19
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                                 (br $label$break$L257
                                   (i32.const 193)
                                 )
                               )
                               (block
-                                (set_local $30
-                                  (get_local $0)
-                                )
-                                (set_local $21
-                                  (get_local $13)
+                                (set_local $20
+                                  (get_local $12)
                                 )
                                 (set_local $11
                                   (i32.const 183)
@@ -13258,18 +12990,18 @@
                       (set_local $4
                         (i32.sub
                           (i32.const 0)
-                          (get_local $21)
+                          (get_local $20)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
                             (get_local $5)
-                            (get_local $21)
+                            (get_local $20)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $21)
+                              (get_local $20)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -13284,8 +13016,8 @@
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $12)
-                                    (get_local $21)
+                                    (get_local $15)
+                                    (get_local $20)
                                   )
                                   (set_local $0
                                     (i32.load
@@ -13314,20 +13046,16 @@
                               )
                               (br $label$break$L279)
                             )
-                            (set_local $0
+                            (set_local $20
                               (i32.add
                                 (get_local $0)
-                                (get_local $21)
+                                (get_local $20)
                               )
                             )
                           )
-                          (set_local $0
-                            (get_local $21)
-                          )
+                          (get_local $20)
                         )
-                        (set_local $0
-                          (get_local $21)
-                        )
+                        (get_local $20)
                       )
                       (if
                         (i32.ne
@@ -13335,11 +13063,11 @@
                           (i32.const -1)
                         )
                         (block
-                          (set_local $16
+                          (set_local $14
                             (get_local $30)
                           )
                           (set_local $19
-                            (get_local $0)
+                            (get_local $20)
                           )
                           (br $label$break$L257
                             (i32.const 193)
@@ -13409,12 +13137,12 @@
                   )
                 )
                 (i32.add
-                  (get_local $8)
+                  (get_local $6)
                   (i32.const 40)
                 )
               )
               (block
-                (set_local $16
+                (set_local $14
                   (get_local $0)
                 )
                 (set_local $19
@@ -13480,18 +13208,18 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $16)
+                    (get_local $14)
                     (get_local $0)
                   )
                 )
                 (i32.store
                   (i32.const 192)
-                  (get_local $16)
+                  (get_local $14)
                 )
               )
               (i32.store
                 (i32.const 624)
-                (get_local $16)
+                (get_local $14)
               )
               (i32.store
                 (i32.const 628)
@@ -13536,7 +13264,7 @@
                 )
                 (if
                   (i32.eq
-                    (set_local $0
+                    (set_local $1
                       (i32.add
                         (get_local $1)
                         (i32.const 1)
@@ -13545,9 +13273,7 @@
                     (i32.const 32)
                   )
                   (br $while-out$46)
-                  (set_local $1
-                    (get_local $0)
-                  )
+                  (get_local $1)
                 )
                 (br $while-in$47)
               )
@@ -13556,7 +13282,7 @@
                   (i32.and
                     (set_local $0
                       (i32.add
-                        (get_local $16)
+                        (get_local $14)
                         (i32.const 8)
                       )
                     )
@@ -13569,7 +13295,7 @@
                 (i32.const 200)
                 (set_local $0
                   (i32.add
-                    (get_local $16)
+                    (get_local $14)
                     (set_local $1
                       (select
                         (i32.const 0)
@@ -13620,24 +13346,24 @@
               )
             )
             (block
-              (set_local $6
+              (set_local $7
                 (i32.const 624)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
-                    (get_local $16)
+                    (get_local $14)
                     (i32.add
                       (set_local $4
                         (i32.load
-                          (get_local $6)
+                          (get_local $7)
                         )
                       )
                       (set_local $3
                         (i32.load
                           (set_local $5
                             (i32.add
-                              (get_local $6)
+                              (get_local $7)
                               (i32.const 4)
                             )
                           )
@@ -13656,7 +13382,7 @@
                       (get_local $5)
                     )
                     (set_local $43
-                      (get_local $6)
+                      (get_local $7)
                     )
                     (set_local $11
                       (i32.const 203)
@@ -13668,13 +13394,13 @@
                   (i32.eq
                     (set_local $4
                       (i32.load offset=8
-                        (get_local $6)
+                        (get_local $7)
                       )
                     )
                     (i32.const 0)
                   )
                   (br $while-out$48)
-                  (set_local $6
+                  (set_local $7
                     (get_local $4)
                   )
                 )
@@ -13699,7 +13425,7 @@
                     (i32.and
                       (i32.lt_u
                         (get_local $0)
-                        (get_local $16)
+                        (get_local $14)
                       )
                       (i32.ge_u
                         (get_local $0)
@@ -13793,7 +13519,7 @@
               (set_local $4
                 (if
                   (i32.lt_u
-                    (get_local $16)
+                    (get_local $14)
                     (set_local $1
                       (i32.load
                         (i32.const 192)
@@ -13803,16 +13529,16 @@
                   (block
                     (i32.store
                       (i32.const 192)
-                      (get_local $16)
+                      (get_local $14)
                     )
-                    (get_local $16)
+                    (get_local $14)
                   )
                   (get_local $1)
                 )
               )
               (set_local $3
                 (i32.add
-                  (get_local $16)
+                  (get_local $14)
                   (get_local $19)
                 )
               )
@@ -13877,7 +13603,7 @@
                   (block
                     (i32.store
                       (get_local $44)
-                      (get_local $16)
+                      (get_local $14)
                     )
                     (set_local $1
                       (i32.add
@@ -13901,7 +13627,7 @@
                         (i32.and
                           (set_local $1
                             (i32.add
-                              (get_local $16)
+                              (get_local $14)
                               (i32.const 8)
                             )
                           )
@@ -13942,9 +13668,9 @@
                             )
                           )
                         )
-                        (set_local $6
+                        (set_local $7
                           (i32.add
-                            (get_local $16)
+                            (get_local $14)
                             (select
                               (i32.const 0)
                               (i32.and
@@ -13962,20 +13688,20 @@
                     )
                     (set_local $5
                       (i32.add
+                        (get_local $7)
                         (get_local $6)
-                        (get_local $8)
                       )
                     )
-                    (set_local $13
+                    (set_local $12
                       (i32.sub
                         (get_local $1)
-                        (get_local $8)
+                        (get_local $6)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $6)
+                      (get_local $7)
                       (i32.or
-                        (get_local $8)
+                        (get_local $6)
                         (i32.const 3)
                       )
                     )
@@ -13993,7 +13719,7 @@
                                 (i32.load
                                   (i32.const 188)
                                 )
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
                           )
@@ -14025,7 +13751,7 @@
                                     (i32.load
                                       (i32.const 184)
                                     )
-                                    (get_local $13)
+                                    (get_local $12)
                                   )
                                 )
                               )
@@ -14232,7 +13958,7 @@
                                                           (i32.load
                                                             (set_local $9
                                                               (i32.add
-                                                                (set_local $20
+                                                                (set_local $21
                                                                   (i32.add
                                                                     (get_local $3)
                                                                     (i32.const 16)
@@ -14249,7 +13975,7 @@
                                                         (i32.eq
                                                           (set_local $1
                                                             (i32.load
-                                                              (get_local $20)
+                                                              (get_local $21)
                                                             )
                                                           )
                                                           (i32.const 0)
@@ -14265,7 +13991,7 @@
                                                             (get_local $1)
                                                           )
                                                           (set_local $9
-                                                            (get_local $20)
+                                                            (get_local $21)
                                                           )
                                                         )
                                                       )
@@ -14278,7 +14004,7 @@
                                                         (i32.ne
                                                           (set_local $1
                                                             (i32.load
-                                                              (set_local $20
+                                                              (set_local $21
                                                                 (i32.add
                                                                   (get_local $2)
                                                                   (i32.const 20)
@@ -14293,7 +14019,7 @@
                                                             (get_local $1)
                                                           )
                                                           (set_local $9
-                                                            (get_local $20)
+                                                            (get_local $21)
                                                           )
                                                           (br $while-in$62)
                                                         )
@@ -14302,7 +14028,7 @@
                                                         (i32.eq
                                                           (set_local $1
                                                             (i32.load
-                                                              (set_local $20
+                                                              (set_local $21
                                                                 (i32.add
                                                                   (get_local $2)
                                                                   (i32.const 16)
@@ -14312,21 +14038,13 @@
                                                           )
                                                           (i32.const 0)
                                                         )
-                                                        (block
-                                                          (set_local $1
-                                                            (get_local $2)
-                                                          )
-                                                          (set_local $2
-                                                            (get_local $9)
-                                                          )
-                                                          (br $while-out$61)
-                                                        )
+                                                        (br $while-out$61)
                                                         (block
                                                           (set_local $2
                                                             (get_local $1)
                                                           )
                                                           (set_local $9
-                                                            (get_local $20)
+                                                            (get_local $21)
                                                           )
                                                         )
                                                       )
@@ -14334,17 +14052,17 @@
                                                     )
                                                     (if
                                                       (i32.lt_u
-                                                        (get_local $2)
+                                                        (get_local $9)
                                                         (get_local $4)
                                                       )
                                                       (call_import $_abort)
                                                       (block
                                                         (i32.store
-                                                          (get_local $2)
+                                                          (get_local $9)
                                                           (i32.const 0)
                                                         )
                                                         (set_local $18
-                                                          (get_local $1)
+                                                          (get_local $2)
                                                         )
                                                       )
                                                     )
@@ -14581,7 +14299,7 @@
                                         (set_local $4
                                           (i32.add
                                             (get_local $10)
-                                            (get_local $13)
+                                            (get_local $12)
                                           )
                                         )
                                         (i32.add
@@ -14591,7 +14309,7 @@
                                       )
                                       (block
                                         (set_local $4
-                                          (get_local $13)
+                                          (get_local $12)
                                         )
                                         (get_local $3)
                                       )
@@ -14671,7 +14389,7 @@
                                         (get_local $1)
                                       )
                                     )
-                                    (set_local $7
+                                    (set_local $8
                                       (i32.add
                                         (get_local $2)
                                         (i32.const 8)
@@ -14699,7 +14417,7 @@
                                         )
                                       )
                                       (block
-                                        (set_local $7
+                                        (set_local $8
                                           (get_local $0)
                                         )
                                         (set_local $33
@@ -14713,7 +14431,7 @@
                                 )
                               )
                               (i32.store
-                                (get_local $7)
+                                (get_local $8)
                                 (get_local $5)
                               )
                               (i32.store offset=12
@@ -14871,7 +14589,7 @@
                                     (i32.const 180)
                                   )
                                 )
-                                (set_local $7
+                                (set_local $8
                                   (i32.shl
                                     (i32.const 1)
                                     (get_local $1)
@@ -14885,7 +14603,7 @@
                                 (i32.const 180)
                                 (i32.or
                                   (get_local $0)
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                               )
                               (i32.store
@@ -14952,7 +14670,7 @@
                                 (br $while-out$71)
                               )
                             )
-                            (set_local $7
+                            (set_local $8
                               (i32.shl
                                 (get_local $1)
                                 (i32.const 1)
@@ -14995,7 +14713,7 @@
                               )
                               (block
                                 (set_local $1
-                                  (get_local $7)
+                                  (get_local $8)
                                 )
                                 (set_local $2
                                   (get_local $0)
@@ -15096,7 +14814,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $6)
+                        (get_local $7)
                         (i32.const 8)
                       )
                     )
@@ -15143,7 +14861,7 @@
                 )
                 (br $while-in$74)
               )
-              (set_local $7
+              (set_local $8
                 (i32.eq
                   (i32.and
                     (set_local $1
@@ -15176,11 +14894,11 @@
                           )
                           (i32.const 7)
                         )
-                        (get_local $7)
+                        (get_local $8)
                       )
                     )
                   )
-                  (set_local $7
+                  (set_local $8
                     (i32.add
                       (get_local $0)
                       (i32.const 16)
@@ -15205,7 +14923,7 @@
                   (i32.and
                     (set_local $1
                       (i32.add
-                        (get_local $16)
+                        (get_local $14)
                         (i32.const 8)
                       )
                     )
@@ -15218,7 +14936,7 @@
                 (i32.const 200)
                 (set_local $1
                   (i32.add
-                    (get_local $16)
+                    (get_local $14)
                     (set_local $3
                       (select
                         (i32.const 0)
@@ -15302,7 +15020,7 @@
               )
               (i32.store
                 (i32.const 624)
-                (get_local $16)
+                (get_local $14)
               )
               (i32.store
                 (i32.const 628)
@@ -15431,7 +15149,7 @@
                               (i32.const 8)
                             )
                           )
-                          (set_local $20
+                          (set_local $21
                             (get_local $4)
                           )
                         )
@@ -15456,7 +15174,7 @@
                             (set_local $9
                               (get_local $1)
                             )
-                            (set_local $20
+                            (set_local $21
                               (get_local $2)
                             )
                           )
@@ -15467,12 +15185,12 @@
                         (get_local $0)
                       )
                       (i32.store offset=12
-                        (get_local $20)
+                        (get_local $21)
                         (get_local $0)
                       )
                       (i32.store offset=8
                         (get_local $0)
-                        (get_local $20)
+                        (get_local $21)
                       )
                       (i32.store offset=12
                         (get_local $0)
@@ -15603,7 +15321,7 @@
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $7)
+                    (get_local $8)
                     (i32.const 0)
                   )
                   (if
@@ -15614,7 +15332,7 @@
                             (i32.const 180)
                           )
                         )
-                        (set_local $7
+                        (set_local $8
                           (i32.shl
                             (i32.const 1)
                             (get_local $2)
@@ -15628,7 +15346,7 @@
                         (i32.const 180)
                         (i32.or
                           (get_local $1)
-                          (get_local $7)
+                          (get_local $8)
                         )
                       )
                       (i32.store
@@ -15695,7 +15413,7 @@
                         (br $while-out$77)
                       )
                     )
-                    (set_local $7
+                    (set_local $8
                       (i32.shl
                         (get_local $2)
                         (i32.const 1)
@@ -15738,7 +15456,7 @@
                       )
                       (block
                         (set_local $2
-                          (get_local $7)
+                          (get_local $8)
                         )
                         (set_local $4
                           (get_local $1)
@@ -15846,7 +15564,7 @@
                 (i32.const 188)
               )
             )
-            (get_local $8)
+            (get_local $6)
           )
           (block
             (i32.store
@@ -15854,7 +15572,7 @@
               (set_local $2
                 (i32.sub
                   (get_local $0)
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
             )
@@ -15867,7 +15585,7 @@
                       (i32.const 200)
                     )
                   )
-                  (get_local $8)
+                  (get_local $6)
                 )
               )
             )
@@ -15881,7 +15599,7 @@
             (i32.store offset=4
               (get_local $0)
               (i32.or
-                (get_local $8)
+                (get_local $6)
                 (i32.const 3)
               )
             )
@@ -15948,7 +15666,7 @@
     )
     (if
       (i32.eq
-        (set_local $6
+        (set_local $8
           (i32.and
             (set_local $0
               (i32.load
@@ -15965,7 +15683,7 @@
       )
       (call_import $_abort)
     )
-    (set_local $8
+    (set_local $9
       (i32.add
         (get_local $2)
         (set_local $7
@@ -15993,7 +15711,7 @@
           )
           (if
             (i32.eq
-              (get_local $6)
+              (get_local $8)
               (i32.const 0)
             )
             (return)
@@ -16006,7 +15724,7 @@
           )
           (if
             (i32.lt_u
-              (set_local $4
+              (set_local $6
                 (i32.add
                   (get_local $2)
                   (i32.sub
@@ -16021,7 +15739,7 @@
           )
           (if
             (i32.eq
-              (get_local $4)
+              (get_local $6)
               (i32.load
                 (i32.const 196)
               )
@@ -16034,7 +15752,7 @@
                       (i32.load
                         (set_local $1
                           (i32.add
-                            (get_local $8)
+                            (get_local $9)
                             (i32.const 4)
                           )
                         )
@@ -16046,7 +15764,7 @@
                 )
                 (block
                   (set_local $3
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (set_local $10
                     (get_local $12)
@@ -16066,7 +15784,7 @@
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $6)
                 (i32.or
                   (get_local $12)
                   (i32.const 1)
@@ -16074,7 +15792,7 @@
               )
               (i32.store
                 (i32.add
-                  (get_local $4)
+                  (get_local $6)
                   (get_local $12)
                 )
                 (get_local $12)
@@ -16096,17 +15814,17 @@
             (block
               (set_local $2
                 (i32.load offset=12
-                  (get_local $4)
+                  (get_local $6)
                 )
               )
               (if
                 (i32.ne
                   (set_local $0
                     (i32.load offset=8
-                      (get_local $4)
+                      (get_local $6)
                     )
                   )
-                  (set_local $6
+                  (set_local $8
                     (i32.add
                       (i32.const 216)
                       (i32.shl
@@ -16132,7 +15850,7 @@
                       (i32.load offset=12
                         (get_local $0)
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (call_import $_abort)
                   )
@@ -16160,7 +15878,7 @@
                     )
                   )
                   (set_local $3
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (set_local $10
                     (get_local $12)
@@ -16171,7 +15889,7 @@
               (if
                 (i32.eq
                   (get_local $2)
-                  (get_local $6)
+                  (get_local $8)
                 )
                 (set_local $13
                   (i32.add
@@ -16197,7 +15915,7 @@
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (set_local $13
                       (get_local $1)
@@ -16215,7 +15933,7 @@
                 (get_local $0)
               )
               (set_local $3
-                (get_local $4)
+                (get_local $6)
               )
               (set_local $10
                 (get_local $12)
@@ -16223,9 +15941,9 @@
               (br $do-once$0)
             )
           )
-          (set_local $6
+          (set_local $8
             (i32.load offset=24
-              (get_local $4)
+              (get_local $6)
             )
           )
           (block $do-once$2
@@ -16233,10 +15951,10 @@
               (i32.eq
                 (set_local $0
                   (i32.load offset=12
-                    (get_local $4)
+                    (get_local $6)
                   )
                 )
-                (get_local $4)
+                (get_local $6)
               )
               (block
                 (if
@@ -16247,7 +15965,7 @@
                           (i32.add
                             (set_local $13
                               (i32.add
-                                (get_local $4)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
@@ -16268,7 +15986,7 @@
                       (i32.const 0)
                     )
                     (block
-                      (set_local $9
+                      (set_local $4
                         (i32.const 0)
                       )
                       (br $do-once$2)
@@ -16325,15 +16043,7 @@
                       )
                       (i32.const 0)
                     )
-                    (block
-                      (set_local $0
-                        (get_local $2)
-                      )
-                      (set_local $2
-                        (get_local $7)
-                      )
-                      (br $while-out$4)
-                    )
+                    (br $while-out$4)
                     (block
                       (set_local $2
                         (get_local $0)
@@ -16347,17 +16057,17 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $2)
+                    (get_local $7)
                     (get_local $1)
                   )
                   (call_import $_abort)
                   (block
                     (i32.store
-                      (get_local $2)
+                      (get_local $7)
                       (i32.const 0)
                     )
-                    (set_local $9
-                      (get_local $0)
+                    (set_local $4
+                      (get_local $2)
                     )
                   )
                 )
@@ -16367,7 +16077,7 @@
                   (i32.lt_u
                     (set_local $2
                       (i32.load offset=8
-                        (get_local $4)
+                        (get_local $6)
                       )
                     )
                     (get_local $1)
@@ -16384,7 +16094,7 @@
                         )
                       )
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (call_import $_abort)
                 )
@@ -16398,7 +16108,7 @@
                         )
                       )
                     )
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (block
                     (i32.store
@@ -16409,7 +16119,7 @@
                       (get_local $7)
                       (get_local $2)
                     )
-                    (set_local $9
+                    (set_local $4
                       (get_local $0)
                     )
                   )
@@ -16420,12 +16130,12 @@
           )
           (if
             (i32.eq
-              (get_local $6)
+              (get_local $8)
               (i32.const 0)
             )
             (block
               (set_local $3
-                (get_local $4)
+                (get_local $6)
               )
               (set_local $10
                 (get_local $12)
@@ -16434,7 +16144,7 @@
             (block
               (if
                 (i32.eq
-                  (get_local $4)
+                  (get_local $6)
                   (i32.load
                     (set_local $1
                       (i32.add
@@ -16442,7 +16152,7 @@
                         (i32.shl
                           (set_local $0
                             (i32.load offset=28
-                              (get_local $4)
+                              (get_local $6)
                             )
                           )
                           (i32.const 2)
@@ -16454,11 +16164,11 @@
                 (block
                   (i32.store
                     (get_local $1)
-                    (get_local $9)
+                    (get_local $4)
                   )
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $4)
                       (i32.const 0)
                     )
                     (block
@@ -16478,7 +16188,7 @@
                         )
                       )
                       (set_local $3
-                        (get_local $4)
+                        (get_local $6)
                       )
                       (set_local $10
                         (get_local $12)
@@ -16490,7 +16200,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $6)
+                      (get_local $8)
                       (i32.load
                         (i32.const 192)
                       )
@@ -16502,30 +16212,30 @@
                       (i32.load
                         (set_local $0
                           (i32.add
-                            (get_local $6)
+                            (get_local $8)
                             (i32.const 16)
                           )
                         )
                       )
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (i32.store
                       (get_local $0)
-                      (get_local $9)
+                      (get_local $4)
                     )
                     (i32.store offset=20
-                      (get_local $6)
-                      (get_local $9)
+                      (get_local $8)
+                      (get_local $4)
                     )
                   )
                   (if
                     (i32.eq
-                      (get_local $9)
+                      (get_local $4)
                       (i32.const 0)
                     )
                     (block
                       (set_local $3
-                        (get_local $4)
+                        (get_local $6)
                       )
                       (set_local $10
                         (get_local $12)
@@ -16537,7 +16247,7 @@
               )
               (if
                 (i32.lt_u
-                  (get_local $9)
+                  (get_local $4)
                   (set_local $0
                     (i32.load
                       (i32.const 192)
@@ -16547,8 +16257,8 @@
                 (call_import $_abort)
               )
               (i32.store offset=24
-                (get_local $9)
-                (get_local $6)
+                (get_local $4)
+                (get_local $8)
               )
               (if
                 (i32.ne
@@ -16556,7 +16266,7 @@
                     (i32.load
                       (set_local $2
                         (i32.add
-                          (get_local $4)
+                          (get_local $6)
                           (i32.const 16)
                         )
                       )
@@ -16572,12 +16282,12 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=16
-                      (get_local $9)
+                      (get_local $4)
                       (get_local $1)
                     )
                     (i32.store offset=24
                       (get_local $1)
-                      (get_local $9)
+                      (get_local $4)
                     )
                   )
                 )
@@ -16593,7 +16303,7 @@
                 )
                 (block
                   (set_local $3
-                    (get_local $4)
+                    (get_local $6)
                   )
                   (set_local $10
                     (get_local $12)
@@ -16609,15 +16319,15 @@
                   (call_import $_abort)
                   (block
                     (i32.store offset=20
-                      (get_local $9)
+                      (get_local $4)
                       (get_local $0)
                     )
                     (i32.store offset=24
                       (get_local $0)
-                      (get_local $9)
+                      (get_local $4)
                     )
                     (set_local $3
-                      (get_local $4)
+                      (get_local $6)
                     )
                     (set_local $10
                       (get_local $12)
@@ -16641,7 +16351,7 @@
     (if
       (i32.ge_u
         (get_local $3)
-        (get_local $8)
+        (get_local $9)
       )
       (call_import $_abort)
     )
@@ -16652,7 +16362,7 @@
             (i32.load
               (set_local $1
                 (i32.add
-                  (get_local $8)
+                  (get_local $9)
                   (i32.const 4)
                 )
               )
@@ -16675,7 +16385,7 @@
       (block
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $9)
             (i32.load
               (i32.const 200)
             )
@@ -16725,7 +16435,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $9)
             (i32.load
               (i32.const 196)
             )
@@ -16763,7 +16473,7 @@
             (return)
           )
         )
-        (set_local $9
+        (set_local $4
           (i32.add
             (i32.and
               (get_local $0)
@@ -16772,7 +16482,7 @@
             (get_local $10)
           )
         )
-        (set_local $6
+        (set_local $8
           (i32.shr_u
             (get_local $0)
             (i32.const 3)
@@ -16787,14 +16497,14 @@
             (block
               (set_local $1
                 (i32.load offset=12
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
               (if
                 (i32.ne
                   (set_local $0
                     (i32.load offset=8
-                      (get_local $8)
+                      (get_local $9)
                     )
                   )
                   (set_local $2
@@ -16802,7 +16512,7 @@
                       (i32.const 216)
                       (i32.shl
                         (i32.shl
-                          (get_local $6)
+                          (get_local $8)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -16825,7 +16535,7 @@
                       (i32.load offset=12
                         (get_local $0)
                       )
-                      (get_local $8)
+                      (get_local $9)
                     )
                     (call_import $_abort)
                   )
@@ -16846,7 +16556,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $6)
+                          (get_local $8)
                         )
                         (i32.const -1)
                       )
@@ -16886,7 +16596,7 @@
                           )
                         )
                       )
-                      (get_local $8)
+                      (get_local $9)
                     )
                     (set_local $16
                       (get_local $2)
@@ -16907,7 +16617,7 @@
             (block
               (set_local $0
                 (i32.load offset=24
-                  (get_local $8)
+                  (get_local $9)
                 )
               )
               (block $do-once$10
@@ -16915,21 +16625,21 @@
                   (i32.eq
                     (set_local $1
                       (i32.load offset=12
-                        (get_local $8)
+                        (get_local $9)
                       )
                     )
-                    (get_local $8)
+                    (get_local $9)
                   )
                   (block
                     (if
                       (i32.eq
                         (set_local $1
                           (i32.load
-                            (set_local $6
+                            (set_local $8
                               (i32.add
                                 (set_local $7
                                   (i32.add
-                                    (get_local $8)
+                                    (get_local $9)
                                     (i32.const 16)
                                   )
                                 )
@@ -16959,7 +16669,7 @@
                           (set_local $2
                             (get_local $1)
                           )
-                          (set_local $6
+                          (set_local $8
                             (get_local $7)
                           )
                         )
@@ -16987,7 +16697,7 @@
                           (set_local $2
                             (get_local $1)
                           )
-                          (set_local $6
+                          (set_local $8
                             (get_local $7)
                           )
                           (br $while-in$13)
@@ -17007,20 +16717,12 @@
                           )
                           (i32.const 0)
                         )
-                        (block
-                          (set_local $1
-                            (get_local $2)
-                          )
-                          (set_local $2
-                            (get_local $6)
-                          )
-                          (br $while-out$12)
-                        )
+                        (br $while-out$12)
                         (block
                           (set_local $2
                             (get_local $1)
                           )
-                          (set_local $6
+                          (set_local $8
                             (get_local $7)
                           )
                         )
@@ -17029,7 +16731,7 @@
                     )
                     (if
                       (i32.lt_u
-                        (get_local $2)
+                        (get_local $8)
                         (i32.load
                           (i32.const 192)
                         )
@@ -17037,11 +16739,11 @@
                       (call_import $_abort)
                       (block
                         (i32.store
-                          (get_local $2)
+                          (get_local $8)
                           (i32.const 0)
                         )
                         (set_local $11
-                          (get_local $1)
+                          (get_local $2)
                         )
                       )
                     )
@@ -17051,7 +16753,7 @@
                       (i32.lt_u
                         (set_local $2
                           (i32.load offset=8
-                            (get_local $8)
+                            (get_local $9)
                           )
                         )
                         (i32.load
@@ -17063,14 +16765,14 @@
                     (if
                       (i32.ne
                         (i32.load
-                          (set_local $6
+                          (set_local $8
                             (i32.add
                               (get_local $2)
                               (i32.const 12)
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $9)
                       )
                       (call_import $_abort)
                     )
@@ -17084,11 +16786,11 @@
                             )
                           )
                         )
-                        (get_local $8)
+                        (get_local $9)
                       )
                       (block
                         (i32.store
-                          (get_local $6)
+                          (get_local $8)
                           (get_local $1)
                         )
                         (i32.store
@@ -17112,7 +16814,7 @@
                 (block
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $9)
                       (i32.load
                         (set_local $2
                           (i32.add
@@ -17120,7 +16822,7 @@
                             (i32.shl
                               (set_local $1
                                 (i32.load offset=28
-                                  (get_local $8)
+                                  (get_local $9)
                                 )
                               )
                               (i32.const 2)
@@ -17179,7 +16881,7 @@
                               )
                             )
                           )
-                          (get_local $8)
+                          (get_local $9)
                         )
                         (i32.store
                           (get_local $1)
@@ -17219,7 +16921,7 @@
                         (i32.load
                           (set_local $2
                             (i32.add
-                              (get_local $8)
+                              (get_local $9)
                               (i32.const 16)
                             )
                           )
@@ -17282,16 +16984,16 @@
         (i32.store offset=4
           (get_local $3)
           (i32.or
-            (get_local $9)
+            (get_local $4)
             (i32.const 1)
           )
         )
         (i32.store
           (i32.add
             (get_local $3)
-            (get_local $9)
+            (get_local $4)
           )
-          (get_local $9)
+          (get_local $4)
         )
         (if
           (i32.eq
@@ -17303,13 +17005,11 @@
           (block
             (i32.store
               (i32.const 184)
-              (get_local $9)
+              (get_local $4)
             )
             (return)
           )
-          (set_local $2
-            (get_local $9)
-          )
+          (get_local $4)
         )
       )
       (block
@@ -17334,20 +17034,20 @@
           )
           (get_local $10)
         )
-        (set_local $2
+        (set_local $4
           (get_local $10)
         )
       )
     )
     (set_local $1
       (i32.shr_u
-        (get_local $2)
+        (get_local $4)
         (i32.const 3)
       )
     )
     (if
       (i32.lt_u
-        (get_local $2)
+        (get_local $4)
         (i32.const 256)
       )
       (block
@@ -17453,7 +17153,7 @@
               (i32.eq
                 (set_local $0
                   (i32.shr_u
-                    (get_local $2)
+                    (get_local $4)
                     (i32.const 8)
                   )
                 )
@@ -17462,7 +17162,7 @@
               (i32.const 0)
               (if
                 (i32.gt_u
-                  (get_local $2)
+                  (get_local $4)
                   (i32.const 16777215)
                 )
                 (i32.const 31)
@@ -17539,7 +17239,7 @@
                   (i32.or
                     (i32.and
                       (i32.shr_u
-                        (get_local $2)
+                        (get_local $4)
                         (i32.add
                           (get_local $0)
                           (i32.const 7)
@@ -17577,7 +17277,7 @@
               (i32.const 180)
             )
           )
-          (set_local $6
+          (set_local $2
             (i32.shl
               (i32.const 1)
               (get_local $5)
@@ -17591,7 +17291,7 @@
           (i32.const 180)
           (i32.or
             (get_local $0)
-            (get_local $6)
+            (get_local $2)
           )
         )
         (i32.store
@@ -17614,7 +17314,7 @@
       (block
         (set_local $5
           (i32.shl
-            (get_local $2)
+            (get_local $4)
             (select
               (i32.const 0)
               (i32.sub
@@ -17645,7 +17345,7 @@
                 )
                 (i32.const -8)
               )
-              (get_local $2)
+              (get_local $4)
             )
             (block
               (set_local $15
@@ -17657,7 +17357,7 @@
               (br $while-out$18)
             )
           )
-          (set_local $6
+          (set_local $2
             (i32.shl
               (get_local $5)
               (i32.const 1)
@@ -17700,7 +17400,7 @@
             )
             (block
               (set_local $5
-                (get_local $6)
+                (get_local $2)
               )
               (set_local $1
                 (get_local $0)
@@ -17814,7 +17514,7 @@
         (get_local $0)
         (i32.const 0)
       )
-      (set_local $0
+      (set_local $5
         (i32.const 632)
       )
       (return)
@@ -17824,7 +17524,7 @@
         (i32.eq
           (set_local $5
             (i32.load
-              (get_local $0)
+              (get_local $5)
             )
           )
           (i32.const 0)
@@ -17839,9 +17539,7 @@
       (if
         (get_local $0)
         (br $while-out$20)
-        (set_local $0
-          (get_local $5)
-        )
+        (get_local $5)
       )
       (br $while-in$21)
     )
@@ -18845,14 +18543,14 @@
     (local $12 i32)
     (local $13 i32)
     (local $14 i32)
-    (set_local $7
+    (set_local $8
       (get_local $0)
     )
     (set_local $5
       (get_local $2)
     )
-    (set_local $8
-      (set_local $11
+    (set_local $7
+      (set_local $14
         (get_local $3)
       )
     )
@@ -18874,7 +18572,7 @@
         )
         (if
           (i32.eq
-            (get_local $8)
+            (get_local $7)
             (i32.const 0)
           )
           (block
@@ -18884,7 +18582,7 @@
                 (i32.store
                   (get_local $4)
                   (i32.rem_u
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $5)
                   )
                 )
@@ -18900,7 +18598,7 @@
             )
             (return
               (i32.div_u
-                (get_local $7)
+                (get_local $8)
                 (get_local $5)
               )
             )
@@ -18947,7 +18645,7 @@
     )
     (set_local $10
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 0)
       )
     )
@@ -18994,7 +18692,7 @@
           )
           (if
             (i32.eq
-              (get_local $7)
+              (get_local $8)
               (i32.const 0)
             )
             (block
@@ -19012,7 +18710,7 @@
                     (get_local $4)
                     (i32.rem_u
                       (get_local $6)
-                      (get_local $8)
+                      (get_local $7)
                     )
                   )
                 )
@@ -19024,7 +18722,7 @@
               (return
                 (i32.div_u
                   (get_local $6)
-                  (get_local $8)
+                  (get_local $7)
                 )
               )
             )
@@ -19034,11 +18732,11 @@
               (i32.and
                 (set_local $5
                   (i32.sub
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 1)
                   )
                 )
-                (get_local $8)
+                (get_local $7)
               )
               (i32.const 0)
             )
@@ -19082,7 +18780,7 @@
                 (i32.shr_u
                   (get_local $6)
                   (i32.ctz
-                    (get_local $8)
+                    (get_local $7)
                   )
                 )
               )
@@ -19093,7 +18791,7 @@
               (set_local $5
                 (i32.sub
                   (i32.clz
-                    (get_local $8)
+                    (get_local $7)
                   )
                   (i32.clz
                     (get_local $6)
@@ -19103,7 +18801,7 @@
               (i32.const 30)
             )
             (block
-              (set_local $13
+              (set_local $12
                 (set_local $0
                   (i32.add
                     (get_local $5)
@@ -19111,7 +18809,7 @@
                   )
                 )
               )
-              (set_local $14
+              (set_local $11
                 (i32.or
                   (i32.shl
                     (get_local $6)
@@ -19123,12 +18821,12 @@
                     )
                   )
                   (i32.shr_u
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $0)
                   )
                 )
               )
-              (set_local $12
+              (set_local $13
                 (i32.shr_u
                   (get_local $6)
                   (get_local $0)
@@ -19139,7 +18837,7 @@
               )
               (set_local $0
                 (i32.shl
-                  (get_local $7)
+                  (get_local $8)
                   (get_local $1)
                 )
               )
@@ -19200,7 +18898,7 @@
                   (set_local $5
                     (i32.sub
                       (i32.clz
-                        (get_local $8)
+                        (get_local $7)
                       )
                       (i32.clz
                         (get_local $6)
@@ -19210,7 +18908,7 @@
                   (i32.const 31)
                 )
                 (block
-                  (set_local $13
+                  (set_local $12
                     (set_local $0
                       (i32.add
                         (get_local $5)
@@ -19218,11 +18916,11 @@
                       )
                     )
                   )
-                  (set_local $14
+                  (set_local $11
                     (i32.or
                       (i32.and
                         (i32.shr_u
-                          (get_local $7)
+                          (get_local $8)
                           (get_local $0)
                         )
                         (set_local $9
@@ -19246,7 +18944,7 @@
                       )
                     )
                   )
-                  (set_local $12
+                  (set_local $13
                     (i32.and
                       (i32.shr_u
                         (get_local $6)
@@ -19260,7 +18958,7 @@
                   )
                   (set_local $0
                     (i32.shl
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $1)
                     )
                   )
@@ -19314,7 +19012,7 @@
           (if
             (i32.ne
               (i32.and
-                (set_local $8
+                (set_local $7
                   (i32.sub
                     (get_local $5)
                     (i32.const 1)
@@ -19356,7 +19054,7 @@
               )
               (set_local $10
                 (i32.shr_s
-                  (set_local $8
+                  (set_local $7
                     (i32.sub
                       (get_local $0)
                       (i32.const 32)
@@ -19365,10 +19063,10 @@
                   (i32.const 31)
                 )
               )
-              (set_local $13
+              (set_local $12
                 (get_local $0)
               )
-              (set_local $14
+              (set_local $11
                 (i32.or
                   (i32.and
                     (i32.shr_s
@@ -19380,7 +19078,7 @@
                     )
                     (i32.shr_u
                       (get_local $6)
-                      (get_local $8)
+                      (get_local $7)
                     )
                   )
                   (i32.and
@@ -19390,7 +19088,7 @@
                         (get_local $9)
                       )
                       (i32.shr_u
-                        (get_local $7)
+                        (get_local $8)
                         (get_local $0)
                       )
                     )
@@ -19398,7 +19096,7 @@
                   )
                 )
               )
-              (set_local $12
+              (set_local $13
                 (i32.and
                   (get_local $10)
                   (i32.shr_u
@@ -19410,7 +19108,7 @@
               (set_local $10
                 (i32.and
                   (i32.shl
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $1)
                   )
                   (get_local $5)
@@ -19425,15 +19123,15 @@
                         (get_local $1)
                       )
                       (i32.shr_u
-                        (get_local $7)
                         (get_local $8)
+                        (get_local $7)
                       )
                     )
                     (get_local $5)
                   )
                   (i32.and
                     (i32.shl
-                      (get_local $7)
+                      (get_local $8)
                       (get_local $9)
                     )
                     (i32.shr_s
@@ -19458,8 +19156,8 @@
               (i32.store
                 (get_local $4)
                 (i32.and
-                  (get_local $8)
                   (get_local $7)
+                  (get_local $8)
                 )
               )
               (i32.store offset=4
@@ -19519,7 +19217,7 @@
                     )
                   )
                   (i32.shr_u
-                    (get_local $7)
+                    (get_local $8)
                     (get_local $0)
                   )
                 )
@@ -19532,21 +19230,12 @@
     (set_local $0
       (if
         (i32.eq
-          (get_local $13)
+          (get_local $12)
           (i32.const 0)
         )
         (block
-          (set_local $9
+          (set_local $6
             (get_local $0)
-          )
-          (set_local $7
-            (get_local $10)
-          )
-          (set_local $3
-            (get_local $12)
-          )
-          (set_local $2
-            (get_local $14)
           )
           (set_local $1
             (i32.const 0)
@@ -19567,7 +19256,7 @@
               )
               (set_local $2
                 (i32.or
-                  (get_local $11)
+                  (get_local $14)
                   (i32.and
                     (get_local $3)
                     (i32.const 0)
@@ -19578,85 +19267,73 @@
               (i32.const -1)
             )
           )
-          (set_local $7
+          (set_local $8
             (i32.load
               (i32.const 168)
             )
           )
-          (set_local $8
-            (get_local $0)
-          )
-          (set_local $11
-            (get_local $10)
-          )
-          (set_local $5
-            (get_local $12)
-          )
-          (set_local $6
-            (get_local $14)
-          )
           (set_local $9
-            (get_local $13)
+            (get_local $0)
           )
           (set_local $0
             (i32.const 0)
           )
           (loop $while-out$2 $while-in$3
-            (set_local $10
+            (set_local $6
               (i32.or
                 (i32.shr_u
-                  (get_local $11)
+                  (get_local $10)
                   (i32.const 31)
                 )
                 (i32.shl
-                  (get_local $8)
+                  (get_local $9)
                   (i32.const 1)
                 )
               )
             )
-            (set_local $0
+            (set_local $10
               (i32.or
                 (get_local $0)
                 (i32.shl
-                  (get_local $11)
+                  (get_local $10)
                   (i32.const 1)
                 )
               )
             )
             (call $_i64Subtract
               (get_local $3)
-              (get_local $7)
-              (set_local $11
+              (get_local $8)
+              (set_local $0
                 (i32.or
                   (i32.const 0)
                   (i32.or
                     (i32.shl
-                      (get_local $6)
+                      (get_local $11)
                       (i32.const 1)
                     )
                     (i32.shr_u
-                      (get_local $8)
+                      (get_local $9)
                       (i32.const 31)
                     )
                   )
                 )
               )
-              (set_local $6
+              (set_local $9
                 (i32.or
                   (i32.shr_u
-                    (get_local $6)
+                    (get_local $11)
                     (i32.const 31)
                   )
                   (i32.shl
-                    (get_local $5)
+                    (get_local $13)
                     (i32.const 1)
                   )
                 )
               )
             )
-            (set_local $12
+            (set_local $7
               (i32.and
-                (set_local $8
+                (set_local $14
                   (i32.or
                     (i32.shr_s
                       (set_local $5
@@ -19682,12 +19359,12 @@
                 (i32.const 1)
               )
             )
-            (set_local $6
+            (set_local $11
               (call $_i64Subtract
-                (get_local $11)
-                (get_local $6)
+                (get_local $0)
+                (get_local $9)
                 (i32.and
-                  (get_local $8)
+                  (get_local $14)
                   (get_local $1)
                 )
                 (i32.and
@@ -19719,16 +19396,16 @@
                 )
               )
             )
-            (set_local $5
+            (set_local $13
               (i32.load
                 (i32.const 168)
               )
             )
             (if
               (i32.eq
-                (set_local $9
+                (set_local $12
                   (i32.sub
-                    (get_local $9)
+                    (get_local $12)
                     (i32.const 1)
                   )
                 )
@@ -19736,42 +19413,27 @@
               )
               (br $while-out$2)
               (block
-                (set_local $8
-                  (get_local $10)
-                )
-                (set_local $11
-                  (get_local $0)
+                (set_local $9
+                  (get_local $6)
                 )
                 (set_local $0
-                  (get_local $12)
+                  (get_local $7)
                 )
               )
             )
             (br $while-in$3)
           )
-          (set_local $9
-            (get_local $10)
-          )
-          (set_local $7
-            (get_local $0)
-          )
-          (set_local $3
-            (get_local $5)
-          )
-          (set_local $2
-            (get_local $6)
-          )
           (set_local $1
             (i32.const 0)
           )
-          (get_local $12)
+          (get_local $7)
         )
       )
     )
-    (set_local $6
+    (set_local $3
       (i32.or
-        (get_local $9)
-        (set_local $9
+        (get_local $6)
+        (set_local $2
           (i32.const 0)
         )
       )
@@ -19786,12 +19448,12 @@
           (get_local $4)
           (i32.or
             (i32.const 0)
-            (get_local $2)
+            (get_local $11)
           )
         )
         (i32.store offset=4
           (get_local $4)
-          (get_local $3)
+          (get_local $13)
         )
       )
     )
@@ -19803,23 +19465,23 @@
             (i32.shr_u
               (i32.or
                 (i32.const 0)
-                (get_local $7)
+                (get_local $10)
               )
               (i32.const 31)
             )
             (i32.shl
-              (get_local $6)
+              (get_local $3)
               (i32.const 1)
             )
           )
           (i32.and
             (i32.or
               (i32.shl
-                (get_local $9)
+                (get_local $2)
                 (i32.const 1)
               )
               (i32.shr_u
-                (get_local $7)
+                (get_local $10)
                 (i32.const 31)
               )
             )
@@ -19833,7 +19495,7 @@
       (i32.and
         (i32.or
           (i32.shl
-            (get_local $7)
+            (get_local $10)
             (i32.const 1)
           )
           (i32.const 0)

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -96,8 +96,7 @@
     (local $52 i32)
     (local $53 i32)
     (local $54 i32)
-    (local $55 i32)
-    (set_local $25
+    (set_local $31
       (i32.load
         (i32.const 8)
       )
@@ -111,8 +110,8 @@
         (i32.const 16)
       )
     )
-    (set_local $7
-      (get_local $25)
+    (set_local $15
+      (get_local $31)
     )
     (block $do-once$0
       (if
@@ -123,16 +122,16 @@
         (block
           (if
             (i32.and
-              (set_local $5
+              (set_local $12
                 (i32.shr_u
-                  (set_local $2
+                  (set_local $16
                     (i32.load
                       (i32.const 1208)
                     )
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.shr_u
-                      (set_local $0
+                      (set_local $14
                         (select
                           (i32.const 16)
                           (i32.and
@@ -156,15 +155,15 @@
               (i32.const 3)
             )
             (block
-              (set_local $7
+              (set_local $11
                 (i32.load
-                  (set_local $12
+                  (set_local $27
                     (i32.add
-                      (set_local $5
+                      (set_local $29
                         (i32.load
-                          (set_local $14
+                          (set_local $25
                             (i32.add
-                              (set_local $1
+                              (set_local $5
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
@@ -173,12 +172,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $5)
+                                              (get_local $12)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $3)
+                                          (get_local $2)
                                         )
                                       )
                                       (i32.const 1)
@@ -199,13 +198,13 @@
               )
               (if
                 (i32.eq
-                  (get_local $1)
-                  (get_local $7)
+                  (get_local $5)
+                  (get_local $11)
                 )
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $2)
+                    (get_local $16)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -218,7 +217,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $11)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -228,23 +227,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $8
+                        (set_local $19
                           (i32.add
-                            (get_local $7)
+                            (get_local $11)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $5)
+                      (get_local $29)
                     )
                     (block
                       (i32.store
-                        (get_local $8)
-                        (get_local $1)
+                        (get_local $19)
+                        (get_local $5)
                       )
                       (i32.store
-                        (get_local $14)
-                        (get_local $7)
+                        (get_local $25)
+                        (get_local $11)
                       )
                     )
                     (call_import $qa)
@@ -252,9 +251,9 @@
                 )
               )
               (i32.store offset=4
-                (get_local $5)
+                (get_local $29)
                 (i32.or
-                  (set_local $7
+                  (set_local $11
                     (i32.shl
                       (get_local $0)
                       (i32.const 3)
@@ -264,35 +263,35 @@
                 )
               )
               (i32.store
-                (set_local $14
+                (set_local $25
                   (i32.add
                     (i32.add
-                      (get_local $5)
-                      (get_local $7)
+                      (get_local $29)
+                      (get_local $11)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $14)
+                    (get_local $25)
                   )
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.const 8)
-                (get_local $25)
+                (get_local $31)
               )
               (return
-                (get_local $12)
+                (get_local $27)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $0)
-              (set_local $14
+              (get_local $14)
+              (set_local $25
                 (i32.load
                   (i32.const 1216)
                 )
@@ -300,37 +299,37 @@
             )
             (block
               (if
-                (get_local $5)
+                (get_local $12)
                 (block
-                  (set_local $1
+                  (set_local $5
                     (i32.and
                       (i32.shr_u
-                        (set_local $7
+                        (set_local $11
                           (i32.add
                             (i32.and
-                              (set_local $1
+                              (set_local $5
                                 (i32.and
                                   (i32.shl
-                                    (get_local $5)
-                                    (get_local $3)
+                                    (get_local $12)
+                                    (get_local $2)
                                   )
                                   (i32.or
-                                    (set_local $7
+                                    (set_local $11
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $3)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $7)
+                                      (get_local $11)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $1)
+                                (get_local $5)
                               )
                             )
                             (i32.const -1)
@@ -341,32 +340,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $1
+                  (set_local $5
                     (i32.load
-                      (set_local $8
+                      (set_local $19
                         (i32.add
-                          (set_local $9
+                          (set_local $8
                             (i32.load
-                              (set_local $12
+                              (set_local $0
                                 (i32.add
-                                  (set_local $6
+                                  (set_local $3
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $21
+                                          (set_local $7
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $7
+                                                      (set_local $11
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $8
+                                                            (set_local $19
                                                               (i32.shr_u
-                                                                (get_local $7)
-                                                                (get_local $1)
+                                                                (get_local $11)
+                                                                (get_local $5)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -374,15 +373,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $1)
+                                                      (get_local $5)
                                                     )
-                                                    (set_local $8
+                                                    (set_local $19
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $9
+                                                          (set_local $8
                                                             (i32.shr_u
-                                                              (get_local $8)
-                                                              (get_local $7)
+                                                              (get_local $19)
+                                                              (get_local $11)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -391,13 +390,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $9
+                                                  (set_local $8
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $6
+                                                        (set_local $3
                                                           (i32.shr_u
-                                                            (get_local $9)
                                                             (get_local $8)
+                                                            (get_local $19)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -406,13 +405,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $3
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $12
+                                                      (set_local $0
                                                         (i32.shr_u
-                                                          (get_local $6)
-                                                          (get_local $9)
+                                                          (get_local $3)
+                                                          (get_local $8)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -422,8 +421,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $12)
-                                                (get_local $6)
+                                                (get_local $0)
+                                                (get_local $3)
                                               )
                                             )
                                           )
@@ -445,31 +444,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $6)
-                      (get_local $1)
+                      (get_local $3)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $2)
+                          (get_local $16)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $21)
+                              (get_local $7)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $33
-                        (get_local $14)
+                      (set_local $39
+                        (get_local $25)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $1)
+                          (get_local $5)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -479,25 +478,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $7
+                            (set_local $11
                               (i32.add
-                                (get_local $1)
+                                (get_local $5)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $9)
+                          (get_local $8)
                         )
                         (block
                           (i32.store
-                            (get_local $7)
-                            (get_local $6)
+                            (get_local $11)
+                            (get_local $3)
                           )
                           (i32.store
-                            (get_local $12)
-                            (get_local $1)
+                            (get_local $0)
+                            (get_local $5)
                           )
-                          (set_local $33
+                          (set_local $39
                             (i32.load
                               (i32.const 1216)
                             )
@@ -508,27 +507,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $9)
+                    (get_local $8)
                     (i32.or
-                      (get_local $0)
+                      (get_local $14)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $12
+                    (set_local $0
                       (i32.add
-                        (get_local $9)
-                        (get_local $0)
+                        (get_local $8)
+                        (get_local $14)
                       )
                     )
                     (i32.or
-                      (set_local $1
+                      (set_local $5
                         (i32.sub
                           (i32.shl
-                            (get_local $21)
+                            (get_local $7)
                             (i32.const 3)
                           )
-                          (get_local $0)
+                          (get_local $14)
                         )
                       )
                       (i32.const 1)
@@ -536,27 +535,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $12)
-                      (get_local $1)
+                      (get_local $0)
+                      (get_local $5)
                     )
-                    (get_local $1)
+                    (get_local $5)
                   )
                   (if
-                    (get_local $33)
+                    (get_local $39)
                     (block
-                      (set_local $6
+                      (set_local $3
                         (i32.load
                           (i32.const 1228)
                         )
                       )
-                      (set_local $2
+                      (set_local $16
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (set_local $14
+                              (set_local $25
                                 (i32.shr_u
-                                  (get_local $33)
+                                  (get_local $39)
                                   (i32.const 3)
                                 )
                               )
@@ -568,25 +567,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $3
+                          (set_local $2
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $5
+                          (set_local $12
                             (i32.shl
                               (i32.const 1)
-                              (get_local $14)
+                              (get_local $25)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $3
+                            (set_local $2
                               (i32.load
-                                (set_local $5
+                                (set_local $12
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $16)
                                     (i32.const 8)
                                   )
                                 )
@@ -598,11 +597,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $41
-                              (get_local $5)
+                            (set_local $44
+                              (get_local $12)
                             )
-                            (set_local $34
-                              (get_local $3)
+                            (set_local $29
+                              (get_local $2)
                             )
                           )
                         )
@@ -610,73 +609,73 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $3)
-                              (get_local $5)
+                              (get_local $2)
+                              (get_local $12)
                             )
                           )
-                          (set_local $41
+                          (set_local $44
                             (i32.add
-                              (get_local $2)
+                              (get_local $16)
                               (i32.const 8)
                             )
                           )
-                          (set_local $34
-                            (get_local $2)
+                          (set_local $29
+                            (get_local $16)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $41)
-                        (get_local $6)
+                        (get_local $44)
+                        (get_local $3)
                       )
                       (i32.store offset=12
-                        (get_local $34)
-                        (get_local $6)
+                        (get_local $29)
+                        (get_local $3)
                       )
                       (i32.store offset=8
-                        (get_local $6)
-                        (get_local $34)
+                        (get_local $3)
+                        (get_local $29)
                       )
                       (i32.store offset=12
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $3)
+                        (get_local $16)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $1)
+                    (get_local $5)
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $12)
+                    (get_local $0)
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $25)
+                    (get_local $31)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $19)
                   )
                 )
               )
               (if
-                (set_local $12
+                (set_local $0
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $12
+                  (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (set_local $1
+                        (set_local $5
                           (i32.add
                             (i32.and
-                              (get_local $12)
+                              (get_local $0)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $12)
+                                (get_local $0)
                               )
                             )
                             (i32.const -1)
@@ -687,11 +686,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $14
+                          (set_local $25
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -700,13 +699,13 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (set_local $1
+                                            (set_local $5
                                               (i32.and
                                                 (i32.shr_u
-                                                  (set_local $2
+                                                  (set_local $16
                                                     (i32.shr_u
-                                                      (get_local $1)
-                                                      (get_local $12)
+                                                      (get_local $5)
+                                                      (get_local $0)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -714,15 +713,15 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $12)
+                                            (get_local $0)
                                           )
-                                          (set_local $2
+                                          (set_local $16
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $6
+                                                (set_local $3
                                                   (i32.shr_u
-                                                    (get_local $2)
-                                                    (get_local $1)
+                                                    (get_local $16)
+                                                    (get_local $5)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -731,13 +730,13 @@
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $3
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $3
+                                              (set_local $2
                                                 (i32.shr_u
-                                                  (get_local $6)
-                                                  (get_local $2)
+                                                  (get_local $3)
+                                                  (get_local $16)
                                                 )
                                               )
                                               (i32.const 1)
@@ -746,13 +745,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $3
+                                      (set_local $2
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $5
+                                            (set_local $12
                                               (i32.shr_u
+                                                (get_local $2)
                                                 (get_local $3)
-                                                (get_local $6)
                                               )
                                             )
                                             (i32.const 1)
@@ -762,8 +761,8 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $5)
-                                      (get_local $3)
+                                      (get_local $12)
+                                      (get_local $2)
                                     )
                                   )
                                   (i32.const 2)
@@ -775,84 +774,84 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $0)
+                      (get_local $14)
                     )
                   )
-                  (set_local $5
-                    (get_local $14)
+                  (set_local $12
+                    (get_local $25)
                   )
-                  (set_local $6
-                    (get_local $14)
+                  (set_local $3
+                    (get_local $25)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $14
+                      (set_local $25
                         (i32.load offset=16
-                          (get_local $5)
+                          (get_local $12)
                         )
                       )
-                      (set_local $7
-                        (get_local $14)
+                      (set_local $0
+                        (get_local $25)
                       )
                       (if
-                        (set_local $2
+                        (set_local $16
                           (i32.load offset=20
-                            (get_local $5)
+                            (get_local $12)
                           )
                         )
-                        (set_local $7
-                          (get_local $2)
+                        (set_local $0
+                          (get_local $16)
                         )
                         (block
-                          (set_local $7
-                            (get_local $3)
+                          (set_local $32
+                            (get_local $2)
                           )
-                          (set_local $1
-                            (get_local $6)
+                          (set_local $26
+                            (get_local $3)
                           )
                           (br $while-out$6)
                         )
                       )
                     )
-                    (set_local $2
+                    (set_local $16
                       (i32.lt_u
-                        (set_local $14
+                        (set_local $25
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $7)
+                                (get_local $0)
                               )
                               (i32.const -8)
                             )
-                            (get_local $0)
+                            (get_local $14)
                           )
                         )
-                        (get_local $3)
+                        (get_local $2)
                       )
+                    )
+                    (set_local $2
+                      (select
+                        (get_local $25)
+                        (get_local $2)
+                        (get_local $16)
+                      )
+                    )
+                    (set_local $12
+                      (get_local $0)
                     )
                     (set_local $3
                       (select
-                        (get_local $14)
+                        (get_local $0)
                         (get_local $3)
-                        (get_local $2)
-                      )
-                    )
-                    (set_local $5
-                      (get_local $7)
-                    )
-                    (set_local $6
-                      (select
-                        (get_local $7)
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $16)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
-                      (set_local $6
+                      (get_local $26)
+                      (set_local $3
                         (i32.load
                           (i32.const 1224)
                         )
@@ -862,66 +861,72 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $1)
-                      (set_local $5
+                      (get_local $26)
+                      (set_local $12
                         (i32.add
-                          (get_local $1)
-                          (get_local $0)
+                          (get_local $26)
+                          (get_local $14)
                         )
                       )
                     )
                     (call_import $qa)
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.load offset=24
-                      (get_local $1)
+                      (get_local $26)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $8
+                        (set_local $19
                           (i32.load offset=12
-                            (get_local $1)
+                            (get_local $26)
                           )
                         )
-                        (get_local $1)
+                        (get_local $26)
                       )
                       (block
                         (if
-                          (set_local $21
+                          (set_local $7
                             (i32.load
-                              (set_local $9
+                              (set_local $8
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $26)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $14
-                              (get_local $21)
+                            (set_local $11
+                              (get_local $7)
                             )
-                            (set_local $2
-                              (get_local $9)
+                            (set_local $0
+                              (get_local $8)
                             )
                           )
                           (if
-                            (i32.eqz
-                              (set_local $14
-                                (i32.load
-                                  (set_local $2
-                                    (i32.add
-                                      (get_local $1)
-                                      (i32.const 16)
-                                    )
+                            (set_local $25
+                              (i32.load
+                                (set_local $16
+                                  (i32.add
+                                    (get_local $26)
+                                    (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $23
+                              (set_local $11
+                                (get_local $25)
+                              )
+                              (set_local $0
+                                (get_local $16)
+                              )
+                            )
+                            (block
+                              (set_local $27
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -930,43 +935,43 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $21
+                            (set_local $7
                               (i32.load
-                                (set_local $9
+                                (set_local $8
                                   (i32.add
-                                    (get_local $14)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $14
-                                (get_local $21)
+                              (set_local $11
+                                (get_local $7)
                               )
-                              (set_local $2
-                                (get_local $9)
+                              (set_local $0
+                                (get_local $8)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
-                            (set_local $21
+                            (set_local $7
                               (i32.load
-                                (set_local $9
+                                (set_local $8
                                   (i32.add
-                                    (get_local $14)
+                                    (get_local $11)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $14
-                                (get_local $21)
+                              (set_local $11
+                                (get_local $7)
                               )
-                              (set_local $2
-                                (get_local $9)
+                              (set_local $0
+                                (get_local $8)
                               )
                             )
                             (br $while-out$10)
@@ -975,17 +980,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $2)
-                            (get_local $6)
+                            (get_local $0)
+                            (get_local $3)
                           )
                           (call_import $qa)
                           (block
                             (i32.store
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $23
-                              (get_local $14)
+                            (set_local $27
+                              (get_local $11)
                             )
                           )
                         )
@@ -993,52 +998,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $9
+                            (set_local $8
                               (i32.load offset=8
-                                (get_local $1)
+                                (get_local $26)
                               )
                             )
-                            (get_local $6)
+                            (get_local $3)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $21
+                              (set_local $7
                                 (i32.add
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $26)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $2
+                              (set_local $16
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $19)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $26)
                           )
                           (block
                             (i32.store
-                              (get_local $21)
-                              (get_local $8)
+                              (get_local $7)
+                              (get_local $19)
                             )
                             (i32.store
-                              (get_local $2)
-                              (get_local $9)
-                            )
-                            (set_local $23
+                              (get_local $16)
                               (get_local $8)
+                            )
+                            (set_local $27
+                              (get_local $19)
                             )
                           )
                           (call_import $qa)
@@ -1048,19 +1053,19 @@
                   )
                   (block $do-once$12
                     (if
-                      (get_local $3)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
-                            (get_local $1)
+                            (get_local $26)
                             (i32.load
-                              (set_local $6
+                              (set_local $3
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (set_local $8
+                                    (set_local $19
                                       (i32.load offset=28
-                                        (get_local $1)
+                                        (get_local $26)
                                       )
                                     )
                                     (i32.const 2)
@@ -1071,12 +1076,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $6)
-                              (get_local $23)
+                              (get_local $3)
+                              (get_local $27)
                             )
                             (if
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $27)
                               )
                               (block
                                 (i32.store
@@ -1088,7 +1093,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $19)
                                       )
                                       (i32.const -1)
                                     )
@@ -1101,7 +1106,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1111,35 +1116,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $8
+                                  (set_local $19
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $26)
                               )
                               (i32.store
-                                (get_local $8)
-                                (get_local $23)
+                                (get_local $19)
+                                (get_local $27)
                               )
                               (i32.store offset=20
-                                (get_local $3)
-                                (get_local $23)
+                                (get_local $2)
+                                (get_local $27)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $27)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $23)
-                            (set_local $8
+                            (get_local $27)
+                            (set_local $19
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1148,42 +1153,42 @@
                           (call_import $qa)
                         )
                         (i32.store offset=24
-                          (get_local $23)
-                          (get_local $3)
+                          (get_local $27)
+                          (get_local $2)
                         )
                         (if
-                          (set_local $6
+                          (set_local $3
                             (i32.load offset=16
-                              (get_local $1)
+                              (get_local $26)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $6)
-                              (get_local $8)
+                              (get_local $3)
+                              (get_local $19)
                             )
                             (call_import $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $23)
-                                (get_local $6)
+                                (get_local $27)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $6)
-                                (get_local $23)
+                                (get_local $3)
+                                (get_local $27)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $6
+                          (set_local $3
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $26)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $6)
+                              (get_local $3)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1191,12 +1196,12 @@
                             (call_import $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $23)
-                                (get_local $6)
+                                (get_local $27)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $6)
-                                (get_local $23)
+                                (get_local $3)
+                                (get_local $27)
                               )
                             )
                           )
@@ -1206,35 +1211,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $32)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $26)
                         (i32.or
-                          (set_local $3
+                          (set_local $2
                             (i32.add
-                              (get_local $7)
-                              (get_local $0)
+                              (get_local $32)
+                              (get_local $14)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (set_local $6
+                        (set_local $3
                           (i32.add
                             (i32.add
-                              (get_local $1)
-                              (get_local $3)
+                              (get_local $26)
+                              (get_local $2)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $6)
+                            (get_local $3)
                           )
                           (i32.const 1)
                         )
@@ -1242,46 +1247,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $26)
                         (i32.or
-                          (get_local $0)
+                          (get_local $14)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $12)
                         (i32.or
-                          (get_local $7)
+                          (get_local $32)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $5)
-                          (get_local $7)
+                          (get_local $12)
+                          (get_local $32)
                         )
-                        (get_local $7)
+                        (get_local $32)
                       )
                       (if
-                        (set_local $6
+                        (set_local $3
                           (i32.load
                             (i32.const 1216)
                           )
                         )
                         (block
-                          (set_local $3
+                          (set_local $2
                             (i32.load
                               (i32.const 1228)
                             )
                           )
-                          (set_local $6
+                          (set_local $3
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $8
+                                  (set_local $19
                                     (i32.shr_u
-                                      (get_local $6)
+                                      (get_local $3)
                                       (i32.const 3)
                                     )
                                   )
@@ -1293,25 +1298,25 @@
                           )
                           (if
                             (i32.and
-                              (set_local $9
+                              (set_local $8
                                 (i32.load
                                   (i32.const 1208)
                                 )
                               )
-                              (set_local $2
+                              (set_local $16
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $19)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $9
+                                (set_local $8
                                   (i32.load
-                                    (set_local $2
+                                    (set_local $16
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
@@ -1323,11 +1328,11 @@
                               )
                               (call_import $qa)
                               (block
-                                (set_local $42
-                                  (get_local $2)
+                                (set_local $34
+                                  (get_local $16)
                                 )
-                                (set_local $35
-                                  (get_local $9)
+                                (set_local $4
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -1335,64 +1340,68 @@
                               (i32.store
                                 (i32.const 1208)
                                 (i32.or
-                                  (get_local $9)
-                                  (get_local $2)
+                                  (get_local $8)
+                                  (get_local $16)
                                 )
                               )
-                              (set_local $42
+                              (set_local $34
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $3)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $35
-                                (get_local $6)
+                              (set_local $4
+                                (get_local $3)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $42)
-                            (get_local $3)
+                            (get_local $34)
+                            (get_local $2)
                           )
                           (i32.store offset=12
-                            (get_local $35)
-                            (get_local $3)
+                            (get_local $4)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $3)
-                            (get_local $35)
+                            (get_local $2)
+                            (get_local $4)
                           )
                           (i32.store offset=12
+                            (get_local $2)
                             (get_local $3)
-                            (get_local $6)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $7)
+                        (get_local $32)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $5)
+                        (get_local $12)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $25)
+                    (get_local $31)
                   )
                   (return
                     (i32.add
-                      (get_local $1)
+                      (get_local $26)
                       (i32.const 8)
                     )
                   )
                 )
-                (get_local $0)
+                (set_local $18
+                  (get_local $14)
+                )
               )
             )
-            (get_local $0)
+            (set_local $18
+              (get_local $14)
+            )
           )
         )
         (if
@@ -1400,13 +1409,13 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $0
+          (set_local $18
             (i32.const -1)
           )
           (block
-            (set_local $3
+            (set_local $2
               (i32.and
-                (set_local $6
+                (set_local $3
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1416,61 +1425,61 @@
               )
             )
             (if
-              (set_local $9
+              (set_local $8
                 (i32.load
                   (i32.const 1212)
                 )
               )
               (block
-                (set_local $2
+                (set_local $16
                   (i32.sub
                     (i32.const 0)
-                    (get_local $3)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$a
                   (if
-                    (set_local $12
+                    (set_local $0
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (set_local $0
+                            (set_local $34
                               (if
-                                (set_local $8
+                                (set_local $19
                                   (i32.shr_u
-                                    (get_local $6)
+                                    (get_local $3)
                                     (i32.const 8)
                                   )
                                 )
                                 (if
                                   (i32.gt_u
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $3)
+                                        (get_local $2)
                                         (i32.add
-                                          (set_local $12
+                                          (set_local $0
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (set_local $8
+                                                    (set_local $19
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $21
+                                                            (set_local $7
                                                               (i32.shl
-                                                                (get_local $8)
-                                                                (set_local $6
+                                                                (get_local $19)
+                                                                (set_local $3
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $8)
+                                                                        (get_local $19)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1487,16 +1496,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $3)
                                                   )
-                                                  (set_local $21
+                                                  (set_local $7
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $14
+                                                          (set_local $25
                                                             (i32.shl
-                                                              (get_local $21)
-                                                              (get_local $8)
+                                                              (get_local $7)
+                                                              (get_local $19)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1510,8 +1519,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $14)
-                                                  (get_local $21)
+                                                  (get_local $25)
+                                                  (get_local $7)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1523,7 +1532,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $12)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                   )
@@ -1538,110 +1547,118 @@
                       )
                     )
                     (block
-                      (set_local $21
-                        (get_local $2)
+                      (set_local $7
+                        (get_local $16)
                       )
-                      (set_local $14
+                      (set_local $25
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $3
                         (i32.shl
-                          (get_local $3)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $0)
+                                (get_local $34)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $0)
+                              (get_local $34)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $8
-                        (get_local $12)
+                      (set_local $19
+                        (get_local $0)
                       )
-                      (set_local $1
+                      (set_local $5
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $5
+                            (set_local $29
                               (i32.sub
-                                (set_local $12
+                                (set_local $27
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $8)
+                                      (get_local $19)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $3)
+                                (get_local $2)
                               )
                             )
-                            (get_local $21)
+                            (get_local $7)
                           )
                           (if
                             (i32.eq
-                              (get_local $12)
-                              (get_local $3)
+                              (get_local $27)
+                              (get_local $2)
                             )
                             (block
-                              (set_local $28
-                                (get_local $5)
+                              (set_local $36
+                                (get_local $29)
                               )
-                              (set_local $27
-                                (get_local $8)
+                              (set_local $18
+                                (get_local $19)
                               )
-                              (set_local $31
-                                (get_local $8)
+                              (set_local $17
+                                (get_local $19)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $21
-                                (get_local $5)
+                              (set_local $4
+                                (get_local $29)
                               )
-                              (set_local $1
-                                (get_local $8)
+                              (set_local $0
+                                (get_local $19)
                               )
                             )
                           )
+                          (block
+                            (set_local $4
+                              (get_local $7)
+                            )
+                            (set_local $0
+                              (get_local $5)
+                            )
+                          )
                         )
-                        (set_local $12
+                        (set_local $27
                           (select
-                            (get_local $14)
-                            (set_local $5
+                            (get_local $25)
+                            (set_local $29
                               (i32.load offset=20
-                                (get_local $8)
+                                (get_local $19)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $5)
+                                (get_local $29)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $5)
-                                (set_local $8
+                                (get_local $29)
+                                (set_local $19
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $8)
+                                        (get_local $19)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $6)
+                                          (get_local $3)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1654,42 +1671,48 @@
                           )
                         )
                         (if
-                          (set_local $5
+                          (set_local $29
                             (i32.eq
-                              (get_local $8)
+                              (get_local $19)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $36
-                              (get_local $21)
+                            (set_local $40
+                              (get_local $4)
                             )
-                            (set_local $37
-                              (get_local $12)
+                            (set_local $12
+                              (get_local $27)
                             )
-                            (set_local $32
-                              (get_local $1)
+                            (set_local $38
+                              (get_local $0)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $14
-                              (get_local $12)
+                            (set_local $7
+                              (get_local $4)
                             )
-                            (set_local $6
+                            (set_local $25
+                              (get_local $27)
+                            )
+                            (set_local $3
                               (i32.shl
-                                (get_local $6)
+                                (get_local $3)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $5)
+                                    (get_local $29)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
                                 )
                               )
+                            )
+                            (set_local $5
+                              (get_local $0)
                             )
                           )
                         )
@@ -1697,16 +1720,16 @@
                       )
                     )
                     (block
-                      (set_local $36
-                        (get_local $2)
+                      (set_local $40
+                        (get_local $16)
                       )
-                      (set_local $37
+                      (set_local $12
                         (i32.const 0)
                       )
-                      (set_local $32
+                      (set_local $38
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 86)
                       )
                     )
@@ -1714,7 +1737,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 86)
                   )
                   (if
@@ -1722,52 +1745,52 @@
                       (if
                         (i32.and
                           (i32.eq
-                            (get_local $37)
+                            (get_local $12)
                             (i32.const 0)
                           )
                           (i32.eq
-                            (get_local $32)
+                            (get_local $38)
                             (i32.const 0)
                           )
                         )
                         (block
                           (if
                             (i32.eqz
-                              (set_local $2
+                              (set_local $16
                                 (i32.and
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.or
-                                    (set_local $12
+                                    (set_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $0)
+                                        (get_local $34)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $12)
+                                      (get_local $0)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $0
-                                (get_local $3)
+                              (set_local $18
+                                (get_local $2)
                               )
                               (br $do-once$0)
                             )
                           )
-                          (set_local $2
+                          (set_local $16
                             (i32.and
                               (i32.shr_u
-                                (set_local $12
+                                (set_local $0
                                   (i32.add
                                     (i32.and
-                                      (get_local $2)
+                                      (get_local $16)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $2)
+                                        (get_local $16)
                                       )
                                     )
                                     (i32.const -1)
@@ -1786,13 +1809,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $12
+                                          (set_local $0
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $0
+                                                (set_local $14
                                                   (i32.shr_u
-                                                    (get_local $12)
-                                                    (get_local $2)
+                                                    (get_local $0)
+                                                    (get_local $16)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1800,15 +1823,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $2)
+                                          (get_local $16)
                                         )
-                                        (set_local $0
+                                        (set_local $14
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $5
+                                              (set_local $12
                                                 (i32.shr_u
+                                                  (get_local $14)
                                                   (get_local $0)
-                                                  (get_local $12)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1817,13 +1840,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $5
+                                      (set_local $12
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $1
+                                            (set_local $5
                                               (i32.shr_u
-                                                (get_local $5)
-                                                (get_local $0)
+                                                (get_local $12)
+                                                (get_local $14)
                                               )
                                             )
                                             (i32.const 1)
@@ -1832,13 +1855,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $1
+                                    (set_local $5
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $6
+                                          (set_local $3
                                             (i32.shr_u
-                                              (get_local $1)
                                               (get_local $5)
+                                              (get_local $12)
                                             )
                                           )
                                           (i32.const 1)
@@ -1848,8 +1871,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $6)
-                                    (get_local $1)
+                                    (get_local $3)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 2)
@@ -1858,111 +1881,111 @@
                             )
                           )
                         )
-                        (get_local $37)
+                        (get_local $12)
                       )
                     )
                     (block
-                      (set_local $28
-                        (get_local $36)
+                      (set_local $36
+                        (get_local $40)
                       )
-                      (set_local $27
+                      (set_local $18
                         (get_local $0)
                       )
-                      (set_local $31
-                        (get_local $32)
+                      (set_local $17
+                        (get_local $38)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $16
-                        (get_local $36)
+                      (set_local $22
+                        (get_local $40)
                       )
-                      (set_local $10
-                        (get_local $32)
+                      (set_local $9
+                        (get_local $38)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $8
+                    (set_local $7
                       (i32.const 0)
                     )
-                    (set_local $6
+                    (set_local $3
                       (i32.lt_u
-                        (set_local $1
+                        (set_local $5
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $27)
+                                (get_local $18)
                               )
                               (i32.const -8)
                             )
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
-                        (get_local $28)
+                        (get_local $36)
+                      )
+                    )
+                    (set_local $12
+                      (select
+                        (get_local $5)
+                        (get_local $36)
+                        (get_local $3)
                       )
                     )
                     (set_local $5
                       (select
-                        (get_local $1)
-                        (get_local $28)
-                        (get_local $6)
-                      )
-                    )
-                    (set_local $1
-                      (select
-                        (get_local $27)
-                        (get_local $31)
-                        (get_local $6)
+                        (get_local $18)
+                        (get_local $17)
+                        (get_local $3)
                       )
                     )
                     (if
-                      (set_local $6
+                      (set_local $3
                         (i32.load offset=16
-                          (get_local $27)
+                          (get_local $18)
                         )
                       )
                       (block
-                        (set_local $28
+                        (set_local $36
+                          (get_local $12)
+                        )
+                        (set_local $18
+                          (get_local $3)
+                        )
+                        (set_local $17
                           (get_local $5)
-                        )
-                        (set_local $27
-                          (get_local $6)
-                        )
-                        (set_local $31
-                          (get_local $1)
                         )
                         (br $while-in$20)
                       )
                     )
                     (if
-                      (set_local $27
+                      (set_local $18
                         (i32.load offset=20
-                          (get_local $27)
+                          (get_local $18)
                         )
                       )
                       (block
-                        (set_local $28
-                          (get_local $5)
+                        (set_local $36
+                          (get_local $12)
                         )
-                        (set_local $31
-                          (get_local $1)
+                        (set_local $17
+                          (get_local $5)
                         )
                       )
                       (block
-                        (set_local $16
-                          (get_local $5)
+                        (set_local $22
+                          (get_local $12)
                         )
-                        (set_local $10
-                          (get_local $1)
+                        (set_local $9
+                          (get_local $5)
                         )
                         (br $while-out$19)
                       )
@@ -1971,22 +1994,22 @@
                   )
                 )
                 (if
-                  (get_local $10)
+                  (get_local $9)
                   (if
                     (i32.lt_u
-                      (get_local $16)
+                      (get_local $22)
                       (i32.sub
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $10)
-                          (set_local $9
+                          (get_local $9)
+                          (set_local $8
                             (i32.load
                               (i32.const 1224)
                             )
@@ -1996,66 +2019,67 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $10)
-                          (set_local $1
+                          (get_local $9)
+                          (set_local $5
                             (i32.add
-                              (get_local $10)
-                              (get_local $3)
+                              (get_local $9)
+                              (get_local $2)
                             )
                           )
                         )
                         (call_import $qa)
                       )
-                      (set_local $5
+                      (set_local $12
                         (i32.load offset=24
-                          (get_local $10)
+                          (get_local $9)
                         )
                       )
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $6
+                            (set_local $3
                               (i32.load offset=12
-                                (get_local $10)
+                                (get_local $9)
                               )
                             )
-                            (get_local $10)
+                            (get_local $9)
                           )
                           (block
                             (if
-                              (set_local $2
+                              (set_local $16
                                 (i32.load
-                                  (set_local $0
+                                  (set_local $14
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $9)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $14
-                                  (get_local $2)
+                                (set_local $11
+                                  (get_local $16)
                                 )
-                                (set_local $12
-                                  (get_local $0)
+                                (set_local $0
+                                  (get_local $14)
                                 )
                               )
                               (if
-                                (i32.eqz
-                                  (set_local $14
-                                    (i32.load
-                                      (set_local $12
-                                        (i32.add
-                                          (get_local $10)
-                                          (i32.const 16)
-                                        )
+                                (set_local $25
+                                  (i32.load
+                                    (set_local $0
+                                      (i32.add
+                                        (get_local $9)
+                                        (i32.const 16)
                                       )
                                     )
                                   )
                                 )
+                                (set_local $11
+                                  (get_local $25)
+                                )
                                 (block
-                                  (set_local $19
+                                  (set_local $20
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
@@ -2064,43 +2088,43 @@
                             )
                             (loop $while-out$23 $while-in$24
                               (if
-                                (set_local $2
+                                (set_local $16
                                   (i32.load
-                                    (set_local $0
+                                    (set_local $14
                                       (i32.add
-                                        (get_local $14)
+                                        (get_local $11)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $14
-                                    (get_local $2)
+                                  (set_local $11
+                                    (get_local $16)
                                   )
-                                  (set_local $12
-                                    (get_local $0)
+                                  (set_local $0
+                                    (get_local $14)
                                   )
                                   (br $while-in$24)
                                 )
                               )
                               (if
-                                (set_local $2
+                                (set_local $16
                                   (i32.load
-                                    (set_local $0
+                                    (set_local $14
                                       (i32.add
-                                        (get_local $14)
+                                        (get_local $11)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $14
-                                    (get_local $2)
+                                  (set_local $11
+                                    (get_local $16)
                                   )
-                                  (set_local $12
-                                    (get_local $0)
+                                  (set_local $0
+                                    (get_local $14)
                                   )
                                 )
                                 (br $while-out$23)
@@ -2109,17 +2133,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $12)
-                                (get_local $9)
+                                (get_local $0)
+                                (get_local $8)
                               )
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $12)
+                                  (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $19
-                                  (get_local $14)
+                                (set_local $20
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -2127,9 +2151,23 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $0
+                                (set_local $14
                                   (i32.load offset=8
-                                    (get_local $10)
+                                    (get_local $9)
+                                  )
+                                )
+                                (get_local $8)
+                              )
+                              (call_import $qa)
+                            )
+                            (if
+                              (i32.ne
+                                (i32.load
+                                  (set_local $16
+                                    (i32.add
+                                      (get_local $14)
+                                      (i32.const 12)
+                                    )
                                   )
                                 )
                                 (get_local $9)
@@ -2137,42 +2175,28 @@
                               (call_import $qa)
                             )
                             (if
-                              (i32.ne
-                                (i32.load
-                                  (set_local $2
-                                    (i32.add
-                                      (get_local $0)
-                                      (i32.const 12)
-                                    )
-                                  )
-                                )
-                                (get_local $10)
-                              )
-                              (call_import $qa)
-                            )
-                            (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $12
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $6)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $9)
                               )
                               (block
                                 (i32.store
-                                  (get_local $2)
-                                  (get_local $6)
+                                  (get_local $16)
+                                  (get_local $3)
                                 )
                                 (i32.store
-                                  (get_local $12)
                                   (get_local $0)
+                                  (get_local $14)
                                 )
-                                (set_local $19
-                                  (get_local $6)
+                                (set_local $20
+                                  (get_local $3)
                                 )
                               )
                               (call_import $qa)
@@ -2182,19 +2206,19 @@
                       )
                       (block $do-once$25
                         (if
-                          (get_local $5)
+                          (get_local $12)
                           (block
                             (if
                               (i32.eq
-                                (get_local $10)
+                                (get_local $9)
                                 (i32.load
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (set_local $6
+                                        (set_local $3
                                           (i32.load offset=28
-                                            (get_local $10)
+                                            (get_local $9)
                                           )
                                         )
                                         (i32.const 2)
@@ -2205,12 +2229,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $9)
-                                  (get_local $19)
+                                  (get_local $8)
+                                  (get_local $20)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $19)
+                                    (get_local $20)
                                   )
                                   (block
                                     (i32.store
@@ -2222,7 +2246,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $6)
+                                            (get_local $3)
                                           )
                                           (i32.const -1)
                                         )
@@ -2235,7 +2259,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $5)
+                                    (get_local $12)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2245,35 +2269,35 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $6
+                                      (set_local $3
                                         (i32.add
-                                          (get_local $5)
+                                          (get_local $12)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $10)
+                                    (get_local $9)
                                   )
                                   (i32.store
-                                    (get_local $6)
-                                    (get_local $19)
+                                    (get_local $3)
+                                    (get_local $20)
                                   )
                                   (i32.store offset=20
-                                    (get_local $5)
-                                    (get_local $19)
+                                    (get_local $12)
+                                    (get_local $20)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eqz
-                                    (get_local $19)
+                                    (get_local $20)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $19)
-                                (set_local $6
+                                (get_local $20)
+                                (set_local $3
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2282,42 +2306,42 @@
                               (call_import $qa)
                             )
                             (i32.store offset=24
-                              (get_local $19)
-                              (get_local $5)
+                              (get_local $20)
+                              (get_local $12)
                             )
                             (if
-                              (set_local $9
+                              (set_local $8
                                 (i32.load offset=16
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $9)
-                                  (get_local $6)
+                                  (get_local $8)
+                                  (get_local $3)
                                 )
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $19)
-                                    (get_local $9)
+                                    (get_local $20)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=24
-                                    (get_local $9)
-                                    (get_local $19)
+                                    (get_local $8)
+                                    (get_local $20)
                                   )
                                 )
                               )
                             )
                             (if
-                              (set_local $9
+                              (set_local $8
                                 (i32.load offset=20
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2325,12 +2349,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $19)
-                                    (get_local $9)
+                                    (get_local $20)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=24
-                                    (get_local $9)
-                                    (get_local $19)
+                                    (get_local $8)
+                                    (get_local $20)
                                   )
                                 )
                               )
@@ -2341,35 +2365,35 @@
                       (block $do-once$29
                         (if
                           (i32.lt_u
-                            (get_local $16)
+                            (get_local $22)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $10)
+                              (get_local $9)
                               (i32.or
-                                (set_local $5
+                                (set_local $12
                                   (i32.add
-                                    (get_local $16)
-                                    (get_local $3)
+                                    (get_local $22)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 3)
                               )
                             )
                             (i32.store
-                              (set_local $9
+                              (set_local $8
                                 (i32.add
                                   (i32.add
-                                    (get_local $10)
-                                    (get_local $5)
+                                    (get_local $9)
+                                    (get_local $12)
                                   )
                                   (i32.const 4)
                                 )
                               )
                               (i32.or
                                 (i32.load
-                                  (get_local $9)
+                                  (get_local $8)
                                 )
                                 (i32.const 1)
                               )
@@ -2377,44 +2401,44 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $10)
+                              (get_local $9)
                               (i32.or
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $1)
+                              (get_local $5)
                               (i32.or
-                                (get_local $16)
+                                (get_local $22)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $1)
-                                (get_local $16)
+                                (get_local $5)
+                                (get_local $22)
                               )
-                              (get_local $16)
+                              (get_local $22)
                             )
-                            (set_local $9
+                            (set_local $8
                               (i32.shr_u
-                                (get_local $16)
+                                (get_local $22)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $16)
+                                (get_local $22)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $5
+                                (set_local $12
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $9)
+                                        (get_local $8)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -2423,25 +2447,25 @@
                                 )
                                 (if
                                   (i32.and
-                                    (set_local $6
+                                    (set_local $3
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $14
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $9)
+                                        (get_local $8)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $6
+                                      (set_local $3
                                         (i32.load
-                                          (set_local $0
+                                          (set_local $14
                                             (i32.add
-                                              (get_local $5)
+                                              (get_local $12)
                                               (i32.const 8)
                                             )
                                           )
@@ -2453,11 +2477,11 @@
                                     )
                                     (call_import $qa)
                                     (block
-                                      (set_local $18
-                                        (get_local $0)
+                                      (set_local $23
+                                        (get_local $14)
                                       )
                                       (set_local $13
-                                        (get_local $6)
+                                        (get_local $3)
                                       )
                                     )
                                   )
@@ -2465,81 +2489,81 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $6)
-                                        (get_local $0)
+                                        (get_local $3)
+                                        (get_local $14)
                                       )
                                     )
-                                    (set_local $18
+                                    (set_local $23
                                       (i32.add
-                                        (get_local $5)
+                                        (get_local $12)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $13
-                                      (get_local $5)
+                                      (get_local $12)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $18)
-                                  (get_local $1)
+                                  (get_local $23)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=12
                                   (get_local $13)
-                                  (get_local $1)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
+                                  (get_local $5)
                                   (get_local $13)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
                                   (get_local $5)
+                                  (get_local $12)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $12
+                            (set_local $0
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (set_local $2
+                                  (set_local $20
                                     (if
-                                      (set_local $5
+                                      (set_local $12
                                         (i32.shr_u
-                                          (get_local $16)
+                                          (get_local $22)
                                           (i32.const 8)
                                         )
                                       )
                                       (if
                                         (i32.gt_u
-                                          (get_local $16)
+                                          (get_local $22)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $16)
+                                              (get_local $22)
                                               (i32.add
-                                                (set_local $12
+                                                (set_local $0
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $5
+                                                          (set_local $12
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $0
+                                                                  (set_local $14
                                                                     (i32.shl
-                                                                      (get_local $5)
-                                                                      (set_local $6
+                                                                      (get_local $12)
+                                                                      (set_local $3
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $5)
+                                                                              (get_local $12)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2556,16 +2580,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $6)
+                                                          (get_local $3)
                                                         )
-                                                        (set_local $0
+                                                        (set_local $14
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $9
+                                                                (set_local $8
                                                                   (i32.shl
-                                                                    (get_local $0)
-                                                                    (get_local $5)
+                                                                    (get_local $14)
+                                                                    (get_local $12)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2579,8 +2603,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $9)
-                                                        (get_local $0)
+                                                        (get_local $8)
+                                                        (get_local $14)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2592,7 +2616,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $12)
+                                            (get_local $0)
                                             (i32.const 1)
                                           )
                                         )
@@ -2605,34 +2629,34 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $1)
-                              (get_local $2)
+                              (get_local $5)
+                              (get_local $20)
                             )
                             (i32.store offset=4
-                              (set_local $0
+                              (set_local $14
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $5)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $0)
+                              (get_local $14)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (set_local $0
+                                  (set_local $14
                                     (i32.load
                                       (i32.const 1212)
                                     )
                                   )
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $2)
+                                      (get_local $20)
                                     )
                                   )
                                 )
@@ -2641,51 +2665,51 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $0)
-                                    (get_local $9)
+                                    (get_local $14)
+                                    (get_local $8)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $12)
-                                  (get_local $1)
+                                  (get_local $0)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $1)
-                                  (get_local $12)
+                                  (get_local $5)
+                                  (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $9
+                            (set_local $8
                               (i32.shl
-                                (get_local $16)
+                                (get_local $22)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $2)
+                                      (get_local $20)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $2)
+                                    (get_local $20)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $0
+                            (set_local $14
                               (i32.load
-                                (get_local $12)
+                                (get_local $0)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -2693,34 +2717,34 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $0)
+                                      (get_local $14)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $16)
+                                  (get_local $22)
                                 )
                                 (block
-                                  (set_local $17
-                                    (get_local $0)
+                                  (set_local $21
+                                    (get_local $14)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 148)
                                   )
                                   (br $while-out$31)
                                 )
                               )
                               (if
-                                (set_local $6
+                                (set_local $3
                                   (i32.load
-                                    (set_local $12
+                                    (set_local $0
                                       (i32.add
                                         (i32.add
-                                          (get_local $0)
+                                          (get_local $14)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $9)
+                                            (get_local $8)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -2730,24 +2754,24 @@
                                   )
                                 )
                                 (block
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.shl
-                                      (get_local $9)
+                                      (get_local $8)
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $0
-                                    (get_local $6)
+                                  (set_local $14
+                                    (get_local $3)
                                   )
                                 )
                                 (block
-                                  (set_local $22
-                                    (get_local $12)
-                                  )
-                                  (set_local $15
+                                  (set_local $6
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $24
+                                    (get_local $14)
+                                  )
+                                  (set_local $7
                                     (i32.const 145)
                                   )
                                   (br $while-out$31)
@@ -2757,12 +2781,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $22)
+                                  (get_local $6)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2770,71 +2794,71 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store
-                                    (get_local $22)
-                                    (get_local $1)
+                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=24
-                                    (get_local $1)
-                                    (get_local $15)
+                                    (get_local $5)
+                                    (get_local $24)
                                   )
                                   (i32.store offset=12
-                                    (get_local $1)
-                                    (get_local $1)
+                                    (get_local $5)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $1)
-                                    (get_local $1)
+                                    (get_local $5)
+                                    (get_local $5)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (set_local $9
+                                      (set_local $8
                                         (i32.load
-                                          (set_local $0
+                                          (set_local $14
                                             (i32.add
-                                              (get_local $17)
+                                              (get_local $21)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $3
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $17)
-                                      (get_local $6)
+                                      (get_local $21)
+                                      (get_local $3)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $9)
-                                      (get_local $1)
+                                      (get_local $8)
+                                      (get_local $5)
                                     )
                                     (i32.store
-                                      (get_local $0)
-                                      (get_local $1)
+                                      (get_local $14)
+                                      (get_local $5)
                                     )
                                     (i32.store offset=8
-                                      (get_local $1)
-                                      (get_local $9)
+                                      (get_local $5)
+                                      (get_local $8)
                                     )
                                     (i32.store offset=12
-                                      (get_local $1)
-                                      (get_local $17)
+                                      (get_local $5)
+                                      (get_local $21)
                                     )
                                     (i32.store offset=24
-                                      (get_local $1)
+                                      (get_local $5)
                                       (i32.const 0)
                                     )
                                   )
@@ -2847,26 +2871,26 @@
                       )
                       (i32.store
                         (i32.const 8)
-                        (get_local $25)
+                        (get_local $31)
                       )
                       (return
                         (i32.add
-                          (get_local $10)
+                          (get_local $9)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $0
-                      (get_local $3)
+                    (set_local $18
+                      (get_local $2)
                     )
                   )
-                  (set_local $0
-                    (get_local $3)
+                  (set_local $18
+                    (get_local $2)
                   )
                 )
               )
-              (set_local $0
-                (get_local $3)
+              (set_local $18
+                (get_local $2)
               )
             )
           )
@@ -2875,25 +2899,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $10
+        (set_local $9
           (i32.load
             (i32.const 1216)
           )
         )
-        (get_local $0)
+        (get_local $18)
       )
       (block
-        (set_local $15
+        (set_local $24
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (set_local $17
+            (set_local $21
               (i32.sub
-                (get_local $10)
-                (get_local $0)
+                (get_local $9)
+                (get_local $18)
               )
             )
             (i32.const 15)
@@ -2901,35 +2925,35 @@
           (block
             (i32.store
               (i32.const 1228)
-              (set_local $22
+              (set_local $6
                 (i32.add
-                  (get_local $15)
-                  (get_local $0)
+                  (get_local $24)
+                  (get_local $18)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $17)
+              (get_local $21)
             )
             (i32.store offset=4
-              (get_local $22)
+              (get_local $6)
               (i32.or
-                (get_local $17)
+                (get_local $21)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $22)
-                (get_local $17)
+                (get_local $6)
+                (get_local $21)
               )
-              (get_local $17)
+              (get_local $21)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $24)
               (i32.or
-                (get_local $0)
+                (get_local $18)
                 (i32.const 3)
               )
             )
@@ -2944,25 +2968,25 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $24)
               (i32.or
-                (get_local $10)
+                (get_local $9)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $17
+              (set_local $21
                 (i32.add
                   (i32.add
-                    (get_local $15)
-                    (get_local $10)
+                    (get_local $24)
+                    (get_local $9)
                   )
                   (i32.const 4)
                 )
               )
               (i32.or
                 (i32.load
-                  (get_local $17)
+                  (get_local $21)
                 )
                 (i32.const 1)
               )
@@ -2971,11 +2995,11 @@
         )
         (i32.store
           (i32.const 8)
-          (get_local $25)
+          (get_local $31)
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $24)
             (i32.const 8)
           )
         )
@@ -2983,57 +3007,57 @@
     )
     (if
       (i32.gt_u
-        (set_local $15
+        (set_local $24
           (i32.load
             (i32.const 1220)
           )
         )
-        (get_local $0)
+        (get_local $18)
       )
       (block
         (i32.store
           (i32.const 1220)
-          (set_local $17
+          (set_local $21
             (i32.sub
-              (get_local $15)
-              (get_local $0)
+              (get_local $24)
+              (get_local $18)
             )
           )
         )
         (i32.store
           (i32.const 1232)
-          (set_local $10
+          (set_local $9
             (i32.add
-              (set_local $15
+              (set_local $24
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $0)
+              (get_local $18)
             )
           )
         )
         (i32.store offset=4
-          (get_local $10)
+          (get_local $9)
           (i32.or
-            (get_local $17)
+            (get_local $21)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $15)
+          (get_local $24)
           (i32.or
-            (get_local $0)
+            (get_local $18)
             (i32.const 3)
           )
         )
         (i32.store
           (i32.const 8)
-          (get_local $25)
+          (get_local $31)
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $24)
             (i32.const 8)
           )
         )
@@ -3071,11 +3095,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $7)
-          (set_local $15
+          (get_local $15)
+          (set_local $24
             (i32.xor
               (i32.and
-                (get_local $7)
+                (get_local $15)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3084,49 +3108,49 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $15)
+          (get_local $24)
         )
       )
     )
-    (set_local $15
+    (set_local $24
       (i32.add
-        (get_local $0)
+        (get_local $18)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $7
+        (set_local $15
           (i32.and
-            (set_local $10
+            (set_local $9
               (i32.add
-                (set_local $7
+                (set_local $15
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (set_local $17
+                (set_local $21
                   (i32.add
-                    (get_local $0)
+                    (get_local $18)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $22
+            (set_local $6
               (i32.sub
                 (i32.const 0)
-                (get_local $7)
+                (get_local $15)
               )
             )
           )
         )
-        (get_local $0)
+        (get_local $18)
       )
       (block
         (i32.store
           (i32.const 8)
-          (get_local $25)
+          (get_local $31)
         )
         (return
           (i32.const 0)
@@ -3134,7 +3158,7 @@
       )
     )
     (if
-      (set_local $16
+      (set_local $22
         (i32.load
           (i32.const 1648)
         )
@@ -3144,25 +3168,25 @@
           (i32.le_u
             (set_local $13
               (i32.add
-                (set_local $2
+                (set_local $20
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $7)
+                (get_local $15)
               )
             )
-            (get_local $2)
+            (get_local $20)
           )
           (i32.gt_u
             (get_local $13)
-            (get_local $16)
+            (get_local $22)
           )
         )
         (block
           (i32.store
             (i32.const 8)
-            (get_local $25)
+            (get_local $31)
           )
           (return
             (i32.const 0)
@@ -3172,7 +3196,7 @@
     )
     (if
       (i32.eq
-        (set_local $8
+        (set_local $7
           (block $label$break$b
             (if
               (i32.and
@@ -3185,7 +3209,7 @@
               (block
                 (block $label$break$c
                   (if
-                    (set_local $16
+                    (set_local $22
                       (i32.load
                         (i32.const 1232)
                       )
@@ -3197,19 +3221,19 @@
                       (loop $while-out$35 $while-in$36
                         (if
                           (i32.le_u
-                            (set_local $2
+                            (set_local $20
                               (i32.load
                                 (get_local $13)
                               )
                             )
-                            (get_local $16)
+                            (get_local $22)
                           )
                           (if
                             (i32.gt_u
                               (i32.add
-                                (get_local $2)
+                                (get_local $20)
                                 (i32.load
-                                  (set_local $18
+                                  (set_local $23
                                     (i32.add
                                       (get_local $13)
                                       (i32.const 4)
@@ -3217,14 +3241,14 @@
                                   )
                                 )
                               )
-                              (get_local $16)
+                              (get_local $22)
                             )
                             (block
-                              (set_local $3
+                              (set_local $0
                                 (get_local $13)
                               )
-                              (set_local $5
-                                (get_local $18)
+                              (set_local $17
+                                (get_local $23)
                               )
                               (br $while-out$35)
                             )
@@ -3239,7 +3263,7 @@
                             )
                           )
                           (block
-                            (set_local $8
+                            (set_local $7
                               (i32.const 171)
                             )
                             (br $label$break$c)
@@ -3252,42 +3276,42 @@
                           (set_local $13
                             (i32.and
                               (i32.sub
-                                (get_local $10)
+                                (get_local $9)
                                 (i32.load
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $22)
+                              (get_local $6)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $18
+                            (set_local $23
                               (call_import $ta
                                 (get_local $13)
                               )
                             )
                             (i32.add
                               (i32.load
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (i32.load
-                                (get_local $5)
+                                (get_local $17)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $18)
+                              (get_local $23)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $20
-                                (get_local $18)
+                              (set_local $28
+                                (get_local $23)
                               )
-                              (set_local $26
+                              (set_local $33
                                 (get_local $13)
                               )
                               (br $label$break$b
@@ -3296,20 +3320,20 @@
                             )
                           )
                           (block
-                            (set_local $11
-                              (get_local $18)
+                            (set_local $10
+                              (get_local $23)
                             )
-                            (set_local $4
+                            (set_local $1
                               (get_local $13)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.const 171)
                     )
                   )
@@ -3317,12 +3341,12 @@
                 (block $do-once$37
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 171)
                     )
                     (if
                       (i32.ne
-                        (set_local $16
+                        (set_local $22
                           (call_import $ta
                             (i32.const 0)
                           )
@@ -3330,10 +3354,10 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $2
+                        (set_local $6
                           (if
                             (i32.and
-                              (set_local $18
+                              (set_local $23
                                 (i32.add
                                   (set_local $13
                                     (i32.load
@@ -3343,19 +3367,19 @@
                                   (i32.const -1)
                                 )
                               )
-                              (set_local $3
-                                (get_local $16)
+                              (set_local $2
+                                (get_local $22)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $7)
-                                (get_local $3)
+                                (get_local $15)
+                                (get_local $2)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $18)
-                                  (get_local $3)
+                                  (get_local $23)
+                                  (get_local $2)
                                 )
                                 (i32.sub
                                   (i32.const 0)
@@ -3363,33 +3387,33 @@
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $15)
                           )
                         )
-                        (set_local $3
+                        (set_local $2
                           (i32.add
                             (set_local $13
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $2)
+                            (get_local $6)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $2)
-                              (get_local $0)
+                              (get_local $6)
+                              (get_local $18)
                             )
                             (i32.lt_u
-                              (get_local $2)
+                              (get_local $6)
                               (i32.const 2147483647)
                             )
                           )
                           (block
                             (if
-                              (set_local $18
+                              (set_local $23
                                 (i32.load
                                   (i32.const 1648)
                                 )
@@ -3397,44 +3421,44 @@
                               (br_if $do-once$37
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $13)
                                   )
                                   (i32.gt_u
-                                    (get_local $3)
-                                    (get_local $18)
+                                    (get_local $2)
+                                    (get_local $23)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $18
+                                (set_local $23
                                   (call_import $ta
-                                    (get_local $2)
+                                    (get_local $6)
                                   )
                                 )
-                                (get_local $16)
+                                (get_local $22)
                               )
                               (block
-                                (set_local $20
-                                  (get_local $16)
+                                (set_local $28
+                                  (get_local $22)
                                 )
-                                (set_local $26
-                                  (get_local $2)
+                                (set_local $33
+                                  (get_local $6)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
                                 )
                               )
                               (block
-                                (set_local $11
-                                  (get_local $18)
+                                (set_local $10
+                                  (get_local $23)
                                 )
-                                (set_local $4
-                                  (get_local $2)
+                                (set_local $1
+                                  (get_local $6)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 181)
                                 )
                               )
@@ -3448,43 +3472,43 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 181)
                     )
                     (block
-                      (set_local $18
+                      (set_local $23
                         (i32.sub
                           (i32.const 0)
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $15)
-                            (get_local $4)
+                            (get_local $24)
+                            (get_local $1)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $11)
+                              (get_local $10)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $3
+                            (set_local $2
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $17)
-                                    (get_local $4)
+                                    (get_local $21)
+                                    (get_local $1)
                                   )
-                                  (set_local $16
+                                  (set_local $22
                                     (i32.load
                                       (i32.const 1688)
                                     )
@@ -3492,7 +3516,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $16)
+                                  (get_local $22)
                                 )
                               )
                             )
@@ -3501,42 +3525,42 @@
                           (if
                             (i32.eq
                               (call_import $ta
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.const -1)
                             )
                             (block
                               (call_import $ta
-                                (get_local $18)
+                                (get_local $23)
                               )
                               (br $label$break$d)
                             )
-                            (set_local $1
+                            (set_local $4
                               (i32.add
-                                (get_local $3)
-                                (get_local $4)
+                                (get_local $2)
+                                (get_local $1)
                               )
                             )
                           )
-                          (set_local $1
-                            (get_local $4)
+                          (set_local $4
+                            (get_local $1)
                           )
                         )
-                        (set_local $1
-                          (get_local $4)
+                        (set_local $4
+                          (get_local $1)
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $11)
+                          (get_local $10)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $20
-                            (get_local $11)
+                          (set_local $28
+                            (get_local $10)
                           )
-                          (set_local $26
-                            (get_local $1)
+                          (set_local $33
+                            (get_local $4)
                           )
                           (br $label$break$b
                             (i32.const 191)
@@ -3564,18 +3588,18 @@
       )
       (if
         (i32.lt_u
-          (get_local $7)
+          (get_local $15)
           (i32.const 2147483647)
         )
         (if
           (i32.and
             (i32.lt_u
-              (set_local $1
+              (set_local $4
                 (call_import $ta
-                  (get_local $7)
+                  (get_local $15)
                 )
               )
-              (set_local $7
+              (set_local $15
                 (call_import $ta
                   (i32.const 0)
                 )
@@ -3583,36 +3607,36 @@
             )
             (i32.and
               (i32.ne
-                (get_local $1)
+                (get_local $4)
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $7)
+                (get_local $15)
                 (i32.const -1)
               )
             )
           )
           (if
             (i32.gt_u
-              (set_local $11
+              (set_local $10
                 (i32.sub
-                  (get_local $7)
-                  (get_local $1)
+                  (get_local $15)
+                  (get_local $4)
                 )
               )
               (i32.add
-                (get_local $0)
+                (get_local $18)
                 (i32.const 40)
               )
             )
             (block
-              (set_local $20
-                (get_local $1)
+              (set_local $28
+                (get_local $4)
               )
-              (set_local $26
-                (get_local $11)
+              (set_local $33
+                (get_local $10)
               )
-              (set_local $8
+              (set_local $7
                 (i32.const 191)
               )
             )
@@ -3622,59 +3646,59 @@
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 191)
       )
       (block
         (i32.store
           (i32.const 1640)
-          (set_local $11
+          (set_local $10
             (i32.add
               (i32.load
                 (i32.const 1640)
               )
-              (get_local $26)
+              (get_local $33)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $11)
+            (get_local $10)
             (i32.load
               (i32.const 1644)
             )
           )
           (i32.store
             (i32.const 1644)
-            (get_local $11)
+            (get_local $10)
           )
         )
         (block $do-once$42
           (if
-            (set_local $11
+            (set_local $10
               (i32.load
                 (i32.const 1232)
               )
             )
             (block
-              (set_local $4
+              (set_local $1
                 (i32.const 1656)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $20)
+                    (get_local $28)
                     (i32.add
-                      (set_local $1
+                      (set_local $4
                         (i32.load
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
-                      (set_local $17
+                      (set_local $21
                         (i32.load
-                          (set_local $7
+                          (set_local $15
                             (i32.add
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 4)
                             )
                           )
@@ -3683,19 +3707,19 @@
                     )
                   )
                   (block
-                    (set_local $49
-                      (get_local $1)
-                    )
                     (set_local $50
-                      (get_local $7)
-                    )
-                    (set_local $51
-                      (get_local $17)
-                    )
-                    (set_local $52
                       (get_local $4)
                     )
-                    (set_local $8
+                    (set_local $51
+                      (get_local $15)
+                    )
+                    (set_local $52
+                      (get_local $21)
+                    )
+                    (set_local $35
+                      (get_local $1)
+                    )
+                    (set_local $7
                       (i32.const 201)
                     )
                     (br $do-out$46)
@@ -3703,9 +3727,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $4
+                    (set_local $1
                       (i32.load offset=8
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
@@ -3714,14 +3738,14 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 201)
                 )
                 (if
                   (i32.eqz
                     (i32.and
                       (i32.load offset=12
-                        (get_local $52)
+                        (get_local $35)
                       )
                       (i32.const 8)
                     )
@@ -3729,34 +3753,34 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $11)
-                        (get_local $20)
+                        (get_local $10)
+                        (get_local $28)
                       )
                       (i32.ge_u
-                        (get_local $11)
-                        (get_local $49)
+                        (get_local $10)
+                        (get_local $50)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $50)
+                        (get_local $51)
                         (i32.add
-                          (get_local $51)
-                          (get_local $26)
+                          (get_local $52)
+                          (get_local $33)
                         )
                       )
-                      (set_local $4
+                      (set_local $1
                         (i32.add
-                          (get_local $11)
-                          (set_local $17
+                          (get_local $10)
+                          (set_local $21
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (set_local $4
+                                  (set_local $1
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $10)
                                       (i32.const 8)
                                     )
                                   )
@@ -3765,7 +3789,7 @@
                               )
                               (i32.eq
                                 (i32.and
-                                  (get_local $4)
+                                  (get_local $1)
                                   (i32.const 7)
                                 )
                                 (i32.const 0)
@@ -3774,11 +3798,11 @@
                           )
                         )
                       )
-                      (set_local $7
+                      (set_local $15
                         (i32.add
                           (i32.sub
-                            (get_local $26)
-                            (get_local $17)
+                            (get_local $33)
+                            (get_local $21)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3787,23 +3811,23 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $7)
+                        (get_local $15)
                       )
                       (i32.store offset=4
-                        (get_local $4)
+                        (get_local $1)
                         (i32.or
-                          (get_local $7)
+                          (get_local $15)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $4)
-                          (get_local $7)
+                          (get_local $1)
+                          (get_local $15)
                         )
                         (i32.const 40)
                       )
@@ -3818,11 +3842,11 @@
                   )
                 )
               )
-              (set_local $14
+              (set_local $35
                 (if
                   (i32.lt_u
-                    (get_local $20)
-                    (set_local $7
+                    (get_local $28)
+                    (set_local $15
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3831,38 +3855,38 @@
                   (block
                     (i32.store
                       (i32.const 1224)
-                      (get_local $20)
+                      (get_local $28)
                     )
-                    (get_local $20)
+                    (get_local $28)
                   )
-                  (get_local $7)
+                  (get_local $15)
                 )
               )
-              (set_local $7
+              (set_local $15
                 (i32.add
-                  (get_local $20)
-                  (get_local $26)
+                  (get_local $28)
+                  (get_local $33)
                 )
               )
-              (set_local $4
+              (set_local $1
                 (i32.const 1656)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $4)
+                      (get_local $1)
                     )
-                    (get_local $7)
+                    (get_local $15)
                   )
                   (block
                     (set_local $53
-                      (get_local $4)
+                      (get_local $1)
                     )
-                    (set_local $43
-                      (get_local $4)
+                    (set_local $45
+                      (get_local $1)
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.const 209)
                     )
                     (br $while-out$48)
@@ -3870,14 +3894,14 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $4
+                    (set_local $1
                       (i32.load offset=8
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                   )
                   (block
-                    (set_local $29
+                    (set_local $37
                       (i32.const 1656)
                     )
                     (br $while-out$48)
@@ -3887,49 +3911,49 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 209)
                 )
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $43)
+                      (get_local $45)
                     )
                     (i32.const 8)
                   )
-                  (set_local $29
+                  (set_local $37
                     (i32.const 1656)
                   )
                   (block
                     (i32.store
                       (get_local $53)
-                      (get_local $20)
+                      (get_local $28)
                     )
                     (i32.store
-                      (set_local $4
+                      (set_local $1
                         (i32.add
-                          (get_local $43)
+                          (get_local $45)
                           (i32.const 4)
                         )
                       )
                       (i32.add
                         (i32.load
-                          (get_local $4)
+                          (get_local $1)
                         )
-                        (get_local $26)
+                        (get_local $33)
                       )
                     )
-                    (set_local $17
+                    (set_local $21
                       (i32.add
-                        (get_local $20)
+                        (get_local $28)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $4
+                              (set_local $1
                                 (i32.add
-                                  (get_local $20)
+                                  (get_local $28)
                                   (i32.const 8)
                                 )
                               )
@@ -3938,34 +3962,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $4)
-                              (i32.const 7)
-                            )
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                    )
-                    (set_local $1
-                      (i32.add
-                        (get_local $7)
-                        (select
-                          (i32.const 0)
-                          (i32.and
-                            (i32.sub
-                              (i32.const 0)
-                              (set_local $4
-                                (i32.add
-                                  (get_local $7)
-                                  (i32.const 8)
-                                )
-                              )
-                            )
-                            (i32.const 7)
-                          )
-                          (i32.eq
-                            (i32.and
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3975,52 +3972,79 @@
                     )
                     (set_local $4
                       (i32.add
-                        (get_local $17)
-                        (get_local $0)
+                        (get_local $15)
+                        (select
+                          (i32.const 0)
+                          (i32.and
+                            (i32.sub
+                              (i32.const 0)
+                              (set_local $1
+                                (i32.add
+                                  (get_local $15)
+                                  (i32.const 8)
+                                )
+                              )
+                            )
+                            (i32.const 7)
+                          )
+                          (i32.eq
+                            (i32.and
+                              (get_local $1)
+                              (i32.const 7)
+                            )
+                            (i32.const 0)
+                          )
+                        )
                       )
                     )
-                    (set_local $15
+                    (set_local $1
+                      (i32.add
+                        (get_local $21)
+                        (get_local $18)
+                      )
+                    )
+                    (set_local $24
                       (i32.sub
                         (i32.sub
-                          (get_local $1)
-                          (get_local $17)
+                          (get_local $4)
+                          (get_local $21)
                         )
-                        (get_local $0)
+                        (get_local $18)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $17)
+                      (get_local $21)
                       (i32.or
-                        (get_local $0)
+                        (get_local $18)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$50
                       (if
                         (i32.eq
-                          (get_local $1)
-                          (get_local $11)
+                          (get_local $4)
+                          (get_local $10)
                         )
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (set_local $2
+                            (set_local $6
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $15)
+                                (get_local $24)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (i32.store offset=4
-                            (get_local $4)
+                            (get_local $1)
                             (i32.or
-                              (get_local $2)
+                              (get_local $6)
                               (i32.const 1)
                             )
                           )
@@ -4028,7 +4052,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $1)
+                              (get_local $4)
                               (i32.load
                                 (i32.const 1228)
                               )
@@ -4036,45 +4060,45 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (set_local $2
+                                (set_local $6
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $15)
+                                    (get_local $24)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $4)
+                                (get_local $1)
                               )
                               (i32.store offset=4
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $4)
-                                  (get_local $2)
+                                  (get_local $1)
+                                  (get_local $6)
                                 )
-                                (get_local $2)
+                                (get_local $6)
                               )
                               (br $do-once$50)
                             )
                           )
                           (i32.store
-                            (set_local $3
+                            (set_local $0
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $2
+                                      (set_local $6
                                         (i32.load offset=4
-                                          (get_local $1)
+                                          (get_local $4)
                                         )
                                       )
                                       (i32.const 3)
@@ -4082,44 +4106,44 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $5
+                                    (set_local $17
                                       (i32.and
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $3
+                                    (set_local $0
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $2)
+                                          (get_local $6)
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $10
+                                          (set_local $9
                                             (i32.load offset=12
-                                              (get_local $1)
+                                              (get_local $4)
                                             )
                                           )
                                           (block $do-once$53
                                             (if
                                               (i32.ne
-                                                (set_local $22
+                                                (set_local $6
                                                   (i32.load offset=8
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                 )
-                                                (set_local $18
+                                                (set_local $23
                                                   (i32.add
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $3)
+                                                        (get_local $0)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4130,17 +4154,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $22)
-                                                    (get_local $14)
+                                                    (get_local $6)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (br_if $do-once$53
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $22)
+                                                      (get_local $6)
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                 )
                                                 (call_import $qa)
@@ -4149,8 +4173,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $10)
-                                              (get_local $22)
+                                              (get_local $9)
+                                              (get_local $6)
                                             )
                                             (block
                                               (i32.store
@@ -4162,7 +4186,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $3)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4174,38 +4198,38 @@
                                           (block $do-once$55
                                             (if
                                               (i32.eq
-                                                (get_local $10)
-                                                (get_local $18)
+                                                (get_local $9)
+                                                (get_local $23)
                                               )
-                                              (set_local $44
+                                              (set_local $46
                                                 (i32.add
-                                                  (get_local $10)
+                                                  (get_local $9)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $10)
-                                                    (get_local $14)
+                                                    (get_local $9)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $3
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $10)
+                                                          (get_local $9)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (block
-                                                    (set_local $44
-                                                      (get_local $3)
+                                                    (set_local $46
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once$55)
                                                   )
@@ -4215,39 +4239,39 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $22)
-                                            (get_local $10)
+                                            (get_local $6)
+                                            (get_local $9)
                                           )
                                           (i32.store
-                                            (get_local $44)
-                                            (get_local $22)
+                                            (get_local $46)
+                                            (get_local $6)
                                           )
                                         )
                                         (block
-                                          (set_local $18
+                                          (set_local $23
                                             (i32.load offset=24
-                                              (get_local $1)
+                                              (get_local $4)
                                             )
                                           )
                                           (block $do-once$57
                                             (if
                                               (i32.eq
-                                                (set_local $3
+                                                (set_local $2
                                                   (i32.load offset=12
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                 )
-                                                (get_local $1)
+                                                (get_local $4)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $2
+                                                  (set_local $20
                                                     (i32.load
                                                       (set_local $13
                                                         (i32.add
-                                                          (set_local $16
+                                                          (set_local $22
                                                             (i32.add
-                                                              (get_local $1)
+                                                              (get_local $4)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4257,23 +4281,29 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $19
-                                                      (get_local $2)
+                                                    (set_local $11
+                                                      (get_local $20)
                                                     )
-                                                    (set_local $16
+                                                    (set_local $0
                                                       (get_local $13)
                                                     )
                                                   )
                                                   (if
-                                                    (i32.eqz
-                                                      (set_local $19
-                                                        (i32.load
-                                                          (get_local $16)
-                                                        )
+                                                    (set_local $20
+                                                      (i32.load
+                                                        (get_local $22)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $24
+                                                      (set_local $11
+                                                        (get_local $20)
+                                                      )
+                                                      (set_local $0
+                                                        (get_local $22)
+                                                      )
+                                                    )
+                                                    (block
+                                                      (set_local $30
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once$57)
@@ -4282,42 +4312,42 @@
                                                 )
                                                 (loop $while-out$59 $while-in$60
                                                   (if
-                                                    (set_local $2
+                                                    (set_local $20
                                                       (i32.load
                                                         (set_local $13
                                                           (i32.add
-                                                            (get_local $19)
+                                                            (get_local $11)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $19
-                                                        (get_local $2)
+                                                      (set_local $11
+                                                        (get_local $20)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $0
                                                         (get_local $13)
                                                       )
                                                       (br $while-in$60)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $2
+                                                    (set_local $20
                                                       (i32.load
                                                         (set_local $13
                                                           (i32.add
-                                                            (get_local $19)
+                                                            (get_local $11)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $19
-                                                        (get_local $2)
+                                                      (set_local $11
+                                                        (get_local $20)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $0
                                                         (get_local $13)
                                                       )
                                                     )
@@ -4327,17 +4357,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $16)
-                                                    (get_local $14)
+                                                    (get_local $0)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $0)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $24
-                                                      (get_local $19)
+                                                    (set_local $30
+                                                      (get_local $11)
                                                     )
                                                   )
                                                 )
@@ -4347,50 +4377,50 @@
                                                   (i32.lt_u
                                                     (set_local $13
                                                       (i32.load offset=8
-                                                        (get_local $1)
+                                                        (get_local $4)
                                                       )
                                                     )
-                                                    (get_local $14)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $2
+                                                      (set_local $20
                                                         (i32.add
                                                           (get_local $13)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $16
+                                                      (set_local $22
                                                         (i32.add
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (block
                                                     (i32.store
+                                                      (get_local $20)
                                                       (get_local $2)
-                                                      (get_local $3)
                                                     )
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $22)
                                                       (get_local $13)
                                                     )
-                                                    (set_local $24
-                                                      (get_local $3)
+                                                    (set_local $30
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (call_import $qa)
@@ -4400,21 +4430,21 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (get_local $18)
+                                              (get_local $23)
                                             )
                                           )
                                           (block $do-once$61
                                             (if
                                               (i32.eq
-                                                (get_local $1)
+                                                (get_local $4)
                                                 (i32.load
-                                                  (set_local $22
+                                                  (set_local $6
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (set_local $3
+                                                        (set_local $2
                                                           (i32.load offset=28
-                                                            (get_local $1)
+                                                            (get_local $4)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4425,11 +4455,11 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $22)
-                                                  (get_local $24)
+                                                  (get_local $6)
+                                                  (get_local $30)
                                                 )
                                                 (br_if $do-once$61
-                                                  (get_local $24)
+                                                  (get_local $30)
                                                 )
                                                 (i32.store
                                                   (i32.const 1212)
@@ -4440,7 +4470,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4451,7 +4481,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $18)
+                                                    (get_local $23)
                                                     (i32.load
                                                       (i32.const 1224)
                                                     )
@@ -4461,27 +4491,27 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $10
+                                                      (set_local $9
                                                         (i32.add
-                                                          (get_local $18)
+                                                          (get_local $23)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (i32.store
-                                                    (get_local $10)
-                                                    (get_local $24)
+                                                    (get_local $9)
+                                                    (get_local $30)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $18)
-                                                    (get_local $24)
+                                                    (get_local $23)
+                                                    (get_local $30)
                                                   )
                                                 )
                                                 (br_if $label$break$e
                                                   (i32.eqz
-                                                    (get_local $24)
+                                                    (get_local $30)
                                                   )
                                                 )
                                               )
@@ -4489,8 +4519,8 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $24)
-                                              (set_local $3
+                                              (get_local $30)
+                                              (set_local $2
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4499,15 +4529,15 @@
                                             (call_import $qa)
                                           )
                                           (i32.store offset=24
-                                            (get_local $24)
-                                            (get_local $18)
+                                            (get_local $30)
+                                            (get_local $23)
                                           )
                                           (if
-                                            (set_local $10
+                                            (set_local $9
                                               (i32.load
-                                                (set_local $22
+                                                (set_local $6
                                                   (i32.add
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4515,34 +4545,34 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $10)
-                                                (get_local $3)
+                                                (get_local $9)
+                                                (get_local $2)
                                               )
                                               (call_import $qa)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $24)
-                                                  (get_local $10)
+                                                  (get_local $30)
+                                                  (get_local $9)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $10)
-                                                  (get_local $24)
+                                                  (get_local $9)
+                                                  (get_local $30)
                                                 )
                                               )
                                             )
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (set_local $10
+                                              (set_local $9
                                                 (i32.load offset=4
-                                                  (get_local $22)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $10)
+                                              (get_local $9)
                                               (i32.load
                                                 (i32.const 1224)
                                               )
@@ -4550,73 +4580,78 @@
                                             (call_import $qa)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $24)
-                                                (get_local $10)
+                                                (get_local $30)
+                                                (get_local $9)
                                               )
                                               (i32.store offset=24
-                                                (get_local $10)
-                                                (get_local $24)
+                                                (get_local $9)
+                                                (get_local $30)
                                               )
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $15
+                                    (set_local $11
                                       (i32.add
-                                        (get_local $5)
-                                        (get_local $15)
+                                        (get_local $17)
+                                        (get_local $24)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $1)
-                                      (get_local $5)
+                                      (get_local $4)
+                                      (get_local $17)
                                     )
                                   )
-                                  (get_local $1)
+                                  (block
+                                    (set_local $11
+                                      (get_local $24)
+                                    )
+                                    (get_local $4)
+                                  )
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.and
                               (i32.load
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $4)
+                            (get_local $1)
                             (i32.or
-                              (get_local $15)
+                              (get_local $11)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $4)
-                              (get_local $15)
+                              (get_local $1)
+                              (get_local $11)
                             )
-                            (get_local $15)
+                            (get_local $11)
                           )
-                          (set_local $3
+                          (set_local $0
                             (i32.shr_u
-                              (get_local $15)
+                              (get_local $11)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $15)
+                              (get_local $11)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $2
+                              (set_local $6
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $3)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4626,26 +4661,26 @@
                               (block $do-once$65
                                 (if
                                   (i32.and
-                                    (set_local $10
+                                    (set_local $9
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $3
+                                    (set_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $3)
+                                        (get_local $0)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $18
+                                        (set_local $23
                                           (i32.load
-                                            (set_local $3
+                                            (set_local $0
                                               (i32.add
-                                                (get_local $2)
+                                                (get_local $6)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4656,11 +4691,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $45
-                                          (get_local $3)
+                                        (set_local $47
+                                          (get_local $0)
                                         )
-                                        (set_local $38
-                                          (get_local $18)
+                                        (set_local $41
+                                          (get_local $23)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4671,51 +4706,51 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $10)
-                                        (get_local $3)
+                                        (get_local $9)
+                                        (get_local $2)
                                       )
                                     )
-                                    (set_local $45
+                                    (set_local $47
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $38
-                                      (get_local $2)
+                                    (set_local $41
+                                      (get_local $6)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $45)
-                                (get_local $4)
+                                (get_local $47)
+                                (get_local $1)
                               )
                               (i32.store offset=12
-                                (get_local $38)
-                                (get_local $4)
+                                (get_local $41)
+                                (get_local $1)
                               )
                               (i32.store offset=8
-                                (get_local $4)
-                                (get_local $38)
+                                (get_local $1)
+                                (get_local $41)
                               )
                               (i32.store offset=12
-                                (get_local $4)
-                                (get_local $2)
+                                (get_local $1)
+                                (get_local $6)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $3
+                          (set_local $2
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
                                 (set_local $0
                                   (block $do-once$67
                                     (if
-                                      (set_local $3
+                                      (set_local $2
                                         (i32.shr_u
-                                          (get_local $15)
+                                          (get_local $11)
                                           (i32.const 8)
                                         )
                                       )
@@ -4723,14 +4758,14 @@
                                         (br_if $do-once$67
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $15)
+                                            (get_local $11)
                                             (i32.const 16777215)
                                           )
                                         )
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $15)
+                                              (get_local $11)
                                               (i32.add
                                                 (set_local $13
                                                   (i32.add
@@ -4738,18 +4773,18 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $18
+                                                          (set_local $23
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $5
+                                                                  (set_local $17
                                                                     (i32.shl
-                                                                      (get_local $3)
-                                                                      (set_local $10
+                                                                      (get_local $2)
+                                                                      (set_local $9
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $3)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4766,16 +4801,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $10)
+                                                          (get_local $9)
                                                         )
-                                                        (set_local $5
+                                                        (set_local $17
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $3
+                                                                (set_local $0
                                                                   (i32.shl
-                                                                    (get_local $5)
-                                                                    (get_local $18)
+                                                                    (get_local $17)
+                                                                    (get_local $23)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4789,8 +4824,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $3)
-                                                        (get_local $5)
+                                                        (get_local $0)
+                                                        (get_local $17)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4816,26 +4851,26 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $4)
+                            (get_local $1)
                             (get_local $0)
                           )
                           (i32.store offset=4
-                            (set_local $2
+                            (set_local $6
                               (i32.add
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $2)
+                            (get_local $6)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $2
+                                (set_local $6
                                   (i32.load
                                     (i32.const 1212)
                                   )
@@ -4852,32 +4887,32 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $6)
                                   (get_local $13)
                                 )
                               )
                               (i32.store
-                                (get_local $3)
-                                (get_local $4)
+                                (get_local $2)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $4)
-                                (get_local $3)
+                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $4)
-                                (get_local $4)
+                                (get_local $1)
+                                (get_local $1)
                               )
                               (i32.store offset=8
-                                (get_local $4)
-                                (get_local $4)
+                                (get_local $1)
+                                (get_local $1)
                               )
                               (br $do-once$50)
                             )
                           )
                           (set_local $13
                             (i32.shl
-                              (get_local $15)
+                              (get_local $11)
                               (select
                                 (i32.const 0)
                                 (i32.sub
@@ -4894,9 +4929,9 @@
                               )
                             )
                           )
-                          (set_local $2
+                          (set_local $6
                             (i32.load
-                              (get_local $3)
+                              (get_local $2)
                             )
                           )
                           (loop $while-out$69 $while-in$70
@@ -4904,29 +4939,29 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $2)
+                                    (get_local $6)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $15)
+                                (get_local $11)
                               )
                               (block
-                                (set_local $39
-                                  (get_local $2)
+                                (set_local $42
+                                  (get_local $6)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 279)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $5
+                              (set_local $17
                                 (i32.load
-                                  (set_local $3
+                                  (set_local $2
                                     (i32.add
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const 16)
                                       )
                                       (i32.shl
@@ -4947,18 +4982,18 @@
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $2
-                                  (get_local $5)
+                                (set_local $6
+                                  (get_local $17)
                                 )
                               )
                               (block
-                                (set_local $46
-                                  (get_local $3)
-                                )
-                                (set_local $54
+                                (set_local $48
                                   (get_local $2)
                                 )
-                                (set_local $8
+                                (set_local $54
+                                  (get_local $6)
+                                )
+                                (set_local $7
                                   (i32.const 276)
                                 )
                                 (br $while-out$69)
@@ -4968,12 +5003,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 276)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $46)
+                                (get_local $48)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -4981,26 +5016,26 @@
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $46)
-                                  (get_local $4)
+                                  (get_local $48)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=24
-                                  (get_local $4)
+                                  (get_local $1)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=8
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 279)
                               )
                               (if
@@ -5008,44 +5043,44 @@
                                   (i32.ge_u
                                     (set_local $13
                                       (i32.load
-                                        (set_local $2
+                                        (set_local $6
                                           (i32.add
-                                            (get_local $39)
+                                            (get_local $42)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $5
+                                    (set_local $17
                                       (i32.load
                                         (i32.const 1224)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $39)
-                                    (get_local $5)
+                                    (get_local $42)
+                                    (get_local $17)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
                                     (get_local $13)
-                                    (get_local $4)
+                                    (get_local $1)
                                   )
                                   (i32.store
-                                    (get_local $2)
-                                    (get_local $4)
+                                    (get_local $6)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=8
-                                    (get_local $4)
+                                    (get_local $1)
                                     (get_local $13)
                                   )
                                   (i32.store offset=12
-                                    (get_local $4)
-                                    (get_local $39)
+                                    (get_local $1)
+                                    (get_local $42)
                                   )
                                   (i32.store offset=24
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.const 0)
                                   )
                                 )
@@ -5058,11 +5093,11 @@
                     )
                     (i32.store
                       (i32.const 8)
-                      (get_local $25)
+                      (get_local $31)
                     )
                     (return
                       (i32.add
-                        (get_local $17)
+                        (get_local $21)
                         (i32.const 8)
                       )
                     )
@@ -5072,71 +5107,71 @@
               (loop $while-out$71 $while-in$72
                 (if
                   (i32.le_u
-                    (set_local $4
+                    (set_local $1
                       (i32.load
-                        (get_local $29)
+                        (get_local $37)
                       )
                     )
-                    (get_local $11)
+                    (get_local $10)
                   )
                   (if
                     (i32.gt_u
-                      (set_local $15
+                      (set_local $24
                         (i32.add
-                          (get_local $4)
+                          (get_local $1)
                           (i32.load offset=4
-                            (get_local $29)
+                            (get_local $37)
                           )
                         )
                       )
-                      (get_local $11)
+                      (get_local $10)
                     )
                     (block
-                      (set_local $3
-                        (get_local $15)
+                      (set_local $0
+                        (get_local $24)
                       )
                       (br $while-out$71)
                     )
                   )
                 )
-                (set_local $29
+                (set_local $37
                   (i32.load offset=8
-                    (get_local $29)
+                    (get_local $37)
                   )
                 )
                 (br $while-in$72)
               )
-              (set_local $15
+              (set_local $24
                 (i32.add
-                  (set_local $17
+                  (set_local $21
                     (i32.add
-                      (get_local $3)
+                      (get_local $0)
                       (i32.const -47)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $4
+              (set_local $1
                 (i32.add
-                  (set_local $17
+                  (set_local $21
                     (select
-                      (get_local $11)
-                      (set_local $4
+                      (get_local $10)
+                      (set_local $1
                         (i32.add
-                          (get_local $17)
+                          (get_local $21)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $15)
+                                (get_local $24)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $15)
+                                (get_local $24)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5145,10 +5180,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $4)
-                        (set_local $15
+                        (get_local $1)
+                        (set_local $24
                           (i32.add
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 16)
                           )
                         )
@@ -5160,18 +5195,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $1
+                (set_local $4
                   (i32.add
-                    (get_local $20)
-                    (set_local $7
+                    (get_local $28)
+                    (set_local $15
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $1
+                            (set_local $4
                               (i32.add
-                                (get_local $20)
+                                (get_local $28)
                                 (i32.const 8)
                               )
                             )
@@ -5180,7 +5215,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5195,15 +5230,15 @@
                 (set_local $13
                   (i32.sub
                     (i32.add
-                      (get_local $26)
+                      (get_local $33)
                       (i32.const -40)
                     )
-                    (get_local $7)
+                    (get_local $15)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $4)
                 (i32.or
                   (get_local $13)
                   (i32.const 1)
@@ -5211,7 +5246,7 @@
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $1)
+                  (get_local $4)
                   (get_local $13)
                 )
                 (i32.const 40)
@@ -5225,43 +5260,43 @@
               (i32.store
                 (set_local $13
                   (i32.add
-                    (get_local $17)
+                    (get_local $21)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1668)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $20)
+                (get_local $28)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $26)
+                (get_local $33)
               )
               (i32.store
                 (i32.const 1668)
@@ -5269,19 +5304,19 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $4)
+                (get_local $1)
               )
-              (set_local $4
+              (set_local $1
                 (i32.add
-                  (get_local $17)
+                  (get_local $21)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $4
+                  (set_local $1
                     (i32.add
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
@@ -5290,17 +5325,17 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 4)
                     )
-                    (get_local $3)
+                    (get_local $0)
                   )
                 )
               )
               (if
                 (i32.ne
-                  (get_local $17)
-                  (get_local $11)
+                  (get_local $21)
+                  (get_local $10)
                 )
                 (block
                   (i32.store
@@ -5313,39 +5348,39 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $11)
+                    (get_local $10)
                     (i32.or
-                      (set_local $4
+                      (set_local $1
                         (i32.sub
-                          (get_local $17)
-                          (get_local $11)
+                          (get_local $21)
+                          (get_local $10)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $17)
-                    (get_local $4)
+                    (get_local $21)
+                    (get_local $1)
                   )
-                  (set_local $1
+                  (set_local $4
                     (i32.shr_u
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $7
+                      (set_local $15
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (get_local $1)
+                              (get_local $4)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5354,25 +5389,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $2
+                          (set_local $6
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $5
+                          (set_local $17
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $4)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $2
+                            (set_local $6
                               (i32.load
-                                (set_local $5
+                                (set_local $17
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $15)
                                     (i32.const 8)
                                   )
                                 )
@@ -5384,11 +5419,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $47
-                              (get_local $5)
+                            (set_local $49
+                              (get_local $17)
                             )
-                            (set_local $40
-                              (get_local $2)
+                            (set_local $43
+                              (get_local $6)
                             )
                           )
                         )
@@ -5396,81 +5431,81 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $2)
-                              (get_local $5)
+                              (get_local $6)
+                              (get_local $17)
                             )
                           )
-                          (set_local $47
+                          (set_local $49
                             (i32.add
-                              (get_local $7)
+                              (get_local $15)
                               (i32.const 8)
                             )
                           )
-                          (set_local $40
-                            (get_local $7)
+                          (set_local $43
+                            (get_local $15)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $47)
-                        (get_local $11)
+                        (get_local $49)
+                        (get_local $10)
                       )
                       (i32.store offset=12
-                        (get_local $40)
-                        (get_local $11)
+                        (get_local $43)
+                        (get_local $10)
                       )
                       (i32.store offset=8
-                        (get_local $11)
-                        (get_local $40)
+                        (get_local $10)
+                        (get_local $43)
                       )
                       (i32.store offset=12
-                        (get_local $11)
-                        (get_local $7)
+                        (get_local $10)
+                        (get_local $15)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (set_local $7
+                        (set_local $0
                           (if
-                            (set_local $7
+                            (set_local $15
                               (i32.shr_u
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.add
-                                      (set_local $3
+                                      (set_local $2
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $7
+                                                (set_local $15
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $5
+                                                        (set_local $17
                                                           (i32.shl
-                                                            (get_local $7)
-                                                            (set_local $2
+                                                            (get_local $15)
+                                                            (set_local $6
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $7)
+                                                                    (get_local $15)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5487,16 +5522,16 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $2)
+                                                (get_local $6)
                                               )
-                                              (set_local $5
+                                              (set_local $17
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $1
+                                                      (set_local $4
                                                         (i32.shl
-                                                          (get_local $5)
-                                                          (get_local $7)
+                                                          (get_local $17)
+                                                          (get_local $15)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5510,8 +5545,8 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $1)
-                                              (get_local $5)
+                                              (get_local $4)
+                                              (get_local $17)
                                             )
                                             (i32.const 15)
                                           )
@@ -5523,7 +5558,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $3)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
@@ -5536,29 +5571,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $11)
-                    (get_local $7)
+                    (get_local $10)
+                    (get_local $0)
                   )
                   (i32.store offset=20
-                    (get_local $11)
+                    (get_local $10)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $15)
+                    (get_local $24)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $5
+                        (set_local $17
                           (i32.load
                             (i32.const 1212)
                           )
                         )
-                        (set_local $1
+                        (set_local $4
                           (i32.shl
                             (i32.const 1)
-                            (get_local $7)
+                            (get_local $0)
                           )
                         )
                       )
@@ -5567,51 +5602,51 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $5)
-                          (get_local $1)
+                          (get_local $17)
+                          (get_local $4)
                         )
                       )
                       (i32.store
-                        (get_local $3)
-                        (get_local $11)
+                        (get_local $2)
+                        (get_local $10)
                       )
                       (i32.store offset=24
-                        (get_local $11)
-                        (get_local $3)
+                        (get_local $10)
+                        (get_local $2)
                       )
                       (i32.store offset=12
-                        (get_local $11)
-                        (get_local $11)
+                        (get_local $10)
+                        (get_local $10)
                       )
                       (i32.store offset=8
-                        (get_local $11)
-                        (get_local $11)
+                        (get_local $10)
+                        (get_local $10)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $1
+                  (set_local $4
                     (i32.shl
-                      (get_local $4)
+                      (get_local $1)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $7)
+                            (get_local $0)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $7)
+                          (get_local $0)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $5
+                  (set_local $17
                     (i32.load
-                      (get_local $3)
+                      (get_local $2)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5619,34 +5654,34 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $5)
+                            (get_local $17)
                           )
                           (i32.const -8)
                         )
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (block
-                        (set_local $30
-                          (get_local $5)
+                        (set_local $32
+                          (get_local $17)
                         )
-                        (set_local $8
+                        (set_local $7
                           (i32.const 305)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $2
+                      (set_local $6
                         (i32.load
-                          (set_local $3
+                          (set_local $2
                             (i32.add
                               (i32.add
-                                (get_local $5)
+                                (get_local $17)
                                 (i32.const 16)
                               )
                               (i32.shl
                                 (i32.shr_u
-                                  (get_local $1)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5656,24 +5691,24 @@
                         )
                       )
                       (block
-                        (set_local $1
+                        (set_local $4
                           (i32.shl
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
-                        (set_local $5
-                          (get_local $2)
+                        (set_local $17
+                          (get_local $6)
                         )
                       )
                       (block
-                        (set_local $48
-                          (get_local $3)
+                        (set_local $26
+                          (get_local $2)
                         )
-                        (set_local $55
-                          (get_local $5)
+                        (set_local $11
+                          (get_local $17)
                         )
-                        (set_local $8
+                        (set_local $7
                           (i32.const 302)
                         )
                         (br $while-out$75)
@@ -5683,12 +5718,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 302)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $48)
+                        (get_local $26)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -5696,71 +5731,71 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $48)
-                          (get_local $11)
+                          (get_local $26)
+                          (get_local $10)
                         )
                         (i32.store offset=24
+                          (get_local $10)
                           (get_local $11)
-                          (get_local $55)
                         )
                         (i32.store offset=12
-                          (get_local $11)
-                          (get_local $11)
+                          (get_local $10)
+                          (get_local $10)
                         )
                         (i32.store offset=8
-                          (get_local $11)
-                          (get_local $11)
+                          (get_local $10)
+                          (get_local $10)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $7)
                         (i32.const 305)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $1
+                            (set_local $4
                               (i32.load
-                                (set_local $5
+                                (set_local $17
                                   (i32.add
-                                    (get_local $30)
+                                    (get_local $32)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $4
+                            (set_local $1
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $30)
-                            (get_local $4)
+                            (get_local $32)
+                            (get_local $1)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $1)
-                            (get_local $11)
+                            (get_local $4)
+                            (get_local $10)
                           )
                           (i32.store
-                            (get_local $5)
-                            (get_local $11)
+                            (get_local $17)
+                            (get_local $10)
                           )
                           (i32.store offset=8
-                            (get_local $11)
-                            (get_local $1)
+                            (get_local $10)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $11)
-                            (get_local $30)
+                            (get_local $10)
+                            (get_local $32)
                           )
                           (i32.store offset=24
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 0)
                           )
                         )
@@ -5775,7 +5810,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $1
+                    (set_local $4
                       (i32.load
                         (i32.const 1224)
                       )
@@ -5783,22 +5818,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $20)
-                    (get_local $1)
+                    (get_local $28)
+                    (get_local $4)
                   )
                 )
                 (i32.store
                   (i32.const 1224)
-                  (get_local $20)
+                  (get_local $28)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $20)
+                (get_local $28)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $26)
+                (get_local $33)
               )
               (i32.store
                 (i32.const 1668)
@@ -5814,34 +5849,34 @@
                 (i32.const 1240)
                 (i32.const -1)
               )
-              (set_local $1
+              (set_local $4
                 (i32.const 0)
               )
               (loop $do-out$44 $do-in$45
                 (i32.store offset=12
-                  (set_local $7
+                  (set_local $15
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $7)
+                  (get_local $15)
                 )
                 (i32.store offset=8
-                  (get_local $7)
-                  (get_local $7)
+                  (get_local $15)
+                  (get_local $15)
                 )
                 (br_if $do-in$45
                   (i32.ne
-                    (set_local $1
+                    (set_local $4
                       (i32.add
-                        (get_local $1)
+                        (get_local $4)
                         (i32.const 1)
                       )
                     )
@@ -5851,18 +5886,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $1
+                (set_local $4
                   (i32.add
-                    (get_local $20)
-                    (set_local $7
+                    (get_local $28)
+                    (set_local $15
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $1
+                            (set_local $4
                               (i32.add
-                                (get_local $20)
+                                (get_local $28)
                                 (i32.const 8)
                               )
                             )
@@ -5871,7 +5906,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5883,27 +5918,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $4
+                (set_local $1
                   (i32.sub
                     (i32.add
-                      (get_local $26)
+                      (get_local $33)
                       (i32.const -40)
                     )
-                    (get_local $7)
+                    (get_local $15)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $4)
                 (i32.or
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $1)
                   (get_local $4)
+                  (get_local $1)
                 )
                 (i32.const 40)
               )
@@ -5918,57 +5953,57 @@
         )
         (if
           (i32.gt_u
-            (set_local $11
+            (set_local $10
               (i32.load
                 (i32.const 1220)
               )
             )
-            (get_local $0)
+            (get_local $18)
           )
           (block
             (i32.store
               (i32.const 1220)
-              (set_local $30
+              (set_local $32
                 (i32.sub
-                  (get_local $11)
-                  (get_local $0)
+                  (get_local $10)
+                  (get_local $18)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (set_local $8
+              (set_local $7
                 (i32.add
-                  (set_local $11
+                  (set_local $10
                     (i32.load
                       (i32.const 1232)
                     )
                   )
-                  (get_local $0)
+                  (get_local $18)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $8)
+              (get_local $7)
               (i32.or
-                (get_local $30)
+                (get_local $32)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $11)
+              (get_local $10)
               (i32.or
-                (get_local $0)
+                (get_local $18)
                 (i32.const 3)
               )
             )
             (i32.store
               (i32.const 8)
-              (get_local $25)
+              (get_local $31)
             )
             (return
               (i32.add
-                (get_local $11)
+                (get_local $10)
                 (i32.const 8)
               )
             )
@@ -5982,7 +6017,7 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $25)
+      (get_local $31)
     )
     (i32.const 0)
   )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -111,7 +111,7 @@
         (i32.const 16)
       )
     )
-    (set_local $4
+    (set_local $7
       (get_local $25)
     )
     (block $do-once$0
@@ -123,7 +123,7 @@
         (block
           (if
             (i32.and
-              (set_local $6
+              (set_local $5
                 (i32.shr_u
                   (set_local $2
                     (i32.load
@@ -156,11 +156,11 @@
               (i32.const 3)
             )
             (block
-              (set_local $4
+              (set_local $7
                 (i32.load
-                  (set_local $13
+                  (set_local $12
                     (i32.add
-                      (set_local $6
+                      (set_local $5
                         (i32.load
                           (set_local $14
                             (i32.add
@@ -173,7 +173,7 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -200,7 +200,7 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $4)
+                  (get_local $7)
                 )
                 (i32.store
                   (i32.const 1208)
@@ -218,7 +218,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $7)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -230,12 +230,12 @@
                       (i32.load
                         (set_local $8
                           (i32.add
-                            (get_local $4)
+                            (get_local $7)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $6)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
@@ -244,7 +244,7 @@
                       )
                       (i32.store
                         (get_local $14)
-                        (get_local $4)
+                        (get_local $7)
                       )
                     )
                     (call_import $qa)
@@ -252,9 +252,9 @@
                 )
               )
               (i32.store offset=4
-                (get_local $6)
+                (get_local $5)
                 (i32.or
-                  (set_local $4
+                  (set_local $7
                     (i32.shl
                       (get_local $0)
                       (i32.const 3)
@@ -267,8 +267,8 @@
                 (set_local $14
                   (i32.add
                     (i32.add
-                      (get_local $6)
-                      (get_local $4)
+                      (get_local $5)
+                      (get_local $7)
                     )
                     (i32.const 4)
                   )
@@ -285,7 +285,7 @@
                 (get_local $25)
               )
               (return
-                (get_local $13)
+                (get_local $12)
               )
             )
           )
@@ -300,22 +300,22 @@
             )
             (block
               (if
-                (get_local $6)
+                (get_local $5)
                 (block
                   (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (set_local $4
+                        (set_local $7
                           (i32.add
                             (i32.and
                               (set_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $6)
+                                    (get_local $5)
                                     (get_local $3)
                                   )
                                   (i32.or
-                                    (set_local $4
+                                    (set_local $7
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $3)
@@ -323,7 +323,7 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $4)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -347,25 +347,25 @@
                         (i32.add
                           (set_local $9
                             (i32.load
-                              (set_local $13
+                              (set_local $12
                                 (i32.add
-                                  (set_local $7
+                                  (set_local $6
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $20
+                                          (set_local $21
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $4
+                                                      (set_local $7
                                                         (i32.and
                                                           (i32.shr_u
                                                             (set_local $8
                                                               (i32.shr_u
-                                                                (get_local $4)
+                                                                (get_local $7)
                                                                 (get_local $1)
                                                               )
                                                             )
@@ -382,7 +382,7 @@
                                                           (set_local $9
                                                             (i32.shr_u
                                                               (get_local $8)
-                                                              (get_local $4)
+                                                              (get_local $7)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -394,7 +394,7 @@
                                                   (set_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $7
+                                                        (set_local $6
                                                           (i32.shr_u
                                                             (get_local $9)
                                                             (get_local $8)
@@ -406,12 +406,12 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $13
+                                                      (set_local $12
                                                         (i32.shr_u
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (get_local $9)
                                                         )
                                                       )
@@ -422,8 +422,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $13)
-                                                (get_local $7)
+                                                (get_local $12)
+                                                (get_local $6)
                                               )
                                             )
                                           )
@@ -445,7 +445,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $7)
+                      (get_local $6)
                       (get_local $1)
                     )
                     (block
@@ -456,7 +456,7 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $20)
+                              (get_local $21)
                             )
                             (i32.const -1)
                           )
@@ -479,7 +479,7 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $4
+                            (set_local $7
                               (i32.add
                                 (get_local $1)
                                 (i32.const 12)
@@ -490,11 +490,11 @@
                         )
                         (block
                           (i32.store
-                            (get_local $4)
                             (get_local $7)
+                            (get_local $6)
                           )
                           (i32.store
-                            (get_local $13)
+                            (get_local $12)
                             (get_local $1)
                           )
                           (set_local $33
@@ -515,7 +515,7 @@
                     )
                   )
                   (i32.store offset=4
-                    (set_local $13
+                    (set_local $12
                       (i32.add
                         (get_local $9)
                         (get_local $0)
@@ -525,7 +525,7 @@
                       (set_local $1
                         (i32.sub
                           (i32.shl
-                            (get_local $20)
+                            (get_local $21)
                             (i32.const 3)
                           )
                           (get_local $0)
@@ -536,7 +536,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $13)
+                      (get_local $12)
                       (get_local $1)
                     )
                     (get_local $1)
@@ -544,7 +544,7 @@
                   (if
                     (get_local $33)
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (i32.const 1228)
                         )
@@ -573,7 +573,7 @@
                               (i32.const 1208)
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.shl
                               (i32.const 1)
                               (get_local $14)
@@ -584,7 +584,7 @@
                           (i32.lt_u
                             (set_local $3
                               (i32.load
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (get_local $2)
                                     (i32.const 8)
@@ -599,7 +599,7 @@
                           (call_import $qa)
                           (block
                             (set_local $41
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (set_local $34
                               (get_local $3)
@@ -611,7 +611,7 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $3)
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                           (set_local $41
@@ -627,18 +627,18 @@
                       )
                       (i32.store
                         (get_local $41)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store offset=12
                         (get_local $34)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store offset=8
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -649,7 +649,7 @@
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $13)
+                    (get_local $12)
                   )
                   (i32.store
                     (i32.const 8)
@@ -661,22 +661,22 @@
                 )
               )
               (if
-                (set_local $13
+                (set_local $12
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $13
+                  (set_local $12
                     (i32.and
                       (i32.shr_u
                         (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $13)
+                              (get_local $12)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
                             (i32.const -1)
@@ -706,7 +706,7 @@
                                                   (set_local $2
                                                     (i32.shr_u
                                                       (get_local $1)
-                                                      (get_local $13)
+                                                      (get_local $12)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -714,12 +714,12 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $13)
+                                            (get_local $12)
                                           )
                                           (set_local $2
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $7
+                                                (set_local $6
                                                   (i32.shr_u
                                                     (get_local $2)
                                                     (get_local $1)
@@ -731,12 +731,12 @@
                                             )
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.and
                                             (i32.shr_u
                                               (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (get_local $2)
                                                 )
                                               )
@@ -749,10 +749,10 @@
                                       (set_local $3
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $6
+                                            (set_local $5
                                               (i32.shr_u
                                                 (get_local $3)
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                             )
                                             (i32.const 1)
@@ -762,7 +762,7 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $6)
+                                      (get_local $5)
                                       (get_local $3)
                                     )
                                   )
@@ -778,37 +778,37 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $6
+                  (set_local $5
                     (get_local $14)
                   )
-                  (set_local $7
+                  (set_local $6
                     (get_local $14)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
                       (set_local $14
                         (i32.load offset=16
-                          (get_local $6)
+                          (get_local $5)
                         )
                       )
-                      (set_local $4
+                      (set_local $7
                         (get_local $14)
                       )
                       (if
                         (set_local $2
                           (i32.load offset=20
-                            (get_local $6)
+                            (get_local $5)
                           )
                         )
-                        (set_local $4
+                        (set_local $7
                           (get_local $2)
                         )
                         (block
-                          (set_local $4
+                          (set_local $7
                             (get_local $3)
                           )
                           (set_local $1
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (br $while-out$6)
                         )
@@ -820,7 +820,7 @@
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $4)
+                                (get_local $7)
                               )
                               (i32.const -8)
                             )
@@ -837,13 +837,13 @@
                         (get_local $2)
                       )
                     )
-                    (set_local $6
-                      (get_local $4)
+                    (set_local $5
+                      (get_local $7)
                     )
-                    (set_local $7
+                    (set_local $6
                       (select
-                        (get_local $4)
                         (get_local $7)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -852,7 +852,7 @@
                   (if
                     (i32.lt_u
                       (get_local $1)
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (i32.const 1224)
                         )
@@ -863,7 +863,7 @@
                   (if
                     (i32.ge_u
                       (get_local $1)
-                      (set_local $6
+                      (set_local $5
                         (i32.add
                           (get_local $1)
                           (get_local $0)
@@ -889,7 +889,7 @@
                       )
                       (block
                         (if
-                          (set_local $20
+                          (set_local $21
                             (i32.load
                               (set_local $9
                                 (i32.add
@@ -901,7 +901,7 @@
                           )
                           (block
                             (set_local $14
-                              (get_local $20)
+                              (get_local $21)
                             )
                             (set_local $2
                               (get_local $9)
@@ -930,7 +930,7 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $20
+                            (set_local $21
                               (i32.load
                                 (set_local $9
                                   (i32.add
@@ -942,7 +942,7 @@
                             )
                             (block
                               (set_local $14
-                                (get_local $20)
+                                (get_local $21)
                               )
                               (set_local $2
                                 (get_local $9)
@@ -951,7 +951,7 @@
                             )
                           )
                           (if
-                            (set_local $20
+                            (set_local $21
                               (i32.load
                                 (set_local $9
                                   (i32.add
@@ -963,7 +963,7 @@
                             )
                             (block
                               (set_local $14
-                                (get_local $20)
+                                (get_local $21)
                               )
                               (set_local $2
                                 (get_local $9)
@@ -976,7 +976,7 @@
                         (if
                           (i32.lt_u
                             (get_local $2)
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (call_import $qa)
                           (block
@@ -998,14 +998,14 @@
                                 (get_local $1)
                               )
                             )
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $20
+                              (set_local $21
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
@@ -1030,7 +1030,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $20)
+                              (get_local $21)
                               (get_local $8)
                             )
                             (i32.store
@@ -1054,7 +1054,7 @@
                           (i32.eq
                             (get_local $1)
                             (i32.load
-                              (set_local $7
+                              (set_local $6
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
@@ -1071,7 +1071,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $23)
                             )
                             (if
@@ -1152,38 +1152,38 @@
                           (get_local $3)
                         )
                         (if
-                          (set_local $7
+                          (set_local $6
                             (i32.load offset=16
                               (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $8)
                             )
                             (call_import $qa)
                             (block
                               (i32.store offset=16
                                 (get_local $23)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $23)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $7
+                          (set_local $6
                             (i32.load offset=20
                               (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $7)
+                              (get_local $6)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1192,10 +1192,10 @@
                             (block
                               (i32.store offset=20
                                 (get_local $23)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $23)
                               )
                             )
@@ -1206,7 +1206,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
@@ -1215,7 +1215,7 @@
                         (i32.or
                           (set_local $3
                             (i32.add
-                              (get_local $4)
+                              (get_local $7)
                               (get_local $0)
                             )
                           )
@@ -1223,7 +1223,7 @@
                         )
                       )
                       (i32.store
-                        (set_local $7
+                        (set_local $6
                           (i32.add
                             (i32.add
                               (get_local $1)
@@ -1234,7 +1234,7 @@
                         )
                         (i32.or
                           (i32.load
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (i32.const 1)
                         )
@@ -1249,21 +1249,21 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $5)
                         (i32.or
-                          (get_local $4)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $6)
-                          (get_local $4)
+                          (get_local $5)
+                          (get_local $7)
                         )
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (if
-                        (set_local $7
+                        (set_local $6
                           (i32.load
                             (i32.const 1216)
                           )
@@ -1274,14 +1274,14 @@
                               (i32.const 1228)
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
                                   (set_local $8
                                     (i32.shr_u
-                                      (get_local $7)
+                                      (get_local $6)
                                       (i32.const 3)
                                     )
                                   )
@@ -1311,7 +1311,7 @@
                                   (i32.load
                                     (set_local $2
                                       (i32.add
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
@@ -1341,12 +1341,12 @@
                               )
                               (set_local $42
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $35
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
@@ -1364,17 +1364,17 @@
                           )
                           (i32.store offset=12
                             (get_local $3)
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $6)
+                        (get_local $5)
                       )
                     )
                   )
@@ -1406,7 +1406,7 @@
           (block
             (set_local $3
               (i32.and
-                (set_local $7
+                (set_local $6
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1430,7 +1430,7 @@
                 )
                 (block $label$break$a
                   (if
-                    (set_local $13
+                    (set_local $12
                       (i32.load
                         (i32.add
                           (i32.shl
@@ -1438,7 +1438,7 @@
                               (if
                                 (set_local $8
                                   (i32.shr_u
-                                    (get_local $7)
+                                    (get_local $6)
                                     (i32.const 8)
                                   )
                                 )
@@ -1453,7 +1453,7 @@
                                       (i32.shr_u
                                         (get_local $3)
                                         (i32.add
-                                          (set_local $13
+                                          (set_local $12
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
@@ -1463,10 +1463,10 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $20
+                                                            (set_local $21
                                                               (i32.shl
                                                                 (get_local $8)
-                                                                (set_local $7
+                                                                (set_local $6
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
@@ -1487,15 +1487,15 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
-                                                  (set_local $20
+                                                  (set_local $21
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
                                                           (set_local $14
                                                             (i32.shl
-                                                              (get_local $20)
+                                                              (get_local $21)
                                                               (get_local $8)
                                                             )
                                                           )
@@ -1511,7 +1511,7 @@
                                               (i32.shr_u
                                                 (i32.shl
                                                   (get_local $14)
-                                                  (get_local $20)
+                                                  (get_local $21)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1523,7 +1523,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $13)
+                                      (get_local $12)
                                       (i32.const 1)
                                     )
                                   )
@@ -1538,13 +1538,13 @@
                       )
                     )
                     (block
-                      (set_local $20
+                      (set_local $21
                         (get_local $2)
                       )
                       (set_local $14
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.shl
                           (get_local $3)
                           (select
@@ -1564,7 +1564,7 @@
                         )
                       )
                       (set_local $8
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (set_local $1
                         (i32.const 0)
@@ -1572,9 +1572,9 @@
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $6
+                            (set_local $5
                               (i32.sub
-                                (set_local $13
+                                (set_local $12
                                   (i32.and
                                     (i32.load offset=4
                                       (get_local $8)
@@ -1585,16 +1585,16 @@
                                 (get_local $3)
                               )
                             )
-                            (get_local $20)
+                            (get_local $21)
                           )
                           (if
                             (i32.eq
-                              (get_local $13)
+                              (get_local $12)
                               (get_local $3)
                             )
                             (block
                               (set_local $28
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (set_local $27
                                 (get_local $8)
@@ -1608,33 +1608,30 @@
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $2
-                                (get_local $6)
+                              (set_local $21
+                                (get_local $5)
                               )
                               (set_local $1
                                 (get_local $8)
                               )
                             )
                           )
-                          (set_local $2
-                            (get_local $20)
-                          )
                         )
-                        (set_local $13
+                        (set_local $12
                           (select
                             (get_local $14)
-                            (set_local $6
+                            (set_local $5
                               (i32.load offset=20
                                 (get_local $8)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (set_local $8
                                   (i32.load
                                     (i32.add
@@ -1644,7 +1641,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1657,7 +1654,7 @@
                           )
                         )
                         (if
-                          (set_local $6
+                          (set_local $5
                             (i32.eq
                               (get_local $8)
                               (i32.const 0)
@@ -1665,10 +1662,10 @@
                           )
                           (block
                             (set_local $36
-                              (get_local $2)
+                              (get_local $21)
                             )
                             (set_local $37
-                              (get_local $13)
+                              (get_local $12)
                             )
                             (set_local $32
                               (get_local $1)
@@ -1679,18 +1676,15 @@
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $20
-                              (get_local $2)
-                            )
                             (set_local $14
-                              (get_local $13)
+                              (get_local $12)
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.shl
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1743,7 +1737,7 @@
                                 (i32.and
                                   (get_local $9)
                                   (i32.or
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $0)
@@ -1751,7 +1745,7 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $13)
+                                      (get_local $12)
                                     )
                                   )
                                 )
@@ -1767,7 +1761,7 @@
                           (set_local $2
                             (i32.and
                               (i32.shr_u
-                                (set_local $13
+                                (set_local $12
                                   (i32.add
                                     (i32.and
                                       (get_local $2)
@@ -1792,12 +1786,12 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $13
+                                          (set_local $12
                                             (i32.and
                                               (i32.shr_u
                                                 (set_local $0
                                                   (i32.shr_u
-                                                    (get_local $13)
+                                                    (get_local $12)
                                                     (get_local $2)
                                                   )
                                                 )
@@ -1811,10 +1805,10 @@
                                         (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $6
+                                              (set_local $5
                                                 (i32.shr_u
                                                   (get_local $0)
-                                                  (get_local $13)
+                                                  (get_local $12)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1823,12 +1817,12 @@
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $5
                                         (i32.and
                                           (i32.shr_u
                                             (set_local $1
                                               (i32.shr_u
-                                                (get_local $6)
+                                                (get_local $5)
                                                 (get_local $0)
                                               )
                                             )
@@ -1841,10 +1835,10 @@
                                     (set_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.shr_u
                                               (get_local $1)
-                                              (get_local $6)
+                                              (get_local $5)
                                             )
                                           )
                                           (i32.const 1)
@@ -1854,7 +1848,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $1)
                                   )
                                 )
@@ -1900,7 +1894,7 @@
                     (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $7
+                    (set_local $6
                       (i32.lt_u
                         (set_local $1
                           (i32.sub
@@ -1916,32 +1910,32 @@
                         (get_local $28)
                       )
                     )
-                    (set_local $6
+                    (set_local $5
                       (select
                         (get_local $1)
                         (get_local $28)
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                     (set_local $1
                       (select
                         (get_local $27)
                         (get_local $31)
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                     (if
-                      (set_local $7
+                      (set_local $6
                         (i32.load offset=16
                           (get_local $27)
                         )
                       )
                       (block
                         (set_local $28
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $27
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (set_local $31
                           (get_local $1)
@@ -1957,7 +1951,7 @@
                       )
                       (block
                         (set_local $28
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $31
                           (get_local $1)
@@ -1965,7 +1959,7 @@
                       )
                       (block
                         (set_local $16
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $10
                           (get_local $1)
@@ -2012,7 +2006,7 @@
                         )
                         (call_import $qa)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.load offset=24
                           (get_local $10)
                         )
@@ -2020,7 +2014,7 @@
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $7
+                            (set_local $6
                               (i32.load offset=12
                                 (get_local $10)
                               )
@@ -2040,34 +2034,28 @@
                                 )
                               )
                               (block
-                                (set_local $4
+                                (set_local $14
                                   (get_local $2)
                                 )
-                                (set_local $14
+                                (set_local $12
                                   (get_local $0)
                                 )
                               )
                               (if
-                                (set_local $14
-                                  (i32.load
-                                    (set_local $13
-                                      (i32.add
-                                        (get_local $10)
-                                        (i32.const 16)
+                                (i32.eqz
+                                  (set_local $14
+                                    (i32.load
+                                      (set_local $12
+                                        (i32.add
+                                          (get_local $10)
+                                          (i32.const 16)
+                                        )
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
-                                    (get_local $14)
-                                  )
-                                  (set_local $14
-                                    (get_local $13)
-                                  )
-                                )
-                                (block
-                                  (set_local $22
+                                  (set_local $19
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
@@ -2080,17 +2068,17 @@
                                   (i32.load
                                     (set_local $0
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $14)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
+                                  (set_local $14
                                     (get_local $2)
                                   )
-                                  (set_local $14
+                                  (set_local $12
                                     (get_local $0)
                                   )
                                   (br $while-in$24)
@@ -2101,45 +2089,37 @@
                                   (i32.load
                                     (set_local $0
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $14)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
+                                  (set_local $14
                                     (get_local $2)
                                   )
-                                  (set_local $14
+                                  (set_local $12
                                     (get_local $0)
                                   )
                                 )
-                                (block
-                                  (set_local $0
-                                    (get_local $4)
-                                  )
-                                  (set_local $4
-                                    (get_local $14)
-                                  )
-                                  (br $while-out$23)
-                                )
+                                (br $while-out$23)
                               )
                               (br $while-in$24)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $4)
+                                (get_local $12)
                                 (get_local $9)
                               )
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $4)
+                                  (get_local $12)
                                   (i32.const 0)
                                 )
-                                (set_local $22
-                                  (get_local $0)
+                                (set_local $19
+                                  (get_local $14)
                                 )
                               )
                             )
@@ -2173,9 +2153,9 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $13
+                                  (set_local $12
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $6)
                                       (i32.const 8)
                                     )
                                   )
@@ -2185,14 +2165,14 @@
                               (block
                                 (i32.store
                                   (get_local $2)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.store
-                                  (get_local $13)
+                                  (get_local $12)
                                   (get_local $0)
                                 )
-                                (set_local $22
-                                  (get_local $7)
+                                (set_local $19
+                                  (get_local $6)
                                 )
                               )
                               (call_import $qa)
@@ -2202,7 +2182,7 @@
                       )
                       (block $do-once$25
                         (if
-                          (get_local $6)
+                          (get_local $5)
                           (block
                             (if
                               (i32.eq
@@ -2212,7 +2192,7 @@
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.load offset=28
                                             (get_local $10)
                                           )
@@ -2226,11 +2206,11 @@
                               (block
                                 (i32.store
                                   (get_local $9)
-                                  (get_local $22)
+                                  (get_local $19)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                   (block
                                     (i32.store
@@ -2242,7 +2222,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                           (i32.const -1)
                                         )
@@ -2255,7 +2235,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2265,9 +2245,9 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $5)
                                           (i32.const 16)
                                         )
                                       )
@@ -2275,25 +2255,25 @@
                                     (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $7)
-                                    (get_local $22)
+                                    (get_local $6)
+                                    (get_local $19)
                                   )
                                   (i32.store offset=20
-                                    (get_local $6)
-                                    (get_local $22)
+                                    (get_local $5)
+                                    (get_local $19)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $22)
-                                (set_local $7
+                                (get_local $19)
+                                (set_local $6
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2302,8 +2282,8 @@
                               (call_import $qa)
                             )
                             (i32.store offset=24
-                              (get_local $22)
-                              (get_local $6)
+                              (get_local $19)
+                              (get_local $5)
                             )
                             (if
                               (set_local $9
@@ -2314,17 +2294,17 @@
                               (if
                                 (i32.lt_u
                                   (get_local $9)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $22)
+                                    (get_local $19)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                 )
                               )
@@ -2345,12 +2325,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $22)
+                                    (get_local $19)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                 )
                               )
@@ -2368,7 +2348,7 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (get_local $16)
                                     (get_local $3)
@@ -2382,7 +2362,7 @@
                                 (i32.add
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                   (i32.const 4)
                                 )
@@ -2429,7 +2409,7 @@
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
@@ -2443,7 +2423,7 @@
                                 )
                                 (if
                                   (i32.and
-                                    (set_local $7
+                                    (set_local $6
                                       (i32.load
                                         (i32.const 1208)
                                       )
@@ -2457,11 +2437,11 @@
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.load
                                           (set_local $0
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.const 8)
                                             )
                                           )
@@ -2473,11 +2453,11 @@
                                     )
                                     (call_import $qa)
                                     (block
-                                      (set_local $17
+                                      (set_local $18
                                         (get_local $0)
                                       )
-                                      (set_local $12
-                                        (get_local $7)
+                                      (set_local $13
+                                        (get_local $6)
                                       )
                                     )
                                   )
@@ -2485,47 +2465,47 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $7)
+                                        (get_local $6)
                                         (get_local $0)
                                       )
                                     )
-                                    (set_local $17
+                                    (set_local $18
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $5)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $12
-                                      (get_local $6)
+                                    (set_local $13
+                                      (get_local $5)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $17)
+                                  (get_local $18)
                                   (get_local $1)
                                 )
                                 (i32.store offset=12
-                                  (get_local $12)
+                                  (get_local $13)
                                   (get_local $1)
                                 )
                                 (i32.store offset=8
                                   (get_local $1)
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                                 (i32.store offset=12
                                   (get_local $1)
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
                                   (set_local $2
                                     (if
-                                      (set_local $6
+                                      (set_local $5
                                         (i32.shr_u
                                           (get_local $16)
                                           (i32.const 8)
@@ -2542,24 +2522,24 @@
                                             (i32.shr_u
                                               (get_local $16)
                                               (i32.add
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $6
+                                                          (set_local $5
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
                                                                   (set_local $0
                                                                     (i32.shl
-                                                                      (get_local $6)
-                                                                      (set_local $7
+                                                                      (get_local $5)
+                                                                      (set_local $6
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $6)
+                                                                              (get_local $5)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2576,7 +2556,7 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                         )
                                                         (set_local $0
                                                           (i32.and
@@ -2585,7 +2565,7 @@
                                                                 (set_local $9
                                                                   (i32.shl
                                                                     (get_local $0)
-                                                                    (get_local $6)
+                                                                    (get_local $5)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2612,7 +2592,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $13)
+                                            (get_local $12)
                                             (i32.const 1)
                                           )
                                         )
@@ -2666,12 +2646,12 @@
                                   )
                                 )
                                 (i32.store
-                                  (get_local $13)
+                                  (get_local $12)
                                   (get_local $1)
                                 )
                                 (i32.store offset=24
                                   (get_local $1)
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                                 (i32.store offset=12
                                   (get_local $1)
@@ -2705,7 +2685,7 @@
                             )
                             (set_local $0
                               (i32.load
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -2720,7 +2700,7 @@
                                   (get_local $16)
                                 )
                                 (block
-                                  (set_local $15
+                                  (set_local $17
                                     (get_local $0)
                                   )
                                   (set_local $8
@@ -2730,9 +2710,9 @@
                                 )
                               )
                               (if
-                                (set_local $7
+                                (set_local $6
                                   (i32.load
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -2757,14 +2737,14 @@
                                     )
                                   )
                                   (set_local $0
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                 )
                                 (block
-                                  (set_local $21
-                                    (get_local $13)
+                                  (set_local $22
+                                    (get_local $12)
                                   )
-                                  (set_local $18
+                                  (set_local $15
                                     (get_local $0)
                                   )
                                   (set_local $8
@@ -2782,7 +2762,7 @@
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $21)
+                                  (get_local $22)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2790,12 +2770,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store
-                                    (get_local $21)
+                                    (get_local $22)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $18)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=12
                                     (get_local $1)
@@ -2819,21 +2799,21 @@
                                         (i32.load
                                           (set_local $0
                                             (i32.add
-                                              (get_local $15)
+                                              (get_local $17)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $15)
-                                      (get_local $7)
+                                      (get_local $17)
+                                      (get_local $6)
                                     )
                                   )
                                   (block
@@ -2851,7 +2831,7 @@
                                     )
                                     (i32.store offset=12
                                       (get_local $1)
-                                      (get_local $15)
+                                      (get_local $17)
                                     )
                                     (i32.store offset=24
                                       (get_local $1)
@@ -2903,14 +2883,14 @@
         (get_local $0)
       )
       (block
-        (set_local $18
+        (set_local $15
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (set_local $15
+            (set_local $17
               (i32.sub
                 (get_local $10)
                 (get_local $0)
@@ -2921,33 +2901,33 @@
           (block
             (i32.store
               (i32.const 1228)
-              (set_local $21
+              (set_local $22
                 (i32.add
-                  (get_local $18)
+                  (get_local $15)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $15)
+              (get_local $17)
             )
             (i32.store offset=4
-              (get_local $21)
+              (get_local $22)
               (i32.or
-                (get_local $15)
+                (get_local $17)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $21)
-                (get_local $15)
+                (get_local $22)
+                (get_local $17)
               )
-              (get_local $15)
+              (get_local $17)
             )
             (i32.store offset=4
-              (get_local $18)
+              (get_local $15)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -2964,17 +2944,17 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $18)
+              (get_local $15)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $15
+              (set_local $17
                 (i32.add
                   (i32.add
-                    (get_local $18)
+                    (get_local $15)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -2982,7 +2962,7 @@
               )
               (i32.or
                 (i32.load
-                  (get_local $15)
+                  (get_local $17)
                 )
                 (i32.const 1)
               )
@@ -2995,7 +2975,7 @@
         )
         (return
           (i32.add
-            (get_local $18)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3003,7 +2983,7 @@
     )
     (if
       (i32.gt_u
-        (set_local $18
+        (set_local $15
           (i32.load
             (i32.const 1220)
           )
@@ -3013,9 +2993,9 @@
       (block
         (i32.store
           (i32.const 1220)
-          (set_local $15
+          (set_local $17
             (i32.sub
-              (get_local $18)
+              (get_local $15)
               (get_local $0)
             )
           )
@@ -3024,7 +3004,7 @@
           (i32.const 1232)
           (set_local $10
             (i32.add
-              (set_local $18
+              (set_local $15
                 (i32.load
                   (i32.const 1232)
                 )
@@ -3036,12 +3016,12 @@
         (i32.store offset=4
           (get_local $10)
           (i32.or
-            (get_local $15)
+            (get_local $17)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $18)
+          (get_local $15)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -3053,7 +3033,7 @@
         )
         (return
           (i32.add
-            (get_local $18)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3091,11 +3071,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $4)
-          (set_local $18
+          (get_local $7)
+          (set_local $15
             (i32.xor
               (i32.and
-                (get_local $4)
+                (get_local $7)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3104,11 +3084,11 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $18)
+          (get_local $15)
         )
       )
     )
-    (set_local $18
+    (set_local $15
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -3116,16 +3096,16 @@
     )
     (if
       (i32.le_u
-        (set_local $4
+        (set_local $7
           (i32.and
             (set_local $10
               (i32.add
-                (set_local $4
+                (set_local $7
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (set_local $15
+                (set_local $17
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -3133,10 +3113,10 @@
                 )
               )
             )
-            (set_local $21
+            (set_local $22
               (i32.sub
                 (i32.const 0)
-                (get_local $4)
+                (get_local $7)
               )
             )
           )
@@ -3162,20 +3142,20 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $12
+            (set_local $13
               (i32.add
                 (set_local $2
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $4)
+                (get_local $7)
               )
             )
             (get_local $2)
           )
           (i32.gt_u
-            (get_local $12)
+            (get_local $13)
             (get_local $16)
           )
         )
@@ -3211,7 +3191,7 @@
                       )
                     )
                     (block
-                      (set_local $12
+                      (set_local $13
                         (i32.const 1656)
                       )
                       (loop $while-out$35 $while-in$36
@@ -3219,7 +3199,7 @@
                           (i32.le_u
                             (set_local $2
                               (i32.load
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
                             (get_local $16)
@@ -3229,9 +3209,9 @@
                               (i32.add
                                 (get_local $2)
                                 (i32.load
-                                  (set_local $17
+                                  (set_local $18
                                     (i32.add
-                                      (get_local $12)
+                                      (get_local $13)
                                       (i32.const 4)
                                     )
                                   )
@@ -3241,10 +3221,10 @@
                             )
                             (block
                               (set_local $3
-                                (get_local $12)
+                                (get_local $13)
                               )
-                              (set_local $6
-                                (get_local $17)
+                              (set_local $5
+                                (get_local $18)
                               )
                               (br $while-out$35)
                             )
@@ -3252,9 +3232,9 @@
                         )
                         (if
                           (i32.eqz
-                            (set_local $12
+                            (set_local $13
                               (i32.load offset=8
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
                           )
@@ -3269,7 +3249,7 @@
                       )
                       (if
                         (i32.lt_u
-                          (set_local $12
+                          (set_local $13
                             (i32.and
                               (i32.sub
                                 (get_local $10)
@@ -3277,16 +3257,16 @@
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $21)
+                              (get_local $22)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $17
+                            (set_local $18
                               (call_import $ta
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
                             (i32.add
@@ -3294,21 +3274,21 @@
                                 (get_local $3)
                               )
                               (i32.load
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $17)
+                              (get_local $18)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $19
-                                (get_local $17)
+                              (set_local $20
+                                (get_local $18)
                               )
                               (set_local $26
-                                (get_local $12)
+                                (get_local $13)
                               )
                               (br $label$break$b
                                 (i32.const 191)
@@ -3317,10 +3297,10 @@
                           )
                           (block
                             (set_local $11
-                              (get_local $17)
+                              (get_local $18)
                             )
-                            (set_local $5
-                              (get_local $12)
+                            (set_local $4
+                              (get_local $13)
                             )
                             (set_local $8
                               (i32.const 181)
@@ -3353,9 +3333,9 @@
                         (set_local $2
                           (if
                             (i32.and
-                              (set_local $17
+                              (set_local $18
                                 (i32.add
-                                  (set_local $12
+                                  (set_local $13
                                     (i32.load
                                       (i32.const 1684)
                                     )
@@ -3369,26 +3349,26 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $4)
+                                (get_local $7)
                                 (get_local $3)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $17)
+                                  (get_local $18)
                                   (get_local $3)
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                             )
-                            (get_local $4)
+                            (get_local $7)
                           )
                         )
                         (set_local $3
                           (i32.add
-                            (set_local $12
+                            (set_local $13
                               (i32.load
                                 (i32.const 1640)
                               )
@@ -3409,7 +3389,7 @@
                           )
                           (block
                             (if
-                              (set_local $17
+                              (set_local $18
                                 (i32.load
                                   (i32.const 1648)
                                 )
@@ -3418,18 +3398,18 @@
                                 (i32.or
                                   (i32.le_u
                                     (get_local $3)
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.gt_u
                                     (get_local $3)
-                                    (get_local $17)
+                                    (get_local $18)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $17
+                                (set_local $18
                                   (call_import $ta
                                     (get_local $2)
                                   )
@@ -3437,7 +3417,7 @@
                                 (get_local $16)
                               )
                               (block
-                                (set_local $19
+                                (set_local $20
                                   (get_local $16)
                                 )
                                 (set_local $26
@@ -3449,9 +3429,9 @@
                               )
                               (block
                                 (set_local $11
-                                  (get_local $17)
+                                  (get_local $18)
                                 )
-                                (set_local $5
+                                (set_local $4
                                   (get_local $2)
                                 )
                                 (set_local $8
@@ -3472,21 +3452,21 @@
                       (i32.const 181)
                     )
                     (block
-                      (set_local $17
+                      (set_local $18
                         (i32.sub
                           (i32.const 0)
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $18)
-                            (get_local $5)
+                            (get_local $15)
+                            (get_local $4)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -3501,8 +3481,8 @@
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $15)
-                                    (get_local $5)
+                                    (get_local $17)
+                                    (get_local $4)
                                   )
                                   (set_local $16
                                     (i32.load
@@ -3527,23 +3507,23 @@
                             )
                             (block
                               (call_import $ta
-                                (get_local $17)
+                                (get_local $18)
                               )
                               (br $label$break$d)
                             )
                             (set_local $1
                               (i32.add
                                 (get_local $3)
-                                (get_local $5)
+                                (get_local $4)
                               )
                             )
                           )
                           (set_local $1
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (set_local $1
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                       (if
@@ -3552,7 +3532,7 @@
                           (i32.const -1)
                         )
                         (block
-                          (set_local $19
+                          (set_local $20
                             (get_local $11)
                           )
                           (set_local $26
@@ -3584,7 +3564,7 @@
       )
       (if
         (i32.lt_u
-          (get_local $4)
+          (get_local $7)
           (i32.const 2147483647)
         )
         (if
@@ -3592,10 +3572,10 @@
             (i32.lt_u
               (set_local $1
                 (call_import $ta
-                  (get_local $4)
+                  (get_local $7)
                 )
               )
-              (set_local $4
+              (set_local $7
                 (call_import $ta
                   (i32.const 0)
                 )
@@ -3607,7 +3587,7 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $4)
+                (get_local $7)
                 (i32.const -1)
               )
             )
@@ -3616,7 +3596,7 @@
             (i32.gt_u
               (set_local $11
                 (i32.sub
-                  (get_local $4)
+                  (get_local $7)
                   (get_local $1)
                 )
               )
@@ -3626,7 +3606,7 @@
               )
             )
             (block
-              (set_local $19
+              (set_local $20
                 (get_local $1)
               )
               (set_local $26
@@ -3677,24 +3657,24 @@
               )
             )
             (block
-              (set_local $5
+              (set_local $4
                 (i32.const 1656)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $19)
+                    (get_local $20)
                     (i32.add
                       (set_local $1
                         (i32.load
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
-                      (set_local $15
+                      (set_local $17
                         (i32.load
-                          (set_local $4
+                          (set_local $7
                             (i32.add
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 4)
                             )
                           )
@@ -3707,13 +3687,13 @@
                       (get_local $1)
                     )
                     (set_local $50
-                      (get_local $4)
+                      (get_local $7)
                     )
                     (set_local $51
-                      (get_local $15)
+                      (get_local $17)
                     )
                     (set_local $52
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (set_local $8
                       (i32.const 201)
@@ -3723,9 +3703,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $5
+                    (set_local $4
                       (i32.load offset=8
-                        (get_local $5)
+                        (get_local $4)
                       )
                     )
                     (i32.const 0)
@@ -3750,7 +3730,7 @@
                     (i32.and
                       (i32.lt_u
                         (get_local $11)
-                        (get_local $19)
+                        (get_local $20)
                       )
                       (i32.ge_u
                         (get_local $11)
@@ -3765,16 +3745,16 @@
                           (get_local $26)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
                           (get_local $11)
-                          (set_local $15
+                          (set_local $17
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (set_local $5
+                                  (set_local $4
                                     (i32.add
                                       (get_local $11)
                                       (i32.const 8)
@@ -3785,7 +3765,7 @@
                               )
                               (i32.eq
                                 (i32.and
-                                  (get_local $5)
+                                  (get_local $4)
                                   (i32.const 7)
                                 )
                                 (i32.const 0)
@@ -3794,11 +3774,11 @@
                           )
                         )
                       )
-                      (set_local $4
+                      (set_local $7
                         (i32.add
                           (i32.sub
                             (get_local $26)
-                            (get_local $15)
+                            (get_local $17)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3807,23 +3787,23 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $5)
+                        (get_local $4)
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $4)
                         (i32.or
-                          (get_local $4)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $5)
                           (get_local $4)
+                          (get_local $7)
                         )
                         (i32.const 40)
                       )
@@ -3841,8 +3821,8 @@
               (set_local $14
                 (if
                   (i32.lt_u
-                    (get_local $19)
-                    (set_local $4
+                    (get_local $20)
+                    (set_local $7
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3851,36 +3831,36 @@
                   (block
                     (i32.store
                       (i32.const 1224)
-                      (get_local $19)
+                      (get_local $20)
                     )
-                    (get_local $19)
+                    (get_local $20)
                   )
-                  (get_local $4)
+                  (get_local $7)
                 )
               )
-              (set_local $4
+              (set_local $7
                 (i32.add
-                  (get_local $19)
+                  (get_local $20)
                   (get_local $26)
                 )
               )
-              (set_local $5
+              (set_local $4
                 (i32.const 1656)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $5)
+                      (get_local $4)
                     )
-                    (get_local $4)
+                    (get_local $7)
                   )
                   (block
                     (set_local $53
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (set_local $43
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (set_local $8
                       (i32.const 209)
@@ -3890,9 +3870,9 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $5
+                    (set_local $4
                       (i32.load offset=8
-                        (get_local $5)
+                        (get_local $4)
                       )
                     )
                   )
@@ -3923,10 +3903,10 @@
                   (block
                     (i32.store
                       (get_local $53)
-                      (get_local $19)
+                      (get_local $20)
                     )
                     (i32.store
-                      (set_local $5
+                      (set_local $4
                         (i32.add
                           (get_local $43)
                           (i32.const 4)
@@ -3934,22 +3914,22 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $5)
+                          (get_local $4)
                         )
                         (get_local $26)
                       )
                     )
-                    (set_local $15
+                    (set_local $17
                       (i32.add
-                        (get_local $19)
+                        (get_local $20)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $5
+                              (set_local $4
                                 (i32.add
-                                  (get_local $19)
+                                  (get_local $20)
                                   (i32.const 8)
                                 )
                               )
@@ -3958,7 +3938,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3968,15 +3948,15 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $7)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $5
+                              (set_local $4
                                 (i32.add
-                                  (get_local $4)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
@@ -3985,7 +3965,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3993,23 +3973,23 @@
                         )
                       )
                     )
-                    (set_local $5
+                    (set_local $4
                       (i32.add
-                        (get_local $15)
+                        (get_local $17)
                         (get_local $0)
                       )
                     )
-                    (set_local $18
+                    (set_local $15
                       (i32.sub
                         (i32.sub
                           (get_local $1)
-                          (get_local $15)
+                          (get_local $17)
                         )
                         (get_local $0)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $15)
+                      (get_local $17)
                       (i32.or
                         (get_local $0)
                         (i32.const 3)
@@ -4029,16 +4009,16 @@
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $18)
+                                (get_local $15)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=4
-                            (get_local $5)
+                            (get_local $4)
                             (i32.or
                               (get_local $2)
                               (i32.const 1)
@@ -4061,16 +4041,16 @@
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $18)
+                                    (get_local $15)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=4
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.or
                                   (get_local $2)
                                   (i32.const 1)
@@ -4078,7 +4058,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $4)
                                   (get_local $2)
                                 )
                                 (get_local $2)
@@ -4102,7 +4082,7 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $6
+                                    (set_local $5
                                       (i32.and
                                         (get_local $2)
                                         (i32.const -8)
@@ -4129,12 +4109,12 @@
                                           (block $do-once$53
                                             (if
                                               (i32.ne
-                                                (set_local $21
+                                                (set_local $22
                                                   (i32.load offset=8
                                                     (get_local $1)
                                                   )
                                                 )
-                                                (set_local $17
+                                                (set_local $18
                                                   (i32.add
                                                     (i32.const 1248)
                                                     (i32.shl
@@ -4150,7 +4130,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $21)
+                                                    (get_local $22)
                                                     (get_local $14)
                                                   )
                                                   (call_import $qa)
@@ -4158,7 +4138,7 @@
                                                 (br_if $do-once$53
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $21)
+                                                      (get_local $22)
                                                     )
                                                     (get_local $1)
                                                   )
@@ -4170,7 +4150,7 @@
                                           (if
                                             (i32.eq
                                               (get_local $10)
-                                              (get_local $21)
+                                              (get_local $22)
                                             )
                                             (block
                                               (i32.store
@@ -4195,7 +4175,7 @@
                                             (if
                                               (i32.eq
                                                 (get_local $10)
-                                                (get_local $17)
+                                                (get_local $18)
                                               )
                                               (set_local $44
                                                 (i32.add
@@ -4235,16 +4215,16 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $21)
+                                            (get_local $22)
                                             (get_local $10)
                                           )
                                           (i32.store
                                             (get_local $44)
-                                            (get_local $21)
+                                            (get_local $22)
                                           )
                                         )
                                         (block
-                                          (set_local $17
+                                          (set_local $18
                                             (i32.load offset=24
                                               (get_local $1)
                                             )
@@ -4263,7 +4243,7 @@
                                                 (if
                                                   (set_local $2
                                                     (i32.load
-                                                      (set_local $12
+                                                      (set_local $13
                                                         (i32.add
                                                           (set_local $16
                                                             (i32.add
@@ -4277,25 +4257,19 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $0
+                                                    (set_local $19
                                                       (get_local $2)
                                                     )
-                                                    (set_local $4
-                                                      (get_local $12)
+                                                    (set_local $16
+                                                      (get_local $13)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $22
-                                                      (i32.load
-                                                        (get_local $16)
-                                                      )
-                                                    )
-                                                    (block
-                                                      (set_local $0
-                                                        (get_local $22)
-                                                      )
-                                                      (set_local $4
-                                                        (get_local $16)
+                                                    (i32.eqz
+                                                      (set_local $19
+                                                        (i32.load
+                                                          (get_local $16)
+                                                        )
                                                       )
                                                     )
                                                     (block
@@ -4310,20 +4284,20 @@
                                                   (if
                                                     (set_local $2
                                                       (i32.load
-                                                        (set_local $12
+                                                        (set_local $13
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $19)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
+                                                      (set_local $19
                                                         (get_local $2)
                                                       )
-                                                      (set_local $4
-                                                        (get_local $12)
+                                                      (set_local $16
+                                                        (get_local $13)
                                                       )
                                                       (br $while-in$60)
                                                     )
@@ -4331,20 +4305,20 @@
                                                   (if
                                                     (set_local $2
                                                       (i32.load
-                                                        (set_local $12
+                                                        (set_local $13
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $19)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
+                                                      (set_local $19
                                                         (get_local $2)
                                                       )
-                                                      (set_local $4
-                                                        (get_local $12)
+                                                      (set_local $16
+                                                        (get_local $13)
                                                       )
                                                     )
                                                     (br $while-out$59)
@@ -4353,17 +4327,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $4)
+                                                    (get_local $16)
                                                     (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $4)
+                                                      (get_local $16)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $19)
                                                     )
                                                   )
                                                 )
@@ -4371,7 +4345,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (set_local $12
+                                                    (set_local $13
                                                       (i32.load offset=8
                                                         (get_local $1)
                                                       )
@@ -4385,7 +4359,7 @@
                                                     (i32.load
                                                       (set_local $2
                                                         (i32.add
-                                                          (get_local $12)
+                                                          (get_local $13)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -4413,7 +4387,7 @@
                                                     )
                                                     (i32.store
                                                       (get_local $16)
-                                                      (get_local $12)
+                                                      (get_local $13)
                                                     )
                                                     (set_local $24
                                                       (get_local $3)
@@ -4426,7 +4400,7 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (get_local $17)
+                                              (get_local $18)
                                             )
                                           )
                                           (block $do-once$61
@@ -4434,7 +4408,7 @@
                                               (i32.eq
                                                 (get_local $1)
                                                 (i32.load
-                                                  (set_local $21
+                                                  (set_local $22
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
@@ -4451,7 +4425,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once$61
@@ -4477,7 +4451,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $17)
+                                                    (get_local $18)
                                                     (i32.load
                                                       (i32.const 1224)
                                                     )
@@ -4489,7 +4463,7 @@
                                                     (i32.load
                                                       (set_local $10
                                                         (i32.add
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                           (i32.const 16)
                                                         )
                                                       )
@@ -4501,7 +4475,7 @@
                                                     (get_local $24)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $17)
+                                                    (get_local $18)
                                                     (get_local $24)
                                                   )
                                                 )
@@ -4526,12 +4500,12 @@
                                           )
                                           (i32.store offset=24
                                             (get_local $24)
-                                            (get_local $17)
+                                            (get_local $18)
                                           )
                                           (if
                                             (set_local $10
                                               (i32.load
-                                                (set_local $21
+                                                (set_local $22
                                                   (i32.add
                                                     (get_local $1)
                                                     (i32.const 16)
@@ -4561,7 +4535,7 @@
                                             (i32.eqz
                                               (set_local $10
                                                 (i32.load offset=4
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                 )
                                               )
                                             )
@@ -4588,23 +4562,18 @@
                                         )
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $15
                                       (i32.add
-                                        (get_local $6)
-                                        (get_local $18)
+                                        (get_local $5)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.add
                                       (get_local $1)
-                                      (get_local $6)
+                                      (get_local $5)
                                     )
                                   )
-                                  (block
-                                    (set_local $0
-                                      (get_local $18)
-                                    )
-                                    (get_local $1)
-                                  )
+                                  (get_local $1)
                                 )
                                 (i32.const 4)
                               )
@@ -4617,28 +4586,28 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $5)
+                            (get_local $4)
                             (i32.or
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $5)
-                              (get_local $0)
+                              (get_local $4)
+                              (get_local $15)
                             )
-                            (get_local $0)
+                            (get_local $15)
                           )
                           (set_local $3
                             (i32.shr_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 256)
                             )
                             (block
@@ -4672,7 +4641,7 @@
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $17
+                                        (set_local $18
                                           (i32.load
                                             (set_local $3
                                               (i32.add
@@ -4691,7 +4660,7 @@
                                           (get_local $3)
                                         )
                                         (set_local $38
-                                          (get_local $17)
+                                          (get_local $18)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4720,18 +4689,18 @@
                               )
                               (i32.store
                                 (get_local $45)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=12
                                 (get_local $38)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $5)
+                                (get_local $4)
                                 (get_local $38)
                               )
                               (i32.store offset=12
-                                (get_local $5)
+                                (get_local $4)
                                 (get_local $2)
                               )
                               (br $do-once$50)
@@ -4741,12 +4710,12 @@
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
-                                (set_local $4
+                                (set_local $0
                                   (block $do-once$67
                                     (if
                                       (set_local $3
                                         (i32.shr_u
-                                          (get_local $0)
+                                          (get_local $15)
                                           (i32.const 8)
                                         )
                                       )
@@ -4754,26 +4723,26 @@
                                         (br_if $do-once$67
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $0)
+                                            (get_local $15)
                                             (i32.const 16777215)
                                           )
                                         )
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $0)
+                                              (get_local $15)
                                               (i32.add
-                                                (set_local $12
+                                                (set_local $13
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $17
+                                                          (set_local $18
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $6
+                                                                  (set_local $5
                                                                     (i32.shl
                                                                       (get_local $3)
                                                                       (set_local $10
@@ -4799,14 +4768,14 @@
                                                           )
                                                           (get_local $10)
                                                         )
-                                                        (set_local $6
+                                                        (set_local $5
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (set_local $3
                                                                   (i32.shl
-                                                                    (get_local $6)
-                                                                    (get_local $17)
+                                                                    (get_local $5)
+                                                                    (get_local $18)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4821,7 +4790,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $3)
-                                                        (get_local $6)
+                                                        (get_local $5)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4833,7 +4802,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $12)
+                                            (get_local $13)
                                             (i32.const 1)
                                           )
                                         )
@@ -4847,13 +4816,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $5)
                             (get_local $4)
+                            (get_local $0)
                           )
                           (i32.store offset=4
                             (set_local $2
                               (i32.add
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
@@ -4871,10 +4840,10 @@
                                     (i32.const 1212)
                                   )
                                 )
-                                (set_local $12
+                                (set_local $13
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $4)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -4884,42 +4853,42 @@
                                 (i32.const 1212)
                                 (i32.or
                                   (get_local $2)
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                               (i32.store
                                 (get_local $3)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=24
-                                (get_local $5)
+                                (get_local $4)
                                 (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $5)
-                                (get_local $5)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $5)
-                                (get_local $5)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $12
+                          (set_local $13
                             (i32.shl
-                              (get_local $0)
+                              (get_local $15)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $4)
+                                  (get_local $0)
                                   (i32.const 31)
                                 )
                               )
@@ -4939,7 +4908,7 @@
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $0)
+                                (get_local $15)
                               )
                               (block
                                 (set_local $39
@@ -4952,7 +4921,7 @@
                               )
                             )
                             (if
-                              (set_local $6
+                              (set_local $5
                                 (i32.load
                                   (set_local $3
                                     (i32.add
@@ -4962,7 +4931,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $12)
+                                          (get_local $13)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -4972,14 +4941,14 @@
                                 )
                               )
                               (block
-                                (set_local $12
+                                (set_local $13
                                   (i32.shl
-                                    (get_local $12)
+                                    (get_local $13)
                                     (i32.const 1)
                                   )
                                 )
                                 (set_local $2
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                               )
                               (block
@@ -5013,19 +4982,19 @@
                               (block
                                 (i32.store
                                   (get_local $46)
-                                  (get_local $5)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=24
-                                  (get_local $5)
+                                  (get_local $4)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=8
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                               )
                             )
@@ -5037,7 +5006,7 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.load
                                         (set_local $2
                                           (i32.add
@@ -5047,7 +5016,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $5
                                       (i32.load
                                         (i32.const 1224)
                                       )
@@ -5055,28 +5024,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $39)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $12)
-                                    (get_local $5)
+                                    (get_local $13)
+                                    (get_local $4)
                                   )
                                   (i32.store
                                     (get_local $2)
-                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                   (i32.store offset=8
-                                    (get_local $5)
-                                    (get_local $12)
+                                    (get_local $4)
+                                    (get_local $13)
                                   )
                                   (i32.store offset=12
-                                    (get_local $5)
+                                    (get_local $4)
                                     (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.const 0)
                                   )
                                 )
@@ -5093,7 +5062,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $15)
+                        (get_local $17)
                         (i32.const 8)
                       )
                     )
@@ -5103,7 +5072,7 @@
               (loop $while-out$71 $while-in$72
                 (if
                   (i32.le_u
-                    (set_local $5
+                    (set_local $4
                       (i32.load
                         (get_local $29)
                       )
@@ -5112,9 +5081,9 @@
                   )
                   (if
                     (i32.gt_u
-                      (set_local $18
+                      (set_local $15
                         (i32.add
-                          (get_local $5)
+                          (get_local $4)
                           (i32.load offset=4
                             (get_local $29)
                           )
@@ -5124,7 +5093,7 @@
                     )
                     (block
                       (set_local $3
-                        (get_local $18)
+                        (get_local $15)
                       )
                       (br $while-out$71)
                     )
@@ -5137,9 +5106,9 @@
                 )
                 (br $while-in$72)
               )
-              (set_local $18
+              (set_local $15
                 (i32.add
-                  (set_local $15
+                  (set_local $17
                     (i32.add
                       (get_local $3)
                       (i32.const -47)
@@ -5148,26 +5117,26 @@
                   (i32.const 8)
                 )
               )
-              (set_local $5
+              (set_local $4
                 (i32.add
-                  (set_local $15
+                  (set_local $17
                     (select
                       (get_local $11)
-                      (set_local $5
+                      (set_local $4
                         (i32.add
-                          (get_local $15)
+                          (get_local $17)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $18)
+                                (get_local $15)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $18)
+                                (get_local $15)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5176,8 +5145,8 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $5)
-                        (set_local $18
+                        (get_local $4)
+                        (set_local $15
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
@@ -5193,8 +5162,8 @@
                 (i32.const 1232)
                 (set_local $1
                   (i32.add
-                    (get_local $19)
-                    (set_local $4
+                    (get_local $20)
+                    (set_local $7
                       (select
                         (i32.const 0)
                         (i32.and
@@ -5202,7 +5171,7 @@
                             (i32.const 0)
                             (set_local $1
                               (i32.add
-                                (get_local $19)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5223,27 +5192,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $12
+                (set_local $13
                   (i32.sub
                     (i32.add
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $4)
+                    (get_local $7)
                   )
                 )
               )
               (i32.store offset=4
                 (get_local $1)
                 (i32.or
-                  (get_local $12)
+                  (get_local $13)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $1)
-                  (get_local $12)
+                  (get_local $13)
                 )
                 (i32.const 40)
               )
@@ -5254,41 +5223,41 @@
                 )
               )
               (i32.store
-                (set_local $12
+                (set_local $13
                   (i32.add
-                    (get_local $15)
+                    (get_local $17)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1668)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $19)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 1660)
@@ -5300,19 +5269,19 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $5)
+                (get_local $4)
               )
-              (set_local $5
+              (set_local $4
                 (i32.add
-                  (get_local $15)
+                  (get_local $17)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $5
+                  (set_local $4
                     (i32.add
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 4)
                     )
                   )
@@ -5321,7 +5290,7 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 4)
                     )
                     (get_local $3)
@@ -5330,15 +5299,15 @@
               )
               (if
                 (i32.ne
-                  (get_local $15)
+                  (get_local $17)
                   (get_local $11)
                 )
                 (block
                   (i32.store
-                    (get_local $12)
+                    (get_local $13)
                     (i32.and
                       (i32.load
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.const -2)
                     )
@@ -5346,9 +5315,9 @@
                   (i32.store offset=4
                     (get_local $11)
                     (i32.or
-                      (set_local $5
+                      (set_local $4
                         (i32.sub
-                          (get_local $15)
+                          (get_local $17)
                           (get_local $11)
                         )
                       )
@@ -5356,22 +5325,22 @@
                     )
                   )
                   (i32.store
-                    (get_local $15)
-                    (get_local $5)
+                    (get_local $17)
+                    (get_local $4)
                   )
                   (set_local $1
                     (i32.shr_u
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $4
+                      (set_local $7
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
@@ -5390,7 +5359,7 @@
                               (i32.const 1208)
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.shl
                               (i32.const 1)
                               (get_local $1)
@@ -5401,9 +5370,9 @@
                           (i32.lt_u
                             (set_local $2
                               (i32.load
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
@@ -5416,7 +5385,7 @@
                           (call_import $qa)
                           (block
                             (set_local $47
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (set_local $40
                               (get_local $2)
@@ -5428,17 +5397,17 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $2)
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                           (set_local $47
                             (i32.add
-                              (get_local $4)
+                              (get_local $7)
                               (i32.const 8)
                             )
                           )
                           (set_local $40
-                            (get_local $4)
+                            (get_local $7)
                           )
                         )
                       )
@@ -5456,7 +5425,7 @@
                       )
                       (i32.store offset=12
                         (get_local $11)
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (br $do-once$42)
                     )
@@ -5465,24 +5434,24 @@
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (set_local $4
+                        (set_local $7
                           (if
-                            (set_local $4
+                            (set_local $7
                               (i32.shr_u
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.add
                                       (set_local $3
                                         (i32.add
@@ -5490,18 +5459,18 @@
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $4
+                                                (set_local $7
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $6
+                                                        (set_local $5
                                                           (i32.shl
-                                                            (get_local $4)
+                                                            (get_local $7)
                                                             (set_local $2
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $4)
+                                                                    (get_local $7)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5520,14 +5489,14 @@
                                                 )
                                                 (get_local $2)
                                               )
-                                              (set_local $6
+                                              (set_local $5
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
                                                       (set_local $1
                                                         (i32.shl
-                                                          (get_local $6)
-                                                          (get_local $4)
+                                                          (get_local $5)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5542,7 +5511,7 @@
                                           (i32.shr_u
                                             (i32.shl
                                               (get_local $1)
-                                              (get_local $6)
+                                              (get_local $5)
                                             )
                                             (i32.const 15)
                                           )
@@ -5568,20 +5537,20 @@
                   )
                   (i32.store offset=28
                     (get_local $11)
-                    (get_local $4)
+                    (get_local $7)
                   )
                   (i32.store offset=20
                     (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $18)
+                    (get_local $15)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $6
+                        (set_local $5
                           (i32.load
                             (i32.const 1212)
                           )
@@ -5589,7 +5558,7 @@
                         (set_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $4)
+                            (get_local $7)
                           )
                         )
                       )
@@ -5598,7 +5567,7 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $6)
+                          (get_local $5)
                           (get_local $1)
                         )
                       )
@@ -5623,24 +5592,24 @@
                   )
                   (set_local $1
                     (i32.shl
-                      (get_local $5)
+                      (get_local $4)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $4)
+                            (get_local $7)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $4)
+                          (get_local $7)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $6
+                  (set_local $5
                     (i32.load
                       (get_local $3)
                     )
@@ -5650,15 +5619,15 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $6)
+                            (get_local $5)
                           )
                           (i32.const -8)
                         )
-                        (get_local $5)
+                        (get_local $4)
                       )
                       (block
                         (set_local $30
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $8
                           (i32.const 305)
@@ -5672,7 +5641,7 @@
                           (set_local $3
                             (i32.add
                               (i32.add
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                               (i32.shl
@@ -5693,7 +5662,7 @@
                             (i32.const 1)
                           )
                         )
-                        (set_local $6
+                        (set_local $5
                           (get_local $2)
                         )
                       )
@@ -5702,7 +5671,7 @@
                           (get_local $3)
                         )
                         (set_local $55
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $8
                           (i32.const 302)
@@ -5754,7 +5723,7 @@
                           (i32.ge_u
                             (set_local $1
                               (i32.load
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (get_local $30)
                                     (i32.const 8)
@@ -5762,7 +5731,7 @@
                                 )
                               )
                             )
-                            (set_local $5
+                            (set_local $4
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -5770,7 +5739,7 @@
                           )
                           (i32.ge_u
                             (get_local $30)
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (block
@@ -5779,7 +5748,7 @@
                             (get_local $11)
                           )
                           (i32.store
-                            (get_local $6)
+                            (get_local $5)
                             (get_local $11)
                           )
                           (i32.store offset=8
@@ -5814,18 +5783,18 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $19)
+                    (get_local $20)
                     (get_local $1)
                   )
                 )
                 (i32.store
                   (i32.const 1224)
-                  (get_local $19)
+                  (get_local $20)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $19)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 1660)
@@ -5850,7 +5819,7 @@
               )
               (loop $do-out$44 $do-in$45
                 (i32.store offset=12
-                  (set_local $4
+                  (set_local $7
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -5862,11 +5831,11 @@
                       )
                     )
                   )
-                  (get_local $4)
+                  (get_local $7)
                 )
                 (i32.store offset=8
-                  (get_local $4)
-                  (get_local $4)
+                  (get_local $7)
+                  (get_local $7)
                 )
                 (br_if $do-in$45
                   (i32.ne
@@ -5884,8 +5853,8 @@
                 (i32.const 1232)
                 (set_local $1
                   (i32.add
-                    (get_local $19)
-                    (set_local $4
+                    (get_local $20)
+                    (set_local $7
                       (select
                         (i32.const 0)
                         (i32.and
@@ -5893,7 +5862,7 @@
                             (i32.const 0)
                             (set_local $1
                               (i32.add
-                                (get_local $19)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5914,27 +5883,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $5
+                (set_local $4
                   (i32.sub
                     (i32.add
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $4)
+                    (get_local $7)
                   )
                 )
               )
               (i32.store offset=4
                 (get_local $1)
                 (i32.or
-                  (get_local $5)
+                  (get_local $4)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $1)
-                  (get_local $5)
+                  (get_local $4)
                 )
                 (i32.const 40)
               )
@@ -6051,7 +6020,7 @@
             (i32.const -8)
           )
         )
-        (set_local $13
+        (set_local $14
           (i32.load
             (i32.const 1224)
           )
@@ -6081,7 +6050,7 @@
     (set_local $7
       (i32.add
         (get_local $1)
-        (set_local $4
+        (set_local $5
           (i32.and
             (get_local $9)
             (i32.const -8)
@@ -6100,7 +6069,7 @@
             (get_local $1)
           )
           (set_local $8
-            (get_local $4)
+            (get_local $5)
           )
         )
         (block
@@ -6115,10 +6084,10 @@
             )
             (return)
           )
-          (set_local $4
+          (set_local $5
             (i32.add
               (get_local $9)
-              (get_local $4)
+              (get_local $5)
             )
           )
           (if
@@ -6132,7 +6101,7 @@
                   )
                 )
               )
-              (get_local $13)
+              (get_local $14)
             )
             (call_import $qa)
           )
@@ -6147,7 +6116,7 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $5
+                    (set_local $6
                       (i32.load
                         (set_local $1
                           (i32.add
@@ -6166,40 +6135,40 @@
                     (get_local $0)
                   )
                   (set_local $8
-                    (get_local $4)
+                    (get_local $5)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $4)
+                (get_local $5)
               )
               (i32.store
                 (get_local $1)
                 (i32.and
-                  (get_local $5)
+                  (get_local $6)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
                 (get_local $0)
                 (i32.or
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
                   (get_local $0)
-                  (get_local $4)
+                  (get_local $5)
                 )
-                (get_local $4)
+                (get_local $5)
               )
               (return)
             )
           )
-          (set_local $5
+          (set_local $6
             (i32.shr_u
               (get_local $9)
               (i32.const 3)
@@ -6223,12 +6192,12 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $6
+                  (set_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $5)
+                          (get_local $6)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6240,7 +6209,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (get_local $13)
+                      (get_local $14)
                     )
                     (call_import $qa)
                   )
@@ -6270,7 +6239,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $5)
+                          (get_local $6)
                         )
                         (i32.const -1)
                       )
@@ -6280,7 +6249,7 @@
                     (get_local $0)
                   )
                   (set_local $8
-                    (get_local $4)
+                    (get_local $5)
                   )
                   (br $do-once$0)
                 )
@@ -6288,7 +6257,7 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $6)
+                  (get_local $4)
                 )
                 (set_local $11
                   (i32.add
@@ -6300,14 +6269,14 @@
                   (if
                     (i32.lt_u
                       (get_local $1)
-                      (get_local $13)
+                      (get_local $14)
                     )
                     (call_import $qa)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (get_local $1)
                             (i32.const 8)
@@ -6317,7 +6286,7 @@
                       (get_local $0)
                     )
                     (set_local $11
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (call_import $qa)
                   )
@@ -6335,7 +6304,7 @@
                 (get_local $0)
               )
               (set_local $8
-                (get_local $4)
+                (get_local $5)
               )
               (br $do-once$0)
             )
@@ -6359,9 +6328,9 @@
                 (if
                   (set_local $11
                     (i32.load
-                      (set_local $5
+                      (set_local $6
                         (i32.add
-                          (set_local $6
+                          (set_local $4
                             (i32.add
                               (get_local $0)
                               (i32.const 16)
@@ -6376,15 +6345,15 @@
                     (set_local $1
                       (get_local $11)
                     )
-                    (set_local $6
-                      (get_local $5)
+                    (set_local $4
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
                       (set_local $1
                         (i32.load
-                          (get_local $6)
+                          (get_local $4)
                         )
                       )
                     )
@@ -6400,7 +6369,7 @@
                   (if
                     (set_local $11
                       (i32.load
-                        (set_local $5
+                        (set_local $6
                           (i32.add
                             (get_local $1)
                             (i32.const 20)
@@ -6412,8 +6381,8 @@
                       (set_local $1
                         (get_local $11)
                       )
-                      (set_local $6
-                        (get_local $5)
+                      (set_local $4
+                        (get_local $6)
                       )
                       (br $while-in$5)
                     )
@@ -6421,7 +6390,7 @@
                   (if
                     (set_local $11
                       (i32.load
-                        (set_local $5
+                        (set_local $6
                           (i32.add
                             (get_local $1)
                             (i32.const 16)
@@ -6433,16 +6402,16 @@
                       (set_local $1
                         (get_local $11)
                       )
-                      (set_local $6
-                        (get_local $5)
+                      (set_local $4
+                        (get_local $6)
                       )
                     )
                     (block
-                      (set_local $5
+                      (set_local $6
                         (get_local $1)
                       )
                       (set_local $10
-                        (get_local $6)
+                        (get_local $4)
                       )
                       (br $while-out$4)
                     )
@@ -6452,7 +6421,7 @@
                 (if
                   (i32.lt_u
                     (get_local $10)
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (call_import $qa)
                   (block
@@ -6461,7 +6430,7 @@
                       (i32.const 0)
                     )
                     (set_local $3
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                 )
@@ -6469,12 +6438,12 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $5
+                    (set_local $6
                       (i32.load offset=8
                         (get_local $0)
                       )
                     )
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (call_import $qa)
                 )
@@ -6483,7 +6452,7 @@
                     (i32.load
                       (set_local $11
                         (i32.add
-                          (get_local $5)
+                          (get_local $6)
                           (i32.const 12)
                         )
                       )
@@ -6495,7 +6464,7 @@
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $6
+                      (set_local $4
                         (i32.add
                           (get_local $1)
                           (i32.const 8)
@@ -6510,8 +6479,8 @@
                       (get_local $1)
                     )
                     (i32.store
+                      (get_local $4)
                       (get_local $6)
-                      (get_local $5)
                     )
                     (set_local $3
                       (get_local $1)
@@ -6529,7 +6498,7 @@
                 (i32.eq
                   (get_local $0)
                   (i32.load
-                    (set_local $5
+                    (set_local $6
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
@@ -6546,7 +6515,7 @@
                 )
                 (block
                   (i32.store
-                    (get_local $5)
+                    (get_local $6)
                     (get_local $3)
                   )
                   (if
@@ -6573,7 +6542,7 @@
                         (get_local $0)
                       )
                       (set_local $8
-                        (get_local $4)
+                        (get_local $5)
                       )
                       (br $do-once$0)
                     )
@@ -6619,7 +6588,7 @@
                         (get_local $0)
                       )
                       (set_local $8
-                        (get_local $4)
+                        (get_local $5)
                       )
                       (br $do-once$0)
                     )
@@ -6642,9 +6611,9 @@
                 (get_local $9)
               )
               (if
-                (set_local $6
+                (set_local $4
                   (i32.load
-                    (set_local $5
+                    (set_local $6
                       (i32.add
                         (get_local $0)
                         (i32.const 16)
@@ -6654,31 +6623,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $6)
+                    (get_local $4)
                     (get_local $1)
                   )
                   (call_import $qa)
                   (block
                     (i32.store offset=16
                       (get_local $3)
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $6)
+                      (get_local $4)
                       (get_local $3)
                     )
                   )
                 )
               )
               (if
-                (set_local $6
+                (set_local $4
                   (i32.load offset=4
-                    (get_local $5)
+                    (get_local $6)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $6)
+                    (get_local $4)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6687,17 +6656,17 @@
                   (block
                     (i32.store offset=20
                       (get_local $3)
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $6)
+                      (get_local $4)
                       (get_local $3)
                     )
                     (set_local $2
                       (get_local $0)
                     )
                     (set_local $8
-                      (get_local $4)
+                      (get_local $5)
                     )
                   )
                 )
@@ -6706,7 +6675,7 @@
                     (get_local $0)
                   )
                   (set_local $8
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
               )
@@ -6716,7 +6685,7 @@
                 (get_local $0)
               )
               (set_local $8
-                (get_local $4)
+                (get_local $5)
               )
             )
           )
@@ -6735,7 +6704,7 @@
         (i32.and
           (set_local $1
             (i32.load
-              (set_local $4
+              (set_local $5
                 (i32.add
                   (get_local $7)
                   (i32.const 4)
@@ -6755,7 +6724,7 @@
       )
       (block
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6879,7 +6848,7 @@
             (get_local $8)
           )
         )
-        (set_local $13
+        (set_local $14
           (i32.shr_u
             (get_local $1)
             (i32.const 3)
@@ -6899,17 +6868,17 @@
               )
               (if
                 (i32.ne
-                  (set_local $5
+                  (set_local $6
                     (i32.load offset=8
                       (get_local $7)
                     )
                   )
-                  (set_local $6
+                  (set_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $13)
+                          (get_local $14)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6920,7 +6889,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $6)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6930,7 +6899,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (get_local $7)
                     )
@@ -6941,7 +6910,7 @@
               (if
                 (i32.eq
                   (get_local $10)
-                  (get_local $5)
+                  (get_local $6)
                 )
                 (block
                   (i32.store
@@ -6953,7 +6922,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $13)
+                          (get_local $14)
                         )
                         (i32.const -1)
                       )
@@ -6965,7 +6934,7 @@
               (if
                 (i32.eq
                   (get_local $10)
-                  (get_local $6)
+                  (get_local $4)
                 )
                 (set_local $17
                   (i32.add
@@ -6986,7 +6955,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (get_local $10)
                             (i32.const 8)
@@ -6996,23 +6965,23 @@
                       (get_local $7)
                     )
                     (set_local $17
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (call_import $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $5)
+                (get_local $6)
                 (get_local $10)
               )
               (i32.store
                 (get_local $17)
-                (get_local $5)
+                (get_local $6)
               )
             )
             (block
-              (set_local $5
+              (set_local $6
                 (i32.load offset=24
                   (get_local $7)
                 )
@@ -7033,7 +7002,7 @@
                         (i32.load
                           (set_local $1
                             (i32.add
-                              (set_local $6
+                              (set_local $4
                                 (i32.add
                                   (get_local $7)
                                   (i32.const 16)
@@ -7048,18 +7017,17 @@
                         (set_local $0
                           (get_local $11)
                         )
-                        (set_local $13
+                        (set_local $4
                           (get_local $1)
                         )
                       )
                       (if
-                        (set_local $0
-                          (i32.load
-                            (get_local $6)
+                        (i32.eqz
+                          (set_local $0
+                            (i32.load
+                              (get_local $4)
+                            )
                           )
-                        )
-                        (set_local $13
-                          (get_local $6)
                         )
                         (block
                           (set_local $12
@@ -7085,7 +7053,7 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $13
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-in$13)
@@ -7106,22 +7074,17 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $13
+                          (set_local $4
                             (get_local $1)
                           )
                         )
-                        (block
-                          (set_local $1
-                            (get_local $13)
-                          )
-                          (br $while-out$12)
-                        )
+                        (br $while-out$12)
                       )
                       (br $while-in$13)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $4)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7129,7 +7092,7 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 0)
                         )
                         (set_local $12
@@ -7169,7 +7132,7 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $6
+                          (set_local $4
                             (i32.add
                               (get_local $10)
                               (i32.const 8)
@@ -7184,7 +7147,7 @@
                           (get_local $10)
                         )
                         (i32.store
-                          (get_local $6)
+                          (get_local $4)
                           (get_local $1)
                         )
                         (set_local $12
@@ -7197,13 +7160,13 @@
                 )
               )
               (if
-                (get_local $5)
+                (get_local $6)
                 (block
                   (if
                     (i32.eq
                       (get_local $7)
                       (i32.load
-                        (set_local $4
+                        (set_local $5
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
@@ -7220,7 +7183,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $4)
+                        (get_local $5)
                         (get_local $12)
                       )
                       (if
@@ -7250,7 +7213,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $5)
+                          (get_local $6)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7262,7 +7225,7 @@
                           (i32.load
                             (set_local $10
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
@@ -7274,7 +7237,7 @@
                           (get_local $12)
                         )
                         (i32.store offset=20
-                          (get_local $5)
+                          (get_local $6)
                           (get_local $12)
                         )
                       )
@@ -7298,12 +7261,12 @@
                   )
                   (i32.store offset=24
                     (get_local $12)
-                    (get_local $5)
+                    (get_local $6)
                   )
                   (if
                     (set_local $0
                       (i32.load
-                        (set_local $4
+                        (set_local $5
                           (i32.add
                             (get_local $7)
                             (i32.const 16)
@@ -7332,7 +7295,7 @@
                   (if
                     (set_local $0
                       (i32.load offset=4
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                     (if
@@ -7420,7 +7383,7 @@
         )
         (if
           (i32.and
-            (set_local $4
+            (set_local $5
               (i32.load
                 (i32.const 1208)
               )
@@ -7434,7 +7397,7 @@
           )
           (if
             (i32.lt_u
-              (set_local $4
+              (set_local $5
                 (i32.load
                   (set_local $3
                     (i32.add
@@ -7453,8 +7416,8 @@
               (set_local $15
                 (get_local $3)
               )
-              (set_local $14
-                (get_local $4)
+              (set_local $13
+                (get_local $5)
               )
             )
           )
@@ -7462,7 +7425,7 @@
             (i32.store
               (i32.const 1208)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (get_local $3)
               )
             )
@@ -7472,7 +7435,7 @@
                 (i32.const 8)
               )
             )
-            (set_local $14
+            (set_local $13
               (get_local $1)
             )
           )
@@ -7482,12 +7445,12 @@
           (get_local $2)
         )
         (i32.store offset=12
-          (get_local $14)
+          (get_local $13)
           (get_local $2)
         )
         (i32.store offset=8
           (get_local $2)
-          (get_local $14)
+          (get_local $13)
         )
         (i32.store offset=12
           (get_local $2)
@@ -7532,7 +7495,7 @@
                                           (set_local $15
                                             (i32.shl
                                               (get_local $1)
-                                              (set_local $14
+                                              (set_local $13
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -7553,13 +7516,13 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $14)
+                                  (get_local $13)
                                 )
                                 (set_local $15
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $4
+                                        (set_local $5
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7576,7 +7539,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $4)
+                                (get_local $5)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7620,7 +7583,7 @@
             (i32.const 1212)
           )
         )
-        (set_local $4
+        (set_local $5
           (i32.shl
             (i32.const 1)
             (get_local $1)
@@ -7628,7 +7591,7 @@
         )
       )
       (block
-        (set_local $14
+        (set_local $13
           (i32.shl
             (get_local $0)
             (select
@@ -7684,7 +7647,7 @@
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $14)
+                        (get_local $13)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7694,9 +7657,9 @@
               )
             )
             (block
-              (set_local $14
+              (set_local $13
                 (i32.shl
-                  (get_local $14)
+                  (get_local $13)
                   (i32.const 1)
                 )
               )
@@ -7759,7 +7722,7 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $14
+                  (set_local $13
                     (i32.load
                       (set_local $1
                         (i32.add
@@ -7769,7 +7732,7 @@
                       )
                     )
                   )
-                  (set_local $4
+                  (set_local $5
                     (i32.load
                       (i32.const 1224)
                     )
@@ -7777,12 +7740,12 @@
                 )
                 (i32.ge_u
                   (get_local $16)
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $14)
+                  (get_local $13)
                   (get_local $2)
                 )
                 (i32.store
@@ -7791,7 +7754,7 @@
                 )
                 (i32.store offset=8
                   (get_local $2)
-                  (get_local $14)
+                  (get_local $13)
                 )
                 (i32.store offset=12
                   (get_local $2)
@@ -7812,7 +7775,7 @@
           (i32.const 1212)
           (i32.or
             (get_local $15)
-            (get_local $4)
+            (get_local $5)
           )
         )
         (i32.store
@@ -8274,7 +8237,7 @@
     (local $6 i32)
     (local $7 i32)
     (if
-      (set_local $6
+      (set_local $5
         (i32.load
           (set_local $3
             (i32.add
@@ -8285,10 +8248,10 @@
         )
       )
       (block
-        (set_local $5
-          (get_local $6)
+        (set_local $7
+          (get_local $5)
         )
-        (set_local $4
+        (set_local $6
           (i32.const 5)
         )
       )
@@ -8296,16 +8259,16 @@
         (call $Xa
           (get_local $2)
         )
-        (set_local $7
+        (set_local $4
           (i32.const 0)
         )
         (block
-          (set_local $5
+          (set_local $7
             (i32.load
               (get_local $3)
             )
           )
-          (set_local $4
+          (set_local $6
             (i32.const 5)
           )
         )
@@ -8314,14 +8277,14 @@
     (block $label$break$a
       (if
         (i32.eq
-          (get_local $4)
+          (get_local $6)
           (i32.const 5)
         )
         (block
-          (set_local $4
+          (set_local $6
             (set_local $3
               (i32.load
-                (set_local $6
+                (set_local $5
                   (i32.add
                     (get_local $2)
                     (i32.const 20)
@@ -8333,13 +8296,13 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $5)
+                (get_local $7)
                 (get_local $3)
               )
               (get_local $1)
             )
             (block
-              (set_local $7
+              (set_local $4
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
@@ -8381,9 +8344,6 @@
                           (get_local $0)
                         )
                         (set_local $3
-                          (get_local $4)
-                        )
-                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$b
@@ -8396,7 +8356,7 @@
                         (i32.load8_s
                           (i32.add
                             (get_local $0)
-                            (set_local $5
+                            (set_local $7
                               (i32.add
                                 (get_local $3)
                                 (i32.const -1)
@@ -8413,7 +8373,7 @@
                         (br $while-out$2)
                       )
                       (set_local $3
-                        (get_local $5)
+                        (get_local $7)
                       )
                     )
                     (br $while-in$3)
@@ -8436,12 +8396,7 @@
                       )
                       (get_local $4)
                     )
-                    (block
-                      (set_local $7
-                        (get_local $4)
-                      )
-                      (br $label$break$a)
-                    )
+                    (br $label$break$a)
                   )
                   (set_local $2
                     (i32.add
@@ -8449,12 +8404,12 @@
                       (get_local $4)
                     )
                   )
-                  (set_local $3
+                  (set_local $6
                     (i32.load
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
-                  (set_local $5
+                  (set_local $3
                     (get_local $4)
                   )
                   (i32.sub
@@ -8467,9 +8422,6 @@
                     (get_local $0)
                   )
                   (set_local $3
-                    (get_local $4)
-                  )
-                  (set_local $5
                     (i32.const 0)
                   )
                   (get_local $1)
@@ -8478,29 +8430,29 @@
             )
           )
           (call $jb
-            (get_local $3)
+            (get_local $6)
             (get_local $2)
             (get_local $0)
           )
           (i32.store
-            (get_local $6)
+            (get_local $5)
             (i32.add
               (i32.load
-                (get_local $6)
+                (get_local $5)
               )
               (get_local $0)
             )
           )
-          (set_local $7
+          (set_local $4
             (i32.add
-              (get_local $5)
+              (get_local $3)
               (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $7)
+    (get_local $4)
   )
   (func $Za (param $0 i32) (result i32)
     (local $1 i32)
@@ -8548,10 +8500,10 @@
               )
               (get_local $0)
               (block
-                (set_local $1
+                (set_local $2
                   (get_local $0)
                 )
-                (set_local $2
+                (set_local $1
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8561,10 +8513,10 @@
           )
         )
         (block
-          (set_local $1
+          (set_local $2
             (get_local $0)
           )
-          (set_local $2
+          (set_local $1
             (i32.const 4)
           )
         )
@@ -8572,21 +8524,21 @@
     )
     (if
       (i32.eq
-        (get_local $2)
+        (get_local $1)
         (i32.const 4)
       )
       (block
-        (set_local $2
-          (get_local $1)
+        (set_local $1
+          (get_local $2)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $1
+                  (set_local $2
                     (i32.load
-                      (get_local $2)
+                      (get_local $1)
                     )
                   )
                   (i32.const -2139062144)
@@ -8594,22 +8546,14 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $1)
+                (get_local $2)
                 (i32.const -16843009)
               )
             )
-            (block
-              (set_local $0
-                (get_local $1)
-              )
-              (set_local $1
-                (get_local $2)
-              )
-              (br $while-out$3)
-            )
-            (set_local $2
+            (br $while-out$3)
+            (set_local $1
               (i32.add
-                (get_local $2)
+                (get_local $1)
                 (i32.const 4)
               )
             )
@@ -8620,7 +8564,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $0)
+                (get_local $2)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8628,7 +8572,7 @@
             (i32.const 24)
           )
           (block
-            (set_local $0
+            (set_local $2
               (get_local $1)
             )
             (loop $while-out$5 $while-in$6
@@ -8636,30 +8580,23 @@
                 (i32.load8_s
                   (set_local $1
                     (i32.add
-                      (get_local $0)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $0
+                (set_local $2
                   (get_local $1)
                 )
-                (block
-                  (set_local $0
-                    (get_local $1)
-                  )
-                  (br $while-out$5)
-                )
+                (br $while-out$5)
               )
               (br $while-in$6)
             )
           )
-          (set_local $0
-            (get_local $1)
-          )
+          (get_local $1)
         )
         (set_local $5
-          (get_local $0)
+          (get_local $1)
         )
       )
     )
@@ -8904,7 +8841,7 @@
             )
             (if
               (i32.ne
-                (set_local $1
+                (set_local $4
                   (i32.and
                     (get_local $1)
                     (i32.const 255)
@@ -8925,9 +8862,6 @@
                 (i32.store8
                   (get_local $2)
                   (get_local $9)
-                )
-                (set_local $4
-                  (get_local $1)
                 )
                 (br $do-once$0)
               )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -95,8 +95,7 @@
     (local $52 i32)
     (local $53 i32)
     (local $54 i32)
-    (local $55 i32)
-    (set_local $25
+    (set_local $31
       (i32.load
         (i32.const 8)
       )
@@ -110,8 +109,8 @@
         (i32.const 16)
       )
     )
-    (set_local $7
-      (get_local $25)
+    (set_local $15
+      (get_local $31)
     )
     (block $do-once$0
       (if
@@ -122,16 +121,16 @@
         (block
           (if
             (i32.and
-              (set_local $5
+              (set_local $12
                 (i32.shr_u
-                  (set_local $2
+                  (set_local $16
                     (i32.load
                       (i32.const 1208)
                     )
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.shr_u
-                      (set_local $0
+                      (set_local $14
                         (select
                           (i32.const 16)
                           (i32.and
@@ -155,15 +154,15 @@
               (i32.const 3)
             )
             (block
-              (set_local $7
+              (set_local $11
                 (i32.load
-                  (set_local $12
+                  (set_local $27
                     (i32.add
-                      (set_local $5
+                      (set_local $29
                         (i32.load
-                          (set_local $14
+                          (set_local $25
                             (i32.add
-                              (set_local $1
+                              (set_local $5
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
@@ -172,12 +171,12 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $5)
+                                              (get_local $12)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
                                           )
-                                          (get_local $3)
+                                          (get_local $2)
                                         )
                                       )
                                       (i32.const 1)
@@ -198,13 +197,13 @@
               )
               (if
                 (i32.eq
-                  (get_local $1)
-                  (get_local $7)
+                  (get_local $5)
+                  (get_local $11)
                 )
                 (i32.store
                   (i32.const 1208)
                   (i32.and
-                    (get_local $2)
+                    (get_local $16)
                     (i32.xor
                       (i32.shl
                         (i32.const 1)
@@ -217,7 +216,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $11)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -227,23 +226,23 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $8
+                        (set_local $19
                           (i32.add
-                            (get_local $7)
+                            (get_local $11)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $5)
+                      (get_local $29)
                     )
                     (block
                       (i32.store
-                        (get_local $8)
-                        (get_local $1)
+                        (get_local $19)
+                        (get_local $5)
                       )
                       (i32.store
-                        (get_local $14)
-                        (get_local $7)
+                        (get_local $25)
+                        (get_local $11)
                       )
                     )
                     (call_import $qa)
@@ -251,9 +250,9 @@
                 )
               )
               (i32.store offset=4
-                (get_local $5)
+                (get_local $29)
                 (i32.or
-                  (set_local $7
+                  (set_local $11
                     (i32.shl
                       (get_local $0)
                       (i32.const 3)
@@ -263,35 +262,35 @@
                 )
               )
               (i32.store
-                (set_local $14
+                (set_local $25
                   (i32.add
                     (i32.add
-                      (get_local $5)
-                      (get_local $7)
+                      (get_local $29)
+                      (get_local $11)
                     )
                     (i32.const 4)
                   )
                 )
                 (i32.or
                   (i32.load
-                    (get_local $14)
+                    (get_local $25)
                   )
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.const 8)
-                (get_local $25)
+                (get_local $31)
               )
               (return
-                (get_local $12)
+                (get_local $27)
               )
             )
           )
           (if
             (i32.gt_u
-              (get_local $0)
-              (set_local $14
+              (get_local $14)
+              (set_local $25
                 (i32.load
                   (i32.const 1216)
                 )
@@ -299,37 +298,37 @@
             )
             (block
               (if
-                (get_local $5)
+                (get_local $12)
                 (block
-                  (set_local $1
+                  (set_local $5
                     (i32.and
                       (i32.shr_u
-                        (set_local $7
+                        (set_local $11
                           (i32.add
                             (i32.and
-                              (set_local $1
+                              (set_local $5
                                 (i32.and
                                   (i32.shl
-                                    (get_local $5)
-                                    (get_local $3)
+                                    (get_local $12)
+                                    (get_local $2)
                                   )
                                   (i32.or
-                                    (set_local $7
+                                    (set_local $11
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $3)
+                                        (get_local $2)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $7)
+                                      (get_local $11)
                                     )
                                   )
                                 )
                               )
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $1)
+                                (get_local $5)
                               )
                             )
                             (i32.const -1)
@@ -340,32 +339,32 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $1
+                  (set_local $5
                     (i32.load
-                      (set_local $8
+                      (set_local $19
                         (i32.add
-                          (set_local $9
+                          (set_local $8
                             (i32.load
-                              (set_local $12
+                              (set_local $0
                                 (i32.add
-                                  (set_local $6
+                                  (set_local $3
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $21
+                                          (set_local $7
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $7
+                                                      (set_local $11
                                                         (i32.and
                                                           (i32.shr_u
-                                                            (set_local $8
+                                                            (set_local $19
                                                               (i32.shr_u
-                                                                (get_local $7)
-                                                                (get_local $1)
+                                                                (get_local $11)
+                                                                (get_local $5)
                                                               )
                                                             )
                                                             (i32.const 5)
@@ -373,15 +372,15 @@
                                                           (i32.const 8)
                                                         )
                                                       )
-                                                      (get_local $1)
+                                                      (get_local $5)
                                                     )
-                                                    (set_local $8
+                                                    (set_local $19
                                                       (i32.and
                                                         (i32.shr_u
-                                                          (set_local $9
+                                                          (set_local $8
                                                             (i32.shr_u
-                                                              (get_local $8)
-                                                              (get_local $7)
+                                                              (get_local $19)
+                                                              (get_local $11)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -390,13 +389,13 @@
                                                       )
                                                     )
                                                   )
-                                                  (set_local $9
+                                                  (set_local $8
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $6
+                                                        (set_local $3
                                                           (i32.shr_u
-                                                            (get_local $9)
                                                             (get_local $8)
+                                                            (get_local $19)
                                                           )
                                                         )
                                                         (i32.const 1)
@@ -405,13 +404,13 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $6
+                                                (set_local $3
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $12
+                                                      (set_local $0
                                                         (i32.shr_u
-                                                          (get_local $6)
-                                                          (get_local $9)
+                                                          (get_local $3)
+                                                          (get_local $8)
                                                         )
                                                       )
                                                       (i32.const 1)
@@ -421,8 +420,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $12)
-                                                (get_local $6)
+                                                (get_local $0)
+                                                (get_local $3)
                                               )
                                             )
                                           )
@@ -444,31 +443,31 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $6)
-                      (get_local $1)
+                      (get_local $3)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
                         (i32.const 1208)
                         (i32.and
-                          (get_local $2)
+                          (get_local $16)
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $21)
+                              (get_local $7)
                             )
                             (i32.const -1)
                           )
                         )
                       )
-                      (set_local $33
-                        (get_local $14)
+                      (set_local $39
+                        (get_local $25)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $1)
+                          (get_local $5)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -478,25 +477,25 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $7
+                            (set_local $11
                               (i32.add
-                                (get_local $1)
+                                (get_local $5)
                                 (i32.const 12)
                               )
                             )
                           )
-                          (get_local $9)
+                          (get_local $8)
                         )
                         (block
                           (i32.store
-                            (get_local $7)
-                            (get_local $6)
+                            (get_local $11)
+                            (get_local $3)
                           )
                           (i32.store
-                            (get_local $12)
-                            (get_local $1)
+                            (get_local $0)
+                            (get_local $5)
                           )
-                          (set_local $33
+                          (set_local $39
                             (i32.load
                               (i32.const 1216)
                             )
@@ -507,27 +506,27 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $9)
+                    (get_local $8)
                     (i32.or
-                      (get_local $0)
+                      (get_local $14)
                       (i32.const 3)
                     )
                   )
                   (i32.store offset=4
-                    (set_local $12
+                    (set_local $0
                       (i32.add
-                        (get_local $9)
-                        (get_local $0)
+                        (get_local $8)
+                        (get_local $14)
                       )
                     )
                     (i32.or
-                      (set_local $1
+                      (set_local $5
                         (i32.sub
                           (i32.shl
-                            (get_local $21)
+                            (get_local $7)
                             (i32.const 3)
                           )
-                          (get_local $0)
+                          (get_local $14)
                         )
                       )
                       (i32.const 1)
@@ -535,27 +534,27 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $12)
-                      (get_local $1)
+                      (get_local $0)
+                      (get_local $5)
                     )
-                    (get_local $1)
+                    (get_local $5)
                   )
                   (if
-                    (get_local $33)
+                    (get_local $39)
                     (block
-                      (set_local $6
+                      (set_local $3
                         (i32.load
                           (i32.const 1228)
                         )
                       )
-                      (set_local $2
+                      (set_local $16
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (set_local $14
+                              (set_local $25
                                 (i32.shr_u
-                                  (get_local $33)
+                                  (get_local $39)
                                   (i32.const 3)
                                 )
                               )
@@ -567,25 +566,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $3
+                          (set_local $2
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $5
+                          (set_local $12
                             (i32.shl
                               (i32.const 1)
-                              (get_local $14)
+                              (get_local $25)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $3
+                            (set_local $2
                               (i32.load
-                                (set_local $5
+                                (set_local $12
                                   (i32.add
-                                    (get_local $2)
+                                    (get_local $16)
                                     (i32.const 8)
                                   )
                                 )
@@ -597,11 +596,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $41
-                              (get_local $5)
+                            (set_local $44
+                              (get_local $12)
                             )
-                            (set_local $34
-                              (get_local $3)
+                            (set_local $29
+                              (get_local $2)
                             )
                           )
                         )
@@ -609,73 +608,73 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $3)
-                              (get_local $5)
+                              (get_local $2)
+                              (get_local $12)
                             )
                           )
-                          (set_local $41
+                          (set_local $44
                             (i32.add
-                              (get_local $2)
+                              (get_local $16)
                               (i32.const 8)
                             )
                           )
-                          (set_local $34
-                            (get_local $2)
+                          (set_local $29
+                            (get_local $16)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $41)
-                        (get_local $6)
+                        (get_local $44)
+                        (get_local $3)
                       )
                       (i32.store offset=12
-                        (get_local $34)
-                        (get_local $6)
+                        (get_local $29)
+                        (get_local $3)
                       )
                       (i32.store offset=8
-                        (get_local $6)
-                        (get_local $34)
+                        (get_local $3)
+                        (get_local $29)
                       )
                       (i32.store offset=12
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $3)
+                        (get_local $16)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 1216)
-                    (get_local $1)
+                    (get_local $5)
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $12)
+                    (get_local $0)
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $25)
+                    (get_local $31)
                   )
                   (return
-                    (get_local $8)
+                    (get_local $19)
                   )
                 )
               )
               (if
-                (set_local $12
+                (set_local $0
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $12
+                  (set_local $0
                     (i32.and
                       (i32.shr_u
-                        (set_local $1
+                        (set_local $5
                           (i32.add
                             (i32.and
-                              (get_local $12)
+                              (get_local $0)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $12)
+                                (get_local $0)
                               )
                             )
                             (i32.const -1)
@@ -686,11 +685,11 @@
                       (i32.const 16)
                     )
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.sub
                       (i32.and
                         (i32.load offset=4
-                          (set_local $14
+                          (set_local $25
                             (i32.load
                               (i32.add
                                 (i32.shl
@@ -699,13 +698,13 @@
                                       (i32.or
                                         (i32.or
                                           (i32.or
-                                            (set_local $1
+                                            (set_local $5
                                               (i32.and
                                                 (i32.shr_u
-                                                  (set_local $2
+                                                  (set_local $16
                                                     (i32.shr_u
-                                                      (get_local $1)
-                                                      (get_local $12)
+                                                      (get_local $5)
+                                                      (get_local $0)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -713,15 +712,15 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $12)
+                                            (get_local $0)
                                           )
-                                          (set_local $2
+                                          (set_local $16
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $6
+                                                (set_local $3
                                                   (i32.shr_u
-                                                    (get_local $2)
-                                                    (get_local $1)
+                                                    (get_local $16)
+                                                    (get_local $5)
                                                   )
                                                 )
                                                 (i32.const 2)
@@ -730,13 +729,13 @@
                                             )
                                           )
                                         )
-                                        (set_local $6
+                                        (set_local $3
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $3
+                                              (set_local $2
                                                 (i32.shr_u
-                                                  (get_local $6)
-                                                  (get_local $2)
+                                                  (get_local $3)
+                                                  (get_local $16)
                                                 )
                                               )
                                               (i32.const 1)
@@ -745,13 +744,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $3
+                                      (set_local $2
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $5
+                                            (set_local $12
                                               (i32.shr_u
+                                                (get_local $2)
                                                 (get_local $3)
-                                                (get_local $6)
                                               )
                                             )
                                             (i32.const 1)
@@ -761,8 +760,8 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $5)
-                                      (get_local $3)
+                                      (get_local $12)
+                                      (get_local $2)
                                     )
                                   )
                                   (i32.const 2)
@@ -774,84 +773,84 @@
                         )
                         (i32.const -8)
                       )
-                      (get_local $0)
+                      (get_local $14)
                     )
                   )
-                  (set_local $5
-                    (get_local $14)
+                  (set_local $12
+                    (get_local $25)
                   )
-                  (set_local $6
-                    (get_local $14)
+                  (set_local $3
+                    (get_local $25)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
-                      (set_local $14
+                      (set_local $25
                         (i32.load offset=16
-                          (get_local $5)
+                          (get_local $12)
                         )
                       )
-                      (set_local $7
-                        (get_local $14)
+                      (set_local $0
+                        (get_local $25)
                       )
                       (if
-                        (set_local $2
+                        (set_local $16
                           (i32.load offset=20
-                            (get_local $5)
+                            (get_local $12)
                           )
                         )
-                        (set_local $7
-                          (get_local $2)
+                        (set_local $0
+                          (get_local $16)
                         )
                         (block
-                          (set_local $7
-                            (get_local $3)
+                          (set_local $32
+                            (get_local $2)
                           )
-                          (set_local $1
-                            (get_local $6)
+                          (set_local $26
+                            (get_local $3)
                           )
                           (br $while-out$6)
                         )
                       )
                     )
-                    (set_local $2
+                    (set_local $16
                       (i32.lt_u
-                        (set_local $14
+                        (set_local $25
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $7)
+                                (get_local $0)
                               )
                               (i32.const -8)
                             )
-                            (get_local $0)
+                            (get_local $14)
                           )
                         )
-                        (get_local $3)
+                        (get_local $2)
                       )
+                    )
+                    (set_local $2
+                      (select
+                        (get_local $25)
+                        (get_local $2)
+                        (get_local $16)
+                      )
+                    )
+                    (set_local $12
+                      (get_local $0)
                     )
                     (set_local $3
                       (select
-                        (get_local $14)
+                        (get_local $0)
                         (get_local $3)
-                        (get_local $2)
-                      )
-                    )
-                    (set_local $5
-                      (get_local $7)
-                    )
-                    (set_local $6
-                      (select
-                        (get_local $7)
-                        (get_local $6)
-                        (get_local $2)
+                        (get_local $16)
                       )
                     )
                     (br $while-in$7)
                   )
                   (if
                     (i32.lt_u
-                      (get_local $1)
-                      (set_local $6
+                      (get_local $26)
+                      (set_local $3
                         (i32.load
                           (i32.const 1224)
                         )
@@ -861,66 +860,72 @@
                   )
                   (if
                     (i32.ge_u
-                      (get_local $1)
-                      (set_local $5
+                      (get_local $26)
+                      (set_local $12
                         (i32.add
-                          (get_local $1)
-                          (get_local $0)
+                          (get_local $26)
+                          (get_local $14)
                         )
                       )
                     )
                     (call_import $qa)
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.load offset=24
-                      (get_local $1)
+                      (get_local $26)
                     )
                   )
                   (block $do-once$8
                     (if
                       (i32.eq
-                        (set_local $8
+                        (set_local $19
                           (i32.load offset=12
-                            (get_local $1)
+                            (get_local $26)
                           )
                         )
-                        (get_local $1)
+                        (get_local $26)
                       )
                       (block
                         (if
-                          (set_local $21
+                          (set_local $7
                             (i32.load
-                              (set_local $9
+                              (set_local $8
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $26)
                                   (i32.const 20)
                                 )
                               )
                             )
                           )
                           (block
-                            (set_local $14
-                              (get_local $21)
+                            (set_local $11
+                              (get_local $7)
                             )
-                            (set_local $2
-                              (get_local $9)
+                            (set_local $0
+                              (get_local $8)
                             )
                           )
                           (if
-                            (i32.eqz
-                              (set_local $14
-                                (i32.load
-                                  (set_local $2
-                                    (i32.add
-                                      (get_local $1)
-                                      (i32.const 16)
-                                    )
+                            (set_local $25
+                              (i32.load
+                                (set_local $16
+                                  (i32.add
+                                    (get_local $26)
+                                    (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $23
+                              (set_local $11
+                                (get_local $25)
+                              )
+                              (set_local $0
+                                (get_local $16)
+                              )
+                            )
+                            (block
+                              (set_local $27
                                 (i32.const 0)
                               )
                               (br $do-once$8)
@@ -929,43 +934,43 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $21
+                            (set_local $7
                               (i32.load
-                                (set_local $9
+                                (set_local $8
                                   (i32.add
-                                    (get_local $14)
+                                    (get_local $11)
                                     (i32.const 20)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $14
-                                (get_local $21)
+                              (set_local $11
+                                (get_local $7)
                               )
-                              (set_local $2
-                                (get_local $9)
+                              (set_local $0
+                                (get_local $8)
                               )
                               (br $while-in$11)
                             )
                           )
                           (if
-                            (set_local $21
+                            (set_local $7
                               (i32.load
-                                (set_local $9
+                                (set_local $8
                                   (i32.add
-                                    (get_local $14)
+                                    (get_local $11)
                                     (i32.const 16)
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $14
-                                (get_local $21)
+                              (set_local $11
+                                (get_local $7)
                               )
-                              (set_local $2
-                                (get_local $9)
+                              (set_local $0
+                                (get_local $8)
                               )
                             )
                             (br $while-out$10)
@@ -974,17 +979,17 @@
                         )
                         (if
                           (i32.lt_u
-                            (get_local $2)
-                            (get_local $6)
+                            (get_local $0)
+                            (get_local $3)
                           )
                           (call_import $qa)
                           (block
                             (i32.store
-                              (get_local $2)
+                              (get_local $0)
                               (i32.const 0)
                             )
-                            (set_local $23
-                              (get_local $14)
+                            (set_local $27
+                              (get_local $11)
                             )
                           )
                         )
@@ -992,52 +997,52 @@
                       (block
                         (if
                           (i32.lt_u
-                            (set_local $9
+                            (set_local $8
                               (i32.load offset=8
-                                (get_local $1)
+                                (get_local $26)
                               )
                             )
-                            (get_local $6)
+                            (get_local $3)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $21
+                              (set_local $7
                                 (i32.add
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.const 12)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $26)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.eq
                             (i32.load
-                              (set_local $2
+                              (set_local $16
                                 (i32.add
-                                  (get_local $8)
+                                  (get_local $19)
                                   (i32.const 8)
                                 )
                               )
                             )
-                            (get_local $1)
+                            (get_local $26)
                           )
                           (block
                             (i32.store
-                              (get_local $21)
-                              (get_local $8)
+                              (get_local $7)
+                              (get_local $19)
                             )
                             (i32.store
-                              (get_local $2)
-                              (get_local $9)
-                            )
-                            (set_local $23
+                              (get_local $16)
                               (get_local $8)
+                            )
+                            (set_local $27
+                              (get_local $19)
                             )
                           )
                           (call_import $qa)
@@ -1047,19 +1052,19 @@
                   )
                   (block $do-once$12
                     (if
-                      (get_local $3)
+                      (get_local $2)
                       (block
                         (if
                           (i32.eq
-                            (get_local $1)
+                            (get_local $26)
                             (i32.load
-                              (set_local $6
+                              (set_local $3
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
-                                    (set_local $8
+                                    (set_local $19
                                       (i32.load offset=28
-                                        (get_local $1)
+                                        (get_local $26)
                                       )
                                     )
                                     (i32.const 2)
@@ -1070,12 +1075,12 @@
                           )
                           (block
                             (i32.store
-                              (get_local $6)
-                              (get_local $23)
+                              (get_local $3)
+                              (get_local $27)
                             )
                             (if
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $27)
                               )
                               (block
                                 (i32.store
@@ -1087,7 +1092,7 @@
                                     (i32.xor
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $8)
+                                        (get_local $19)
                                       )
                                       (i32.const -1)
                                     )
@@ -1100,7 +1105,7 @@
                           (block
                             (if
                               (i32.lt_u
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -1110,35 +1115,35 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $8
+                                  (set_local $19
                                     (i32.add
-                                      (get_local $3)
+                                      (get_local $2)
                                       (i32.const 16)
                                     )
                                   )
                                 )
-                                (get_local $1)
+                                (get_local $26)
                               )
                               (i32.store
-                                (get_local $8)
-                                (get_local $23)
+                                (get_local $19)
+                                (get_local $27)
                               )
                               (i32.store offset=20
-                                (get_local $3)
-                                (get_local $23)
+                                (get_local $2)
+                                (get_local $27)
                               )
                             )
                             (br_if $do-once$12
                               (i32.eqz
-                                (get_local $23)
+                                (get_local $27)
                               )
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (get_local $23)
-                            (set_local $8
+                            (get_local $27)
+                            (set_local $19
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1147,42 +1152,42 @@
                           (call_import $qa)
                         )
                         (i32.store offset=24
-                          (get_local $23)
-                          (get_local $3)
+                          (get_local $27)
+                          (get_local $2)
                         )
                         (if
-                          (set_local $6
+                          (set_local $3
                             (i32.load offset=16
-                              (get_local $1)
+                              (get_local $26)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $6)
-                              (get_local $8)
+                              (get_local $3)
+                              (get_local $19)
                             )
                             (call_import $qa)
                             (block
                               (i32.store offset=16
-                                (get_local $23)
-                                (get_local $6)
+                                (get_local $27)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $6)
-                                (get_local $23)
+                                (get_local $3)
+                                (get_local $27)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $6
+                          (set_local $3
                             (i32.load offset=20
-                              (get_local $1)
+                              (get_local $26)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $6)
+                              (get_local $3)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1190,12 +1195,12 @@
                             (call_import $qa)
                             (block
                               (i32.store offset=20
-                                (get_local $23)
-                                (get_local $6)
+                                (get_local $27)
+                                (get_local $3)
                               )
                               (i32.store offset=24
-                                (get_local $6)
-                                (get_local $23)
+                                (get_local $3)
+                                (get_local $27)
                               )
                             )
                           )
@@ -1205,35 +1210,35 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $7)
+                      (get_local $32)
                       (i32.const 16)
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $26)
                         (i32.or
-                          (set_local $3
+                          (set_local $2
                             (i32.add
-                              (get_local $7)
-                              (get_local $0)
+                              (get_local $32)
+                              (get_local $14)
                             )
                           )
                           (i32.const 3)
                         )
                       )
                       (i32.store
-                        (set_local $6
+                        (set_local $3
                           (i32.add
                             (i32.add
-                              (get_local $1)
-                              (get_local $3)
+                              (get_local $26)
+                              (get_local $2)
                             )
                             (i32.const 4)
                           )
                         )
                         (i32.or
                           (i32.load
-                            (get_local $6)
+                            (get_local $3)
                           )
                           (i32.const 1)
                         )
@@ -1241,46 +1246,46 @@
                     )
                     (block
                       (i32.store offset=4
-                        (get_local $1)
+                        (get_local $26)
                         (i32.or
-                          (get_local $0)
+                          (get_local $14)
                           (i32.const 3)
                         )
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $12)
                         (i32.or
-                          (get_local $7)
+                          (get_local $32)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $5)
-                          (get_local $7)
+                          (get_local $12)
+                          (get_local $32)
                         )
-                        (get_local $7)
+                        (get_local $32)
                       )
                       (if
-                        (set_local $6
+                        (set_local $3
                           (i32.load
                             (i32.const 1216)
                           )
                         )
                         (block
-                          (set_local $3
+                          (set_local $2
                             (i32.load
                               (i32.const 1228)
                             )
                           )
-                          (set_local $6
+                          (set_local $3
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
-                                  (set_local $8
+                                  (set_local $19
                                     (i32.shr_u
-                                      (get_local $6)
+                                      (get_local $3)
                                       (i32.const 3)
                                     )
                                   )
@@ -1292,25 +1297,25 @@
                           )
                           (if
                             (i32.and
-                              (set_local $9
+                              (set_local $8
                                 (i32.load
                                   (i32.const 1208)
                                 )
                               )
-                              (set_local $2
+                              (set_local $16
                                 (i32.shl
                                   (i32.const 1)
-                                  (get_local $8)
+                                  (get_local $19)
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (set_local $9
+                                (set_local $8
                                   (i32.load
-                                    (set_local $2
+                                    (set_local $16
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $3)
                                         (i32.const 8)
                                       )
                                     )
@@ -1322,11 +1327,11 @@
                               )
                               (call_import $qa)
                               (block
-                                (set_local $42
-                                  (get_local $2)
+                                (set_local $34
+                                  (get_local $16)
                                 )
-                                (set_local $35
-                                  (get_local $9)
+                                (set_local $4
+                                  (get_local $8)
                                 )
                               )
                             )
@@ -1334,64 +1339,68 @@
                               (i32.store
                                 (i32.const 1208)
                                 (i32.or
-                                  (get_local $9)
-                                  (get_local $2)
+                                  (get_local $8)
+                                  (get_local $16)
                                 )
                               )
-                              (set_local $42
+                              (set_local $34
                                 (i32.add
-                                  (get_local $6)
+                                  (get_local $3)
                                   (i32.const 8)
                                 )
                               )
-                              (set_local $35
-                                (get_local $6)
+                              (set_local $4
+                                (get_local $3)
                               )
                             )
                           )
                           (i32.store
-                            (get_local $42)
-                            (get_local $3)
+                            (get_local $34)
+                            (get_local $2)
                           )
                           (i32.store offset=12
-                            (get_local $35)
-                            (get_local $3)
+                            (get_local $4)
+                            (get_local $2)
                           )
                           (i32.store offset=8
-                            (get_local $3)
-                            (get_local $35)
+                            (get_local $2)
+                            (get_local $4)
                           )
                           (i32.store offset=12
+                            (get_local $2)
                             (get_local $3)
-                            (get_local $6)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $7)
+                        (get_local $32)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $5)
+                        (get_local $12)
                       )
                     )
                   )
                   (i32.store
                     (i32.const 8)
-                    (get_local $25)
+                    (get_local $31)
                   )
                   (return
                     (i32.add
-                      (get_local $1)
+                      (get_local $26)
                       (i32.const 8)
                     )
                   )
                 )
-                (get_local $0)
+                (set_local $18
+                  (get_local $14)
+                )
               )
             )
-            (get_local $0)
+            (set_local $18
+              (get_local $14)
+            )
           )
         )
         (if
@@ -1399,13 +1408,13 @@
             (get_local $0)
             (i32.const -65)
           )
-          (set_local $0
+          (set_local $18
             (i32.const -1)
           )
           (block
-            (set_local $3
+            (set_local $2
               (i32.and
-                (set_local $6
+                (set_local $3
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1415,61 +1424,61 @@
               )
             )
             (if
-              (set_local $9
+              (set_local $8
                 (i32.load
                   (i32.const 1212)
                 )
               )
               (block
-                (set_local $2
+                (set_local $16
                   (i32.sub
                     (i32.const 0)
-                    (get_local $3)
+                    (get_local $2)
                   )
                 )
                 (block $label$break$a
                   (if
-                    (set_local $12
+                    (set_local $0
                       (i32.load
                         (i32.add
                           (i32.shl
-                            (set_local $0
+                            (set_local $34
                               (if
-                                (set_local $8
+                                (set_local $19
                                   (i32.shr_u
-                                    (get_local $6)
+                                    (get_local $3)
                                     (i32.const 8)
                                   )
                                 )
                                 (if
                                   (i32.gt_u
-                                    (get_local $3)
+                                    (get_local $2)
                                     (i32.const 16777215)
                                   )
                                   (i32.const 31)
                                   (i32.or
                                     (i32.and
                                       (i32.shr_u
-                                        (get_local $3)
+                                        (get_local $2)
                                         (i32.add
-                                          (set_local $12
+                                          (set_local $0
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
                                                 (i32.or
                                                   (i32.or
-                                                    (set_local $8
+                                                    (set_local $19
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $21
+                                                            (set_local $7
                                                               (i32.shl
-                                                                (get_local $8)
-                                                                (set_local $6
+                                                                (get_local $19)
+                                                                (set_local $3
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
-                                                                        (get_local $8)
+                                                                        (get_local $19)
                                                                         (i32.const 1048320)
                                                                       )
                                                                       (i32.const 16)
@@ -1486,16 +1495,16 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $6)
+                                                    (get_local $3)
                                                   )
-                                                  (set_local $21
+                                                  (set_local $7
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
-                                                          (set_local $14
+                                                          (set_local $25
                                                             (i32.shl
-                                                              (get_local $21)
-                                                              (get_local $8)
+                                                              (get_local $7)
+                                                              (get_local $19)
                                                             )
                                                           )
                                                           (i32.const 245760)
@@ -1509,8 +1518,8 @@
                                               )
                                               (i32.shr_u
                                                 (i32.shl
-                                                  (get_local $14)
-                                                  (get_local $21)
+                                                  (get_local $25)
+                                                  (get_local $7)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1522,7 +1531,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $12)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                   )
@@ -1537,110 +1546,118 @@
                       )
                     )
                     (block
-                      (set_local $21
-                        (get_local $2)
+                      (set_local $7
+                        (get_local $16)
                       )
-                      (set_local $14
+                      (set_local $25
                         (i32.const 0)
                       )
-                      (set_local $6
+                      (set_local $3
                         (i32.shl
-                          (get_local $3)
+                          (get_local $2)
                           (select
                             (i32.const 0)
                             (i32.sub
                               (i32.const 25)
                               (i32.shr_u
-                                (get_local $0)
+                                (get_local $34)
                                 (i32.const 1)
                               )
                             )
                             (i32.eq
-                              (get_local $0)
+                              (get_local $34)
                               (i32.const 31)
                             )
                           )
                         )
                       )
-                      (set_local $8
-                        (get_local $12)
+                      (set_local $19
+                        (get_local $0)
                       )
-                      (set_local $1
+                      (set_local $5
                         (i32.const 0)
                       )
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $5
+                            (set_local $29
                               (i32.sub
-                                (set_local $12
+                                (set_local $27
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $8)
+                                      (get_local $19)
                                     )
                                     (i32.const -8)
                                   )
                                 )
-                                (get_local $3)
+                                (get_local $2)
                               )
                             )
-                            (get_local $21)
+                            (get_local $7)
                           )
                           (if
                             (i32.eq
-                              (get_local $12)
-                              (get_local $3)
+                              (get_local $27)
+                              (get_local $2)
                             )
                             (block
-                              (set_local $28
-                                (get_local $5)
+                              (set_local $36
+                                (get_local $29)
                               )
-                              (set_local $27
-                                (get_local $8)
+                              (set_local $18
+                                (get_local $19)
                               )
-                              (set_local $31
-                                (get_local $8)
+                              (set_local $17
+                                (get_local $19)
                               )
-                              (set_local $8
+                              (set_local $7
                                 (i32.const 90)
                               )
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $21
-                                (get_local $5)
+                              (set_local $4
+                                (get_local $29)
                               )
-                              (set_local $1
-                                (get_local $8)
+                              (set_local $0
+                                (get_local $19)
                               )
                             )
                           )
+                          (block
+                            (set_local $4
+                              (get_local $7)
+                            )
+                            (set_local $0
+                              (get_local $5)
+                            )
+                          )
                         )
-                        (set_local $12
+                        (set_local $27
                           (select
-                            (get_local $14)
-                            (set_local $5
+                            (get_local $25)
+                            (set_local $29
                               (i32.load offset=20
-                                (get_local $8)
+                                (get_local $19)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $5)
+                                (get_local $29)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $5)
-                                (set_local $8
+                                (get_local $29)
+                                (set_local $19
                                   (i32.load
                                     (i32.add
                                       (i32.add
-                                        (get_local $8)
+                                        (get_local $19)
                                         (i32.const 16)
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $6)
+                                          (get_local $3)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1653,42 +1670,48 @@
                           )
                         )
                         (if
-                          (set_local $5
+                          (set_local $29
                             (i32.eq
-                              (get_local $8)
+                              (get_local $19)
                               (i32.const 0)
                             )
                           )
                           (block
-                            (set_local $36
-                              (get_local $21)
+                            (set_local $40
+                              (get_local $4)
                             )
-                            (set_local $37
-                              (get_local $12)
+                            (set_local $12
+                              (get_local $27)
                             )
-                            (set_local $32
-                              (get_local $1)
+                            (set_local $38
+                              (get_local $0)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 86)
                             )
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $14
-                              (get_local $12)
+                            (set_local $7
+                              (get_local $4)
                             )
-                            (set_local $6
+                            (set_local $25
+                              (get_local $27)
+                            )
+                            (set_local $3
                               (i32.shl
-                                (get_local $6)
+                                (get_local $3)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $5)
+                                    (get_local $29)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
                                 )
                               )
+                            )
+                            (set_local $5
+                              (get_local $0)
                             )
                           )
                         )
@@ -1696,16 +1719,16 @@
                       )
                     )
                     (block
-                      (set_local $36
-                        (get_local $2)
+                      (set_local $40
+                        (get_local $16)
                       )
-                      (set_local $37
+                      (set_local $12
                         (i32.const 0)
                       )
-                      (set_local $32
+                      (set_local $38
                         (i32.const 0)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 86)
                       )
                     )
@@ -1713,7 +1736,7 @@
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 86)
                   )
                   (if
@@ -1721,52 +1744,52 @@
                       (if
                         (i32.and
                           (i32.eq
-                            (get_local $37)
+                            (get_local $12)
                             (i32.const 0)
                           )
                           (i32.eq
-                            (get_local $32)
+                            (get_local $38)
                             (i32.const 0)
                           )
                         )
                         (block
                           (if
                             (i32.eqz
-                              (set_local $2
+                              (set_local $16
                                 (i32.and
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.or
-                                    (set_local $12
+                                    (set_local $0
                                       (i32.shl
                                         (i32.const 2)
-                                        (get_local $0)
+                                        (get_local $34)
                                       )
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $12)
+                                      (get_local $0)
                                     )
                                   )
                                 )
                               )
                             )
                             (block
-                              (set_local $0
-                                (get_local $3)
+                              (set_local $18
+                                (get_local $2)
                               )
                               (br $do-once$0)
                             )
                           )
-                          (set_local $2
+                          (set_local $16
                             (i32.and
                               (i32.shr_u
-                                (set_local $12
+                                (set_local $0
                                   (i32.add
                                     (i32.and
-                                      (get_local $2)
+                                      (get_local $16)
                                       (i32.sub
                                         (i32.const 0)
-                                        (get_local $2)
+                                        (get_local $16)
                                       )
                                     )
                                     (i32.const -1)
@@ -1785,13 +1808,13 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $12
+                                          (set_local $0
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $0
+                                                (set_local $14
                                                   (i32.shr_u
-                                                    (get_local $12)
-                                                    (get_local $2)
+                                                    (get_local $0)
+                                                    (get_local $16)
                                                   )
                                                 )
                                                 (i32.const 5)
@@ -1799,15 +1822,15 @@
                                               (i32.const 8)
                                             )
                                           )
-                                          (get_local $2)
+                                          (get_local $16)
                                         )
-                                        (set_local $0
+                                        (set_local $14
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $5
+                                              (set_local $12
                                                 (i32.shr_u
+                                                  (get_local $14)
                                                   (get_local $0)
-                                                  (get_local $12)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1816,13 +1839,13 @@
                                           )
                                         )
                                       )
-                                      (set_local $5
+                                      (set_local $12
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $1
+                                            (set_local $5
                                               (i32.shr_u
-                                                (get_local $5)
-                                                (get_local $0)
+                                                (get_local $12)
+                                                (get_local $14)
                                               )
                                             )
                                             (i32.const 1)
@@ -1831,13 +1854,13 @@
                                         )
                                       )
                                     )
-                                    (set_local $1
+                                    (set_local $5
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $6
+                                          (set_local $3
                                             (i32.shr_u
-                                              (get_local $1)
                                               (get_local $5)
+                                              (get_local $12)
                                             )
                                           )
                                           (i32.const 1)
@@ -1847,8 +1870,8 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $6)
-                                    (get_local $1)
+                                    (get_local $3)
+                                    (get_local $5)
                                   )
                                 )
                                 (i32.const 2)
@@ -1857,111 +1880,111 @@
                             )
                           )
                         )
-                        (get_local $37)
+                        (get_local $12)
                       )
                     )
                     (block
-                      (set_local $28
-                        (get_local $36)
+                      (set_local $36
+                        (get_local $40)
                       )
-                      (set_local $27
+                      (set_local $18
                         (get_local $0)
                       )
-                      (set_local $31
-                        (get_local $32)
+                      (set_local $17
+                        (get_local $38)
                       )
-                      (set_local $8
+                      (set_local $7
                         (i32.const 90)
                       )
                     )
                     (block
-                      (set_local $16
-                        (get_local $36)
+                      (set_local $22
+                        (get_local $40)
                       )
-                      (set_local $10
-                        (get_local $32)
+                      (set_local $9
+                        (get_local $38)
                       )
                     )
                   )
                 )
                 (if
                   (i32.eq
-                    (get_local $8)
+                    (get_local $7)
                     (i32.const 90)
                   )
                   (loop $while-out$19 $while-in$20
-                    (set_local $8
+                    (set_local $7
                       (i32.const 0)
                     )
-                    (set_local $6
+                    (set_local $3
                       (i32.lt_u
-                        (set_local $1
+                        (set_local $5
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $27)
+                                (get_local $18)
                               )
                               (i32.const -8)
                             )
-                            (get_local $3)
+                            (get_local $2)
                           )
                         )
-                        (get_local $28)
+                        (get_local $36)
+                      )
+                    )
+                    (set_local $12
+                      (select
+                        (get_local $5)
+                        (get_local $36)
+                        (get_local $3)
                       )
                     )
                     (set_local $5
                       (select
-                        (get_local $1)
-                        (get_local $28)
-                        (get_local $6)
-                      )
-                    )
-                    (set_local $1
-                      (select
-                        (get_local $27)
-                        (get_local $31)
-                        (get_local $6)
+                        (get_local $18)
+                        (get_local $17)
+                        (get_local $3)
                       )
                     )
                     (if
-                      (set_local $6
+                      (set_local $3
                         (i32.load offset=16
-                          (get_local $27)
+                          (get_local $18)
                         )
                       )
                       (block
-                        (set_local $28
+                        (set_local $36
+                          (get_local $12)
+                        )
+                        (set_local $18
+                          (get_local $3)
+                        )
+                        (set_local $17
                           (get_local $5)
-                        )
-                        (set_local $27
-                          (get_local $6)
-                        )
-                        (set_local $31
-                          (get_local $1)
                         )
                         (br $while-in$20)
                       )
                     )
                     (if
-                      (set_local $27
+                      (set_local $18
                         (i32.load offset=20
-                          (get_local $27)
+                          (get_local $18)
                         )
                       )
                       (block
-                        (set_local $28
-                          (get_local $5)
+                        (set_local $36
+                          (get_local $12)
                         )
-                        (set_local $31
-                          (get_local $1)
+                        (set_local $17
+                          (get_local $5)
                         )
                       )
                       (block
-                        (set_local $16
-                          (get_local $5)
+                        (set_local $22
+                          (get_local $12)
                         )
-                        (set_local $10
-                          (get_local $1)
+                        (set_local $9
+                          (get_local $5)
                         )
                         (br $while-out$19)
                       )
@@ -1970,22 +1993,22 @@
                   )
                 )
                 (if
-                  (get_local $10)
+                  (get_local $9)
                   (if
                     (i32.lt_u
-                      (get_local $16)
+                      (get_local $22)
                       (i32.sub
                         (i32.load
                           (i32.const 1216)
                         )
-                        (get_local $3)
+                        (get_local $2)
                       )
                     )
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $10)
-                          (set_local $9
+                          (get_local $9)
+                          (set_local $8
                             (i32.load
                               (i32.const 1224)
                             )
@@ -1995,66 +2018,67 @@
                       )
                       (if
                         (i32.ge_u
-                          (get_local $10)
-                          (set_local $1
+                          (get_local $9)
+                          (set_local $5
                             (i32.add
-                              (get_local $10)
-                              (get_local $3)
+                              (get_local $9)
+                              (get_local $2)
                             )
                           )
                         )
                         (call_import $qa)
                       )
-                      (set_local $5
+                      (set_local $12
                         (i32.load offset=24
-                          (get_local $10)
+                          (get_local $9)
                         )
                       )
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $6
+                            (set_local $3
                               (i32.load offset=12
-                                (get_local $10)
+                                (get_local $9)
                               )
                             )
-                            (get_local $10)
+                            (get_local $9)
                           )
                           (block
                             (if
-                              (set_local $2
+                              (set_local $16
                                 (i32.load
-                                  (set_local $0
+                                  (set_local $14
                                     (i32.add
-                                      (get_local $10)
+                                      (get_local $9)
                                       (i32.const 20)
                                     )
                                   )
                                 )
                               )
                               (block
-                                (set_local $14
-                                  (get_local $2)
+                                (set_local $11
+                                  (get_local $16)
                                 )
-                                (set_local $12
-                                  (get_local $0)
+                                (set_local $0
+                                  (get_local $14)
                                 )
                               )
                               (if
-                                (i32.eqz
-                                  (set_local $14
-                                    (i32.load
-                                      (set_local $12
-                                        (i32.add
-                                          (get_local $10)
-                                          (i32.const 16)
-                                        )
+                                (set_local $25
+                                  (i32.load
+                                    (set_local $0
+                                      (i32.add
+                                        (get_local $9)
+                                        (i32.const 16)
                                       )
                                     )
                                   )
                                 )
+                                (set_local $11
+                                  (get_local $25)
+                                )
                                 (block
-                                  (set_local $19
+                                  (set_local $20
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
@@ -2063,43 +2087,43 @@
                             )
                             (loop $while-out$23 $while-in$24
                               (if
-                                (set_local $2
+                                (set_local $16
                                   (i32.load
-                                    (set_local $0
+                                    (set_local $14
                                       (i32.add
-                                        (get_local $14)
+                                        (get_local $11)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $14
-                                    (get_local $2)
+                                  (set_local $11
+                                    (get_local $16)
                                   )
-                                  (set_local $12
-                                    (get_local $0)
+                                  (set_local $0
+                                    (get_local $14)
                                   )
                                   (br $while-in$24)
                                 )
                               )
                               (if
-                                (set_local $2
+                                (set_local $16
                                   (i32.load
-                                    (set_local $0
+                                    (set_local $14
                                       (i32.add
-                                        (get_local $14)
+                                        (get_local $11)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $14
-                                    (get_local $2)
+                                  (set_local $11
+                                    (get_local $16)
                                   )
-                                  (set_local $12
-                                    (get_local $0)
+                                  (set_local $0
+                                    (get_local $14)
                                   )
                                 )
                                 (br $while-out$23)
@@ -2108,17 +2132,17 @@
                             )
                             (if
                               (i32.lt_u
-                                (get_local $12)
-                                (get_local $9)
+                                (get_local $0)
+                                (get_local $8)
                               )
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $12)
+                                  (get_local $0)
                                   (i32.const 0)
                                 )
-                                (set_local $19
-                                  (get_local $14)
+                                (set_local $20
+                                  (get_local $11)
                                 )
                               )
                             )
@@ -2126,9 +2150,23 @@
                           (block
                             (if
                               (i32.lt_u
-                                (set_local $0
+                                (set_local $14
                                   (i32.load offset=8
-                                    (get_local $10)
+                                    (get_local $9)
+                                  )
+                                )
+                                (get_local $8)
+                              )
+                              (call_import $qa)
+                            )
+                            (if
+                              (i32.ne
+                                (i32.load
+                                  (set_local $16
+                                    (i32.add
+                                      (get_local $14)
+                                      (i32.const 12)
+                                    )
                                   )
                                 )
                                 (get_local $9)
@@ -2136,42 +2174,28 @@
                               (call_import $qa)
                             )
                             (if
-                              (i32.ne
-                                (i32.load
-                                  (set_local $2
-                                    (i32.add
-                                      (get_local $0)
-                                      (i32.const 12)
-                                    )
-                                  )
-                                )
-                                (get_local $10)
-                              )
-                              (call_import $qa)
-                            )
-                            (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $12
+                                  (set_local $0
                                     (i32.add
-                                      (get_local $6)
+                                      (get_local $3)
                                       (i32.const 8)
                                     )
                                   )
                                 )
-                                (get_local $10)
+                                (get_local $9)
                               )
                               (block
                                 (i32.store
-                                  (get_local $2)
-                                  (get_local $6)
+                                  (get_local $16)
+                                  (get_local $3)
                                 )
                                 (i32.store
-                                  (get_local $12)
                                   (get_local $0)
+                                  (get_local $14)
                                 )
-                                (set_local $19
-                                  (get_local $6)
+                                (set_local $20
+                                  (get_local $3)
                                 )
                               )
                               (call_import $qa)
@@ -2181,19 +2205,19 @@
                       )
                       (block $do-once$25
                         (if
-                          (get_local $5)
+                          (get_local $12)
                           (block
                             (if
                               (i32.eq
-                                (get_local $10)
+                                (get_local $9)
                                 (i32.load
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (set_local $6
+                                        (set_local $3
                                           (i32.load offset=28
-                                            (get_local $10)
+                                            (get_local $9)
                                           )
                                         )
                                         (i32.const 2)
@@ -2204,12 +2228,12 @@
                               )
                               (block
                                 (i32.store
-                                  (get_local $9)
-                                  (get_local $19)
+                                  (get_local $8)
+                                  (get_local $20)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $19)
+                                    (get_local $20)
                                   )
                                   (block
                                     (i32.store
@@ -2221,7 +2245,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $6)
+                                            (get_local $3)
                                           )
                                           (i32.const -1)
                                         )
@@ -2234,7 +2258,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $5)
+                                    (get_local $12)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2244,35 +2268,35 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $6
+                                      (set_local $3
                                         (i32.add
-                                          (get_local $5)
+                                          (get_local $12)
                                           (i32.const 16)
                                         )
                                       )
                                     )
-                                    (get_local $10)
+                                    (get_local $9)
                                   )
                                   (i32.store
-                                    (get_local $6)
-                                    (get_local $19)
+                                    (get_local $3)
+                                    (get_local $20)
                                   )
                                   (i32.store offset=20
-                                    (get_local $5)
-                                    (get_local $19)
+                                    (get_local $12)
+                                    (get_local $20)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eqz
-                                    (get_local $19)
+                                    (get_local $20)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $19)
-                                (set_local $6
+                                (get_local $20)
+                                (set_local $3
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2281,42 +2305,42 @@
                               (call_import $qa)
                             )
                             (i32.store offset=24
-                              (get_local $19)
-                              (get_local $5)
+                              (get_local $20)
+                              (get_local $12)
                             )
                             (if
-                              (set_local $9
+                              (set_local $8
                                 (i32.load offset=16
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $9)
-                                  (get_local $6)
+                                  (get_local $8)
+                                  (get_local $3)
                                 )
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $19)
-                                    (get_local $9)
+                                    (get_local $20)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=24
-                                    (get_local $9)
-                                    (get_local $19)
+                                    (get_local $8)
+                                    (get_local $20)
                                   )
                                 )
                               )
                             )
                             (if
-                              (set_local $9
+                              (set_local $8
                                 (i32.load offset=20
-                                  (get_local $10)
+                                  (get_local $9)
                                 )
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $9)
+                                  (get_local $8)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2324,12 +2348,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $19)
-                                    (get_local $9)
+                                    (get_local $20)
+                                    (get_local $8)
                                   )
                                   (i32.store offset=24
-                                    (get_local $9)
-                                    (get_local $19)
+                                    (get_local $8)
+                                    (get_local $20)
                                   )
                                 )
                               )
@@ -2340,35 +2364,35 @@
                       (block $do-once$29
                         (if
                           (i32.lt_u
-                            (get_local $16)
+                            (get_local $22)
                             (i32.const 16)
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $10)
+                              (get_local $9)
                               (i32.or
-                                (set_local $5
+                                (set_local $12
                                   (i32.add
-                                    (get_local $16)
-                                    (get_local $3)
+                                    (get_local $22)
+                                    (get_local $2)
                                   )
                                 )
                                 (i32.const 3)
                               )
                             )
                             (i32.store
-                              (set_local $9
+                              (set_local $8
                                 (i32.add
                                   (i32.add
-                                    (get_local $10)
-                                    (get_local $5)
+                                    (get_local $9)
+                                    (get_local $12)
                                   )
                                   (i32.const 4)
                                 )
                               )
                               (i32.or
                                 (i32.load
-                                  (get_local $9)
+                                  (get_local $8)
                                 )
                                 (i32.const 1)
                               )
@@ -2376,44 +2400,44 @@
                           )
                           (block
                             (i32.store offset=4
-                              (get_local $10)
+                              (get_local $9)
                               (i32.or
-                                (get_local $3)
+                                (get_local $2)
                                 (i32.const 3)
                               )
                             )
                             (i32.store offset=4
-                              (get_local $1)
+                              (get_local $5)
                               (i32.or
-                                (get_local $16)
+                                (get_local $22)
                                 (i32.const 1)
                               )
                             )
                             (i32.store
                               (i32.add
-                                (get_local $1)
-                                (get_local $16)
+                                (get_local $5)
+                                (get_local $22)
                               )
-                              (get_local $16)
+                              (get_local $22)
                             )
-                            (set_local $9
+                            (set_local $8
                               (i32.shr_u
-                                (get_local $16)
+                                (get_local $22)
                                 (i32.const 3)
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $16)
+                                (get_local $22)
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $5
+                                (set_local $12
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
                                       (i32.shl
-                                        (get_local $9)
+                                        (get_local $8)
                                         (i32.const 1)
                                       )
                                       (i32.const 2)
@@ -2422,25 +2446,25 @@
                                 )
                                 (if
                                   (i32.and
-                                    (set_local $6
+                                    (set_local $3
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $14
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $9)
+                                        (get_local $8)
                                       )
                                     )
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $6
+                                      (set_local $3
                                         (i32.load
-                                          (set_local $0
+                                          (set_local $14
                                             (i32.add
-                                              (get_local $5)
+                                              (get_local $12)
                                               (i32.const 8)
                                             )
                                           )
@@ -2452,11 +2476,11 @@
                                     )
                                     (call_import $qa)
                                     (block
-                                      (set_local $18
-                                        (get_local $0)
+                                      (set_local $23
+                                        (get_local $14)
                                       )
                                       (set_local $13
-                                        (get_local $6)
+                                        (get_local $3)
                                       )
                                     )
                                   )
@@ -2464,81 +2488,81 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $6)
-                                        (get_local $0)
+                                        (get_local $3)
+                                        (get_local $14)
                                       )
                                     )
-                                    (set_local $18
+                                    (set_local $23
                                       (i32.add
-                                        (get_local $5)
+                                        (get_local $12)
                                         (i32.const 8)
                                       )
                                     )
                                     (set_local $13
-                                      (get_local $5)
+                                      (get_local $12)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $18)
-                                  (get_local $1)
+                                  (get_local $23)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=12
                                   (get_local $13)
-                                  (get_local $1)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
+                                  (get_local $5)
                                   (get_local $13)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
                                   (get_local $5)
+                                  (get_local $12)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $12
+                            (set_local $0
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
-                                  (set_local $2
+                                  (set_local $20
                                     (if
-                                      (set_local $5
+                                      (set_local $12
                                         (i32.shr_u
-                                          (get_local $16)
+                                          (get_local $22)
                                           (i32.const 8)
                                         )
                                       )
                                       (if
                                         (i32.gt_u
-                                          (get_local $16)
+                                          (get_local $22)
                                           (i32.const 16777215)
                                         )
                                         (i32.const 31)
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $16)
+                                              (get_local $22)
                                               (i32.add
-                                                (set_local $12
+                                                (set_local $0
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $5
+                                                          (set_local $12
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $0
+                                                                  (set_local $14
                                                                     (i32.shl
-                                                                      (get_local $5)
-                                                                      (set_local $6
+                                                                      (get_local $12)
+                                                                      (set_local $3
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $5)
+                                                                              (get_local $12)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2555,16 +2579,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $6)
+                                                          (get_local $3)
                                                         )
-                                                        (set_local $0
+                                                        (set_local $14
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $9
+                                                                (set_local $8
                                                                   (i32.shl
-                                                                    (get_local $0)
-                                                                    (get_local $5)
+                                                                    (get_local $14)
+                                                                    (get_local $12)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2578,8 +2602,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $9)
-                                                        (get_local $0)
+                                                        (get_local $8)
+                                                        (get_local $14)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -2591,7 +2615,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $12)
+                                            (get_local $0)
                                             (i32.const 1)
                                           )
                                         )
@@ -2604,34 +2628,34 @@
                               )
                             )
                             (i32.store offset=28
-                              (get_local $1)
-                              (get_local $2)
+                              (get_local $5)
+                              (get_local $20)
                             )
                             (i32.store offset=4
-                              (set_local $0
+                              (set_local $14
                                 (i32.add
-                                  (get_local $1)
+                                  (get_local $5)
                                   (i32.const 16)
                                 )
                               )
                               (i32.const 0)
                             )
                             (i32.store
-                              (get_local $0)
+                              (get_local $14)
                               (i32.const 0)
                             )
                             (if
                               (i32.eqz
                                 (i32.and
-                                  (set_local $0
+                                  (set_local $14
                                     (i32.load
                                       (i32.const 1212)
                                     )
                                   )
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.shl
                                       (i32.const 1)
-                                      (get_local $2)
+                                      (get_local $20)
                                     )
                                   )
                                 )
@@ -2640,51 +2664,51 @@
                                 (i32.store
                                   (i32.const 1212)
                                   (i32.or
-                                    (get_local $0)
-                                    (get_local $9)
+                                    (get_local $14)
+                                    (get_local $8)
                                   )
                                 )
                                 (i32.store
-                                  (get_local $12)
-                                  (get_local $1)
+                                  (get_local $0)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=24
-                                  (get_local $1)
-                                  (get_local $12)
+                                  (get_local $5)
+                                  (get_local $0)
                                 )
                                 (i32.store offset=12
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (i32.store offset=8
-                                  (get_local $1)
-                                  (get_local $1)
+                                  (get_local $5)
+                                  (get_local $5)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $9
+                            (set_local $8
                               (i32.shl
-                                (get_local $16)
+                                (get_local $22)
                                 (select
                                   (i32.const 0)
                                   (i32.sub
                                     (i32.const 25)
                                     (i32.shr_u
-                                      (get_local $2)
+                                      (get_local $20)
                                       (i32.const 1)
                                     )
                                   )
                                   (i32.eq
-                                    (get_local $2)
+                                    (get_local $20)
                                     (i32.const 31)
                                   )
                                 )
                               )
                             )
-                            (set_local $0
+                            (set_local $14
                               (i32.load
-                                (get_local $12)
+                                (get_local $0)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -2692,34 +2716,34 @@
                                 (i32.eq
                                   (i32.and
                                     (i32.load offset=4
-                                      (get_local $0)
+                                      (get_local $14)
                                     )
                                     (i32.const -8)
                                   )
-                                  (get_local $16)
+                                  (get_local $22)
                                 )
                                 (block
-                                  (set_local $17
-                                    (get_local $0)
+                                  (set_local $21
+                                    (get_local $14)
                                   )
-                                  (set_local $8
+                                  (set_local $7
                                     (i32.const 148)
                                   )
                                   (br $while-out$31)
                                 )
                               )
                               (if
-                                (set_local $6
+                                (set_local $3
                                   (i32.load
-                                    (set_local $12
+                                    (set_local $0
                                       (i32.add
                                         (i32.add
-                                          (get_local $0)
+                                          (get_local $14)
                                           (i32.const 16)
                                         )
                                         (i32.shl
                                           (i32.shr_u
-                                            (get_local $9)
+                                            (get_local $8)
                                             (i32.const 31)
                                           )
                                           (i32.const 2)
@@ -2729,24 +2753,24 @@
                                   )
                                 )
                                 (block
-                                  (set_local $9
+                                  (set_local $8
                                     (i32.shl
-                                      (get_local $9)
+                                      (get_local $8)
                                       (i32.const 1)
                                     )
                                   )
-                                  (set_local $0
-                                    (get_local $6)
+                                  (set_local $14
+                                    (get_local $3)
                                   )
                                 )
                                 (block
-                                  (set_local $22
-                                    (get_local $12)
-                                  )
-                                  (set_local $15
+                                  (set_local $6
                                     (get_local $0)
                                   )
-                                  (set_local $8
+                                  (set_local $24
+                                    (get_local $14)
+                                  )
+                                  (set_local $7
                                     (i32.const 145)
                                   )
                                   (br $while-out$31)
@@ -2756,12 +2780,12 @@
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 145)
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $22)
+                                  (get_local $6)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2769,71 +2793,71 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store
-                                    (get_local $22)
-                                    (get_local $1)
+                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=24
-                                    (get_local $1)
-                                    (get_local $15)
+                                    (get_local $5)
+                                    (get_local $24)
                                   )
                                   (i32.store offset=12
-                                    (get_local $1)
-                                    (get_local $1)
+                                    (get_local $5)
+                                    (get_local $5)
                                   )
                                   (i32.store offset=8
-                                    (get_local $1)
-                                    (get_local $1)
+                                    (get_local $5)
+                                    (get_local $5)
                                   )
                                 )
                               )
                               (if
                                 (i32.eq
-                                  (get_local $8)
+                                  (get_local $7)
                                   (i32.const 148)
                                 )
                                 (if
                                   (i32.and
                                     (i32.ge_u
-                                      (set_local $9
+                                      (set_local $8
                                         (i32.load
-                                          (set_local $0
+                                          (set_local $14
                                             (i32.add
-                                              (get_local $17)
+                                              (get_local $21)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $3
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $17)
-                                      (get_local $6)
+                                      (get_local $21)
+                                      (get_local $3)
                                     )
                                   )
                                   (block
                                     (i32.store offset=12
-                                      (get_local $9)
-                                      (get_local $1)
+                                      (get_local $8)
+                                      (get_local $5)
                                     )
                                     (i32.store
-                                      (get_local $0)
-                                      (get_local $1)
+                                      (get_local $14)
+                                      (get_local $5)
                                     )
                                     (i32.store offset=8
-                                      (get_local $1)
-                                      (get_local $9)
+                                      (get_local $5)
+                                      (get_local $8)
                                     )
                                     (i32.store offset=12
-                                      (get_local $1)
-                                      (get_local $17)
+                                      (get_local $5)
+                                      (get_local $21)
                                     )
                                     (i32.store offset=24
-                                      (get_local $1)
+                                      (get_local $5)
                                       (i32.const 0)
                                     )
                                   )
@@ -2846,26 +2870,26 @@
                       )
                       (i32.store
                         (i32.const 8)
-                        (get_local $25)
+                        (get_local $31)
                       )
                       (return
                         (i32.add
-                          (get_local $10)
+                          (get_local $9)
                           (i32.const 8)
                         )
                       )
                     )
-                    (set_local $0
-                      (get_local $3)
+                    (set_local $18
+                      (get_local $2)
                     )
                   )
-                  (set_local $0
-                    (get_local $3)
+                  (set_local $18
+                    (get_local $2)
                   )
                 )
               )
-              (set_local $0
-                (get_local $3)
+              (set_local $18
+                (get_local $2)
               )
             )
           )
@@ -2874,25 +2898,25 @@
     )
     (if
       (i32.ge_u
-        (set_local $10
+        (set_local $9
           (i32.load
             (i32.const 1216)
           )
         )
-        (get_local $0)
+        (get_local $18)
       )
       (block
-        (set_local $15
+        (set_local $24
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (set_local $17
+            (set_local $21
               (i32.sub
-                (get_local $10)
-                (get_local $0)
+                (get_local $9)
+                (get_local $18)
               )
             )
             (i32.const 15)
@@ -2900,35 +2924,35 @@
           (block
             (i32.store
               (i32.const 1228)
-              (set_local $22
+              (set_local $6
                 (i32.add
-                  (get_local $15)
-                  (get_local $0)
+                  (get_local $24)
+                  (get_local $18)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $17)
+              (get_local $21)
             )
             (i32.store offset=4
-              (get_local $22)
+              (get_local $6)
               (i32.or
-                (get_local $17)
+                (get_local $21)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $22)
-                (get_local $17)
+                (get_local $6)
+                (get_local $21)
               )
-              (get_local $17)
+              (get_local $21)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $24)
               (i32.or
-                (get_local $0)
+                (get_local $18)
                 (i32.const 3)
               )
             )
@@ -2943,25 +2967,25 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $15)
+              (get_local $24)
               (i32.or
-                (get_local $10)
+                (get_local $9)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $17
+              (set_local $21
                 (i32.add
                   (i32.add
-                    (get_local $15)
-                    (get_local $10)
+                    (get_local $24)
+                    (get_local $9)
                   )
                   (i32.const 4)
                 )
               )
               (i32.or
                 (i32.load
-                  (get_local $17)
+                  (get_local $21)
                 )
                 (i32.const 1)
               )
@@ -2970,11 +2994,11 @@
         )
         (i32.store
           (i32.const 8)
-          (get_local $25)
+          (get_local $31)
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $24)
             (i32.const 8)
           )
         )
@@ -2982,57 +3006,57 @@
     )
     (if
       (i32.gt_u
-        (set_local $15
+        (set_local $24
           (i32.load
             (i32.const 1220)
           )
         )
-        (get_local $0)
+        (get_local $18)
       )
       (block
         (i32.store
           (i32.const 1220)
-          (set_local $17
+          (set_local $21
             (i32.sub
-              (get_local $15)
-              (get_local $0)
+              (get_local $24)
+              (get_local $18)
             )
           )
         )
         (i32.store
           (i32.const 1232)
-          (set_local $10
+          (set_local $9
             (i32.add
-              (set_local $15
+              (set_local $24
                 (i32.load
                   (i32.const 1232)
                 )
               )
-              (get_local $0)
+              (get_local $18)
             )
           )
         )
         (i32.store offset=4
-          (get_local $10)
+          (get_local $9)
           (i32.or
-            (get_local $17)
+            (get_local $21)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $15)
+          (get_local $24)
           (i32.or
-            (get_local $0)
+            (get_local $18)
             (i32.const 3)
           )
         )
         (i32.store
           (i32.const 8)
-          (get_local $25)
+          (get_local $31)
         )
         (return
           (i32.add
-            (get_local $15)
+            (get_local $24)
             (i32.const 8)
           )
         )
@@ -3070,11 +3094,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $7)
-          (set_local $15
+          (get_local $15)
+          (set_local $24
             (i32.xor
               (i32.and
-                (get_local $7)
+                (get_local $15)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3083,49 +3107,49 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $15)
+          (get_local $24)
         )
       )
     )
-    (set_local $15
+    (set_local $24
       (i32.add
-        (get_local $0)
+        (get_local $18)
         (i32.const 48)
       )
     )
     (if
       (i32.le_u
-        (set_local $7
+        (set_local $15
           (i32.and
-            (set_local $10
+            (set_local $9
               (i32.add
-                (set_local $7
+                (set_local $15
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (set_local $17
+                (set_local $21
                   (i32.add
-                    (get_local $0)
+                    (get_local $18)
                     (i32.const 47)
                   )
                 )
               )
             )
-            (set_local $22
+            (set_local $6
               (i32.sub
                 (i32.const 0)
-                (get_local $7)
+                (get_local $15)
               )
             )
           )
         )
-        (get_local $0)
+        (get_local $18)
       )
       (block
         (i32.store
           (i32.const 8)
-          (get_local $25)
+          (get_local $31)
         )
         (return
           (i32.const 0)
@@ -3133,7 +3157,7 @@
       )
     )
     (if
-      (set_local $16
+      (set_local $22
         (i32.load
           (i32.const 1648)
         )
@@ -3143,25 +3167,25 @@
           (i32.le_u
             (set_local $13
               (i32.add
-                (set_local $2
+                (set_local $20
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $7)
+                (get_local $15)
               )
             )
-            (get_local $2)
+            (get_local $20)
           )
           (i32.gt_u
             (get_local $13)
-            (get_local $16)
+            (get_local $22)
           )
         )
         (block
           (i32.store
             (i32.const 8)
-            (get_local $25)
+            (get_local $31)
           )
           (return
             (i32.const 0)
@@ -3171,7 +3195,7 @@
     )
     (if
       (i32.eq
-        (set_local $8
+        (set_local $7
           (block $label$break$b
             (if
               (i32.and
@@ -3184,7 +3208,7 @@
               (block
                 (block $label$break$c
                   (if
-                    (set_local $16
+                    (set_local $22
                       (i32.load
                         (i32.const 1232)
                       )
@@ -3196,19 +3220,19 @@
                       (loop $while-out$35 $while-in$36
                         (if
                           (i32.le_u
-                            (set_local $2
+                            (set_local $20
                               (i32.load
                                 (get_local $13)
                               )
                             )
-                            (get_local $16)
+                            (get_local $22)
                           )
                           (if
                             (i32.gt_u
                               (i32.add
-                                (get_local $2)
+                                (get_local $20)
                                 (i32.load
-                                  (set_local $18
+                                  (set_local $23
                                     (i32.add
                                       (get_local $13)
                                       (i32.const 4)
@@ -3216,14 +3240,14 @@
                                   )
                                 )
                               )
-                              (get_local $16)
+                              (get_local $22)
                             )
                             (block
-                              (set_local $3
+                              (set_local $0
                                 (get_local $13)
                               )
-                              (set_local $5
-                                (get_local $18)
+                              (set_local $17
+                                (get_local $23)
                               )
                               (br $while-out$35)
                             )
@@ -3238,7 +3262,7 @@
                             )
                           )
                           (block
-                            (set_local $8
+                            (set_local $7
                               (i32.const 171)
                             )
                             (br $label$break$c)
@@ -3251,42 +3275,42 @@
                           (set_local $13
                             (i32.and
                               (i32.sub
-                                (get_local $10)
+                                (get_local $9)
                                 (i32.load
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $22)
+                              (get_local $6)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $18
+                            (set_local $23
                               (call_import $ta
                                 (get_local $13)
                               )
                             )
                             (i32.add
                               (i32.load
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (i32.load
-                                (get_local $5)
+                                (get_local $17)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $18)
+                              (get_local $23)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $20
-                                (get_local $18)
+                              (set_local $28
+                                (get_local $23)
                               )
-                              (set_local $26
+                              (set_local $33
                                 (get_local $13)
                               )
                               (br $label$break$b
@@ -3295,20 +3319,20 @@
                             )
                           )
                           (block
-                            (set_local $11
-                              (get_local $18)
+                            (set_local $10
+                              (get_local $23)
                             )
-                            (set_local $4
+                            (set_local $1
                               (get_local $13)
                             )
-                            (set_local $8
+                            (set_local $7
                               (i32.const 181)
                             )
                           )
                         )
                       )
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.const 171)
                     )
                   )
@@ -3316,12 +3340,12 @@
                 (block $do-once$37
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 171)
                     )
                     (if
                       (i32.ne
-                        (set_local $16
+                        (set_local $22
                           (call_import $ta
                             (i32.const 0)
                           )
@@ -3329,10 +3353,10 @@
                         (i32.const -1)
                       )
                       (block
-                        (set_local $2
+                        (set_local $6
                           (if
                             (i32.and
-                              (set_local $18
+                              (set_local $23
                                 (i32.add
                                   (set_local $13
                                     (i32.load
@@ -3342,19 +3366,19 @@
                                   (i32.const -1)
                                 )
                               )
-                              (set_local $3
-                                (get_local $16)
+                              (set_local $2
+                                (get_local $22)
                               )
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $7)
-                                (get_local $3)
+                                (get_local $15)
+                                (get_local $2)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $18)
-                                  (get_local $3)
+                                  (get_local $23)
+                                  (get_local $2)
                                 )
                                 (i32.sub
                                   (i32.const 0)
@@ -3362,33 +3386,33 @@
                                 )
                               )
                             )
-                            (get_local $7)
+                            (get_local $15)
                           )
                         )
-                        (set_local $3
+                        (set_local $2
                           (i32.add
                             (set_local $13
                               (i32.load
                                 (i32.const 1640)
                               )
                             )
-                            (get_local $2)
+                            (get_local $6)
                           )
                         )
                         (if
                           (i32.and
                             (i32.gt_u
-                              (get_local $2)
-                              (get_local $0)
+                              (get_local $6)
+                              (get_local $18)
                             )
                             (i32.lt_u
-                              (get_local $2)
+                              (get_local $6)
                               (i32.const 2147483647)
                             )
                           )
                           (block
                             (if
-                              (set_local $18
+                              (set_local $23
                                 (i32.load
                                   (i32.const 1648)
                                 )
@@ -3396,44 +3420,44 @@
                               (br_if $do-once$37
                                 (i32.or
                                   (i32.le_u
-                                    (get_local $3)
+                                    (get_local $2)
                                     (get_local $13)
                                   )
                                   (i32.gt_u
-                                    (get_local $3)
-                                    (get_local $18)
+                                    (get_local $2)
+                                    (get_local $23)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $18
+                                (set_local $23
                                   (call_import $ta
-                                    (get_local $2)
+                                    (get_local $6)
                                   )
                                 )
-                                (get_local $16)
+                                (get_local $22)
                               )
                               (block
-                                (set_local $20
-                                  (get_local $16)
+                                (set_local $28
+                                  (get_local $22)
                                 )
-                                (set_local $26
-                                  (get_local $2)
+                                (set_local $33
+                                  (get_local $6)
                                 )
                                 (br $label$break$b
                                   (i32.const 191)
                                 )
                               )
                               (block
-                                (set_local $11
-                                  (get_local $18)
+                                (set_local $10
+                                  (get_local $23)
                                 )
-                                (set_local $4
-                                  (get_local $2)
+                                (set_local $1
+                                  (get_local $6)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 181)
                                 )
                               )
@@ -3447,43 +3471,43 @@
                 (block $label$break$d
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 181)
                     )
                     (block
-                      (set_local $18
+                      (set_local $23
                         (i32.sub
                           (i32.const 0)
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $15)
-                            (get_local $4)
+                            (get_local $24)
+                            (get_local $1)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 2147483647)
                             )
                             (i32.ne
-                              (get_local $11)
+                              (get_local $10)
                               (i32.const -1)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $3
+                            (set_local $2
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $17)
-                                    (get_local $4)
+                                    (get_local $21)
+                                    (get_local $1)
                                   )
-                                  (set_local $16
+                                  (set_local $22
                                     (i32.load
                                       (i32.const 1688)
                                     )
@@ -3491,7 +3515,7 @@
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $16)
+                                  (get_local $22)
                                 )
                               )
                             )
@@ -3500,42 +3524,42 @@
                           (if
                             (i32.eq
                               (call_import $ta
-                                (get_local $3)
+                                (get_local $2)
                               )
                               (i32.const -1)
                             )
                             (block
                               (call_import $ta
-                                (get_local $18)
+                                (get_local $23)
                               )
                               (br $label$break$d)
                             )
-                            (set_local $1
+                            (set_local $4
                               (i32.add
-                                (get_local $3)
-                                (get_local $4)
+                                (get_local $2)
+                                (get_local $1)
                               )
                             )
                           )
-                          (set_local $1
-                            (get_local $4)
+                          (set_local $4
+                            (get_local $1)
                           )
                         )
-                        (set_local $1
-                          (get_local $4)
+                        (set_local $4
+                          (get_local $1)
                         )
                       )
                       (if
                         (i32.ne
-                          (get_local $11)
+                          (get_local $10)
                           (i32.const -1)
                         )
                         (block
-                          (set_local $20
-                            (get_local $11)
+                          (set_local $28
+                            (get_local $10)
                           )
-                          (set_local $26
-                            (get_local $1)
+                          (set_local $33
+                            (get_local $4)
                           )
                           (br $label$break$b
                             (i32.const 191)
@@ -3563,18 +3587,18 @@
       )
       (if
         (i32.lt_u
-          (get_local $7)
+          (get_local $15)
           (i32.const 2147483647)
         )
         (if
           (i32.and
             (i32.lt_u
-              (set_local $1
+              (set_local $4
                 (call_import $ta
-                  (get_local $7)
+                  (get_local $15)
                 )
               )
-              (set_local $7
+              (set_local $15
                 (call_import $ta
                   (i32.const 0)
                 )
@@ -3582,36 +3606,36 @@
             )
             (i32.and
               (i32.ne
-                (get_local $1)
+                (get_local $4)
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $7)
+                (get_local $15)
                 (i32.const -1)
               )
             )
           )
           (if
             (i32.gt_u
-              (set_local $11
+              (set_local $10
                 (i32.sub
-                  (get_local $7)
-                  (get_local $1)
+                  (get_local $15)
+                  (get_local $4)
                 )
               )
               (i32.add
-                (get_local $0)
+                (get_local $18)
                 (i32.const 40)
               )
             )
             (block
-              (set_local $20
-                (get_local $1)
+              (set_local $28
+                (get_local $4)
               )
-              (set_local $26
-                (get_local $11)
+              (set_local $33
+                (get_local $10)
               )
-              (set_local $8
+              (set_local $7
                 (i32.const 191)
               )
             )
@@ -3621,59 +3645,59 @@
     )
     (if
       (i32.eq
-        (get_local $8)
+        (get_local $7)
         (i32.const 191)
       )
       (block
         (i32.store
           (i32.const 1640)
-          (set_local $11
+          (set_local $10
             (i32.add
               (i32.load
                 (i32.const 1640)
               )
-              (get_local $26)
+              (get_local $33)
             )
           )
         )
         (if
           (i32.gt_u
-            (get_local $11)
+            (get_local $10)
             (i32.load
               (i32.const 1644)
             )
           )
           (i32.store
             (i32.const 1644)
-            (get_local $11)
+            (get_local $10)
           )
         )
         (block $do-once$42
           (if
-            (set_local $11
+            (set_local $10
               (i32.load
                 (i32.const 1232)
               )
             )
             (block
-              (set_local $4
+              (set_local $1
                 (i32.const 1656)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $20)
+                    (get_local $28)
                     (i32.add
-                      (set_local $1
+                      (set_local $4
                         (i32.load
-                          (get_local $4)
+                          (get_local $1)
                         )
                       )
-                      (set_local $17
+                      (set_local $21
                         (i32.load
-                          (set_local $7
+                          (set_local $15
                             (i32.add
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 4)
                             )
                           )
@@ -3682,19 +3706,19 @@
                     )
                   )
                   (block
-                    (set_local $49
-                      (get_local $1)
-                    )
                     (set_local $50
-                      (get_local $7)
-                    )
-                    (set_local $51
-                      (get_local $17)
-                    )
-                    (set_local $52
                       (get_local $4)
                     )
-                    (set_local $8
+                    (set_local $51
+                      (get_local $15)
+                    )
+                    (set_local $52
+                      (get_local $21)
+                    )
+                    (set_local $35
+                      (get_local $1)
+                    )
+                    (set_local $7
                       (i32.const 201)
                     )
                     (br $do-out$46)
@@ -3702,9 +3726,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $4
+                    (set_local $1
                       (i32.load offset=8
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                     (i32.const 0)
@@ -3713,14 +3737,14 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 201)
                 )
                 (if
                   (i32.eqz
                     (i32.and
                       (i32.load offset=12
-                        (get_local $52)
+                        (get_local $35)
                       )
                       (i32.const 8)
                     )
@@ -3728,34 +3752,34 @@
                   (if
                     (i32.and
                       (i32.lt_u
-                        (get_local $11)
-                        (get_local $20)
+                        (get_local $10)
+                        (get_local $28)
                       )
                       (i32.ge_u
-                        (get_local $11)
-                        (get_local $49)
+                        (get_local $10)
+                        (get_local $50)
                       )
                     )
                     (block
                       (i32.store
-                        (get_local $50)
+                        (get_local $51)
                         (i32.add
-                          (get_local $51)
-                          (get_local $26)
+                          (get_local $52)
+                          (get_local $33)
                         )
                       )
-                      (set_local $4
+                      (set_local $1
                         (i32.add
-                          (get_local $11)
-                          (set_local $17
+                          (get_local $10)
+                          (set_local $21
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (set_local $4
+                                  (set_local $1
                                     (i32.add
-                                      (get_local $11)
+                                      (get_local $10)
                                       (i32.const 8)
                                     )
                                   )
@@ -3764,7 +3788,7 @@
                               )
                               (i32.eq
                                 (i32.and
-                                  (get_local $4)
+                                  (get_local $1)
                                   (i32.const 7)
                                 )
                                 (i32.const 0)
@@ -3773,11 +3797,11 @@
                           )
                         )
                       )
-                      (set_local $7
+                      (set_local $15
                         (i32.add
                           (i32.sub
-                            (get_local $26)
-                            (get_local $17)
+                            (get_local $33)
+                            (get_local $21)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3786,23 +3810,23 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $7)
+                        (get_local $15)
                       )
                       (i32.store offset=4
-                        (get_local $4)
+                        (get_local $1)
                         (i32.or
-                          (get_local $7)
+                          (get_local $15)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $4)
-                          (get_local $7)
+                          (get_local $1)
+                          (get_local $15)
                         )
                         (i32.const 40)
                       )
@@ -3817,11 +3841,11 @@
                   )
                 )
               )
-              (set_local $14
+              (set_local $35
                 (if
                   (i32.lt_u
-                    (get_local $20)
-                    (set_local $7
+                    (get_local $28)
+                    (set_local $15
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3830,38 +3854,38 @@
                   (block
                     (i32.store
                       (i32.const 1224)
-                      (get_local $20)
+                      (get_local $28)
                     )
-                    (get_local $20)
+                    (get_local $28)
                   )
-                  (get_local $7)
+                  (get_local $15)
                 )
               )
-              (set_local $7
+              (set_local $15
                 (i32.add
-                  (get_local $20)
-                  (get_local $26)
+                  (get_local $28)
+                  (get_local $33)
                 )
               )
-              (set_local $4
+              (set_local $1
                 (i32.const 1656)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $4)
+                      (get_local $1)
                     )
-                    (get_local $7)
+                    (get_local $15)
                   )
                   (block
                     (set_local $53
-                      (get_local $4)
+                      (get_local $1)
                     )
-                    (set_local $43
-                      (get_local $4)
+                    (set_local $45
+                      (get_local $1)
                     )
-                    (set_local $8
+                    (set_local $7
                       (i32.const 209)
                     )
                     (br $while-out$48)
@@ -3869,14 +3893,14 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $4
+                    (set_local $1
                       (i32.load offset=8
-                        (get_local $4)
+                        (get_local $1)
                       )
                     )
                   )
                   (block
-                    (set_local $29
+                    (set_local $37
                       (i32.const 1656)
                     )
                     (br $while-out$48)
@@ -3886,49 +3910,49 @@
               )
               (if
                 (i32.eq
-                  (get_local $8)
+                  (get_local $7)
                   (i32.const 209)
                 )
                 (if
                   (i32.and
                     (i32.load offset=12
-                      (get_local $43)
+                      (get_local $45)
                     )
                     (i32.const 8)
                   )
-                  (set_local $29
+                  (set_local $37
                     (i32.const 1656)
                   )
                   (block
                     (i32.store
                       (get_local $53)
-                      (get_local $20)
+                      (get_local $28)
                     )
                     (i32.store
-                      (set_local $4
+                      (set_local $1
                         (i32.add
-                          (get_local $43)
+                          (get_local $45)
                           (i32.const 4)
                         )
                       )
                       (i32.add
                         (i32.load
-                          (get_local $4)
+                          (get_local $1)
                         )
-                        (get_local $26)
+                        (get_local $33)
                       )
                     )
-                    (set_local $17
+                    (set_local $21
                       (i32.add
-                        (get_local $20)
+                        (get_local $28)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $4
+                              (set_local $1
                                 (i32.add
-                                  (get_local $20)
+                                  (get_local $28)
                                   (i32.const 8)
                                 )
                               )
@@ -3937,34 +3961,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $4)
-                              (i32.const 7)
-                            )
-                            (i32.const 0)
-                          )
-                        )
-                      )
-                    )
-                    (set_local $1
-                      (i32.add
-                        (get_local $7)
-                        (select
-                          (i32.const 0)
-                          (i32.and
-                            (i32.sub
-                              (i32.const 0)
-                              (set_local $4
-                                (i32.add
-                                  (get_local $7)
-                                  (i32.const 8)
-                                )
-                              )
-                            )
-                            (i32.const 7)
-                          )
-                          (i32.eq
-                            (i32.and
-                              (get_local $4)
+                              (get_local $1)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3974,52 +3971,79 @@
                     )
                     (set_local $4
                       (i32.add
-                        (get_local $17)
-                        (get_local $0)
+                        (get_local $15)
+                        (select
+                          (i32.const 0)
+                          (i32.and
+                            (i32.sub
+                              (i32.const 0)
+                              (set_local $1
+                                (i32.add
+                                  (get_local $15)
+                                  (i32.const 8)
+                                )
+                              )
+                            )
+                            (i32.const 7)
+                          )
+                          (i32.eq
+                            (i32.and
+                              (get_local $1)
+                              (i32.const 7)
+                            )
+                            (i32.const 0)
+                          )
+                        )
                       )
                     )
-                    (set_local $15
+                    (set_local $1
+                      (i32.add
+                        (get_local $21)
+                        (get_local $18)
+                      )
+                    )
+                    (set_local $24
                       (i32.sub
                         (i32.sub
-                          (get_local $1)
-                          (get_local $17)
+                          (get_local $4)
+                          (get_local $21)
                         )
-                        (get_local $0)
+                        (get_local $18)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $17)
+                      (get_local $21)
                       (i32.or
-                        (get_local $0)
+                        (get_local $18)
                         (i32.const 3)
                       )
                     )
                     (block $do-once$50
                       (if
                         (i32.eq
-                          (get_local $1)
-                          (get_local $11)
+                          (get_local $4)
+                          (get_local $10)
                         )
                         (block
                           (i32.store
                             (i32.const 1220)
-                            (set_local $2
+                            (set_local $6
                               (i32.add
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $15)
+                                (get_local $24)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $4)
+                            (get_local $1)
                           )
                           (i32.store offset=4
-                            (get_local $4)
+                            (get_local $1)
                             (i32.or
-                              (get_local $2)
+                              (get_local $6)
                               (i32.const 1)
                             )
                           )
@@ -4027,7 +4051,7 @@
                         (block
                           (if
                             (i32.eq
-                              (get_local $1)
+                              (get_local $4)
                               (i32.load
                                 (i32.const 1228)
                               )
@@ -4035,45 +4059,45 @@
                             (block
                               (i32.store
                                 (i32.const 1216)
-                                (set_local $2
+                                (set_local $6
                                   (i32.add
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $15)
+                                    (get_local $24)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $4)
+                                (get_local $1)
                               )
                               (i32.store offset=4
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $6)
                                   (i32.const 1)
                                 )
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $4)
-                                  (get_local $2)
+                                  (get_local $1)
+                                  (get_local $6)
                                 )
-                                (get_local $2)
+                                (get_local $6)
                               )
                               (br $do-once$50)
                             )
                           )
                           (i32.store
-                            (set_local $3
+                            (set_local $0
                               (i32.add
                                 (if
                                   (i32.eq
                                     (i32.and
-                                      (set_local $2
+                                      (set_local $6
                                         (i32.load offset=4
-                                          (get_local $1)
+                                          (get_local $4)
                                         )
                                       )
                                       (i32.const 3)
@@ -4081,44 +4105,44 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $5
+                                    (set_local $17
                                       (i32.and
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const -8)
                                       )
                                     )
-                                    (set_local $3
+                                    (set_local $0
                                       (i32.shr_u
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const 3)
                                       )
                                     )
                                     (block $label$break$e
                                       (if
                                         (i32.lt_u
-                                          (get_local $2)
+                                          (get_local $6)
                                           (i32.const 256)
                                         )
                                         (block
-                                          (set_local $10
+                                          (set_local $9
                                             (i32.load offset=12
-                                              (get_local $1)
+                                              (get_local $4)
                                             )
                                           )
                                           (block $do-once$53
                                             (if
                                               (i32.ne
-                                                (set_local $22
+                                                (set_local $6
                                                   (i32.load offset=8
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                 )
-                                                (set_local $18
+                                                (set_local $23
                                                   (i32.add
                                                     (i32.const 1248)
                                                     (i32.shl
                                                       (i32.shl
-                                                        (get_local $3)
+                                                        (get_local $0)
                                                         (i32.const 1)
                                                       )
                                                       (i32.const 2)
@@ -4129,17 +4153,17 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $22)
-                                                    (get_local $14)
+                                                    (get_local $6)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (br_if $do-once$53
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $22)
+                                                      (get_local $6)
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                 )
                                                 (call_import $qa)
@@ -4148,8 +4172,8 @@
                                           )
                                           (if
                                             (i32.eq
-                                              (get_local $10)
-                                              (get_local $22)
+                                              (get_local $9)
+                                              (get_local $6)
                                             )
                                             (block
                                               (i32.store
@@ -4161,7 +4185,7 @@
                                                   (i32.xor
                                                     (i32.shl
                                                       (i32.const 1)
-                                                      (get_local $3)
+                                                      (get_local $0)
                                                     )
                                                     (i32.const -1)
                                                   )
@@ -4173,38 +4197,38 @@
                                           (block $do-once$55
                                             (if
                                               (i32.eq
-                                                (get_local $10)
-                                                (get_local $18)
+                                                (get_local $9)
+                                                (get_local $23)
                                               )
-                                              (set_local $44
+                                              (set_local $46
                                                 (i32.add
-                                                  (get_local $10)
+                                                  (get_local $9)
                                                   (i32.const 8)
                                                 )
                                               )
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $10)
-                                                    (get_local $14)
+                                                    (get_local $9)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $3
+                                                      (set_local $2
                                                         (i32.add
-                                                          (get_local $10)
+                                                          (get_local $9)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (block
-                                                    (set_local $44
-                                                      (get_local $3)
+                                                    (set_local $46
+                                                      (get_local $2)
                                                     )
                                                     (br $do-once$55)
                                                   )
@@ -4214,39 +4238,39 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $22)
-                                            (get_local $10)
+                                            (get_local $6)
+                                            (get_local $9)
                                           )
                                           (i32.store
-                                            (get_local $44)
-                                            (get_local $22)
+                                            (get_local $46)
+                                            (get_local $6)
                                           )
                                         )
                                         (block
-                                          (set_local $18
+                                          (set_local $23
                                             (i32.load offset=24
-                                              (get_local $1)
+                                              (get_local $4)
                                             )
                                           )
                                           (block $do-once$57
                                             (if
                                               (i32.eq
-                                                (set_local $3
+                                                (set_local $2
                                                   (i32.load offset=12
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                 )
-                                                (get_local $1)
+                                                (get_local $4)
                                               )
                                               (block
                                                 (if
-                                                  (set_local $2
+                                                  (set_local $20
                                                     (i32.load
                                                       (set_local $13
                                                         (i32.add
-                                                          (set_local $16
+                                                          (set_local $22
                                                             (i32.add
-                                                              (get_local $1)
+                                                              (get_local $4)
                                                               (i32.const 16)
                                                             )
                                                           )
@@ -4256,23 +4280,29 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $19
-                                                      (get_local $2)
+                                                    (set_local $11
+                                                      (get_local $20)
                                                     )
-                                                    (set_local $16
+                                                    (set_local $0
                                                       (get_local $13)
                                                     )
                                                   )
                                                   (if
-                                                    (i32.eqz
-                                                      (set_local $19
-                                                        (i32.load
-                                                          (get_local $16)
-                                                        )
+                                                    (set_local $20
+                                                      (i32.load
+                                                        (get_local $22)
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $24
+                                                      (set_local $11
+                                                        (get_local $20)
+                                                      )
+                                                      (set_local $0
+                                                        (get_local $22)
+                                                      )
+                                                    )
+                                                    (block
+                                                      (set_local $30
                                                         (i32.const 0)
                                                       )
                                                       (br $do-once$57)
@@ -4281,42 +4311,42 @@
                                                 )
                                                 (loop $while-out$59 $while-in$60
                                                   (if
-                                                    (set_local $2
+                                                    (set_local $20
                                                       (i32.load
                                                         (set_local $13
                                                           (i32.add
-                                                            (get_local $19)
+                                                            (get_local $11)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $19
-                                                        (get_local $2)
+                                                      (set_local $11
+                                                        (get_local $20)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $0
                                                         (get_local $13)
                                                       )
                                                       (br $while-in$60)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $2
+                                                    (set_local $20
                                                       (i32.load
                                                         (set_local $13
                                                           (i32.add
-                                                            (get_local $19)
+                                                            (get_local $11)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $19
-                                                        (get_local $2)
+                                                      (set_local $11
+                                                        (get_local $20)
                                                       )
-                                                      (set_local $16
+                                                      (set_local $0
                                                         (get_local $13)
                                                       )
                                                     )
@@ -4326,17 +4356,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $16)
-                                                    (get_local $14)
+                                                    (get_local $0)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $0)
                                                       (i32.const 0)
                                                     )
-                                                    (set_local $24
-                                                      (get_local $19)
+                                                    (set_local $30
+                                                      (get_local $11)
                                                     )
                                                   )
                                                 )
@@ -4346,50 +4376,50 @@
                                                   (i32.lt_u
                                                     (set_local $13
                                                       (i32.load offset=8
-                                                        (get_local $1)
+                                                        (get_local $4)
                                                       )
                                                     )
-                                                    (get_local $14)
+                                                    (get_local $35)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.ne
                                                     (i32.load
-                                                      (set_local $2
+                                                      (set_local $20
                                                         (i32.add
                                                           (get_local $13)
                                                           (i32.const 12)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (call_import $qa)
                                                 )
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $16
+                                                      (set_local $22
                                                         (i32.add
-                                                          (get_local $3)
+                                                          (get_local $2)
                                                           (i32.const 8)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (block
                                                     (i32.store
+                                                      (get_local $20)
                                                       (get_local $2)
-                                                      (get_local $3)
                                                     )
                                                     (i32.store
-                                                      (get_local $16)
+                                                      (get_local $22)
                                                       (get_local $13)
                                                     )
-                                                    (set_local $24
-                                                      (get_local $3)
+                                                    (set_local $30
+                                                      (get_local $2)
                                                     )
                                                   )
                                                   (call_import $qa)
@@ -4399,21 +4429,21 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (get_local $18)
+                                              (get_local $23)
                                             )
                                           )
                                           (block $do-once$61
                                             (if
                                               (i32.eq
-                                                (get_local $1)
+                                                (get_local $4)
                                                 (i32.load
-                                                  (set_local $22
+                                                  (set_local $6
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
-                                                        (set_local $3
+                                                        (set_local $2
                                                           (i32.load offset=28
-                                                            (get_local $1)
+                                                            (get_local $4)
                                                           )
                                                         )
                                                         (i32.const 2)
@@ -4424,11 +4454,11 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $22)
-                                                  (get_local $24)
+                                                  (get_local $6)
+                                                  (get_local $30)
                                                 )
                                                 (br_if $do-once$61
-                                                  (get_local $24)
+                                                  (get_local $30)
                                                 )
                                                 (i32.store
                                                   (i32.const 1212)
@@ -4439,7 +4469,7 @@
                                                     (i32.xor
                                                       (i32.shl
                                                         (i32.const 1)
-                                                        (get_local $3)
+                                                        (get_local $2)
                                                       )
                                                       (i32.const -1)
                                                     )
@@ -4450,7 +4480,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $18)
+                                                    (get_local $23)
                                                     (i32.load
                                                       (i32.const 1224)
                                                     )
@@ -4460,27 +4490,27 @@
                                                 (if
                                                   (i32.eq
                                                     (i32.load
-                                                      (set_local $10
+                                                      (set_local $9
                                                         (i32.add
-                                                          (get_local $18)
+                                                          (get_local $23)
                                                           (i32.const 16)
                                                         )
                                                       )
                                                     )
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                   )
                                                   (i32.store
-                                                    (get_local $10)
-                                                    (get_local $24)
+                                                    (get_local $9)
+                                                    (get_local $30)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $18)
-                                                    (get_local $24)
+                                                    (get_local $23)
+                                                    (get_local $30)
                                                   )
                                                 )
                                                 (br_if $label$break$e
                                                   (i32.eqz
-                                                    (get_local $24)
+                                                    (get_local $30)
                                                   )
                                                 )
                                               )
@@ -4488,8 +4518,8 @@
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $24)
-                                              (set_local $3
+                                              (get_local $30)
+                                              (set_local $2
                                                 (i32.load
                                                   (i32.const 1224)
                                                 )
@@ -4498,15 +4528,15 @@
                                             (call_import $qa)
                                           )
                                           (i32.store offset=24
-                                            (get_local $24)
-                                            (get_local $18)
+                                            (get_local $30)
+                                            (get_local $23)
                                           )
                                           (if
-                                            (set_local $10
+                                            (set_local $9
                                               (i32.load
-                                                (set_local $22
+                                                (set_local $6
                                                   (i32.add
-                                                    (get_local $1)
+                                                    (get_local $4)
                                                     (i32.const 16)
                                                   )
                                                 )
@@ -4514,34 +4544,34 @@
                                             )
                                             (if
                                               (i32.lt_u
-                                                (get_local $10)
-                                                (get_local $3)
+                                                (get_local $9)
+                                                (get_local $2)
                                               )
                                               (call_import $qa)
                                               (block
                                                 (i32.store offset=16
-                                                  (get_local $24)
-                                                  (get_local $10)
+                                                  (get_local $30)
+                                                  (get_local $9)
                                                 )
                                                 (i32.store offset=24
-                                                  (get_local $10)
-                                                  (get_local $24)
+                                                  (get_local $9)
+                                                  (get_local $30)
                                                 )
                                               )
                                             )
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (set_local $10
+                                              (set_local $9
                                                 (i32.load offset=4
-                                                  (get_local $22)
+                                                  (get_local $6)
                                                 )
                                               )
                                             )
                                           )
                                           (if
                                             (i32.lt_u
-                                              (get_local $10)
+                                              (get_local $9)
                                               (i32.load
                                                 (i32.const 1224)
                                               )
@@ -4549,73 +4579,78 @@
                                             (call_import $qa)
                                             (block
                                               (i32.store offset=20
-                                                (get_local $24)
-                                                (get_local $10)
+                                                (get_local $30)
+                                                (get_local $9)
                                               )
                                               (i32.store offset=24
-                                                (get_local $10)
-                                                (get_local $24)
+                                                (get_local $9)
+                                                (get_local $30)
                                               )
                                             )
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $15
+                                    (set_local $11
                                       (i32.add
-                                        (get_local $5)
-                                        (get_local $15)
+                                        (get_local $17)
+                                        (get_local $24)
                                       )
                                     )
                                     (i32.add
-                                      (get_local $1)
-                                      (get_local $5)
+                                      (get_local $4)
+                                      (get_local $17)
                                     )
                                   )
-                                  (get_local $1)
+                                  (block
+                                    (set_local $11
+                                      (get_local $24)
+                                    )
+                                    (get_local $4)
+                                  )
                                 )
                                 (i32.const 4)
                               )
                             )
                             (i32.and
                               (i32.load
-                                (get_local $3)
+                                (get_local $0)
                               )
                               (i32.const -2)
                             )
                           )
                           (i32.store offset=4
-                            (get_local $4)
+                            (get_local $1)
                             (i32.or
-                              (get_local $15)
+                              (get_local $11)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $4)
-                              (get_local $15)
+                              (get_local $1)
+                              (get_local $11)
                             )
-                            (get_local $15)
+                            (get_local $11)
                           )
-                          (set_local $3
+                          (set_local $0
                             (i32.shr_u
-                              (get_local $15)
+                              (get_local $11)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $15)
+                              (get_local $11)
                               (i32.const 256)
                             )
                             (block
-                              (set_local $2
+                              (set_local $6
                                 (i32.add
                                   (i32.const 1248)
                                   (i32.shl
                                     (i32.shl
-                                      (get_local $3)
+                                      (get_local $0)
                                       (i32.const 1)
                                     )
                                     (i32.const 2)
@@ -4625,26 +4660,26 @@
                               (block $do-once$65
                                 (if
                                   (i32.and
-                                    (set_local $10
+                                    (set_local $9
                                       (i32.load
                                         (i32.const 1208)
                                       )
                                     )
-                                    (set_local $3
+                                    (set_local $2
                                       (i32.shl
                                         (i32.const 1)
-                                        (get_local $3)
+                                        (get_local $0)
                                       )
                                     )
                                   )
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $18
+                                        (set_local $23
                                           (i32.load
-                                            (set_local $3
+                                            (set_local $0
                                               (i32.add
-                                                (get_local $2)
+                                                (get_local $6)
                                                 (i32.const 8)
                                               )
                                             )
@@ -4655,11 +4690,11 @@
                                         )
                                       )
                                       (block
-                                        (set_local $45
-                                          (get_local $3)
+                                        (set_local $47
+                                          (get_local $0)
                                         )
-                                        (set_local $38
-                                          (get_local $18)
+                                        (set_local $41
+                                          (get_local $23)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4670,51 +4705,51 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $10)
-                                        (get_local $3)
+                                        (get_local $9)
+                                        (get_local $2)
                                       )
                                     )
-                                    (set_local $45
+                                    (set_local $47
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $38
-                                      (get_local $2)
+                                    (set_local $41
+                                      (get_local $6)
                                     )
                                   )
                                 )
                               )
                               (i32.store
-                                (get_local $45)
-                                (get_local $4)
+                                (get_local $47)
+                                (get_local $1)
                               )
                               (i32.store offset=12
-                                (get_local $38)
-                                (get_local $4)
+                                (get_local $41)
+                                (get_local $1)
                               )
                               (i32.store offset=8
-                                (get_local $4)
-                                (get_local $38)
+                                (get_local $1)
+                                (get_local $41)
                               )
                               (i32.store offset=12
-                                (get_local $4)
-                                (get_local $2)
+                                (get_local $1)
+                                (get_local $6)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $3
+                          (set_local $2
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
                                 (set_local $0
                                   (block $do-once$67
                                     (if
-                                      (set_local $3
+                                      (set_local $2
                                         (i32.shr_u
-                                          (get_local $15)
+                                          (get_local $11)
                                           (i32.const 8)
                                         )
                                       )
@@ -4722,14 +4757,14 @@
                                         (br_if $do-once$67
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $15)
+                                            (get_local $11)
                                             (i32.const 16777215)
                                           )
                                         )
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $15)
+                                              (get_local $11)
                                               (i32.add
                                                 (set_local $13
                                                   (i32.add
@@ -4737,18 +4772,18 @@
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $18
+                                                          (set_local $23
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $5
+                                                                  (set_local $17
                                                                     (i32.shl
-                                                                      (get_local $3)
-                                                                      (set_local $10
+                                                                      (get_local $2)
+                                                                      (set_local $9
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $3)
+                                                                              (get_local $2)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -4765,16 +4800,16 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $10)
+                                                          (get_local $9)
                                                         )
-                                                        (set_local $5
+                                                        (set_local $17
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
-                                                                (set_local $3
+                                                                (set_local $0
                                                                   (i32.shl
-                                                                    (get_local $5)
-                                                                    (get_local $18)
+                                                                    (get_local $17)
+                                                                    (get_local $23)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4788,8 +4823,8 @@
                                                     )
                                                     (i32.shr_u
                                                       (i32.shl
-                                                        (get_local $3)
-                                                        (get_local $5)
+                                                        (get_local $0)
+                                                        (get_local $17)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4815,26 +4850,26 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $4)
+                            (get_local $1)
                             (get_local $0)
                           )
                           (i32.store offset=4
-                            (set_local $2
+                            (set_local $6
                               (i32.add
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.const 16)
                               )
                             )
                             (i32.const 0)
                           )
                           (i32.store
-                            (get_local $2)
+                            (get_local $6)
                             (i32.const 0)
                           )
                           (if
                             (i32.eqz
                               (i32.and
-                                (set_local $2
+                                (set_local $6
                                   (i32.load
                                     (i32.const 1212)
                                   )
@@ -4851,32 +4886,32 @@
                               (i32.store
                                 (i32.const 1212)
                                 (i32.or
-                                  (get_local $2)
+                                  (get_local $6)
                                   (get_local $13)
                                 )
                               )
                               (i32.store
-                                (get_local $3)
-                                (get_local $4)
+                                (get_local $2)
+                                (get_local $1)
                               )
                               (i32.store offset=24
-                                (get_local $4)
-                                (get_local $3)
+                                (get_local $1)
+                                (get_local $2)
                               )
                               (i32.store offset=12
-                                (get_local $4)
-                                (get_local $4)
+                                (get_local $1)
+                                (get_local $1)
                               )
                               (i32.store offset=8
-                                (get_local $4)
-                                (get_local $4)
+                                (get_local $1)
+                                (get_local $1)
                               )
                               (br $do-once$50)
                             )
                           )
                           (set_local $13
                             (i32.shl
-                              (get_local $15)
+                              (get_local $11)
                               (select
                                 (i32.const 0)
                                 (i32.sub
@@ -4893,9 +4928,9 @@
                               )
                             )
                           )
-                          (set_local $2
+                          (set_local $6
                             (i32.load
-                              (get_local $3)
+                              (get_local $2)
                             )
                           )
                           (loop $while-out$69 $while-in$70
@@ -4903,29 +4938,29 @@
                               (i32.eq
                                 (i32.and
                                   (i32.load offset=4
-                                    (get_local $2)
+                                    (get_local $6)
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $15)
+                                (get_local $11)
                               )
                               (block
-                                (set_local $39
-                                  (get_local $2)
+                                (set_local $42
+                                  (get_local $6)
                                 )
-                                (set_local $8
+                                (set_local $7
                                   (i32.const 279)
                                 )
                                 (br $while-out$69)
                               )
                             )
                             (if
-                              (set_local $5
+                              (set_local $17
                                 (i32.load
-                                  (set_local $3
+                                  (set_local $2
                                     (i32.add
                                       (i32.add
-                                        (get_local $2)
+                                        (get_local $6)
                                         (i32.const 16)
                                       )
                                       (i32.shl
@@ -4946,18 +4981,18 @@
                                     (i32.const 1)
                                   )
                                 )
-                                (set_local $2
-                                  (get_local $5)
+                                (set_local $6
+                                  (get_local $17)
                                 )
                               )
                               (block
-                                (set_local $46
-                                  (get_local $3)
-                                )
-                                (set_local $54
+                                (set_local $48
                                   (get_local $2)
                                 )
-                                (set_local $8
+                                (set_local $54
+                                  (get_local $6)
+                                )
+                                (set_local $7
                                   (i32.const 276)
                                 )
                                 (br $while-out$69)
@@ -4967,12 +5002,12 @@
                           )
                           (if
                             (i32.eq
-                              (get_local $8)
+                              (get_local $7)
                               (i32.const 276)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $46)
+                                (get_local $48)
                                 (i32.load
                                   (i32.const 1224)
                                 )
@@ -4980,26 +5015,26 @@
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $46)
-                                  (get_local $4)
+                                  (get_local $48)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=24
-                                  (get_local $4)
+                                  (get_local $1)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                                 (i32.store offset=8
-                                  (get_local $4)
-                                  (get_local $4)
+                                  (get_local $1)
+                                  (get_local $1)
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (get_local $8)
+                                (get_local $7)
                                 (i32.const 279)
                               )
                               (if
@@ -5007,44 +5042,44 @@
                                   (i32.ge_u
                                     (set_local $13
                                       (i32.load
-                                        (set_local $2
+                                        (set_local $6
                                           (i32.add
-                                            (get_local $39)
+                                            (get_local $42)
                                             (i32.const 8)
                                           )
                                         )
                                       )
                                     )
-                                    (set_local $5
+                                    (set_local $17
                                       (i32.load
                                         (i32.const 1224)
                                       )
                                     )
                                   )
                                   (i32.ge_u
-                                    (get_local $39)
-                                    (get_local $5)
+                                    (get_local $42)
+                                    (get_local $17)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
                                     (get_local $13)
-                                    (get_local $4)
+                                    (get_local $1)
                                   )
                                   (i32.store
-                                    (get_local $2)
-                                    (get_local $4)
+                                    (get_local $6)
+                                    (get_local $1)
                                   )
                                   (i32.store offset=8
-                                    (get_local $4)
+                                    (get_local $1)
                                     (get_local $13)
                                   )
                                   (i32.store offset=12
-                                    (get_local $4)
-                                    (get_local $39)
+                                    (get_local $1)
+                                    (get_local $42)
                                   )
                                   (i32.store offset=24
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.const 0)
                                   )
                                 )
@@ -5057,11 +5092,11 @@
                     )
                     (i32.store
                       (i32.const 8)
-                      (get_local $25)
+                      (get_local $31)
                     )
                     (return
                       (i32.add
-                        (get_local $17)
+                        (get_local $21)
                         (i32.const 8)
                       )
                     )
@@ -5071,71 +5106,71 @@
               (loop $while-out$71 $while-in$72
                 (if
                   (i32.le_u
-                    (set_local $4
+                    (set_local $1
                       (i32.load
-                        (get_local $29)
+                        (get_local $37)
                       )
                     )
-                    (get_local $11)
+                    (get_local $10)
                   )
                   (if
                     (i32.gt_u
-                      (set_local $15
+                      (set_local $24
                         (i32.add
-                          (get_local $4)
+                          (get_local $1)
                           (i32.load offset=4
-                            (get_local $29)
+                            (get_local $37)
                           )
                         )
                       )
-                      (get_local $11)
+                      (get_local $10)
                     )
                     (block
-                      (set_local $3
-                        (get_local $15)
+                      (set_local $0
+                        (get_local $24)
                       )
                       (br $while-out$71)
                     )
                   )
                 )
-                (set_local $29
+                (set_local $37
                   (i32.load offset=8
-                    (get_local $29)
+                    (get_local $37)
                   )
                 )
                 (br $while-in$72)
               )
-              (set_local $15
+              (set_local $24
                 (i32.add
-                  (set_local $17
+                  (set_local $21
                     (i32.add
-                      (get_local $3)
+                      (get_local $0)
                       (i32.const -47)
                     )
                   )
                   (i32.const 8)
                 )
               )
-              (set_local $4
+              (set_local $1
                 (i32.add
-                  (set_local $17
+                  (set_local $21
                     (select
-                      (get_local $11)
-                      (set_local $4
+                      (get_local $10)
+                      (set_local $1
                         (i32.add
-                          (get_local $17)
+                          (get_local $21)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $15)
+                                (get_local $24)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $15)
+                                (get_local $24)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5144,10 +5179,10 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $4)
-                        (set_local $15
+                        (get_local $1)
+                        (set_local $24
                           (i32.add
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 16)
                           )
                         )
@@ -5159,18 +5194,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $1
+                (set_local $4
                   (i32.add
-                    (get_local $20)
-                    (set_local $7
+                    (get_local $28)
+                    (set_local $15
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $1
+                            (set_local $4
                               (i32.add
-                                (get_local $20)
+                                (get_local $28)
                                 (i32.const 8)
                               )
                             )
@@ -5179,7 +5214,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5194,15 +5229,15 @@
                 (set_local $13
                   (i32.sub
                     (i32.add
-                      (get_local $26)
+                      (get_local $33)
                       (i32.const -40)
                     )
-                    (get_local $7)
+                    (get_local $15)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $4)
                 (i32.or
                   (get_local $13)
                   (i32.const 1)
@@ -5210,7 +5245,7 @@
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $1)
+                  (get_local $4)
                   (get_local $13)
                 )
                 (i32.const 40)
@@ -5224,43 +5259,43 @@
               (i32.store
                 (set_local $13
                   (i32.add
-                    (get_local $17)
+                    (get_local $21)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $4)
+                (get_local $1)
                 (i32.load
                   (i32.const 1668)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $20)
+                (get_local $28)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $26)
+                (get_local $33)
               )
               (i32.store
                 (i32.const 1668)
@@ -5268,19 +5303,19 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $4)
+                (get_local $1)
               )
-              (set_local $4
+              (set_local $1
                 (i32.add
-                  (get_local $17)
+                  (get_local $21)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $4
+                  (set_local $1
                     (i32.add
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 4)
                     )
                   )
@@ -5289,17 +5324,17 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 4)
                     )
-                    (get_local $3)
+                    (get_local $0)
                   )
                 )
               )
               (if
                 (i32.ne
-                  (get_local $17)
-                  (get_local $11)
+                  (get_local $21)
+                  (get_local $10)
                 )
                 (block
                   (i32.store
@@ -5312,39 +5347,39 @@
                     )
                   )
                   (i32.store offset=4
-                    (get_local $11)
+                    (get_local $10)
                     (i32.or
-                      (set_local $4
+                      (set_local $1
                         (i32.sub
-                          (get_local $17)
-                          (get_local $11)
+                          (get_local $21)
+                          (get_local $10)
                         )
                       )
                       (i32.const 1)
                     )
                   )
                   (i32.store
-                    (get_local $17)
-                    (get_local $4)
+                    (get_local $21)
+                    (get_local $1)
                   )
-                  (set_local $1
+                  (set_local $4
                     (i32.shr_u
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $1)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $7
+                      (set_local $15
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
                             (i32.shl
-                              (get_local $1)
+                              (get_local $4)
                               (i32.const 1)
                             )
                             (i32.const 2)
@@ -5353,25 +5388,25 @@
                       )
                       (if
                         (i32.and
-                          (set_local $2
+                          (set_local $6
                             (i32.load
                               (i32.const 1208)
                             )
                           )
-                          (set_local $5
+                          (set_local $17
                             (i32.shl
                               (i32.const 1)
-                              (get_local $1)
+                              (get_local $4)
                             )
                           )
                         )
                         (if
                           (i32.lt_u
-                            (set_local $2
+                            (set_local $6
                               (i32.load
-                                (set_local $5
+                                (set_local $17
                                   (i32.add
-                                    (get_local $7)
+                                    (get_local $15)
                                     (i32.const 8)
                                   )
                                 )
@@ -5383,11 +5418,11 @@
                           )
                           (call_import $qa)
                           (block
-                            (set_local $47
-                              (get_local $5)
+                            (set_local $49
+                              (get_local $17)
                             )
-                            (set_local $40
-                              (get_local $2)
+                            (set_local $43
+                              (get_local $6)
                             )
                           )
                         )
@@ -5395,81 +5430,81 @@
                           (i32.store
                             (i32.const 1208)
                             (i32.or
-                              (get_local $2)
-                              (get_local $5)
+                              (get_local $6)
+                              (get_local $17)
                             )
                           )
-                          (set_local $47
+                          (set_local $49
                             (i32.add
-                              (get_local $7)
+                              (get_local $15)
                               (i32.const 8)
                             )
                           )
-                          (set_local $40
-                            (get_local $7)
+                          (set_local $43
+                            (get_local $15)
                           )
                         )
                       )
                       (i32.store
-                        (get_local $47)
-                        (get_local $11)
+                        (get_local $49)
+                        (get_local $10)
                       )
                       (i32.store offset=12
-                        (get_local $40)
-                        (get_local $11)
+                        (get_local $43)
+                        (get_local $10)
                       )
                       (i32.store offset=8
-                        (get_local $11)
-                        (get_local $40)
+                        (get_local $10)
+                        (get_local $43)
                       )
                       (i32.store offset=12
-                        (get_local $11)
-                        (get_local $7)
+                        (get_local $10)
+                        (get_local $15)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $3
+                  (set_local $2
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (set_local $7
+                        (set_local $0
                           (if
-                            (set_local $7
+                            (set_local $15
                               (i32.shr_u
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $4)
+                                (get_local $1)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $1)
                                     (i32.add
-                                      (set_local $3
+                                      (set_local $2
                                         (i32.add
                                           (i32.sub
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $7
+                                                (set_local $15
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $5
+                                                        (set_local $17
                                                           (i32.shl
-                                                            (get_local $7)
-                                                            (set_local $2
+                                                            (get_local $15)
+                                                            (set_local $6
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $7)
+                                                                    (get_local $15)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5486,16 +5521,16 @@
                                                     (i32.const 4)
                                                   )
                                                 )
-                                                (get_local $2)
+                                                (get_local $6)
                                               )
-                                              (set_local $5
+                                              (set_local $17
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
-                                                      (set_local $1
+                                                      (set_local $4
                                                         (i32.shl
-                                                          (get_local $5)
-                                                          (get_local $7)
+                                                          (get_local $17)
+                                                          (get_local $15)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5509,8 +5544,8 @@
                                           )
                                           (i32.shr_u
                                             (i32.shl
-                                              (get_local $1)
-                                              (get_local $5)
+                                              (get_local $4)
+                                              (get_local $17)
                                             )
                                             (i32.const 15)
                                           )
@@ -5522,7 +5557,7 @@
                                   (i32.const 1)
                                 )
                                 (i32.shl
-                                  (get_local $3)
+                                  (get_local $2)
                                   (i32.const 1)
                                 )
                               )
@@ -5535,29 +5570,29 @@
                     )
                   )
                   (i32.store offset=28
-                    (get_local $11)
-                    (get_local $7)
+                    (get_local $10)
+                    (get_local $0)
                   )
                   (i32.store offset=20
-                    (get_local $11)
+                    (get_local $10)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $15)
+                    (get_local $24)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $5
+                        (set_local $17
                           (i32.load
                             (i32.const 1212)
                           )
                         )
-                        (set_local $1
+                        (set_local $4
                           (i32.shl
                             (i32.const 1)
-                            (get_local $7)
+                            (get_local $0)
                           )
                         )
                       )
@@ -5566,51 +5601,51 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $5)
-                          (get_local $1)
+                          (get_local $17)
+                          (get_local $4)
                         )
                       )
                       (i32.store
-                        (get_local $3)
-                        (get_local $11)
+                        (get_local $2)
+                        (get_local $10)
                       )
                       (i32.store offset=24
-                        (get_local $11)
-                        (get_local $3)
+                        (get_local $10)
+                        (get_local $2)
                       )
                       (i32.store offset=12
-                        (get_local $11)
-                        (get_local $11)
+                        (get_local $10)
+                        (get_local $10)
                       )
                       (i32.store offset=8
-                        (get_local $11)
-                        (get_local $11)
+                        (get_local $10)
+                        (get_local $10)
                       )
                       (br $do-once$42)
                     )
                   )
-                  (set_local $1
+                  (set_local $4
                     (i32.shl
-                      (get_local $4)
+                      (get_local $1)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $7)
+                            (get_local $0)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $7)
+                          (get_local $0)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $5
+                  (set_local $17
                     (i32.load
-                      (get_local $3)
+                      (get_local $2)
                     )
                   )
                   (loop $while-out$75 $while-in$76
@@ -5618,34 +5653,34 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $5)
+                            (get_local $17)
                           )
                           (i32.const -8)
                         )
-                        (get_local $4)
+                        (get_local $1)
                       )
                       (block
-                        (set_local $30
-                          (get_local $5)
+                        (set_local $32
+                          (get_local $17)
                         )
-                        (set_local $8
+                        (set_local $7
                           (i32.const 305)
                         )
                         (br $while-out$75)
                       )
                     )
                     (if
-                      (set_local $2
+                      (set_local $6
                         (i32.load
-                          (set_local $3
+                          (set_local $2
                             (i32.add
                               (i32.add
-                                (get_local $5)
+                                (get_local $17)
                                 (i32.const 16)
                               )
                               (i32.shl
                                 (i32.shr_u
-                                  (get_local $1)
+                                  (get_local $4)
                                   (i32.const 31)
                                 )
                                 (i32.const 2)
@@ -5655,24 +5690,24 @@
                         )
                       )
                       (block
-                        (set_local $1
+                        (set_local $4
                           (i32.shl
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 1)
                           )
                         )
-                        (set_local $5
-                          (get_local $2)
+                        (set_local $17
+                          (get_local $6)
                         )
                       )
                       (block
-                        (set_local $48
-                          (get_local $3)
+                        (set_local $26
+                          (get_local $2)
                         )
-                        (set_local $55
-                          (get_local $5)
+                        (set_local $11
+                          (get_local $17)
                         )
-                        (set_local $8
+                        (set_local $7
                           (i32.const 302)
                         )
                         (br $while-out$75)
@@ -5682,12 +5717,12 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $8)
+                      (get_local $7)
                       (i32.const 302)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $48)
+                        (get_local $26)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -5695,71 +5730,71 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $48)
-                          (get_local $11)
+                          (get_local $26)
+                          (get_local $10)
                         )
                         (i32.store offset=24
+                          (get_local $10)
                           (get_local $11)
-                          (get_local $55)
                         )
                         (i32.store offset=12
-                          (get_local $11)
-                          (get_local $11)
+                          (get_local $10)
+                          (get_local $10)
                         )
                         (i32.store offset=8
-                          (get_local $11)
-                          (get_local $11)
+                          (get_local $10)
+                          (get_local $10)
                         )
                       )
                     )
                     (if
                       (i32.eq
-                        (get_local $8)
+                        (get_local $7)
                         (i32.const 305)
                       )
                       (if
                         (i32.and
                           (i32.ge_u
-                            (set_local $1
+                            (set_local $4
                               (i32.load
-                                (set_local $5
+                                (set_local $17
                                   (i32.add
-                                    (get_local $30)
+                                    (get_local $32)
                                     (i32.const 8)
                                   )
                                 )
                               )
                             )
-                            (set_local $4
+                            (set_local $1
                               (i32.load
                                 (i32.const 1224)
                               )
                             )
                           )
                           (i32.ge_u
-                            (get_local $30)
-                            (get_local $4)
+                            (get_local $32)
+                            (get_local $1)
                           )
                         )
                         (block
                           (i32.store offset=12
-                            (get_local $1)
-                            (get_local $11)
+                            (get_local $4)
+                            (get_local $10)
                           )
                           (i32.store
-                            (get_local $5)
-                            (get_local $11)
+                            (get_local $17)
+                            (get_local $10)
                           )
                           (i32.store offset=8
-                            (get_local $11)
-                            (get_local $1)
+                            (get_local $10)
+                            (get_local $4)
                           )
                           (i32.store offset=12
-                            (get_local $11)
-                            (get_local $30)
+                            (get_local $10)
+                            (get_local $32)
                           )
                           (i32.store offset=24
-                            (get_local $11)
+                            (get_local $10)
                             (i32.const 0)
                           )
                         )
@@ -5774,7 +5809,7 @@
               (if
                 (i32.or
                   (i32.eq
-                    (set_local $1
+                    (set_local $4
                       (i32.load
                         (i32.const 1224)
                       )
@@ -5782,22 +5817,22 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $20)
-                    (get_local $1)
+                    (get_local $28)
+                    (get_local $4)
                   )
                 )
                 (i32.store
                   (i32.const 1224)
-                  (get_local $20)
+                  (get_local $28)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $20)
+                (get_local $28)
               )
               (i32.store
                 (i32.const 1660)
-                (get_local $26)
+                (get_local $33)
               )
               (i32.store
                 (i32.const 1668)
@@ -5813,34 +5848,34 @@
                 (i32.const 1240)
                 (i32.const -1)
               )
-              (set_local $1
+              (set_local $4
                 (i32.const 0)
               )
               (loop $do-out$44 $do-in$45
                 (i32.store offset=12
-                  (set_local $7
+                  (set_local $15
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 1)
                         )
                         (i32.const 2)
                       )
                     )
                   )
-                  (get_local $7)
+                  (get_local $15)
                 )
                 (i32.store offset=8
-                  (get_local $7)
-                  (get_local $7)
+                  (get_local $15)
+                  (get_local $15)
                 )
                 (br_if $do-in$45
                   (i32.ne
-                    (set_local $1
+                    (set_local $4
                       (i32.add
-                        (get_local $1)
+                        (get_local $4)
                         (i32.const 1)
                       )
                     )
@@ -5850,18 +5885,18 @@
               )
               (i32.store
                 (i32.const 1232)
-                (set_local $1
+                (set_local $4
                   (i32.add
-                    (get_local $20)
-                    (set_local $7
+                    (get_local $28)
+                    (set_local $15
                       (select
                         (i32.const 0)
                         (i32.and
                           (i32.sub
                             (i32.const 0)
-                            (set_local $1
+                            (set_local $4
                               (i32.add
-                                (get_local $20)
+                                (get_local $28)
                                 (i32.const 8)
                               )
                             )
@@ -5870,7 +5905,7 @@
                         )
                         (i32.eq
                           (i32.and
-                            (get_local $1)
+                            (get_local $4)
                             (i32.const 7)
                           )
                           (i32.const 0)
@@ -5882,27 +5917,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $4
+                (set_local $1
                   (i32.sub
                     (i32.add
-                      (get_local $26)
+                      (get_local $33)
                       (i32.const -40)
                     )
-                    (get_local $7)
+                    (get_local $15)
                   )
                 )
               )
               (i32.store offset=4
-                (get_local $1)
+                (get_local $4)
                 (i32.or
-                  (get_local $4)
+                  (get_local $1)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
-                  (get_local $1)
                   (get_local $4)
+                  (get_local $1)
                 )
                 (i32.const 40)
               )
@@ -5917,57 +5952,57 @@
         )
         (if
           (i32.gt_u
-            (set_local $11
+            (set_local $10
               (i32.load
                 (i32.const 1220)
               )
             )
-            (get_local $0)
+            (get_local $18)
           )
           (block
             (i32.store
               (i32.const 1220)
-              (set_local $30
+              (set_local $32
                 (i32.sub
-                  (get_local $11)
-                  (get_local $0)
+                  (get_local $10)
+                  (get_local $18)
                 )
               )
             )
             (i32.store
               (i32.const 1232)
-              (set_local $8
+              (set_local $7
                 (i32.add
-                  (set_local $11
+                  (set_local $10
                     (i32.load
                       (i32.const 1232)
                     )
                   )
-                  (get_local $0)
+                  (get_local $18)
                 )
               )
             )
             (i32.store offset=4
-              (get_local $8)
+              (get_local $7)
               (i32.or
-                (get_local $30)
+                (get_local $32)
                 (i32.const 1)
               )
             )
             (i32.store offset=4
-              (get_local $11)
+              (get_local $10)
               (i32.or
-                (get_local $0)
+                (get_local $18)
                 (i32.const 3)
               )
             )
             (i32.store
               (i32.const 8)
-              (get_local $25)
+              (get_local $31)
             )
             (return
               (i32.add
-                (get_local $11)
+                (get_local $10)
                 (i32.const 8)
               )
             )
@@ -5981,7 +6016,7 @@
     )
     (i32.store
       (i32.const 8)
-      (get_local $25)
+      (get_local $31)
     )
     (i32.const 0)
   )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -110,7 +110,7 @@
         (i32.const 16)
       )
     )
-    (set_local $4
+    (set_local $7
       (get_local $25)
     )
     (block $do-once$0
@@ -122,7 +122,7 @@
         (block
           (if
             (i32.and
-              (set_local $6
+              (set_local $5
                 (i32.shr_u
                   (set_local $2
                     (i32.load
@@ -155,11 +155,11 @@
               (i32.const 3)
             )
             (block
-              (set_local $4
+              (set_local $7
                 (i32.load
-                  (set_local $13
+                  (set_local $12
                     (i32.add
-                      (set_local $6
+                      (set_local $5
                         (i32.load
                           (set_local $14
                             (i32.add
@@ -172,7 +172,7 @@
                                         (i32.add
                                           (i32.xor
                                             (i32.and
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.const 1)
                                             )
                                             (i32.const 1)
@@ -199,7 +199,7 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $4)
+                  (get_local $7)
                 )
                 (i32.store
                   (i32.const 1208)
@@ -217,7 +217,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $7)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -229,12 +229,12 @@
                       (i32.load
                         (set_local $8
                           (i32.add
-                            (get_local $4)
+                            (get_local $7)
                             (i32.const 12)
                           )
                         )
                       )
-                      (get_local $6)
+                      (get_local $5)
                     )
                     (block
                       (i32.store
@@ -243,7 +243,7 @@
                       )
                       (i32.store
                         (get_local $14)
-                        (get_local $4)
+                        (get_local $7)
                       )
                     )
                     (call_import $qa)
@@ -251,9 +251,9 @@
                 )
               )
               (i32.store offset=4
-                (get_local $6)
+                (get_local $5)
                 (i32.or
-                  (set_local $4
+                  (set_local $7
                     (i32.shl
                       (get_local $0)
                       (i32.const 3)
@@ -266,8 +266,8 @@
                 (set_local $14
                   (i32.add
                     (i32.add
-                      (get_local $6)
-                      (get_local $4)
+                      (get_local $5)
+                      (get_local $7)
                     )
                     (i32.const 4)
                   )
@@ -284,7 +284,7 @@
                 (get_local $25)
               )
               (return
-                (get_local $13)
+                (get_local $12)
               )
             )
           )
@@ -299,22 +299,22 @@
             )
             (block
               (if
-                (get_local $6)
+                (get_local $5)
                 (block
                   (set_local $1
                     (i32.and
                       (i32.shr_u
-                        (set_local $4
+                        (set_local $7
                           (i32.add
                             (i32.and
                               (set_local $1
                                 (i32.and
                                   (i32.shl
-                                    (get_local $6)
+                                    (get_local $5)
                                     (get_local $3)
                                   )
                                   (i32.or
-                                    (set_local $4
+                                    (set_local $7
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $3)
@@ -322,7 +322,7 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $4)
+                                      (get_local $7)
                                     )
                                   )
                                 )
@@ -346,25 +346,25 @@
                         (i32.add
                           (set_local $9
                             (i32.load
-                              (set_local $13
+                              (set_local $12
                                 (i32.add
-                                  (set_local $7
+                                  (set_local $6
                                     (i32.add
                                       (i32.const 1248)
                                       (i32.shl
                                         (i32.shl
-                                          (set_local $20
+                                          (set_local $21
                                             (i32.add
                                               (i32.or
                                                 (i32.or
                                                   (i32.or
                                                     (i32.or
-                                                      (set_local $4
+                                                      (set_local $7
                                                         (i32.and
                                                           (i32.shr_u
                                                             (set_local $8
                                                               (i32.shr_u
-                                                                (get_local $4)
+                                                                (get_local $7)
                                                                 (get_local $1)
                                                               )
                                                             )
@@ -381,7 +381,7 @@
                                                           (set_local $9
                                                             (i32.shr_u
                                                               (get_local $8)
-                                                              (get_local $4)
+                                                              (get_local $7)
                                                             )
                                                           )
                                                           (i32.const 2)
@@ -393,7 +393,7 @@
                                                   (set_local $9
                                                     (i32.and
                                                       (i32.shr_u
-                                                        (set_local $7
+                                                        (set_local $6
                                                           (i32.shr_u
                                                             (get_local $9)
                                                             (get_local $8)
@@ -405,12 +405,12 @@
                                                     )
                                                   )
                                                 )
-                                                (set_local $7
+                                                (set_local $6
                                                   (i32.and
                                                     (i32.shr_u
-                                                      (set_local $13
+                                                      (set_local $12
                                                         (i32.shr_u
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                           (get_local $9)
                                                         )
                                                       )
@@ -421,8 +421,8 @@
                                                 )
                                               )
                                               (i32.shr_u
-                                                (get_local $13)
-                                                (get_local $7)
+                                                (get_local $12)
+                                                (get_local $6)
                                               )
                                             )
                                           )
@@ -444,7 +444,7 @@
                   )
                   (if
                     (i32.eq
-                      (get_local $7)
+                      (get_local $6)
                       (get_local $1)
                     )
                     (block
@@ -455,7 +455,7 @@
                           (i32.xor
                             (i32.shl
                               (i32.const 1)
-                              (get_local $20)
+                              (get_local $21)
                             )
                             (i32.const -1)
                           )
@@ -478,7 +478,7 @@
                       (if
                         (i32.eq
                           (i32.load
-                            (set_local $4
+                            (set_local $7
                               (i32.add
                                 (get_local $1)
                                 (i32.const 12)
@@ -489,11 +489,11 @@
                         )
                         (block
                           (i32.store
-                            (get_local $4)
                             (get_local $7)
+                            (get_local $6)
                           )
                           (i32.store
-                            (get_local $13)
+                            (get_local $12)
                             (get_local $1)
                           )
                           (set_local $33
@@ -514,7 +514,7 @@
                     )
                   )
                   (i32.store offset=4
-                    (set_local $13
+                    (set_local $12
                       (i32.add
                         (get_local $9)
                         (get_local $0)
@@ -524,7 +524,7 @@
                       (set_local $1
                         (i32.sub
                           (i32.shl
-                            (get_local $20)
+                            (get_local $21)
                             (i32.const 3)
                           )
                           (get_local $0)
@@ -535,7 +535,7 @@
                   )
                   (i32.store
                     (i32.add
-                      (get_local $13)
+                      (get_local $12)
                       (get_local $1)
                     )
                     (get_local $1)
@@ -543,7 +543,7 @@
                   (if
                     (get_local $33)
                     (block
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (i32.const 1228)
                         )
@@ -572,7 +572,7 @@
                               (i32.const 1208)
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.shl
                               (i32.const 1)
                               (get_local $14)
@@ -583,7 +583,7 @@
                           (i32.lt_u
                             (set_local $3
                               (i32.load
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (get_local $2)
                                     (i32.const 8)
@@ -598,7 +598,7 @@
                           (call_import $qa)
                           (block
                             (set_local $41
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (set_local $34
                               (get_local $3)
@@ -610,7 +610,7 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $3)
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                           (set_local $41
@@ -626,18 +626,18 @@
                       )
                       (i32.store
                         (get_local $41)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store offset=12
                         (get_local $34)
-                        (get_local $7)
+                        (get_local $6)
                       )
                       (i32.store offset=8
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $34)
                       )
                       (i32.store offset=12
-                        (get_local $7)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -648,7 +648,7 @@
                   )
                   (i32.store
                     (i32.const 1228)
-                    (get_local $13)
+                    (get_local $12)
                   )
                   (i32.store
                     (i32.const 8)
@@ -660,22 +660,22 @@
                 )
               )
               (if
-                (set_local $13
+                (set_local $12
                   (i32.load
                     (i32.const 1212)
                   )
                 )
                 (block
-                  (set_local $13
+                  (set_local $12
                     (i32.and
                       (i32.shr_u
                         (set_local $1
                           (i32.add
                             (i32.and
-                              (get_local $13)
+                              (get_local $12)
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
                             (i32.const -1)
@@ -705,7 +705,7 @@
                                                   (set_local $2
                                                     (i32.shr_u
                                                       (get_local $1)
-                                                      (get_local $13)
+                                                      (get_local $12)
                                                     )
                                                   )
                                                   (i32.const 5)
@@ -713,12 +713,12 @@
                                                 (i32.const 8)
                                               )
                                             )
-                                            (get_local $13)
+                                            (get_local $12)
                                           )
                                           (set_local $2
                                             (i32.and
                                               (i32.shr_u
-                                                (set_local $7
+                                                (set_local $6
                                                   (i32.shr_u
                                                     (get_local $2)
                                                     (get_local $1)
@@ -730,12 +730,12 @@
                                             )
                                           )
                                         )
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.and
                                             (i32.shr_u
                                               (set_local $3
                                                 (i32.shr_u
-                                                  (get_local $7)
+                                                  (get_local $6)
                                                   (get_local $2)
                                                 )
                                               )
@@ -748,10 +748,10 @@
                                       (set_local $3
                                         (i32.and
                                           (i32.shr_u
-                                            (set_local $6
+                                            (set_local $5
                                               (i32.shr_u
                                                 (get_local $3)
-                                                (get_local $7)
+                                                (get_local $6)
                                               )
                                             )
                                             (i32.const 1)
@@ -761,7 +761,7 @@
                                       )
                                     )
                                     (i32.shr_u
-                                      (get_local $6)
+                                      (get_local $5)
                                       (get_local $3)
                                     )
                                   )
@@ -777,37 +777,37 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $6
+                  (set_local $5
                     (get_local $14)
                   )
-                  (set_local $7
+                  (set_local $6
                     (get_local $14)
                   )
                   (loop $while-out$6 $while-in$7
                     (if
                       (set_local $14
                         (i32.load offset=16
-                          (get_local $6)
+                          (get_local $5)
                         )
                       )
-                      (set_local $4
+                      (set_local $7
                         (get_local $14)
                       )
                       (if
                         (set_local $2
                           (i32.load offset=20
-                            (get_local $6)
+                            (get_local $5)
                           )
                         )
-                        (set_local $4
+                        (set_local $7
                           (get_local $2)
                         )
                         (block
-                          (set_local $4
+                          (set_local $7
                             (get_local $3)
                           )
                           (set_local $1
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (br $while-out$6)
                         )
@@ -819,7 +819,7 @@
                           (i32.sub
                             (i32.and
                               (i32.load offset=4
-                                (get_local $4)
+                                (get_local $7)
                               )
                               (i32.const -8)
                             )
@@ -836,13 +836,13 @@
                         (get_local $2)
                       )
                     )
-                    (set_local $6
-                      (get_local $4)
+                    (set_local $5
+                      (get_local $7)
                     )
-                    (set_local $7
+                    (set_local $6
                       (select
-                        (get_local $4)
                         (get_local $7)
+                        (get_local $6)
                         (get_local $2)
                       )
                     )
@@ -851,7 +851,7 @@
                   (if
                     (i32.lt_u
                       (get_local $1)
-                      (set_local $7
+                      (set_local $6
                         (i32.load
                           (i32.const 1224)
                         )
@@ -862,7 +862,7 @@
                   (if
                     (i32.ge_u
                       (get_local $1)
-                      (set_local $6
+                      (set_local $5
                         (i32.add
                           (get_local $1)
                           (get_local $0)
@@ -888,7 +888,7 @@
                       )
                       (block
                         (if
-                          (set_local $20
+                          (set_local $21
                             (i32.load
                               (set_local $9
                                 (i32.add
@@ -900,7 +900,7 @@
                           )
                           (block
                             (set_local $14
-                              (get_local $20)
+                              (get_local $21)
                             )
                             (set_local $2
                               (get_local $9)
@@ -929,7 +929,7 @@
                         )
                         (loop $while-out$10 $while-in$11
                           (if
-                            (set_local $20
+                            (set_local $21
                               (i32.load
                                 (set_local $9
                                   (i32.add
@@ -941,7 +941,7 @@
                             )
                             (block
                               (set_local $14
-                                (get_local $20)
+                                (get_local $21)
                               )
                               (set_local $2
                                 (get_local $9)
@@ -950,7 +950,7 @@
                             )
                           )
                           (if
-                            (set_local $20
+                            (set_local $21
                               (i32.load
                                 (set_local $9
                                   (i32.add
@@ -962,7 +962,7 @@
                             )
                             (block
                               (set_local $14
-                                (get_local $20)
+                                (get_local $21)
                               )
                               (set_local $2
                                 (get_local $9)
@@ -975,7 +975,7 @@
                         (if
                           (i32.lt_u
                             (get_local $2)
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (call_import $qa)
                           (block
@@ -997,14 +997,14 @@
                                 (get_local $1)
                               )
                             )
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (call_import $qa)
                         )
                         (if
                           (i32.ne
                             (i32.load
-                              (set_local $20
+                              (set_local $21
                                 (i32.add
                                   (get_local $9)
                                   (i32.const 12)
@@ -1029,7 +1029,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $20)
+                              (get_local $21)
                               (get_local $8)
                             )
                             (i32.store
@@ -1053,7 +1053,7 @@
                           (i32.eq
                             (get_local $1)
                             (i32.load
-                              (set_local $7
+                              (set_local $6
                                 (i32.add
                                   (i32.const 1512)
                                   (i32.shl
@@ -1070,7 +1070,7 @@
                           )
                           (block
                             (i32.store
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $23)
                             )
                             (if
@@ -1151,38 +1151,38 @@
                           (get_local $3)
                         )
                         (if
-                          (set_local $7
+                          (set_local $6
                             (i32.load offset=16
                               (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $7)
+                              (get_local $6)
                               (get_local $8)
                             )
                             (call_import $qa)
                             (block
                               (i32.store offset=16
                                 (get_local $23)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $23)
                               )
                             )
                           )
                         )
                         (if
-                          (set_local $7
+                          (set_local $6
                             (i32.load offset=20
                               (get_local $1)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $7)
+                              (get_local $6)
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -1191,10 +1191,10 @@
                             (block
                               (i32.store offset=20
                                 (get_local $23)
-                                (get_local $7)
+                                (get_local $6)
                               )
                               (i32.store offset=24
-                                (get_local $7)
+                                (get_local $6)
                                 (get_local $23)
                               )
                             )
@@ -1205,7 +1205,7 @@
                   )
                   (if
                     (i32.lt_u
-                      (get_local $4)
+                      (get_local $7)
                       (i32.const 16)
                     )
                     (block
@@ -1214,7 +1214,7 @@
                         (i32.or
                           (set_local $3
                             (i32.add
-                              (get_local $4)
+                              (get_local $7)
                               (get_local $0)
                             )
                           )
@@ -1222,7 +1222,7 @@
                         )
                       )
                       (i32.store
-                        (set_local $7
+                        (set_local $6
                           (i32.add
                             (i32.add
                               (get_local $1)
@@ -1233,7 +1233,7 @@
                         )
                         (i32.or
                           (i32.load
-                            (get_local $7)
+                            (get_local $6)
                           )
                           (i32.const 1)
                         )
@@ -1248,21 +1248,21 @@
                         )
                       )
                       (i32.store offset=4
-                        (get_local $6)
+                        (get_local $5)
                         (i32.or
-                          (get_local $4)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store
                         (i32.add
-                          (get_local $6)
-                          (get_local $4)
+                          (get_local $5)
+                          (get_local $7)
                         )
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (if
-                        (set_local $7
+                        (set_local $6
                           (i32.load
                             (i32.const 1216)
                           )
@@ -1273,14 +1273,14 @@
                               (i32.const 1228)
                             )
                           )
-                          (set_local $7
+                          (set_local $6
                             (i32.add
                               (i32.const 1248)
                               (i32.shl
                                 (i32.shl
                                   (set_local $8
                                     (i32.shr_u
-                                      (get_local $7)
+                                      (get_local $6)
                                       (i32.const 3)
                                     )
                                   )
@@ -1310,7 +1310,7 @@
                                   (i32.load
                                     (set_local $2
                                       (i32.add
-                                        (get_local $7)
+                                        (get_local $6)
                                         (i32.const 8)
                                       )
                                     )
@@ -1340,12 +1340,12 @@
                               )
                               (set_local $42
                                 (i32.add
-                                  (get_local $7)
+                                  (get_local $6)
                                   (i32.const 8)
                                 )
                               )
                               (set_local $35
-                                (get_local $7)
+                                (get_local $6)
                               )
                             )
                           )
@@ -1363,17 +1363,17 @@
                           )
                           (i32.store offset=12
                             (get_local $3)
-                            (get_local $7)
+                            (get_local $6)
                           )
                         )
                       )
                       (i32.store
                         (i32.const 1216)
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (i32.store
                         (i32.const 1228)
-                        (get_local $6)
+                        (get_local $5)
                       )
                     )
                   )
@@ -1405,7 +1405,7 @@
           (block
             (set_local $3
               (i32.and
-                (set_local $7
+                (set_local $6
                   (i32.add
                     (get_local $0)
                     (i32.const 11)
@@ -1429,7 +1429,7 @@
                 )
                 (block $label$break$a
                   (if
-                    (set_local $13
+                    (set_local $12
                       (i32.load
                         (i32.add
                           (i32.shl
@@ -1437,7 +1437,7 @@
                               (if
                                 (set_local $8
                                   (i32.shr_u
-                                    (get_local $7)
+                                    (get_local $6)
                                     (i32.const 8)
                                   )
                                 )
@@ -1452,7 +1452,7 @@
                                       (i32.shr_u
                                         (get_local $3)
                                         (i32.add
-                                          (set_local $13
+                                          (set_local $12
                                             (i32.add
                                               (i32.sub
                                                 (i32.const 14)
@@ -1462,10 +1462,10 @@
                                                       (i32.and
                                                         (i32.shr_u
                                                           (i32.add
-                                                            (set_local $20
+                                                            (set_local $21
                                                               (i32.shl
                                                                 (get_local $8)
-                                                                (set_local $7
+                                                                (set_local $6
                                                                   (i32.and
                                                                     (i32.shr_u
                                                                       (i32.add
@@ -1486,15 +1486,15 @@
                                                         (i32.const 4)
                                                       )
                                                     )
-                                                    (get_local $7)
+                                                    (get_local $6)
                                                   )
-                                                  (set_local $20
+                                                  (set_local $21
                                                     (i32.and
                                                       (i32.shr_u
                                                         (i32.add
                                                           (set_local $14
                                                             (i32.shl
-                                                              (get_local $20)
+                                                              (get_local $21)
                                                               (get_local $8)
                                                             )
                                                           )
@@ -1510,7 +1510,7 @@
                                               (i32.shr_u
                                                 (i32.shl
                                                   (get_local $14)
-                                                  (get_local $20)
+                                                  (get_local $21)
                                                 )
                                                 (i32.const 15)
                                               )
@@ -1522,7 +1522,7 @@
                                       (i32.const 1)
                                     )
                                     (i32.shl
-                                      (get_local $13)
+                                      (get_local $12)
                                       (i32.const 1)
                                     )
                                   )
@@ -1537,13 +1537,13 @@
                       )
                     )
                     (block
-                      (set_local $20
+                      (set_local $21
                         (get_local $2)
                       )
                       (set_local $14
                         (i32.const 0)
                       )
-                      (set_local $7
+                      (set_local $6
                         (i32.shl
                           (get_local $3)
                           (select
@@ -1563,7 +1563,7 @@
                         )
                       )
                       (set_local $8
-                        (get_local $13)
+                        (get_local $12)
                       )
                       (set_local $1
                         (i32.const 0)
@@ -1571,9 +1571,9 @@
                       (loop $while-out$17 $while-in$18
                         (if
                           (i32.lt_u
-                            (set_local $6
+                            (set_local $5
                               (i32.sub
-                                (set_local $13
+                                (set_local $12
                                   (i32.and
                                     (i32.load offset=4
                                       (get_local $8)
@@ -1584,16 +1584,16 @@
                                 (get_local $3)
                               )
                             )
-                            (get_local $20)
+                            (get_local $21)
                           )
                           (if
                             (i32.eq
-                              (get_local $13)
+                              (get_local $12)
                               (get_local $3)
                             )
                             (block
                               (set_local $28
-                                (get_local $6)
+                                (get_local $5)
                               )
                               (set_local $27
                                 (get_local $8)
@@ -1607,33 +1607,30 @@
                               (br $label$break$a)
                             )
                             (block
-                              (set_local $2
-                                (get_local $6)
+                              (set_local $21
+                                (get_local $5)
                               )
                               (set_local $1
                                 (get_local $8)
                               )
                             )
                           )
-                          (set_local $2
-                            (get_local $20)
-                          )
                         )
-                        (set_local $13
+                        (set_local $12
                           (select
                             (get_local $14)
-                            (set_local $6
+                            (set_local $5
                               (i32.load offset=20
                                 (get_local $8)
                               )
                             )
                             (i32.or
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 0)
                               )
                               (i32.eq
-                                (get_local $6)
+                                (get_local $5)
                                 (set_local $8
                                   (i32.load
                                     (i32.add
@@ -1643,7 +1640,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $7)
+                                          (get_local $6)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -1656,7 +1653,7 @@
                           )
                         )
                         (if
-                          (set_local $6
+                          (set_local $5
                             (i32.eq
                               (get_local $8)
                               (i32.const 0)
@@ -1664,10 +1661,10 @@
                           )
                           (block
                             (set_local $36
-                              (get_local $2)
+                              (get_local $21)
                             )
                             (set_local $37
-                              (get_local $13)
+                              (get_local $12)
                             )
                             (set_local $32
                               (get_local $1)
@@ -1678,18 +1675,15 @@
                             (br $while-out$17)
                           )
                           (block
-                            (set_local $20
-                              (get_local $2)
-                            )
                             (set_local $14
-                              (get_local $13)
+                              (get_local $12)
                             )
-                            (set_local $7
+                            (set_local $6
                               (i32.shl
-                                (get_local $7)
+                                (get_local $6)
                                 (i32.xor
                                   (i32.and
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.const 1)
                                   )
                                   (i32.const 1)
@@ -1742,7 +1736,7 @@
                                 (i32.and
                                   (get_local $9)
                                   (i32.or
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.shl
                                         (i32.const 2)
                                         (get_local $0)
@@ -1750,7 +1744,7 @@
                                     )
                                     (i32.sub
                                       (i32.const 0)
-                                      (get_local $13)
+                                      (get_local $12)
                                     )
                                   )
                                 )
@@ -1766,7 +1760,7 @@
                           (set_local $2
                             (i32.and
                               (i32.shr_u
-                                (set_local $13
+                                (set_local $12
                                   (i32.add
                                     (i32.and
                                       (get_local $2)
@@ -1791,12 +1785,12 @@
                                     (i32.or
                                       (i32.or
                                         (i32.or
-                                          (set_local $13
+                                          (set_local $12
                                             (i32.and
                                               (i32.shr_u
                                                 (set_local $0
                                                   (i32.shr_u
-                                                    (get_local $13)
+                                                    (get_local $12)
                                                     (get_local $2)
                                                   )
                                                 )
@@ -1810,10 +1804,10 @@
                                         (set_local $0
                                           (i32.and
                                             (i32.shr_u
-                                              (set_local $6
+                                              (set_local $5
                                                 (i32.shr_u
                                                   (get_local $0)
-                                                  (get_local $13)
+                                                  (get_local $12)
                                                 )
                                               )
                                               (i32.const 2)
@@ -1822,12 +1816,12 @@
                                           )
                                         )
                                       )
-                                      (set_local $6
+                                      (set_local $5
                                         (i32.and
                                           (i32.shr_u
                                             (set_local $1
                                               (i32.shr_u
-                                                (get_local $6)
+                                                (get_local $5)
                                                 (get_local $0)
                                               )
                                             )
@@ -1840,10 +1834,10 @@
                                     (set_local $1
                                       (i32.and
                                         (i32.shr_u
-                                          (set_local $7
+                                          (set_local $6
                                             (i32.shr_u
                                               (get_local $1)
-                                              (get_local $6)
+                                              (get_local $5)
                                             )
                                           )
                                           (i32.const 1)
@@ -1853,7 +1847,7 @@
                                     )
                                   )
                                   (i32.shr_u
-                                    (get_local $7)
+                                    (get_local $6)
                                     (get_local $1)
                                   )
                                 )
@@ -1899,7 +1893,7 @@
                     (set_local $8
                       (i32.const 0)
                     )
-                    (set_local $7
+                    (set_local $6
                       (i32.lt_u
                         (set_local $1
                           (i32.sub
@@ -1915,32 +1909,32 @@
                         (get_local $28)
                       )
                     )
-                    (set_local $6
+                    (set_local $5
                       (select
                         (get_local $1)
                         (get_local $28)
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                     (set_local $1
                       (select
                         (get_local $27)
                         (get_local $31)
-                        (get_local $7)
+                        (get_local $6)
                       )
                     )
                     (if
-                      (set_local $7
+                      (set_local $6
                         (i32.load offset=16
                           (get_local $27)
                         )
                       )
                       (block
                         (set_local $28
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $27
-                          (get_local $7)
+                          (get_local $6)
                         )
                         (set_local $31
                           (get_local $1)
@@ -1956,7 +1950,7 @@
                       )
                       (block
                         (set_local $28
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $31
                           (get_local $1)
@@ -1964,7 +1958,7 @@
                       )
                       (block
                         (set_local $16
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $10
                           (get_local $1)
@@ -2011,7 +2005,7 @@
                         )
                         (call_import $qa)
                       )
-                      (set_local $6
+                      (set_local $5
                         (i32.load offset=24
                           (get_local $10)
                         )
@@ -2019,7 +2013,7 @@
                       (block $do-once$21
                         (if
                           (i32.eq
-                            (set_local $7
+                            (set_local $6
                               (i32.load offset=12
                                 (get_local $10)
                               )
@@ -2039,34 +2033,28 @@
                                 )
                               )
                               (block
-                                (set_local $4
+                                (set_local $14
                                   (get_local $2)
                                 )
-                                (set_local $14
+                                (set_local $12
                                   (get_local $0)
                                 )
                               )
                               (if
-                                (set_local $14
-                                  (i32.load
-                                    (set_local $13
-                                      (i32.add
-                                        (get_local $10)
-                                        (i32.const 16)
+                                (i32.eqz
+                                  (set_local $14
+                                    (i32.load
+                                      (set_local $12
+                                        (i32.add
+                                          (get_local $10)
+                                          (i32.const 16)
+                                        )
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
-                                    (get_local $14)
-                                  )
-                                  (set_local $14
-                                    (get_local $13)
-                                  )
-                                )
-                                (block
-                                  (set_local $22
+                                  (set_local $19
                                     (i32.const 0)
                                   )
                                   (br $do-once$21)
@@ -2079,17 +2067,17 @@
                                   (i32.load
                                     (set_local $0
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $14)
                                         (i32.const 20)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
+                                  (set_local $14
                                     (get_local $2)
                                   )
-                                  (set_local $14
+                                  (set_local $12
                                     (get_local $0)
                                   )
                                   (br $while-in$24)
@@ -2100,45 +2088,37 @@
                                   (i32.load
                                     (set_local $0
                                       (i32.add
-                                        (get_local $4)
+                                        (get_local $14)
                                         (i32.const 16)
                                       )
                                     )
                                   )
                                 )
                                 (block
-                                  (set_local $4
+                                  (set_local $14
                                     (get_local $2)
                                   )
-                                  (set_local $14
+                                  (set_local $12
                                     (get_local $0)
                                   )
                                 )
-                                (block
-                                  (set_local $0
-                                    (get_local $4)
-                                  )
-                                  (set_local $4
-                                    (get_local $14)
-                                  )
-                                  (br $while-out$23)
-                                )
+                                (br $while-out$23)
                               )
                               (br $while-in$24)
                             )
                             (if
                               (i32.lt_u
-                                (get_local $4)
+                                (get_local $12)
                                 (get_local $9)
                               )
                               (call_import $qa)
                               (block
                                 (i32.store
-                                  (get_local $4)
+                                  (get_local $12)
                                   (i32.const 0)
                                 )
-                                (set_local $22
-                                  (get_local $0)
+                                (set_local $19
+                                  (get_local $14)
                                 )
                               )
                             )
@@ -2172,9 +2152,9 @@
                             (if
                               (i32.eq
                                 (i32.load
-                                  (set_local $13
+                                  (set_local $12
                                     (i32.add
-                                      (get_local $7)
+                                      (get_local $6)
                                       (i32.const 8)
                                     )
                                   )
@@ -2184,14 +2164,14 @@
                               (block
                                 (i32.store
                                   (get_local $2)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (i32.store
-                                  (get_local $13)
+                                  (get_local $12)
                                   (get_local $0)
                                 )
-                                (set_local $22
-                                  (get_local $7)
+                                (set_local $19
+                                  (get_local $6)
                                 )
                               )
                               (call_import $qa)
@@ -2201,7 +2181,7 @@
                       )
                       (block $do-once$25
                         (if
-                          (get_local $6)
+                          (get_local $5)
                           (block
                             (if
                               (i32.eq
@@ -2211,7 +2191,7 @@
                                     (i32.add
                                       (i32.const 1512)
                                       (i32.shl
-                                        (set_local $7
+                                        (set_local $6
                                           (i32.load offset=28
                                             (get_local $10)
                                           )
@@ -2225,11 +2205,11 @@
                               (block
                                 (i32.store
                                   (get_local $9)
-                                  (get_local $22)
+                                  (get_local $19)
                                 )
                                 (if
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                   (block
                                     (i32.store
@@ -2241,7 +2221,7 @@
                                         (i32.xor
                                           (i32.shl
                                             (i32.const 1)
-                                            (get_local $7)
+                                            (get_local $6)
                                           )
                                           (i32.const -1)
                                         )
@@ -2254,7 +2234,7 @@
                               (block
                                 (if
                                   (i32.lt_u
-                                    (get_local $6)
+                                    (get_local $5)
                                     (i32.load
                                       (i32.const 1224)
                                     )
@@ -2264,9 +2244,9 @@
                                 (if
                                   (i32.eq
                                     (i32.load
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.add
-                                          (get_local $6)
+                                          (get_local $5)
                                           (i32.const 16)
                                         )
                                       )
@@ -2274,25 +2254,25 @@
                                     (get_local $10)
                                   )
                                   (i32.store
-                                    (get_local $7)
-                                    (get_local $22)
+                                    (get_local $6)
+                                    (get_local $19)
                                   )
                                   (i32.store offset=20
-                                    (get_local $6)
-                                    (get_local $22)
+                                    (get_local $5)
+                                    (get_local $19)
                                   )
                                 )
                                 (br_if $do-once$25
                                   (i32.eqz
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.lt_u
-                                (get_local $22)
-                                (set_local $7
+                                (get_local $19)
+                                (set_local $6
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2301,8 +2281,8 @@
                               (call_import $qa)
                             )
                             (i32.store offset=24
-                              (get_local $22)
-                              (get_local $6)
+                              (get_local $19)
+                              (get_local $5)
                             )
                             (if
                               (set_local $9
@@ -2313,17 +2293,17 @@
                               (if
                                 (i32.lt_u
                                   (get_local $9)
-                                  (get_local $7)
+                                  (get_local $6)
                                 )
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=16
-                                    (get_local $22)
+                                    (get_local $19)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                 )
                               )
@@ -2344,12 +2324,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store offset=20
-                                    (get_local $22)
+                                    (get_local $19)
                                     (get_local $9)
                                   )
                                   (i32.store offset=24
                                     (get_local $9)
-                                    (get_local $22)
+                                    (get_local $19)
                                   )
                                 )
                               )
@@ -2367,7 +2347,7 @@
                             (i32.store offset=4
                               (get_local $10)
                               (i32.or
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (get_local $16)
                                     (get_local $3)
@@ -2381,7 +2361,7 @@
                                 (i32.add
                                   (i32.add
                                     (get_local $10)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                   (i32.const 4)
                                 )
@@ -2428,7 +2408,7 @@
                                 (i32.const 256)
                               )
                               (block
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (i32.const 1248)
                                     (i32.shl
@@ -2442,7 +2422,7 @@
                                 )
                                 (if
                                   (i32.and
-                                    (set_local $7
+                                    (set_local $6
                                       (i32.load
                                         (i32.const 1208)
                                       )
@@ -2456,11 +2436,11 @@
                                   )
                                   (if
                                     (i32.lt_u
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.load
                                           (set_local $0
                                             (i32.add
-                                              (get_local $6)
+                                              (get_local $5)
                                               (i32.const 8)
                                             )
                                           )
@@ -2472,11 +2452,11 @@
                                     )
                                     (call_import $qa)
                                     (block
-                                      (set_local $17
+                                      (set_local $18
                                         (get_local $0)
                                       )
-                                      (set_local $12
-                                        (get_local $7)
+                                      (set_local $13
+                                        (get_local $6)
                                       )
                                     )
                                   )
@@ -2484,47 +2464,47 @@
                                     (i32.store
                                       (i32.const 1208)
                                       (i32.or
-                                        (get_local $7)
+                                        (get_local $6)
                                         (get_local $0)
                                       )
                                     )
-                                    (set_local $17
+                                    (set_local $18
                                       (i32.add
-                                        (get_local $6)
+                                        (get_local $5)
                                         (i32.const 8)
                                       )
                                     )
-                                    (set_local $12
-                                      (get_local $6)
+                                    (set_local $13
+                                      (get_local $5)
                                     )
                                   )
                                 )
                                 (i32.store
-                                  (get_local $17)
+                                  (get_local $18)
                                   (get_local $1)
                                 )
                                 (i32.store offset=12
-                                  (get_local $12)
+                                  (get_local $13)
                                   (get_local $1)
                                 )
                                 (i32.store offset=8
                                   (get_local $1)
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                                 (i32.store offset=12
                                   (get_local $1)
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                                 (br $do-once$29)
                               )
                             )
-                            (set_local $13
+                            (set_local $12
                               (i32.add
                                 (i32.const 1512)
                                 (i32.shl
                                   (set_local $2
                                     (if
-                                      (set_local $6
+                                      (set_local $5
                                         (i32.shr_u
                                           (get_local $16)
                                           (i32.const 8)
@@ -2541,24 +2521,24 @@
                                             (i32.shr_u
                                               (get_local $16)
                                               (i32.add
-                                                (set_local $13
+                                                (set_local $12
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $6
+                                                          (set_local $5
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
                                                                   (set_local $0
                                                                     (i32.shl
-                                                                      (get_local $6)
-                                                                      (set_local $7
+                                                                      (get_local $5)
+                                                                      (set_local $6
                                                                         (i32.and
                                                                           (i32.shr_u
                                                                             (i32.add
-                                                                              (get_local $6)
+                                                                              (get_local $5)
                                                                               (i32.const 1048320)
                                                                             )
                                                                             (i32.const 16)
@@ -2575,7 +2555,7 @@
                                                               (i32.const 4)
                                                             )
                                                           )
-                                                          (get_local $7)
+                                                          (get_local $6)
                                                         )
                                                         (set_local $0
                                                           (i32.and
@@ -2584,7 +2564,7 @@
                                                                 (set_local $9
                                                                   (i32.shl
                                                                     (get_local $0)
-                                                                    (get_local $6)
+                                                                    (get_local $5)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -2611,7 +2591,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $13)
+                                            (get_local $12)
                                             (i32.const 1)
                                           )
                                         )
@@ -2665,12 +2645,12 @@
                                   )
                                 )
                                 (i32.store
-                                  (get_local $13)
+                                  (get_local $12)
                                   (get_local $1)
                                 )
                                 (i32.store offset=24
                                   (get_local $1)
-                                  (get_local $13)
+                                  (get_local $12)
                                 )
                                 (i32.store offset=12
                                   (get_local $1)
@@ -2704,7 +2684,7 @@
                             )
                             (set_local $0
                               (i32.load
-                                (get_local $13)
+                                (get_local $12)
                               )
                             )
                             (loop $while-out$31 $while-in$32
@@ -2719,7 +2699,7 @@
                                   (get_local $16)
                                 )
                                 (block
-                                  (set_local $15
+                                  (set_local $17
                                     (get_local $0)
                                   )
                                   (set_local $8
@@ -2729,9 +2709,9 @@
                                 )
                               )
                               (if
-                                (set_local $7
+                                (set_local $6
                                   (i32.load
-                                    (set_local $13
+                                    (set_local $12
                                       (i32.add
                                         (i32.add
                                           (get_local $0)
@@ -2756,14 +2736,14 @@
                                     )
                                   )
                                   (set_local $0
-                                    (get_local $7)
+                                    (get_local $6)
                                   )
                                 )
                                 (block
-                                  (set_local $21
-                                    (get_local $13)
+                                  (set_local $22
+                                    (get_local $12)
                                   )
-                                  (set_local $18
+                                  (set_local $15
                                     (get_local $0)
                                   )
                                   (set_local $8
@@ -2781,7 +2761,7 @@
                               )
                               (if
                                 (i32.lt_u
-                                  (get_local $21)
+                                  (get_local $22)
                                   (i32.load
                                     (i32.const 1224)
                                   )
@@ -2789,12 +2769,12 @@
                                 (call_import $qa)
                                 (block
                                   (i32.store
-                                    (get_local $21)
+                                    (get_local $22)
                                     (get_local $1)
                                   )
                                   (i32.store offset=24
                                     (get_local $1)
-                                    (get_local $18)
+                                    (get_local $15)
                                   )
                                   (i32.store offset=12
                                     (get_local $1)
@@ -2818,21 +2798,21 @@
                                         (i32.load
                                           (set_local $0
                                             (i32.add
-                                              (get_local $15)
+                                              (get_local $17)
                                               (i32.const 8)
                                             )
                                           )
                                         )
                                       )
-                                      (set_local $7
+                                      (set_local $6
                                         (i32.load
                                           (i32.const 1224)
                                         )
                                       )
                                     )
                                     (i32.ge_u
-                                      (get_local $15)
-                                      (get_local $7)
+                                      (get_local $17)
+                                      (get_local $6)
                                     )
                                   )
                                   (block
@@ -2850,7 +2830,7 @@
                                     )
                                     (i32.store offset=12
                                       (get_local $1)
-                                      (get_local $15)
+                                      (get_local $17)
                                     )
                                     (i32.store offset=24
                                       (get_local $1)
@@ -2902,14 +2882,14 @@
         (get_local $0)
       )
       (block
-        (set_local $18
+        (set_local $15
           (i32.load
             (i32.const 1228)
           )
         )
         (if
           (i32.gt_u
-            (set_local $15
+            (set_local $17
               (i32.sub
                 (get_local $10)
                 (get_local $0)
@@ -2920,33 +2900,33 @@
           (block
             (i32.store
               (i32.const 1228)
-              (set_local $21
+              (set_local $22
                 (i32.add
-                  (get_local $18)
+                  (get_local $15)
                   (get_local $0)
                 )
               )
             )
             (i32.store
               (i32.const 1216)
-              (get_local $15)
+              (get_local $17)
             )
             (i32.store offset=4
-              (get_local $21)
+              (get_local $22)
               (i32.or
-                (get_local $15)
+                (get_local $17)
                 (i32.const 1)
               )
             )
             (i32.store
               (i32.add
-                (get_local $21)
-                (get_local $15)
+                (get_local $22)
+                (get_local $17)
               )
-              (get_local $15)
+              (get_local $17)
             )
             (i32.store offset=4
-              (get_local $18)
+              (get_local $15)
               (i32.or
                 (get_local $0)
                 (i32.const 3)
@@ -2963,17 +2943,17 @@
               (i32.const 0)
             )
             (i32.store offset=4
-              (get_local $18)
+              (get_local $15)
               (i32.or
                 (get_local $10)
                 (i32.const 3)
               )
             )
             (i32.store
-              (set_local $15
+              (set_local $17
                 (i32.add
                   (i32.add
-                    (get_local $18)
+                    (get_local $15)
                     (get_local $10)
                   )
                   (i32.const 4)
@@ -2981,7 +2961,7 @@
               )
               (i32.or
                 (i32.load
-                  (get_local $15)
+                  (get_local $17)
                 )
                 (i32.const 1)
               )
@@ -2994,7 +2974,7 @@
         )
         (return
           (i32.add
-            (get_local $18)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3002,7 +2982,7 @@
     )
     (if
       (i32.gt_u
-        (set_local $18
+        (set_local $15
           (i32.load
             (i32.const 1220)
           )
@@ -3012,9 +2992,9 @@
       (block
         (i32.store
           (i32.const 1220)
-          (set_local $15
+          (set_local $17
             (i32.sub
-              (get_local $18)
+              (get_local $15)
               (get_local $0)
             )
           )
@@ -3023,7 +3003,7 @@
           (i32.const 1232)
           (set_local $10
             (i32.add
-              (set_local $18
+              (set_local $15
                 (i32.load
                   (i32.const 1232)
                 )
@@ -3035,12 +3015,12 @@
         (i32.store offset=4
           (get_local $10)
           (i32.or
-            (get_local $15)
+            (get_local $17)
             (i32.const 1)
           )
         )
         (i32.store offset=4
-          (get_local $18)
+          (get_local $15)
           (i32.or
             (get_local $0)
             (i32.const 3)
@@ -3052,7 +3032,7 @@
         )
         (return
           (i32.add
-            (get_local $18)
+            (get_local $15)
             (i32.const 8)
           )
         )
@@ -3090,11 +3070,11 @@
           (i32.const 0)
         )
         (i32.store
-          (get_local $4)
-          (set_local $18
+          (get_local $7)
+          (set_local $15
             (i32.xor
               (i32.and
-                (get_local $4)
+                (get_local $7)
                 (i32.const -16)
               )
               (i32.const 1431655768)
@@ -3103,11 +3083,11 @@
         )
         (i32.store
           (i32.const 1680)
-          (get_local $18)
+          (get_local $15)
         )
       )
     )
-    (set_local $18
+    (set_local $15
       (i32.add
         (get_local $0)
         (i32.const 48)
@@ -3115,16 +3095,16 @@
     )
     (if
       (i32.le_u
-        (set_local $4
+        (set_local $7
           (i32.and
             (set_local $10
               (i32.add
-                (set_local $4
+                (set_local $7
                   (i32.load
                     (i32.const 1688)
                   )
                 )
-                (set_local $15
+                (set_local $17
                   (i32.add
                     (get_local $0)
                     (i32.const 47)
@@ -3132,10 +3112,10 @@
                 )
               )
             )
-            (set_local $21
+            (set_local $22
               (i32.sub
                 (i32.const 0)
-                (get_local $4)
+                (get_local $7)
               )
             )
           )
@@ -3161,20 +3141,20 @@
       (if
         (i32.or
           (i32.le_u
-            (set_local $12
+            (set_local $13
               (i32.add
                 (set_local $2
                   (i32.load
                     (i32.const 1640)
                   )
                 )
-                (get_local $4)
+                (get_local $7)
               )
             )
             (get_local $2)
           )
           (i32.gt_u
-            (get_local $12)
+            (get_local $13)
             (get_local $16)
           )
         )
@@ -3210,7 +3190,7 @@
                       )
                     )
                     (block
-                      (set_local $12
+                      (set_local $13
                         (i32.const 1656)
                       )
                       (loop $while-out$35 $while-in$36
@@ -3218,7 +3198,7 @@
                           (i32.le_u
                             (set_local $2
                               (i32.load
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
                             (get_local $16)
@@ -3228,9 +3208,9 @@
                               (i32.add
                                 (get_local $2)
                                 (i32.load
-                                  (set_local $17
+                                  (set_local $18
                                     (i32.add
-                                      (get_local $12)
+                                      (get_local $13)
                                       (i32.const 4)
                                     )
                                   )
@@ -3240,10 +3220,10 @@
                             )
                             (block
                               (set_local $3
-                                (get_local $12)
+                                (get_local $13)
                               )
-                              (set_local $6
-                                (get_local $17)
+                              (set_local $5
+                                (get_local $18)
                               )
                               (br $while-out$35)
                             )
@@ -3251,9 +3231,9 @@
                         )
                         (if
                           (i32.eqz
-                            (set_local $12
+                            (set_local $13
                               (i32.load offset=8
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
                           )
@@ -3268,7 +3248,7 @@
                       )
                       (if
                         (i32.lt_u
-                          (set_local $12
+                          (set_local $13
                             (i32.and
                               (i32.sub
                                 (get_local $10)
@@ -3276,16 +3256,16 @@
                                   (i32.const 1220)
                                 )
                               )
-                              (get_local $21)
+                              (get_local $22)
                             )
                           )
                           (i32.const 2147483647)
                         )
                         (if
                           (i32.eq
-                            (set_local $17
+                            (set_local $18
                               (call_import $ta
-                                (get_local $12)
+                                (get_local $13)
                               )
                             )
                             (i32.add
@@ -3293,21 +3273,21 @@
                                 (get_local $3)
                               )
                               (i32.load
-                                (get_local $6)
+                                (get_local $5)
                               )
                             )
                           )
                           (if
                             (i32.ne
-                              (get_local $17)
+                              (get_local $18)
                               (i32.const -1)
                             )
                             (block
-                              (set_local $19
-                                (get_local $17)
+                              (set_local $20
+                                (get_local $18)
                               )
                               (set_local $26
-                                (get_local $12)
+                                (get_local $13)
                               )
                               (br $label$break$b
                                 (i32.const 191)
@@ -3316,10 +3296,10 @@
                           )
                           (block
                             (set_local $11
-                              (get_local $17)
+                              (get_local $18)
                             )
-                            (set_local $5
-                              (get_local $12)
+                            (set_local $4
+                              (get_local $13)
                             )
                             (set_local $8
                               (i32.const 181)
@@ -3352,9 +3332,9 @@
                         (set_local $2
                           (if
                             (i32.and
-                              (set_local $17
+                              (set_local $18
                                 (i32.add
-                                  (set_local $12
+                                  (set_local $13
                                     (i32.load
                                       (i32.const 1684)
                                     )
@@ -3368,26 +3348,26 @@
                             )
                             (i32.add
                               (i32.sub
-                                (get_local $4)
+                                (get_local $7)
                                 (get_local $3)
                               )
                               (i32.and
                                 (i32.add
-                                  (get_local $17)
+                                  (get_local $18)
                                   (get_local $3)
                                 )
                                 (i32.sub
                                   (i32.const 0)
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                             )
-                            (get_local $4)
+                            (get_local $7)
                           )
                         )
                         (set_local $3
                           (i32.add
-                            (set_local $12
+                            (set_local $13
                               (i32.load
                                 (i32.const 1640)
                               )
@@ -3408,7 +3388,7 @@
                           )
                           (block
                             (if
-                              (set_local $17
+                              (set_local $18
                                 (i32.load
                                   (i32.const 1648)
                                 )
@@ -3417,18 +3397,18 @@
                                 (i32.or
                                   (i32.le_u
                                     (get_local $3)
-                                    (get_local $12)
+                                    (get_local $13)
                                   )
                                   (i32.gt_u
                                     (get_local $3)
-                                    (get_local $17)
+                                    (get_local $18)
                                   )
                                 )
                               )
                             )
                             (if
                               (i32.eq
-                                (set_local $17
+                                (set_local $18
                                   (call_import $ta
                                     (get_local $2)
                                   )
@@ -3436,7 +3416,7 @@
                                 (get_local $16)
                               )
                               (block
-                                (set_local $19
+                                (set_local $20
                                   (get_local $16)
                                 )
                                 (set_local $26
@@ -3448,9 +3428,9 @@
                               )
                               (block
                                 (set_local $11
-                                  (get_local $17)
+                                  (get_local $18)
                                 )
-                                (set_local $5
+                                (set_local $4
                                   (get_local $2)
                                 )
                                 (set_local $8
@@ -3471,21 +3451,21 @@
                       (i32.const 181)
                     )
                     (block
-                      (set_local $17
+                      (set_local $18
                         (i32.sub
                           (i32.const 0)
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                       (if
                         (i32.and
                           (i32.gt_u
-                            (get_local $18)
-                            (get_local $5)
+                            (get_local $15)
+                            (get_local $4)
                           )
                           (i32.and
                             (i32.lt_u
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 2147483647)
                             )
                             (i32.ne
@@ -3500,8 +3480,8 @@
                               (i32.and
                                 (i32.add
                                   (i32.sub
-                                    (get_local $15)
-                                    (get_local $5)
+                                    (get_local $17)
+                                    (get_local $4)
                                   )
                                   (set_local $16
                                     (i32.load
@@ -3526,23 +3506,23 @@
                             )
                             (block
                               (call_import $ta
-                                (get_local $17)
+                                (get_local $18)
                               )
                               (br $label$break$d)
                             )
                             (set_local $1
                               (i32.add
                                 (get_local $3)
-                                (get_local $5)
+                                (get_local $4)
                               )
                             )
                           )
                           (set_local $1
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (set_local $1
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
                       (if
@@ -3551,7 +3531,7 @@
                           (i32.const -1)
                         )
                         (block
-                          (set_local $19
+                          (set_local $20
                             (get_local $11)
                           )
                           (set_local $26
@@ -3583,7 +3563,7 @@
       )
       (if
         (i32.lt_u
-          (get_local $4)
+          (get_local $7)
           (i32.const 2147483647)
         )
         (if
@@ -3591,10 +3571,10 @@
             (i32.lt_u
               (set_local $1
                 (call_import $ta
-                  (get_local $4)
+                  (get_local $7)
                 )
               )
-              (set_local $4
+              (set_local $7
                 (call_import $ta
                   (i32.const 0)
                 )
@@ -3606,7 +3586,7 @@
                 (i32.const -1)
               )
               (i32.ne
-                (get_local $4)
+                (get_local $7)
                 (i32.const -1)
               )
             )
@@ -3615,7 +3595,7 @@
             (i32.gt_u
               (set_local $11
                 (i32.sub
-                  (get_local $4)
+                  (get_local $7)
                   (get_local $1)
                 )
               )
@@ -3625,7 +3605,7 @@
               )
             )
             (block
-              (set_local $19
+              (set_local $20
                 (get_local $1)
               )
               (set_local $26
@@ -3676,24 +3656,24 @@
               )
             )
             (block
-              (set_local $5
+              (set_local $4
                 (i32.const 1656)
               )
               (loop $do-out$46 $do-in$47
                 (if
                   (i32.eq
-                    (get_local $19)
+                    (get_local $20)
                     (i32.add
                       (set_local $1
                         (i32.load
-                          (get_local $5)
+                          (get_local $4)
                         )
                       )
-                      (set_local $15
+                      (set_local $17
                         (i32.load
-                          (set_local $4
+                          (set_local $7
                             (i32.add
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 4)
                             )
                           )
@@ -3706,13 +3686,13 @@
                       (get_local $1)
                     )
                     (set_local $50
-                      (get_local $4)
+                      (get_local $7)
                     )
                     (set_local $51
-                      (get_local $15)
+                      (get_local $17)
                     )
                     (set_local $52
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (set_local $8
                       (i32.const 201)
@@ -3722,9 +3702,9 @@
                 )
                 (br_if $do-in$47
                   (i32.ne
-                    (set_local $5
+                    (set_local $4
                       (i32.load offset=8
-                        (get_local $5)
+                        (get_local $4)
                       )
                     )
                     (i32.const 0)
@@ -3749,7 +3729,7 @@
                     (i32.and
                       (i32.lt_u
                         (get_local $11)
-                        (get_local $19)
+                        (get_local $20)
                       )
                       (i32.ge_u
                         (get_local $11)
@@ -3764,16 +3744,16 @@
                           (get_local $26)
                         )
                       )
-                      (set_local $5
+                      (set_local $4
                         (i32.add
                           (get_local $11)
-                          (set_local $15
+                          (set_local $17
                             (select
                               (i32.const 0)
                               (i32.and
                                 (i32.sub
                                   (i32.const 0)
-                                  (set_local $5
+                                  (set_local $4
                                     (i32.add
                                       (get_local $11)
                                       (i32.const 8)
@@ -3784,7 +3764,7 @@
                               )
                               (i32.eq
                                 (i32.and
-                                  (get_local $5)
+                                  (get_local $4)
                                   (i32.const 7)
                                 )
                                 (i32.const 0)
@@ -3793,11 +3773,11 @@
                           )
                         )
                       )
-                      (set_local $4
+                      (set_local $7
                         (i32.add
                           (i32.sub
                             (get_local $26)
-                            (get_local $15)
+                            (get_local $17)
                           )
                           (i32.load
                             (i32.const 1220)
@@ -3806,23 +3786,23 @@
                       )
                       (i32.store
                         (i32.const 1232)
-                        (get_local $5)
+                        (get_local $4)
                       )
                       (i32.store
                         (i32.const 1220)
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (i32.store offset=4
-                        (get_local $5)
+                        (get_local $4)
                         (i32.or
-                          (get_local $4)
+                          (get_local $7)
                           (i32.const 1)
                         )
                       )
                       (i32.store offset=4
                         (i32.add
-                          (get_local $5)
                           (get_local $4)
+                          (get_local $7)
                         )
                         (i32.const 40)
                       )
@@ -3840,8 +3820,8 @@
               (set_local $14
                 (if
                   (i32.lt_u
-                    (get_local $19)
-                    (set_local $4
+                    (get_local $20)
+                    (set_local $7
                       (i32.load
                         (i32.const 1224)
                       )
@@ -3850,36 +3830,36 @@
                   (block
                     (i32.store
                       (i32.const 1224)
-                      (get_local $19)
+                      (get_local $20)
                     )
-                    (get_local $19)
+                    (get_local $20)
                   )
-                  (get_local $4)
+                  (get_local $7)
                 )
               )
-              (set_local $4
+              (set_local $7
                 (i32.add
-                  (get_local $19)
+                  (get_local $20)
                   (get_local $26)
                 )
               )
-              (set_local $5
+              (set_local $4
                 (i32.const 1656)
               )
               (loop $while-out$48 $while-in$49
                 (if
                   (i32.eq
                     (i32.load
-                      (get_local $5)
+                      (get_local $4)
                     )
-                    (get_local $4)
+                    (get_local $7)
                   )
                   (block
                     (set_local $53
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (set_local $43
-                      (get_local $5)
+                      (get_local $4)
                     )
                     (set_local $8
                       (i32.const 209)
@@ -3889,9 +3869,9 @@
                 )
                 (if
                   (i32.eqz
-                    (set_local $5
+                    (set_local $4
                       (i32.load offset=8
-                        (get_local $5)
+                        (get_local $4)
                       )
                     )
                   )
@@ -3922,10 +3902,10 @@
                   (block
                     (i32.store
                       (get_local $53)
-                      (get_local $19)
+                      (get_local $20)
                     )
                     (i32.store
-                      (set_local $5
+                      (set_local $4
                         (i32.add
                           (get_local $43)
                           (i32.const 4)
@@ -3933,22 +3913,22 @@
                       )
                       (i32.add
                         (i32.load
-                          (get_local $5)
+                          (get_local $4)
                         )
                         (get_local $26)
                       )
                     )
-                    (set_local $15
+                    (set_local $17
                       (i32.add
-                        (get_local $19)
+                        (get_local $20)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $5
+                              (set_local $4
                                 (i32.add
-                                  (get_local $19)
+                                  (get_local $20)
                                   (i32.const 8)
                                 )
                               )
@@ -3957,7 +3937,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3967,15 +3947,15 @@
                     )
                     (set_local $1
                       (i32.add
-                        (get_local $4)
+                        (get_local $7)
                         (select
                           (i32.const 0)
                           (i32.and
                             (i32.sub
                               (i32.const 0)
-                              (set_local $5
+                              (set_local $4
                                 (i32.add
-                                  (get_local $4)
+                                  (get_local $7)
                                   (i32.const 8)
                                 )
                               )
@@ -3984,7 +3964,7 @@
                           )
                           (i32.eq
                             (i32.and
-                              (get_local $5)
+                              (get_local $4)
                               (i32.const 7)
                             )
                             (i32.const 0)
@@ -3992,23 +3972,23 @@
                         )
                       )
                     )
-                    (set_local $5
+                    (set_local $4
                       (i32.add
-                        (get_local $15)
+                        (get_local $17)
                         (get_local $0)
                       )
                     )
-                    (set_local $18
+                    (set_local $15
                       (i32.sub
                         (i32.sub
                           (get_local $1)
-                          (get_local $15)
+                          (get_local $17)
                         )
                         (get_local $0)
                       )
                     )
                     (i32.store offset=4
-                      (get_local $15)
+                      (get_local $17)
                       (i32.or
                         (get_local $0)
                         (i32.const 3)
@@ -4028,16 +4008,16 @@
                                 (i32.load
                                   (i32.const 1220)
                                 )
-                                (get_local $18)
+                                (get_local $15)
                               )
                             )
                           )
                           (i32.store
                             (i32.const 1232)
-                            (get_local $5)
+                            (get_local $4)
                           )
                           (i32.store offset=4
-                            (get_local $5)
+                            (get_local $4)
                             (i32.or
                               (get_local $2)
                               (i32.const 1)
@@ -4060,16 +4040,16 @@
                                     (i32.load
                                       (i32.const 1216)
                                     )
-                                    (get_local $18)
+                                    (get_local $15)
                                   )
                                 )
                               )
                               (i32.store
                                 (i32.const 1228)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=4
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.or
                                   (get_local $2)
                                   (i32.const 1)
@@ -4077,7 +4057,7 @@
                               )
                               (i32.store
                                 (i32.add
-                                  (get_local $5)
+                                  (get_local $4)
                                   (get_local $2)
                                 )
                                 (get_local $2)
@@ -4101,7 +4081,7 @@
                                     (i32.const 1)
                                   )
                                   (block
-                                    (set_local $6
+                                    (set_local $5
                                       (i32.and
                                         (get_local $2)
                                         (i32.const -8)
@@ -4128,12 +4108,12 @@
                                           (block $do-once$53
                                             (if
                                               (i32.ne
-                                                (set_local $21
+                                                (set_local $22
                                                   (i32.load offset=8
                                                     (get_local $1)
                                                   )
                                                 )
-                                                (set_local $17
+                                                (set_local $18
                                                   (i32.add
                                                     (i32.const 1248)
                                                     (i32.shl
@@ -4149,7 +4129,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $21)
+                                                    (get_local $22)
                                                     (get_local $14)
                                                   )
                                                   (call_import $qa)
@@ -4157,7 +4137,7 @@
                                                 (br_if $do-once$53
                                                   (i32.eq
                                                     (i32.load offset=12
-                                                      (get_local $21)
+                                                      (get_local $22)
                                                     )
                                                     (get_local $1)
                                                   )
@@ -4169,7 +4149,7 @@
                                           (if
                                             (i32.eq
                                               (get_local $10)
-                                              (get_local $21)
+                                              (get_local $22)
                                             )
                                             (block
                                               (i32.store
@@ -4194,7 +4174,7 @@
                                             (if
                                               (i32.eq
                                                 (get_local $10)
-                                                (get_local $17)
+                                                (get_local $18)
                                               )
                                               (set_local $44
                                                 (i32.add
@@ -4234,16 +4214,16 @@
                                             )
                                           )
                                           (i32.store offset=12
-                                            (get_local $21)
+                                            (get_local $22)
                                             (get_local $10)
                                           )
                                           (i32.store
                                             (get_local $44)
-                                            (get_local $21)
+                                            (get_local $22)
                                           )
                                         )
                                         (block
-                                          (set_local $17
+                                          (set_local $18
                                             (i32.load offset=24
                                               (get_local $1)
                                             )
@@ -4262,7 +4242,7 @@
                                                 (if
                                                   (set_local $2
                                                     (i32.load
-                                                      (set_local $12
+                                                      (set_local $13
                                                         (i32.add
                                                           (set_local $16
                                                             (i32.add
@@ -4276,25 +4256,19 @@
                                                     )
                                                   )
                                                   (block
-                                                    (set_local $0
+                                                    (set_local $19
                                                       (get_local $2)
                                                     )
-                                                    (set_local $4
-                                                      (get_local $12)
+                                                    (set_local $16
+                                                      (get_local $13)
                                                     )
                                                   )
                                                   (if
-                                                    (set_local $22
-                                                      (i32.load
-                                                        (get_local $16)
-                                                      )
-                                                    )
-                                                    (block
-                                                      (set_local $0
-                                                        (get_local $22)
-                                                      )
-                                                      (set_local $4
-                                                        (get_local $16)
+                                                    (i32.eqz
+                                                      (set_local $19
+                                                        (i32.load
+                                                          (get_local $16)
+                                                        )
                                                       )
                                                     )
                                                     (block
@@ -4309,20 +4283,20 @@
                                                   (if
                                                     (set_local $2
                                                       (i32.load
-                                                        (set_local $12
+                                                        (set_local $13
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $19)
                                                             (i32.const 20)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
+                                                      (set_local $19
                                                         (get_local $2)
                                                       )
-                                                      (set_local $4
-                                                        (get_local $12)
+                                                      (set_local $16
+                                                        (get_local $13)
                                                       )
                                                       (br $while-in$60)
                                                     )
@@ -4330,20 +4304,20 @@
                                                   (if
                                                     (set_local $2
                                                       (i32.load
-                                                        (set_local $12
+                                                        (set_local $13
                                                           (i32.add
-                                                            (get_local $0)
+                                                            (get_local $19)
                                                             (i32.const 16)
                                                           )
                                                         )
                                                       )
                                                     )
                                                     (block
-                                                      (set_local $0
+                                                      (set_local $19
                                                         (get_local $2)
                                                       )
-                                                      (set_local $4
-                                                        (get_local $12)
+                                                      (set_local $16
+                                                        (get_local $13)
                                                       )
                                                     )
                                                     (br $while-out$59)
@@ -4352,17 +4326,17 @@
                                                 )
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $4)
+                                                    (get_local $16)
                                                     (get_local $14)
                                                   )
                                                   (call_import $qa)
                                                   (block
                                                     (i32.store
-                                                      (get_local $4)
+                                                      (get_local $16)
                                                       (i32.const 0)
                                                     )
                                                     (set_local $24
-                                                      (get_local $0)
+                                                      (get_local $19)
                                                     )
                                                   )
                                                 )
@@ -4370,7 +4344,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (set_local $12
+                                                    (set_local $13
                                                       (i32.load offset=8
                                                         (get_local $1)
                                                       )
@@ -4384,7 +4358,7 @@
                                                     (i32.load
                                                       (set_local $2
                                                         (i32.add
-                                                          (get_local $12)
+                                                          (get_local $13)
                                                           (i32.const 12)
                                                         )
                                                       )
@@ -4412,7 +4386,7 @@
                                                     )
                                                     (i32.store
                                                       (get_local $16)
-                                                      (get_local $12)
+                                                      (get_local $13)
                                                     )
                                                     (set_local $24
                                                       (get_local $3)
@@ -4425,7 +4399,7 @@
                                           )
                                           (br_if $label$break$e
                                             (i32.eqz
-                                              (get_local $17)
+                                              (get_local $18)
                                             )
                                           )
                                           (block $do-once$61
@@ -4433,7 +4407,7 @@
                                               (i32.eq
                                                 (get_local $1)
                                                 (i32.load
-                                                  (set_local $21
+                                                  (set_local $22
                                                     (i32.add
                                                       (i32.const 1512)
                                                       (i32.shl
@@ -4450,7 +4424,7 @@
                                               )
                                               (block
                                                 (i32.store
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                   (get_local $24)
                                                 )
                                                 (br_if $do-once$61
@@ -4476,7 +4450,7 @@
                                               (block
                                                 (if
                                                   (i32.lt_u
-                                                    (get_local $17)
+                                                    (get_local $18)
                                                     (i32.load
                                                       (i32.const 1224)
                                                     )
@@ -4488,7 +4462,7 @@
                                                     (i32.load
                                                       (set_local $10
                                                         (i32.add
-                                                          (get_local $17)
+                                                          (get_local $18)
                                                           (i32.const 16)
                                                         )
                                                       )
@@ -4500,7 +4474,7 @@
                                                     (get_local $24)
                                                   )
                                                   (i32.store offset=20
-                                                    (get_local $17)
+                                                    (get_local $18)
                                                     (get_local $24)
                                                   )
                                                 )
@@ -4525,12 +4499,12 @@
                                           )
                                           (i32.store offset=24
                                             (get_local $24)
-                                            (get_local $17)
+                                            (get_local $18)
                                           )
                                           (if
                                             (set_local $10
                                               (i32.load
-                                                (set_local $21
+                                                (set_local $22
                                                   (i32.add
                                                     (get_local $1)
                                                     (i32.const 16)
@@ -4560,7 +4534,7 @@
                                             (i32.eqz
                                               (set_local $10
                                                 (i32.load offset=4
-                                                  (get_local $21)
+                                                  (get_local $22)
                                                 )
                                               )
                                             )
@@ -4587,23 +4561,18 @@
                                         )
                                       )
                                     )
-                                    (set_local $0
+                                    (set_local $15
                                       (i32.add
-                                        (get_local $6)
-                                        (get_local $18)
+                                        (get_local $5)
+                                        (get_local $15)
                                       )
                                     )
                                     (i32.add
                                       (get_local $1)
-                                      (get_local $6)
+                                      (get_local $5)
                                     )
                                   )
-                                  (block
-                                    (set_local $0
-                                      (get_local $18)
-                                    )
-                                    (get_local $1)
-                                  )
+                                  (get_local $1)
                                 )
                                 (i32.const 4)
                               )
@@ -4616,28 +4585,28 @@
                             )
                           )
                           (i32.store offset=4
-                            (get_local $5)
+                            (get_local $4)
                             (i32.or
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 1)
                             )
                           )
                           (i32.store
                             (i32.add
-                              (get_local $5)
-                              (get_local $0)
+                              (get_local $4)
+                              (get_local $15)
                             )
-                            (get_local $0)
+                            (get_local $15)
                           )
                           (set_local $3
                             (i32.shr_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 3)
                             )
                           )
                           (if
                             (i32.lt_u
-                              (get_local $0)
+                              (get_local $15)
                               (i32.const 256)
                             )
                             (block
@@ -4671,7 +4640,7 @@
                                   (block
                                     (if
                                       (i32.ge_u
-                                        (set_local $17
+                                        (set_local $18
                                           (i32.load
                                             (set_local $3
                                               (i32.add
@@ -4690,7 +4659,7 @@
                                           (get_local $3)
                                         )
                                         (set_local $38
-                                          (get_local $17)
+                                          (get_local $18)
                                         )
                                         (br $do-once$65)
                                       )
@@ -4719,18 +4688,18 @@
                               )
                               (i32.store
                                 (get_local $45)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=12
                                 (get_local $38)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $5)
+                                (get_local $4)
                                 (get_local $38)
                               )
                               (i32.store offset=12
-                                (get_local $5)
+                                (get_local $4)
                                 (get_local $2)
                               )
                               (br $do-once$50)
@@ -4740,12 +4709,12 @@
                             (i32.add
                               (i32.const 1512)
                               (i32.shl
-                                (set_local $4
+                                (set_local $0
                                   (block $do-once$67
                                     (if
                                       (set_local $3
                                         (i32.shr_u
-                                          (get_local $0)
+                                          (get_local $15)
                                           (i32.const 8)
                                         )
                                       )
@@ -4753,26 +4722,26 @@
                                         (br_if $do-once$67
                                           (i32.const 31)
                                           (i32.gt_u
-                                            (get_local $0)
+                                            (get_local $15)
                                             (i32.const 16777215)
                                           )
                                         )
                                         (i32.or
                                           (i32.and
                                             (i32.shr_u
-                                              (get_local $0)
+                                              (get_local $15)
                                               (i32.add
-                                                (set_local $12
+                                                (set_local $13
                                                   (i32.add
                                                     (i32.sub
                                                       (i32.const 14)
                                                       (i32.or
                                                         (i32.or
-                                                          (set_local $17
+                                                          (set_local $18
                                                             (i32.and
                                                               (i32.shr_u
                                                                 (i32.add
-                                                                  (set_local $6
+                                                                  (set_local $5
                                                                     (i32.shl
                                                                       (get_local $3)
                                                                       (set_local $10
@@ -4798,14 +4767,14 @@
                                                           )
                                                           (get_local $10)
                                                         )
-                                                        (set_local $6
+                                                        (set_local $5
                                                           (i32.and
                                                             (i32.shr_u
                                                               (i32.add
                                                                 (set_local $3
                                                                   (i32.shl
-                                                                    (get_local $6)
-                                                                    (get_local $17)
+                                                                    (get_local $5)
+                                                                    (get_local $18)
                                                                   )
                                                                 )
                                                                 (i32.const 245760)
@@ -4820,7 +4789,7 @@
                                                     (i32.shr_u
                                                       (i32.shl
                                                         (get_local $3)
-                                                        (get_local $6)
+                                                        (get_local $5)
                                                       )
                                                       (i32.const 15)
                                                     )
@@ -4832,7 +4801,7 @@
                                             (i32.const 1)
                                           )
                                           (i32.shl
-                                            (get_local $12)
+                                            (get_local $13)
                                             (i32.const 1)
                                           )
                                         )
@@ -4846,13 +4815,13 @@
                             )
                           )
                           (i32.store offset=28
-                            (get_local $5)
                             (get_local $4)
+                            (get_local $0)
                           )
                           (i32.store offset=4
                             (set_local $2
                               (i32.add
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.const 16)
                               )
                             )
@@ -4870,10 +4839,10 @@
                                     (i32.const 1212)
                                   )
                                 )
-                                (set_local $12
+                                (set_local $13
                                   (i32.shl
                                     (i32.const 1)
-                                    (get_local $4)
+                                    (get_local $0)
                                   )
                                 )
                               )
@@ -4883,42 +4852,42 @@
                                 (i32.const 1212)
                                 (i32.or
                                   (get_local $2)
-                                  (get_local $12)
+                                  (get_local $13)
                                 )
                               )
                               (i32.store
                                 (get_local $3)
-                                (get_local $5)
+                                (get_local $4)
                               )
                               (i32.store offset=24
-                                (get_local $5)
+                                (get_local $4)
                                 (get_local $3)
                               )
                               (i32.store offset=12
-                                (get_local $5)
-                                (get_local $5)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (i32.store offset=8
-                                (get_local $5)
-                                (get_local $5)
+                                (get_local $4)
+                                (get_local $4)
                               )
                               (br $do-once$50)
                             )
                           )
-                          (set_local $12
+                          (set_local $13
                             (i32.shl
-                              (get_local $0)
+                              (get_local $15)
                               (select
                                 (i32.const 0)
                                 (i32.sub
                                   (i32.const 25)
                                   (i32.shr_u
-                                    (get_local $4)
+                                    (get_local $0)
                                     (i32.const 1)
                                   )
                                 )
                                 (i32.eq
-                                  (get_local $4)
+                                  (get_local $0)
                                   (i32.const 31)
                                 )
                               )
@@ -4938,7 +4907,7 @@
                                   )
                                   (i32.const -8)
                                 )
-                                (get_local $0)
+                                (get_local $15)
                               )
                               (block
                                 (set_local $39
@@ -4951,7 +4920,7 @@
                               )
                             )
                             (if
-                              (set_local $6
+                              (set_local $5
                                 (i32.load
                                   (set_local $3
                                     (i32.add
@@ -4961,7 +4930,7 @@
                                       )
                                       (i32.shl
                                         (i32.shr_u
-                                          (get_local $12)
+                                          (get_local $13)
                                           (i32.const 31)
                                         )
                                         (i32.const 2)
@@ -4971,14 +4940,14 @@
                                 )
                               )
                               (block
-                                (set_local $12
+                                (set_local $13
                                   (i32.shl
-                                    (get_local $12)
+                                    (get_local $13)
                                     (i32.const 1)
                                   )
                                 )
                                 (set_local $2
-                                  (get_local $6)
+                                  (get_local $5)
                                 )
                               )
                               (block
@@ -5012,19 +4981,19 @@
                               (block
                                 (i32.store
                                   (get_local $46)
-                                  (get_local $5)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=24
-                                  (get_local $5)
+                                  (get_local $4)
                                   (get_local $54)
                                 )
                                 (i32.store offset=12
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                                 (i32.store offset=8
-                                  (get_local $5)
-                                  (get_local $5)
+                                  (get_local $4)
+                                  (get_local $4)
                                 )
                               )
                             )
@@ -5036,7 +5005,7 @@
                               (if
                                 (i32.and
                                   (i32.ge_u
-                                    (set_local $12
+                                    (set_local $13
                                       (i32.load
                                         (set_local $2
                                           (i32.add
@@ -5046,7 +5015,7 @@
                                         )
                                       )
                                     )
-                                    (set_local $6
+                                    (set_local $5
                                       (i32.load
                                         (i32.const 1224)
                                       )
@@ -5054,28 +5023,28 @@
                                   )
                                   (i32.ge_u
                                     (get_local $39)
-                                    (get_local $6)
+                                    (get_local $5)
                                   )
                                 )
                                 (block
                                   (i32.store offset=12
-                                    (get_local $12)
-                                    (get_local $5)
+                                    (get_local $13)
+                                    (get_local $4)
                                   )
                                   (i32.store
                                     (get_local $2)
-                                    (get_local $5)
+                                    (get_local $4)
                                   )
                                   (i32.store offset=8
-                                    (get_local $5)
-                                    (get_local $12)
+                                    (get_local $4)
+                                    (get_local $13)
                                   )
                                   (i32.store offset=12
-                                    (get_local $5)
+                                    (get_local $4)
                                     (get_local $39)
                                   )
                                   (i32.store offset=24
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.const 0)
                                   )
                                 )
@@ -5092,7 +5061,7 @@
                     )
                     (return
                       (i32.add
-                        (get_local $15)
+                        (get_local $17)
                         (i32.const 8)
                       )
                     )
@@ -5102,7 +5071,7 @@
               (loop $while-out$71 $while-in$72
                 (if
                   (i32.le_u
-                    (set_local $5
+                    (set_local $4
                       (i32.load
                         (get_local $29)
                       )
@@ -5111,9 +5080,9 @@
                   )
                   (if
                     (i32.gt_u
-                      (set_local $18
+                      (set_local $15
                         (i32.add
-                          (get_local $5)
+                          (get_local $4)
                           (i32.load offset=4
                             (get_local $29)
                           )
@@ -5123,7 +5092,7 @@
                     )
                     (block
                       (set_local $3
-                        (get_local $18)
+                        (get_local $15)
                       )
                       (br $while-out$71)
                     )
@@ -5136,9 +5105,9 @@
                 )
                 (br $while-in$72)
               )
-              (set_local $18
+              (set_local $15
                 (i32.add
-                  (set_local $15
+                  (set_local $17
                     (i32.add
                       (get_local $3)
                       (i32.const -47)
@@ -5147,26 +5116,26 @@
                   (i32.const 8)
                 )
               )
-              (set_local $5
+              (set_local $4
                 (i32.add
-                  (set_local $15
+                  (set_local $17
                     (select
                       (get_local $11)
-                      (set_local $5
+                      (set_local $4
                         (i32.add
-                          (get_local $15)
+                          (get_local $17)
                           (select
                             (i32.const 0)
                             (i32.and
                               (i32.sub
                                 (i32.const 0)
-                                (get_local $18)
+                                (get_local $15)
                               )
                               (i32.const 7)
                             )
                             (i32.eq
                               (i32.and
-                                (get_local $18)
+                                (get_local $15)
                                 (i32.const 7)
                               )
                               (i32.const 0)
@@ -5175,8 +5144,8 @@
                         )
                       )
                       (i32.lt_u
-                        (get_local $5)
-                        (set_local $18
+                        (get_local $4)
+                        (set_local $15
                           (i32.add
                             (get_local $11)
                             (i32.const 16)
@@ -5192,8 +5161,8 @@
                 (i32.const 1232)
                 (set_local $1
                   (i32.add
-                    (get_local $19)
-                    (set_local $4
+                    (get_local $20)
+                    (set_local $7
                       (select
                         (i32.const 0)
                         (i32.and
@@ -5201,7 +5170,7 @@
                             (i32.const 0)
                             (set_local $1
                               (i32.add
-                                (get_local $19)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5222,27 +5191,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $12
+                (set_local $13
                   (i32.sub
                     (i32.add
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $4)
+                    (get_local $7)
                   )
                 )
               )
               (i32.store offset=4
                 (get_local $1)
                 (i32.or
-                  (get_local $12)
+                  (get_local $13)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $1)
-                  (get_local $12)
+                  (get_local $13)
                 )
                 (i32.const 40)
               )
@@ -5253,41 +5222,41 @@
                 )
               )
               (i32.store
-                (set_local $12
+                (set_local $13
                   (i32.add
-                    (get_local $15)
+                    (get_local $17)
                     (i32.const 4)
                   )
                 )
                 (i32.const 27)
               )
               (i32.store
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1656)
                 )
               )
               (i32.store offset=4
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1660)
                 )
               )
               (i32.store offset=8
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1664)
                 )
               )
               (i32.store offset=12
-                (get_local $5)
+                (get_local $4)
                 (i32.load
                   (i32.const 1668)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $19)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 1660)
@@ -5299,19 +5268,19 @@
               )
               (i32.store
                 (i32.const 1664)
-                (get_local $5)
+                (get_local $4)
               )
-              (set_local $5
+              (set_local $4
                 (i32.add
-                  (get_local $15)
+                  (get_local $17)
                   (i32.const 24)
                 )
               )
               (loop $do-out$73 $do-in$74
                 (i32.store
-                  (set_local $5
+                  (set_local $4
                     (i32.add
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 4)
                     )
                   )
@@ -5320,7 +5289,7 @@
                 (br_if $do-in$74
                   (i32.lt_u
                     (i32.add
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 4)
                     )
                     (get_local $3)
@@ -5329,15 +5298,15 @@
               )
               (if
                 (i32.ne
-                  (get_local $15)
+                  (get_local $17)
                   (get_local $11)
                 )
                 (block
                   (i32.store
-                    (get_local $12)
+                    (get_local $13)
                     (i32.and
                       (i32.load
-                        (get_local $12)
+                        (get_local $13)
                       )
                       (i32.const -2)
                     )
@@ -5345,9 +5314,9 @@
                   (i32.store offset=4
                     (get_local $11)
                     (i32.or
-                      (set_local $5
+                      (set_local $4
                         (i32.sub
-                          (get_local $15)
+                          (get_local $17)
                           (get_local $11)
                         )
                       )
@@ -5355,22 +5324,22 @@
                     )
                   )
                   (i32.store
-                    (get_local $15)
-                    (get_local $5)
+                    (get_local $17)
+                    (get_local $4)
                   )
                   (set_local $1
                     (i32.shr_u
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 3)
                     )
                   )
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $4)
                       (i32.const 256)
                     )
                     (block
-                      (set_local $4
+                      (set_local $7
                         (i32.add
                           (i32.const 1248)
                           (i32.shl
@@ -5389,7 +5358,7 @@
                               (i32.const 1208)
                             )
                           )
-                          (set_local $6
+                          (set_local $5
                             (i32.shl
                               (i32.const 1)
                               (get_local $1)
@@ -5400,9 +5369,9 @@
                           (i32.lt_u
                             (set_local $2
                               (i32.load
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
-                                    (get_local $4)
+                                    (get_local $7)
                                     (i32.const 8)
                                   )
                                 )
@@ -5415,7 +5384,7 @@
                           (call_import $qa)
                           (block
                             (set_local $47
-                              (get_local $6)
+                              (get_local $5)
                             )
                             (set_local $40
                               (get_local $2)
@@ -5427,17 +5396,17 @@
                             (i32.const 1208)
                             (i32.or
                               (get_local $2)
-                              (get_local $6)
+                              (get_local $5)
                             )
                           )
                           (set_local $47
                             (i32.add
-                              (get_local $4)
+                              (get_local $7)
                               (i32.const 8)
                             )
                           )
                           (set_local $40
-                            (get_local $4)
+                            (get_local $7)
                           )
                         )
                       )
@@ -5455,7 +5424,7 @@
                       )
                       (i32.store offset=12
                         (get_local $11)
-                        (get_local $4)
+                        (get_local $7)
                       )
                       (br $do-once$42)
                     )
@@ -5464,24 +5433,24 @@
                     (i32.add
                       (i32.const 1512)
                       (i32.shl
-                        (set_local $4
+                        (set_local $7
                           (if
-                            (set_local $4
+                            (set_local $7
                               (i32.shr_u
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.const 8)
                               )
                             )
                             (if
                               (i32.gt_u
-                                (get_local $5)
+                                (get_local $4)
                                 (i32.const 16777215)
                               )
                               (i32.const 31)
                               (i32.or
                                 (i32.and
                                   (i32.shr_u
-                                    (get_local $5)
+                                    (get_local $4)
                                     (i32.add
                                       (set_local $3
                                         (i32.add
@@ -5489,18 +5458,18 @@
                                             (i32.const 14)
                                             (i32.or
                                               (i32.or
-                                                (set_local $4
+                                                (set_local $7
                                                   (i32.and
                                                     (i32.shr_u
                                                       (i32.add
-                                                        (set_local $6
+                                                        (set_local $5
                                                           (i32.shl
-                                                            (get_local $4)
+                                                            (get_local $7)
                                                             (set_local $2
                                                               (i32.and
                                                                 (i32.shr_u
                                                                   (i32.add
-                                                                    (get_local $4)
+                                                                    (get_local $7)
                                                                     (i32.const 1048320)
                                                                   )
                                                                   (i32.const 16)
@@ -5519,14 +5488,14 @@
                                                 )
                                                 (get_local $2)
                                               )
-                                              (set_local $6
+                                              (set_local $5
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
                                                       (set_local $1
                                                         (i32.shl
-                                                          (get_local $6)
-                                                          (get_local $4)
+                                                          (get_local $5)
+                                                          (get_local $7)
                                                         )
                                                       )
                                                       (i32.const 245760)
@@ -5541,7 +5510,7 @@
                                           (i32.shr_u
                                             (i32.shl
                                               (get_local $1)
-                                              (get_local $6)
+                                              (get_local $5)
                                             )
                                             (i32.const 15)
                                           )
@@ -5567,20 +5536,20 @@
                   )
                   (i32.store offset=28
                     (get_local $11)
-                    (get_local $4)
+                    (get_local $7)
                   )
                   (i32.store offset=20
                     (get_local $11)
                     (i32.const 0)
                   )
                   (i32.store
-                    (get_local $18)
+                    (get_local $15)
                     (i32.const 0)
                   )
                   (if
                     (i32.eqz
                       (i32.and
-                        (set_local $6
+                        (set_local $5
                           (i32.load
                             (i32.const 1212)
                           )
@@ -5588,7 +5557,7 @@
                         (set_local $1
                           (i32.shl
                             (i32.const 1)
-                            (get_local $4)
+                            (get_local $7)
                           )
                         )
                       )
@@ -5597,7 +5566,7 @@
                       (i32.store
                         (i32.const 1212)
                         (i32.or
-                          (get_local $6)
+                          (get_local $5)
                           (get_local $1)
                         )
                       )
@@ -5622,24 +5591,24 @@
                   )
                   (set_local $1
                     (i32.shl
-                      (get_local $5)
+                      (get_local $4)
                       (select
                         (i32.const 0)
                         (i32.sub
                           (i32.const 25)
                           (i32.shr_u
-                            (get_local $4)
+                            (get_local $7)
                             (i32.const 1)
                           )
                         )
                         (i32.eq
-                          (get_local $4)
+                          (get_local $7)
                           (i32.const 31)
                         )
                       )
                     )
                   )
-                  (set_local $6
+                  (set_local $5
                     (i32.load
                       (get_local $3)
                     )
@@ -5649,15 +5618,15 @@
                       (i32.eq
                         (i32.and
                           (i32.load offset=4
-                            (get_local $6)
+                            (get_local $5)
                           )
                           (i32.const -8)
                         )
-                        (get_local $5)
+                        (get_local $4)
                       )
                       (block
                         (set_local $30
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $8
                           (i32.const 305)
@@ -5671,7 +5640,7 @@
                           (set_local $3
                             (i32.add
                               (i32.add
-                                (get_local $6)
+                                (get_local $5)
                                 (i32.const 16)
                               )
                               (i32.shl
@@ -5692,7 +5661,7 @@
                             (i32.const 1)
                           )
                         )
-                        (set_local $6
+                        (set_local $5
                           (get_local $2)
                         )
                       )
@@ -5701,7 +5670,7 @@
                           (get_local $3)
                         )
                         (set_local $55
-                          (get_local $6)
+                          (get_local $5)
                         )
                         (set_local $8
                           (i32.const 302)
@@ -5753,7 +5722,7 @@
                           (i32.ge_u
                             (set_local $1
                               (i32.load
-                                (set_local $6
+                                (set_local $5
                                   (i32.add
                                     (get_local $30)
                                     (i32.const 8)
@@ -5761,7 +5730,7 @@
                                 )
                               )
                             )
-                            (set_local $5
+                            (set_local $4
                               (i32.load
                                 (i32.const 1224)
                               )
@@ -5769,7 +5738,7 @@
                           )
                           (i32.ge_u
                             (get_local $30)
-                            (get_local $5)
+                            (get_local $4)
                           )
                         )
                         (block
@@ -5778,7 +5747,7 @@
                             (get_local $11)
                           )
                           (i32.store
-                            (get_local $6)
+                            (get_local $5)
                             (get_local $11)
                           )
                           (i32.store offset=8
@@ -5813,18 +5782,18 @@
                     (i32.const 0)
                   )
                   (i32.lt_u
-                    (get_local $19)
+                    (get_local $20)
                     (get_local $1)
                   )
                 )
                 (i32.store
                   (i32.const 1224)
-                  (get_local $19)
+                  (get_local $20)
                 )
               )
               (i32.store
                 (i32.const 1656)
-                (get_local $19)
+                (get_local $20)
               )
               (i32.store
                 (i32.const 1660)
@@ -5849,7 +5818,7 @@
               )
               (loop $do-out$44 $do-in$45
                 (i32.store offset=12
-                  (set_local $4
+                  (set_local $7
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
@@ -5861,11 +5830,11 @@
                       )
                     )
                   )
-                  (get_local $4)
+                  (get_local $7)
                 )
                 (i32.store offset=8
-                  (get_local $4)
-                  (get_local $4)
+                  (get_local $7)
+                  (get_local $7)
                 )
                 (br_if $do-in$45
                   (i32.ne
@@ -5883,8 +5852,8 @@
                 (i32.const 1232)
                 (set_local $1
                   (i32.add
-                    (get_local $19)
-                    (set_local $4
+                    (get_local $20)
+                    (set_local $7
                       (select
                         (i32.const 0)
                         (i32.and
@@ -5892,7 +5861,7 @@
                             (i32.const 0)
                             (set_local $1
                               (i32.add
-                                (get_local $19)
+                                (get_local $20)
                                 (i32.const 8)
                               )
                             )
@@ -5913,27 +5882,27 @@
               )
               (i32.store
                 (i32.const 1220)
-                (set_local $5
+                (set_local $4
                   (i32.sub
                     (i32.add
                       (get_local $26)
                       (i32.const -40)
                     )
-                    (get_local $4)
+                    (get_local $7)
                   )
                 )
               )
               (i32.store offset=4
                 (get_local $1)
                 (i32.or
-                  (get_local $5)
+                  (get_local $4)
                   (i32.const 1)
                 )
               )
               (i32.store offset=4
                 (i32.add
                   (get_local $1)
-                  (get_local $5)
+                  (get_local $4)
                 )
                 (i32.const 40)
               )
@@ -6050,7 +6019,7 @@
             (i32.const -8)
           )
         )
-        (set_local $13
+        (set_local $14
           (i32.load
             (i32.const 1224)
           )
@@ -6080,7 +6049,7 @@
     (set_local $7
       (i32.add
         (get_local $1)
-        (set_local $4
+        (set_local $5
           (i32.and
             (get_local $9)
             (i32.const -8)
@@ -6099,7 +6068,7 @@
             (get_local $1)
           )
           (set_local $8
-            (get_local $4)
+            (get_local $5)
           )
         )
         (block
@@ -6114,10 +6083,10 @@
             )
             (return)
           )
-          (set_local $4
+          (set_local $5
             (i32.add
               (get_local $9)
-              (get_local $4)
+              (get_local $5)
             )
           )
           (if
@@ -6131,7 +6100,7 @@
                   )
                 )
               )
-              (get_local $13)
+              (get_local $14)
             )
             (call_import $qa)
           )
@@ -6146,7 +6115,7 @@
               (if
                 (i32.ne
                   (i32.and
-                    (set_local $5
+                    (set_local $6
                       (i32.load
                         (set_local $1
                           (i32.add
@@ -6165,40 +6134,40 @@
                     (get_local $0)
                   )
                   (set_local $8
-                    (get_local $4)
+                    (get_local $5)
                   )
                   (br $do-once$0)
                 )
               )
               (i32.store
                 (i32.const 1216)
-                (get_local $4)
+                (get_local $5)
               )
               (i32.store
                 (get_local $1)
                 (i32.and
-                  (get_local $5)
+                  (get_local $6)
                   (i32.const -2)
                 )
               )
               (i32.store offset=4
                 (get_local $0)
                 (i32.or
-                  (get_local $4)
+                  (get_local $5)
                   (i32.const 1)
                 )
               )
               (i32.store
                 (i32.add
                   (get_local $0)
-                  (get_local $4)
+                  (get_local $5)
                 )
-                (get_local $4)
+                (get_local $5)
               )
               (return)
             )
           )
-          (set_local $5
+          (set_local $6
             (i32.shr_u
               (get_local $9)
               (i32.const 3)
@@ -6222,12 +6191,12 @@
                       (get_local $0)
                     )
                   )
-                  (set_local $6
+                  (set_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $5)
+                          (get_local $6)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6239,7 +6208,7 @@
                   (if
                     (i32.lt_u
                       (get_local $9)
-                      (get_local $13)
+                      (get_local $14)
                     )
                     (call_import $qa)
                   )
@@ -6269,7 +6238,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $5)
+                          (get_local $6)
                         )
                         (i32.const -1)
                       )
@@ -6279,7 +6248,7 @@
                     (get_local $0)
                   )
                   (set_local $8
-                    (get_local $4)
+                    (get_local $5)
                   )
                   (br $do-once$0)
                 )
@@ -6287,7 +6256,7 @@
               (if
                 (i32.eq
                   (get_local $1)
-                  (get_local $6)
+                  (get_local $4)
                 )
                 (set_local $11
                   (i32.add
@@ -6299,14 +6268,14 @@
                   (if
                     (i32.lt_u
                       (get_local $1)
-                      (get_local $13)
+                      (get_local $14)
                     )
                     (call_import $qa)
                   )
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (get_local $1)
                             (i32.const 8)
@@ -6316,7 +6285,7 @@
                       (get_local $0)
                     )
                     (set_local $11
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (call_import $qa)
                   )
@@ -6334,7 +6303,7 @@
                 (get_local $0)
               )
               (set_local $8
-                (get_local $4)
+                (get_local $5)
               )
               (br $do-once$0)
             )
@@ -6358,9 +6327,9 @@
                 (if
                   (set_local $11
                     (i32.load
-                      (set_local $5
+                      (set_local $6
                         (i32.add
-                          (set_local $6
+                          (set_local $4
                             (i32.add
                               (get_local $0)
                               (i32.const 16)
@@ -6375,15 +6344,15 @@
                     (set_local $1
                       (get_local $11)
                     )
-                    (set_local $6
-                      (get_local $5)
+                    (set_local $4
+                      (get_local $6)
                     )
                   )
                   (if
                     (i32.eqz
                       (set_local $1
                         (i32.load
-                          (get_local $6)
+                          (get_local $4)
                         )
                       )
                     )
@@ -6399,7 +6368,7 @@
                   (if
                     (set_local $11
                       (i32.load
-                        (set_local $5
+                        (set_local $6
                           (i32.add
                             (get_local $1)
                             (i32.const 20)
@@ -6411,8 +6380,8 @@
                       (set_local $1
                         (get_local $11)
                       )
-                      (set_local $6
-                        (get_local $5)
+                      (set_local $4
+                        (get_local $6)
                       )
                       (br $while-in$5)
                     )
@@ -6420,7 +6389,7 @@
                   (if
                     (set_local $11
                       (i32.load
-                        (set_local $5
+                        (set_local $6
                           (i32.add
                             (get_local $1)
                             (i32.const 16)
@@ -6432,16 +6401,16 @@
                       (set_local $1
                         (get_local $11)
                       )
-                      (set_local $6
-                        (get_local $5)
+                      (set_local $4
+                        (get_local $6)
                       )
                     )
                     (block
-                      (set_local $5
+                      (set_local $6
                         (get_local $1)
                       )
                       (set_local $10
-                        (get_local $6)
+                        (get_local $4)
                       )
                       (br $while-out$4)
                     )
@@ -6451,7 +6420,7 @@
                 (if
                   (i32.lt_u
                     (get_local $10)
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (call_import $qa)
                   (block
@@ -6460,7 +6429,7 @@
                       (i32.const 0)
                     )
                     (set_local $3
-                      (get_local $5)
+                      (get_local $6)
                     )
                   )
                 )
@@ -6468,12 +6437,12 @@
               (block
                 (if
                   (i32.lt_u
-                    (set_local $5
+                    (set_local $6
                       (i32.load offset=8
                         (get_local $0)
                       )
                     )
-                    (get_local $13)
+                    (get_local $14)
                   )
                   (call_import $qa)
                 )
@@ -6482,7 +6451,7 @@
                     (i32.load
                       (set_local $11
                         (i32.add
-                          (get_local $5)
+                          (get_local $6)
                           (i32.const 12)
                         )
                       )
@@ -6494,7 +6463,7 @@
                 (if
                   (i32.eq
                     (i32.load
-                      (set_local $6
+                      (set_local $4
                         (i32.add
                           (get_local $1)
                           (i32.const 8)
@@ -6509,8 +6478,8 @@
                       (get_local $1)
                     )
                     (i32.store
+                      (get_local $4)
                       (get_local $6)
-                      (get_local $5)
                     )
                     (set_local $3
                       (get_local $1)
@@ -6528,7 +6497,7 @@
                 (i32.eq
                   (get_local $0)
                   (i32.load
-                    (set_local $5
+                    (set_local $6
                       (i32.add
                         (i32.const 1512)
                         (i32.shl
@@ -6545,7 +6514,7 @@
                 )
                 (block
                   (i32.store
-                    (get_local $5)
+                    (get_local $6)
                     (get_local $3)
                   )
                   (if
@@ -6572,7 +6541,7 @@
                         (get_local $0)
                       )
                       (set_local $8
-                        (get_local $4)
+                        (get_local $5)
                       )
                       (br $do-once$0)
                     )
@@ -6618,7 +6587,7 @@
                         (get_local $0)
                       )
                       (set_local $8
-                        (get_local $4)
+                        (get_local $5)
                       )
                       (br $do-once$0)
                     )
@@ -6641,9 +6610,9 @@
                 (get_local $9)
               )
               (if
-                (set_local $6
+                (set_local $4
                   (i32.load
-                    (set_local $5
+                    (set_local $6
                       (i32.add
                         (get_local $0)
                         (i32.const 16)
@@ -6653,31 +6622,31 @@
                 )
                 (if
                   (i32.lt_u
-                    (get_local $6)
+                    (get_local $4)
                     (get_local $1)
                   )
                   (call_import $qa)
                   (block
                     (i32.store offset=16
                       (get_local $3)
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $6)
+                      (get_local $4)
                       (get_local $3)
                     )
                   )
                 )
               )
               (if
-                (set_local $6
+                (set_local $4
                   (i32.load offset=4
-                    (get_local $5)
+                    (get_local $6)
                   )
                 )
                 (if
                   (i32.lt_u
-                    (get_local $6)
+                    (get_local $4)
                     (i32.load
                       (i32.const 1224)
                     )
@@ -6686,17 +6655,17 @@
                   (block
                     (i32.store offset=20
                       (get_local $3)
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (i32.store offset=24
-                      (get_local $6)
+                      (get_local $4)
                       (get_local $3)
                     )
                     (set_local $2
                       (get_local $0)
                     )
                     (set_local $8
-                      (get_local $4)
+                      (get_local $5)
                     )
                   )
                 )
@@ -6705,7 +6674,7 @@
                     (get_local $0)
                   )
                   (set_local $8
-                    (get_local $4)
+                    (get_local $5)
                   )
                 )
               )
@@ -6715,7 +6684,7 @@
                 (get_local $0)
               )
               (set_local $8
-                (get_local $4)
+                (get_local $5)
               )
             )
           )
@@ -6734,7 +6703,7 @@
         (i32.and
           (set_local $1
             (i32.load
-              (set_local $4
+              (set_local $5
                 (i32.add
                   (get_local $7)
                   (i32.const 4)
@@ -6754,7 +6723,7 @@
       )
       (block
         (i32.store
-          (get_local $4)
+          (get_local $5)
           (i32.and
             (get_local $1)
             (i32.const -2)
@@ -6878,7 +6847,7 @@
             (get_local $8)
           )
         )
-        (set_local $13
+        (set_local $14
           (i32.shr_u
             (get_local $1)
             (i32.const 3)
@@ -6898,17 +6867,17 @@
               )
               (if
                 (i32.ne
-                  (set_local $5
+                  (set_local $6
                     (i32.load offset=8
                       (get_local $7)
                     )
                   )
-                  (set_local $6
+                  (set_local $4
                     (i32.add
                       (i32.const 1248)
                       (i32.shl
                         (i32.shl
-                          (get_local $13)
+                          (get_local $14)
                           (i32.const 1)
                         )
                         (i32.const 2)
@@ -6919,7 +6888,7 @@
                 (block
                   (if
                     (i32.lt_u
-                      (get_local $5)
+                      (get_local $6)
                       (i32.load
                         (i32.const 1224)
                       )
@@ -6929,7 +6898,7 @@
                   (if
                     (i32.ne
                       (i32.load offset=12
-                        (get_local $5)
+                        (get_local $6)
                       )
                       (get_local $7)
                     )
@@ -6940,7 +6909,7 @@
               (if
                 (i32.eq
                   (get_local $10)
-                  (get_local $5)
+                  (get_local $6)
                 )
                 (block
                   (i32.store
@@ -6952,7 +6921,7 @@
                       (i32.xor
                         (i32.shl
                           (i32.const 1)
-                          (get_local $13)
+                          (get_local $14)
                         )
                         (i32.const -1)
                       )
@@ -6964,7 +6933,7 @@
               (if
                 (i32.eq
                   (get_local $10)
-                  (get_local $6)
+                  (get_local $4)
                 )
                 (set_local $17
                   (i32.add
@@ -6985,7 +6954,7 @@
                   (if
                     (i32.eq
                       (i32.load
-                        (set_local $6
+                        (set_local $4
                           (i32.add
                             (get_local $10)
                             (i32.const 8)
@@ -6995,23 +6964,23 @@
                       (get_local $7)
                     )
                     (set_local $17
-                      (get_local $6)
+                      (get_local $4)
                     )
                     (call_import $qa)
                   )
                 )
               )
               (i32.store offset=12
-                (get_local $5)
+                (get_local $6)
                 (get_local $10)
               )
               (i32.store
                 (get_local $17)
-                (get_local $5)
+                (get_local $6)
               )
             )
             (block
-              (set_local $5
+              (set_local $6
                 (i32.load offset=24
                   (get_local $7)
                 )
@@ -7032,7 +7001,7 @@
                         (i32.load
                           (set_local $1
                             (i32.add
-                              (set_local $6
+                              (set_local $4
                                 (i32.add
                                   (get_local $7)
                                   (i32.const 16)
@@ -7047,18 +7016,17 @@
                         (set_local $0
                           (get_local $11)
                         )
-                        (set_local $13
+                        (set_local $4
                           (get_local $1)
                         )
                       )
                       (if
-                        (set_local $0
-                          (i32.load
-                            (get_local $6)
+                        (i32.eqz
+                          (set_local $0
+                            (i32.load
+                              (get_local $4)
+                            )
                           )
-                        )
-                        (set_local $13
-                          (get_local $6)
                         )
                         (block
                           (set_local $12
@@ -7084,7 +7052,7 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $13
+                          (set_local $4
                             (get_local $1)
                           )
                           (br $while-in$13)
@@ -7105,22 +7073,17 @@
                           (set_local $0
                             (get_local $11)
                           )
-                          (set_local $13
+                          (set_local $4
                             (get_local $1)
                           )
                         )
-                        (block
-                          (set_local $1
-                            (get_local $13)
-                          )
-                          (br $while-out$12)
-                        )
+                        (br $while-out$12)
                       )
                       (br $while-in$13)
                     )
                     (if
                       (i32.lt_u
-                        (get_local $1)
+                        (get_local $4)
                         (i32.load
                           (i32.const 1224)
                         )
@@ -7128,7 +7091,7 @@
                       (call_import $qa)
                       (block
                         (i32.store
-                          (get_local $1)
+                          (get_local $4)
                           (i32.const 0)
                         )
                         (set_local $12
@@ -7168,7 +7131,7 @@
                     (if
                       (i32.eq
                         (i32.load
-                          (set_local $6
+                          (set_local $4
                             (i32.add
                               (get_local $10)
                               (i32.const 8)
@@ -7183,7 +7146,7 @@
                           (get_local $10)
                         )
                         (i32.store
-                          (get_local $6)
+                          (get_local $4)
                           (get_local $1)
                         )
                         (set_local $12
@@ -7196,13 +7159,13 @@
                 )
               )
               (if
-                (get_local $5)
+                (get_local $6)
                 (block
                   (if
                     (i32.eq
                       (get_local $7)
                       (i32.load
-                        (set_local $4
+                        (set_local $5
                           (i32.add
                             (i32.const 1512)
                             (i32.shl
@@ -7219,7 +7182,7 @@
                     )
                     (block
                       (i32.store
-                        (get_local $4)
+                        (get_local $5)
                         (get_local $12)
                       )
                       (if
@@ -7249,7 +7212,7 @@
                     (block
                       (if
                         (i32.lt_u
-                          (get_local $5)
+                          (get_local $6)
                           (i32.load
                             (i32.const 1224)
                           )
@@ -7261,7 +7224,7 @@
                           (i32.load
                             (set_local $10
                               (i32.add
-                                (get_local $5)
+                                (get_local $6)
                                 (i32.const 16)
                               )
                             )
@@ -7273,7 +7236,7 @@
                           (get_local $12)
                         )
                         (i32.store offset=20
-                          (get_local $5)
+                          (get_local $6)
                           (get_local $12)
                         )
                       )
@@ -7297,12 +7260,12 @@
                   )
                   (i32.store offset=24
                     (get_local $12)
-                    (get_local $5)
+                    (get_local $6)
                   )
                   (if
                     (set_local $0
                       (i32.load
-                        (set_local $4
+                        (set_local $5
                           (i32.add
                             (get_local $7)
                             (i32.const 16)
@@ -7331,7 +7294,7 @@
                   (if
                     (set_local $0
                       (i32.load offset=4
-                        (get_local $4)
+                        (get_local $5)
                       )
                     )
                     (if
@@ -7419,7 +7382,7 @@
         )
         (if
           (i32.and
-            (set_local $4
+            (set_local $5
               (i32.load
                 (i32.const 1208)
               )
@@ -7433,7 +7396,7 @@
           )
           (if
             (i32.lt_u
-              (set_local $4
+              (set_local $5
                 (i32.load
                   (set_local $3
                     (i32.add
@@ -7452,8 +7415,8 @@
               (set_local $15
                 (get_local $3)
               )
-              (set_local $14
-                (get_local $4)
+              (set_local $13
+                (get_local $5)
               )
             )
           )
@@ -7461,7 +7424,7 @@
             (i32.store
               (i32.const 1208)
               (i32.or
-                (get_local $4)
+                (get_local $5)
                 (get_local $3)
               )
             )
@@ -7471,7 +7434,7 @@
                 (i32.const 8)
               )
             )
-            (set_local $14
+            (set_local $13
               (get_local $1)
             )
           )
@@ -7481,12 +7444,12 @@
           (get_local $2)
         )
         (i32.store offset=12
-          (get_local $14)
+          (get_local $13)
           (get_local $2)
         )
         (i32.store offset=8
           (get_local $2)
-          (get_local $14)
+          (get_local $13)
         )
         (i32.store offset=12
           (get_local $2)
@@ -7531,7 +7494,7 @@
                                           (set_local $15
                                             (i32.shl
                                               (get_local $1)
-                                              (set_local $14
+                                              (set_local $13
                                                 (i32.and
                                                   (i32.shr_u
                                                     (i32.add
@@ -7552,13 +7515,13 @@
                                       (i32.const 4)
                                     )
                                   )
-                                  (get_local $14)
+                                  (get_local $13)
                                 )
                                 (set_local $15
                                   (i32.and
                                     (i32.shr_u
                                       (i32.add
-                                        (set_local $4
+                                        (set_local $5
                                           (i32.shl
                                             (get_local $15)
                                             (get_local $1)
@@ -7575,7 +7538,7 @@
                             )
                             (i32.shr_u
                               (i32.shl
-                                (get_local $4)
+                                (get_local $5)
                                 (get_local $15)
                               )
                               (i32.const 15)
@@ -7619,7 +7582,7 @@
             (i32.const 1212)
           )
         )
-        (set_local $4
+        (set_local $5
           (i32.shl
             (i32.const 1)
             (get_local $1)
@@ -7627,7 +7590,7 @@
         )
       )
       (block
-        (set_local $14
+        (set_local $13
           (i32.shl
             (get_local $0)
             (select
@@ -7683,7 +7646,7 @@
                     )
                     (i32.shl
                       (i32.shr_u
-                        (get_local $14)
+                        (get_local $13)
                         (i32.const 31)
                       )
                       (i32.const 2)
@@ -7693,9 +7656,9 @@
               )
             )
             (block
-              (set_local $14
+              (set_local $13
                 (i32.shl
-                  (get_local $14)
+                  (get_local $13)
                   (i32.const 1)
                 )
               )
@@ -7758,7 +7721,7 @@
             (if
               (i32.and
                 (i32.ge_u
-                  (set_local $14
+                  (set_local $13
                     (i32.load
                       (set_local $1
                         (i32.add
@@ -7768,7 +7731,7 @@
                       )
                     )
                   )
-                  (set_local $4
+                  (set_local $5
                     (i32.load
                       (i32.const 1224)
                     )
@@ -7776,12 +7739,12 @@
                 )
                 (i32.ge_u
                   (get_local $16)
-                  (get_local $4)
+                  (get_local $5)
                 )
               )
               (block
                 (i32.store offset=12
-                  (get_local $14)
+                  (get_local $13)
                   (get_local $2)
                 )
                 (i32.store
@@ -7790,7 +7753,7 @@
                 )
                 (i32.store offset=8
                   (get_local $2)
-                  (get_local $14)
+                  (get_local $13)
                 )
                 (i32.store offset=12
                   (get_local $2)
@@ -7811,7 +7774,7 @@
           (i32.const 1212)
           (i32.or
             (get_local $15)
-            (get_local $4)
+            (get_local $5)
           )
         )
         (i32.store
@@ -8273,7 +8236,7 @@
     (local $6 i32)
     (local $7 i32)
     (if
-      (set_local $6
+      (set_local $5
         (i32.load
           (set_local $3
             (i32.add
@@ -8284,10 +8247,10 @@
         )
       )
       (block
-        (set_local $5
-          (get_local $6)
+        (set_local $7
+          (get_local $5)
         )
-        (set_local $4
+        (set_local $6
           (i32.const 5)
         )
       )
@@ -8295,16 +8258,16 @@
         (call $Xa
           (get_local $2)
         )
-        (set_local $7
+        (set_local $4
           (i32.const 0)
         )
         (block
-          (set_local $5
+          (set_local $7
             (i32.load
               (get_local $3)
             )
           )
-          (set_local $4
+          (set_local $6
             (i32.const 5)
           )
         )
@@ -8313,14 +8276,14 @@
     (block $label$break$a
       (if
         (i32.eq
-          (get_local $4)
+          (get_local $6)
           (i32.const 5)
         )
         (block
-          (set_local $4
+          (set_local $6
             (set_local $3
               (i32.load
-                (set_local $6
+                (set_local $5
                   (i32.add
                     (get_local $2)
                     (i32.const 20)
@@ -8332,13 +8295,13 @@
           (if
             (i32.lt_u
               (i32.sub
-                (get_local $5)
+                (get_local $7)
                 (get_local $3)
               )
               (get_local $1)
             )
             (block
-              (set_local $7
+              (set_local $4
                 (call_indirect $FUNCSIG$iiii
                   (i32.add
                     (i32.and
@@ -8380,9 +8343,6 @@
                           (get_local $0)
                         )
                         (set_local $3
-                          (get_local $4)
-                        )
-                        (set_local $5
                           (i32.const 0)
                         )
                         (br $label$break$b
@@ -8395,7 +8355,7 @@
                         (i32.load8_s
                           (i32.add
                             (get_local $0)
-                            (set_local $5
+                            (set_local $7
                               (i32.add
                                 (get_local $3)
                                 (i32.const -1)
@@ -8412,7 +8372,7 @@
                         (br $while-out$2)
                       )
                       (set_local $3
-                        (get_local $5)
+                        (get_local $7)
                       )
                     )
                     (br $while-in$3)
@@ -8435,12 +8395,7 @@
                       )
                       (get_local $4)
                     )
-                    (block
-                      (set_local $7
-                        (get_local $4)
-                      )
-                      (br $label$break$a)
-                    )
+                    (br $label$break$a)
                   )
                   (set_local $2
                     (i32.add
@@ -8448,12 +8403,12 @@
                       (get_local $4)
                     )
                   )
-                  (set_local $3
+                  (set_local $6
                     (i32.load
-                      (get_local $6)
+                      (get_local $5)
                     )
                   )
-                  (set_local $5
+                  (set_local $3
                     (get_local $4)
                   )
                   (i32.sub
@@ -8466,9 +8421,6 @@
                     (get_local $0)
                   )
                   (set_local $3
-                    (get_local $4)
-                  )
-                  (set_local $5
                     (i32.const 0)
                   )
                   (get_local $1)
@@ -8477,29 +8429,29 @@
             )
           )
           (call $jb
-            (get_local $3)
+            (get_local $6)
             (get_local $2)
             (get_local $0)
           )
           (i32.store
-            (get_local $6)
+            (get_local $5)
             (i32.add
               (i32.load
-                (get_local $6)
+                (get_local $5)
               )
               (get_local $0)
             )
           )
-          (set_local $7
+          (set_local $4
             (i32.add
-              (get_local $5)
+              (get_local $3)
               (get_local $0)
             )
           )
         )
       )
     )
-    (get_local $7)
+    (get_local $4)
   )
   (func $Za (param $0 i32) (result i32)
     (local $1 i32)
@@ -8547,10 +8499,10 @@
               )
               (get_local $0)
               (block
-                (set_local $1
+                (set_local $2
                   (get_local $0)
                 )
-                (set_local $2
+                (set_local $1
                   (i32.const 4)
                 )
                 (br $while-out$1)
@@ -8560,10 +8512,10 @@
           )
         )
         (block
-          (set_local $1
+          (set_local $2
             (get_local $0)
           )
-          (set_local $2
+          (set_local $1
             (i32.const 4)
           )
         )
@@ -8571,21 +8523,21 @@
     )
     (if
       (i32.eq
-        (get_local $2)
+        (get_local $1)
         (i32.const 4)
       )
       (block
-        (set_local $2
-          (get_local $1)
+        (set_local $1
+          (get_local $2)
         )
         (loop $while-out$3 $while-in$4
           (if
             (i32.and
               (i32.xor
                 (i32.and
-                  (set_local $1
+                  (set_local $2
                     (i32.load
-                      (get_local $2)
+                      (get_local $1)
                     )
                   )
                   (i32.const -2139062144)
@@ -8593,22 +8545,14 @@
                 (i32.const -2139062144)
               )
               (i32.add
-                (get_local $1)
+                (get_local $2)
                 (i32.const -16843009)
               )
             )
-            (block
-              (set_local $0
-                (get_local $1)
-              )
-              (set_local $1
-                (get_local $2)
-              )
-              (br $while-out$3)
-            )
-            (set_local $2
+            (br $while-out$3)
+            (set_local $1
               (i32.add
-                (get_local $2)
+                (get_local $1)
                 (i32.const 4)
               )
             )
@@ -8619,7 +8563,7 @@
           (i32.shr_s
             (i32.shl
               (i32.and
-                (get_local $0)
+                (get_local $2)
                 (i32.const 255)
               )
               (i32.const 24)
@@ -8627,7 +8571,7 @@
             (i32.const 24)
           )
           (block
-            (set_local $0
+            (set_local $2
               (get_local $1)
             )
             (loop $while-out$5 $while-in$6
@@ -8635,30 +8579,23 @@
                 (i32.load8_s
                   (set_local $1
                     (i32.add
-                      (get_local $0)
+                      (get_local $2)
                       (i32.const 1)
                     )
                   )
                 )
-                (set_local $0
+                (set_local $2
                   (get_local $1)
                 )
-                (block
-                  (set_local $0
-                    (get_local $1)
-                  )
-                  (br $while-out$5)
-                )
+                (br $while-out$5)
               )
               (br $while-in$6)
             )
           )
-          (set_local $0
-            (get_local $1)
-          )
+          (get_local $1)
         )
         (set_local $5
-          (get_local $0)
+          (get_local $1)
         )
       )
     )
@@ -8903,7 +8840,7 @@
             )
             (if
               (i32.ne
-                (set_local $1
+                (set_local $4
                   (i32.and
                     (get_local $1)
                     (i32.const 255)
@@ -8924,9 +8861,6 @@
                 (i32.store8
                   (get_local $2)
                   (get_local $9)
-                )
-                (set_local $4
-                  (get_local $1)
                 )
                 (br $do-once$0)
               )

--- a/test/passes/coalesce-locals.txt
+++ b/test/passes/coalesce-locals.txt
@@ -679,4 +679,30 @@
     )
     (get_local $0)
   )
+  (func $prefer-remove-copies1
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $0
+      (i32.const 0)
+    )
+    (get_local $0)
+    (set_local $1
+      (i32.const 1)
+    )
+    (get_local $0)
+    (get_local $1)
+  )
+  (func $prefer-remove-copies1
+    (local $0 i32)
+    (local $1 i32)
+    (set_local $1
+      (i32.const 0)
+    )
+    (get_local $1)
+    (set_local $0
+      (i32.const 1)
+    )
+    (get_local $0)
+    (get_local $1)
+  )
 )

--- a/test/passes/coalesce-locals.wast
+++ b/test/passes/coalesce-locals.wast
@@ -590,5 +590,25 @@
     )
     (get_local $x) ;; this ends up with the wrong value in the test
   )
+  (func $prefer-remove-copies1
+    (local $y i32)
+    (local $z i32)
+    (local $x i32) ;; y and z interfere, x can be with either, but has a copy which should be prefered
+    (set_local $x (i32.const 0))
+    (set_local $y (get_local $x))
+    (set_local $z (i32.const 1))
+    (get_local $y)
+    (get_local $z)
+  )
+  (func $prefer-remove-copies1
+    (local $y i32)
+    (local $z i32)
+    (local $x i32) ;; y and z interfere, x can be with either, but has a copy which should be prefered
+    (set_local $x (i32.const 0))
+    (set_local $z (get_local $x))
+    (set_local $y (i32.const 1))
+    (get_local $y)
+    (get_local $z)
+  )
 )
 


### PR DESCRIPTION
Removes almost 1% of locals on BB.

Makes the pass significantly slower, but not horribly so. If there is an issue perhaps we should split it out into a separate option.